### PR TITLE
Update some python deps for python>=3.8 compat

### DIFF
--- a/sandbox/grist/functions/date.py
+++ b/sandbox/grist/functions/date.py
@@ -292,7 +292,7 @@ def DATEVALUE(date_string, tz=None):
   >>> DATEVALUE("asdf")
   Traceback (most recent call last):
   ...
-  ValueError: Unknown string format
+  dateutil.parser._parser.ParserError: Unknown string format: asdf
   """
   return dateutil.parser.parse(date_string).replace(tzinfo=_get_tzinfo(tz))
 

--- a/sandbox/requirements3.txt
+++ b/sandbox/requirements3.txt
@@ -13,7 +13,7 @@ backports.functools-lru-cache==1.6.4
 chardet==4.0.0
 enum34==1.1.10
 et-xmlfile==1.0.1
-html5lib==0.999999999
+html5lib==1.1
 iso8601==0.1.12
 jdcal==1.4.1
 json_table_schema==0.2.1
@@ -21,12 +21,12 @@ lazy_object_proxy==1.6.0
 lxml==4.6.3                # used in csv plugin only?
 messytables==0.15.2
 openpyxl==2.6.4
-python_dateutil==2.6.0
+python_dateutil==2.8.2
 python_magic==0.4.12
 roman==2.0.0
 singledispatch==3.6.2
 six==1.16.0
-sortedcontainers==1.5.7
+sortedcontainers==2.4.0
 webencodings==0.5
 wrapt==1.12.1
 xlrd==1.2.0


### PR DESCRIPTION
Trying to run tests, I've hit some bugs related to my local python version (3.10).

The issue is related to ABC classes moved from collections to collections.abc since
python 3.3, and retro compat has ended with 3.8

I suggest to upgrade those two packages html5lib and sortedcontainers.

It's gonna be harder for the other package hitting the same issue: messytables. This package seems prehistoric (like I am, I've worked too with OKFN long time ago…), it seems no more maintained (messytables is deprecated in favour of tabular-py, which itself seems deprecated in favor of the Frictionless Framework). The package has a lot of old dependencies, including nosetests, which itself is unmaintained.

I can work on clearing this situation, either by updating the Grist code to move over from messytables or by trying to update messytables (hopefully then released), but I'll wait for your advices on this before ;)

Note: after updating those packages and patching messytables, I still have 17 failing tests. Those seems unrelated to my python version, but I may miss something.