### PR TITLE
remove watch flag no longer available under newer webpack

### DIFF
--- a/sandbox/watch.sh
+++ b/sandbox/watch.sh
@@ -13,7 +13,7 @@ if [ ! -e _build ]; then
 fi
 
 tsc --build -w --preserveWatchOutput $PROJECT &
-catw app/client/*.css app/client/*/*.css -o static/bundle.css -v & webpack --config buildtools/webpack.config.js --mode development --watch --hide-modules &
+catw app/client/*.css app/client/*/*.css -o static/bundle.css -v & webpack --config buildtools/webpack.config.js --mode development --watch &
 NODE_PATH=_build:_build/stubs:_build/ext nodemon --delay 1 -w _build/app/server -w _build/app/common _build/stubs/app/server/server.js &
 
 wait


### PR DESCRIPTION
This fixes `yarn start` so that it watches client code correctly again.

The `--hide-modules` flag tweaked how much webpack outputs to the console when in watch mode, but this flag got removed in a newer webpack version. 