### PR TITLE
Reverse proxy auth support

### DIFF
--- a/buildtools/prepare_python.sh
+++ b/buildtools/prepare_python.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/buildtools/prepare_python2.sh
+++ b/buildtools/prepare_python2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/buildtools/prepare_python3.sh
+++ b/buildtools/prepare_python3.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
#### Changes

- Add rudimentary support for a new header `x-remote-user`, to allow webserver-based authentication
- Use `/usr/bin/env bash` instead of `/bin/bash` to support `bash` in non-standard locations

#### Tasks

- [ ] Passed header should be configurable via an environment variable
- [ ] Disable feature altogether if not configured