### PR TITLE
Import ABC through six.moves for Python 2/3 compatibility.

### DIFF
--- a/sandbox/grist/engine.py
+++ b/sandbox/grist/engine.py
@@ -10,10 +10,11 @@ import rlcompleter
 import sys
 import time
 import traceback
-from collections import namedtuple, OrderedDict, Hashable, defaultdict
+from collections import namedtuple, OrderedDict, defaultdict
 
 import six
 from six.moves import zip
+from six.moves.collections_abc import Hashable
 from sortedcontainers import SortedSet
 
 import acl

--- a/sandbox/grist/test_match_counter.py
+++ b/sandbox/grist/test_match_counter.py
@@ -2,10 +2,10 @@ import random
 import string
 import timeit
 import unittest
-from collections import Hashable
 
 import six
 from six.moves import xrange
+from six.moves.collections_abc import Hashable
 
 import match_counter
 from testutil import repeat_until_passes


### PR DESCRIPTION
Importing ABC directly from collections has been removed in Python 3.10. Use six.moves.collections_abc as compatibility layer that uses collections in Python 2 and collections.abc in Python 3.