### PR TITLE
remove stray redis dependency, and upgrade node in tests

### DIFF
--- a/.github/workflows/docker_latest.yml
+++ b/.github/workflows/docker_latest.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7]
-        node-version: [10.x]
+        node-version: [14.x]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7]
-        node-version: [10.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "install:python3": "buildtools/prepare_python3.sh",
     "build:prod": "tsc --build && webpack --config buildtools/webpack.config.js --mode production && webpack --config buildtools/webpack.check.js --mode production && cat app/client/*.css app/client/*/*.css > static/bundle.css",
     "start:prod": "NODE_PATH=_build:_build/stubs node _build/stubs/app/server/server.js",
-    "test": "GRIST_SESSION_COOKIE=grist_test_cookie GRIST_TEST_LOGIN=1 TEST_SUPPORT_API_KEY=api_key_for_support NODE_PATH=_build:_build/stubs mocha _build/test/nbrowser/*.js _build/test/server/**/*.js _build/test/gen-server/**/*.js",
+    "test": "GRIST_SESSION_COOKIE=grist_test_cookie GRIST_TEST_LOGIN=1 TEST_SUPPORT_API_KEY=api_key_for_support TEST_CLEAN_DATABASE=true NODE_PATH=_build:_build/stubs mocha _build/test/nbrowser/*.js _build/test/server/**/*.js _build/test/gen-server/**/*.js",
     "test:server": "GRIST_SESSION_COOKIE=grist_test_cookie NODE_PATH=_build:_build/stubs mocha _build/test/server/**/*.js _build/test/gen-server/**/*.js",
     "test:smoke": "NODE_PATH=_build:_build/stubs mocha _build/test/nbrowser/Smoke.js",
     "test:docker": "./test/test_under_docker.sh"

--- a/test/gen-server/seed.ts
+++ b/test/gen-server/seed.ts
@@ -604,8 +604,7 @@ export function setUpDB(context?: IHookCallbackContext) {
 async function main() {
   const cmd = process.argv[2];
   if (cmd === 'init') {
-    const connection = await createConnection();
-    await createInitialDb(connection);
+    await createInitialDb();
     return;
   } else if (cmd === 'benchmark') {
     const connection = await createConnection();

--- a/test/nbrowser/testServer.ts
+++ b/test/nbrowser/testServer.ts
@@ -23,6 +23,7 @@ import {driver, IMochaServer, WebDriver} from 'mocha-webdriver';
 import fetch from 'node-fetch';
 import {tmpdir} from 'os';
 import * as path from 'path';
+import {removeConnection} from 'test/gen-server/seed';
 import {HomeUtil} from 'test/nbrowser/homeUtil';
 
 export class TestServerMerged implements IMochaServer {
@@ -38,7 +39,7 @@ export class TestServerMerged implements IMochaServer {
   private _server: ChildProcess;
   private _exitPromise: Promise<number|string>;
   private _starts: number = 0;
-  private _dbManager: HomeDBManager;
+  private _dbManager?: HomeDBManager;
   private _driver: WebDriver;
 
   // The name is used to name the directory for server logs and data.
@@ -242,6 +243,11 @@ export class TestServerMerged implements IMochaServer {
       }
     }
     return this._dbManager;
+  }
+
+  public async closeDatabase() {
+    this._dbManager = undefined;
+    await removeConnection();
   }
 
   public get driver() {

--- a/test/nbrowser/testUtils.ts
+++ b/test/nbrowser/testUtils.ts
@@ -98,6 +98,10 @@ export function setupTestSuite(options?: TestSuiteOptions) {
   // always call resume.
   afterEach(() => server.resume());
 
+  // Close database until next test explicitly needs it, to avoid conflicts
+  // with tests that don't use the same server.
+  after(async () => server.closeDatabase());
+
   return setupRequirement({team: true, ...options});
 }
 

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -2163,7 +2163,8 @@ function testDocApi() {
       assert.deepEqual(response.data, {error: `Exceeded daily limit for document ${docId}`});
     });
 
-    after(async () => {
+    after(async function() {
+      if (!process.env.TEST_REDIS_URL) { this.skip(); }
       await redisClient.quitAsync();
     });
   });


### PR DESCRIPTION
Our core tests are run without redis, to ensure that core functionality without redis. A test of optional redis-dependent functionality accidentally had an unconditional `after` clause.

Separately, type guessing has trouble on the old version of node tests use, so I upgraded it.