### PR TITLE
use python3 for workflows

### DIFF
--- a/.github/workflows/docker_latest.yml
+++ b/.github/workflows/docker_latest.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7]
+        python-version: [3.9]
         node-version: [14.x]
     steps:
       - name: Check out the repo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7]
+        python-version: [3.9]
         node-version: [14.x]
 
     steps:


### PR DESCRIPTION
Use python3 for running tests. Grist has supported python3 for a while, and is slowly slowly starting to inch away from python2 support. Grist now needs python3 when doing imports, although python2 is still supported for regular document operation.