### PR TITLE
Add GRIST_DEFAULT_LOCALE env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ GRIST_BACKUP_DELAY_SECS | wait this long after a doc change before making a back
 GRIST_DATA_DIR      | directory in which to store document caches.
 GRIST_DEFAULT_EMAIL | if set, login as this user if no other credentials presented
 GRIST_DEFAULT_PRODUCT  | if set, this controls enabled features and limits of new sites. See names of PRODUCTS in Product.ts.
+GRIST_DEFAULT_LOCALE  | Locale to use as fallback when Grist cannot honour the browser locale.
 GRIST_DOMAIN        | in hosted Grist, Grist is served from subdomains of this domain.  Defaults to "getgrist.com".
 GRIST_EXPERIMENTAL_PLUGINS | enables experimental plugins
 GRIST_HIDE_UI_ELEMENTS | comma-separated list of parts of the UI to hide. Allowed names of parts: `helpCenter,billing,templates,multiSite,multiAccounts`

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -128,7 +128,7 @@ bluebird.promisifyAll(tmp);
 const MAX_RECENT_ACTIONS = 100;
 
 const DEFAULT_TIMEZONE = (process.versions as any).electron ? moment.tz.guess() : "UTC";
-const DEFAULT_LOCALE = "en-US";
+const DEFAULT_LOCALE = process.env.GRIST_DEFAULT_LOCALE || "en-US";
 
 // Number of seconds an ActiveDoc is retained without any clients.
 // In dev environment, it is convenient to keep this low for quick tests.


### PR DESCRIPTION
Quotting @paulfitz (in https://community.getgrist.com/t/configure-default-local-i18n/1350/6):

> The solution may be a fix or improvement in Grist rather than adding more configuration.

For sure!
But I'd say: either we are strong and confident and we do not need a fallback, either we allow to control the fallback ;)

So here is a proposal.

Feel free to close it if you think it's useless or it creates confusion or whatever :)