### PR TITLE
Suggestion to add docs/ and sandbox_venv*/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 /static/*.bundle.js.*.txt
 /grist-sessions.db
 /landing.db
+/docs/
+/sandbox_venv*
 
 # Build helper files.
 /.build*


### PR DESCRIPTION
docs/ is the default path where docs are storer when running app locally
sandbox_venv*/ are created when installing python