### PR TITLE
Fix typo in email fallback for SAML

### DIFF
--- a/app/server/lib/SamlConfig.ts
+++ b/app/server/lib/SamlConfig.ts
@@ -183,7 +183,7 @@ export class SamlConfig {
         // available. Otherwise we use user.attributes which has the form {Name: [Value]}.
         const fname = samlUser.given_name || samlUser.attributes.FirstName || '';
         const lname = samlUser.surname || samlUser.attributes.LastName || '';
-        const email = samlUser.email || samlUser.nameId;
+        const email = samlUser.email || samlUser.name_id;
         const profile = {
           email,
           name: `${fname} ${lname}`.trim(),


### PR DESCRIPTION
It looks like nameId doesn't exist as a property but name_id does (as is used elsewhere in the function)