### PR TITLE
Export xlsx #256

### DIFF
--- a/app/client/components/GristDoc.ts
+++ b/app/client/components/GristDoc.ts
@@ -845,6 +845,23 @@ export class GristDoc extends DisposableWithEvents {
     return this.docPageModel.appModel.api.getDocAPI(this.docId()).getDownloadCsvUrl(params);
   }
 
+  public getXlsxActiveViewLink() {
+    const filters = this.viewModel.activeSection.peek().activeFilters.get().map(filterInfo => ({
+      colRef : filterInfo.fieldOrColumn.origCol().origColRef(),
+      filter : filterInfo.filter()
+    }));
+
+    const params = {
+      viewSection: this.viewModel.activeSectionId(),
+      tableId: this.viewModel.activeSection().table().tableId(),
+      activeSortSpec: JSON.stringify(this.viewModel.activeSection().activeSortSpec()),
+      filters : JSON.stringify(filters),
+      activeViewOnly : true,
+    };
+
+    return this.docPageModel.appModel.api.getDocAPI(this.docId()).getDownloadXlsxUrl(params); 
+  }
+
   public hasGranularAccessRules(): boolean {
     const rulesTable = this.docData.getMetaTable('_grist_ACLRules');
     // To check if there are rules, ignore the default no-op rule created for an older incarnation

--- a/app/client/components/GristDoc.ts
+++ b/app/client/components/GristDoc.ts
@@ -830,22 +830,16 @@ export class GristDoc extends DisposableWithEvents {
   }
 
   public getCsvLink() {
-    const filters = this.viewModel.activeSection.peek().activeFilters.get().map(filterInfo => ({
-      colRef : filterInfo.fieldOrColumn.origCol().origColRef(),
-      filter : filterInfo.filter()
-    }));
-
-    const params = {
-      viewSection: this.viewModel.activeSectionId(),
-      tableId: this.viewModel.activeSection().table().tableId(),
-      activeSortSpec: JSON.stringify(this.viewModel.activeSection().activeSortSpec()),
-      filters : JSON.stringify(filters),
-    };
-
+    const params = this._getDocApiDownloadParams();
     return this.docPageModel.appModel.api.getDocAPI(this.docId()).getDownloadCsvUrl(params);
   }
 
   public getXlsxActiveViewLink() {
+    const params = this._getDocApiDownloadParams();
+    return this.docPageModel.appModel.api.getDocAPI(this.docId()).getDownloadXlsxUrl(params);
+  }
+
+  private _getDocApiDownloadParams() {
     const filters = this.viewModel.activeSection.peek().activeFilters.get().map(filterInfo => ({
       colRef : filterInfo.fieldOrColumn.origCol().origColRef(),
       filter : filterInfo.filter()
@@ -856,10 +850,8 @@ export class GristDoc extends DisposableWithEvents {
       tableId: this.viewModel.activeSection().table().tableId(),
       activeSortSpec: JSON.stringify(this.viewModel.activeSection().activeSortSpec()),
       filters : JSON.stringify(filters),
-      activeViewOnly : true,
     };
-
-    return this.docPageModel.appModel.api.getDocAPI(this.docId()).getDownloadXlsxUrl(params); 
+    return params;
   }
 
   public hasGranularAccessRules(): boolean {

--- a/app/client/ui/ViewLayoutMenu.ts
+++ b/app/client/ui/ViewLayoutMenu.ts
@@ -41,6 +41,8 @@ export function makeViewLayoutMenu(viewSection: ViewSectionRec, isReadonly: bool
     menuItemCmd(allCommands.printSection, 'Print widget', testId('print-section')),
     menuItemLink({ href: gristDoc.getCsvLink(), target: '_blank', download: ''},
       'Download as CSV', testId('download-section')),
+    menuItemLink({ href: gristDoc.getXlsxActiveViewLink(), target: '_blank', download: ''},
+    'Download as XLSX', testId('download-section')),
     dom.maybe((use) => ['detail', 'single'].includes(use(viewSection.parentKey)), () =>
       menuItemCmd(allCommands.editLayout, 'Edit Card Layout',
         dom.cls('disabled', isReadonly))),

--- a/app/common/UserAPI.ts
+++ b/app/common/UserAPI.ts
@@ -355,6 +355,13 @@ export interface UserAPI {
   filters?: string;
 }
 
+/**
+ * Parameters for the download XLSX endpoint (/download/xlsx).
+ */
+ export interface DownloadXLSXParams extends DownloadCsvParams{
+  activeView?: string;
+}
+
 interface GetRowsParams {
   filters?: QueryFilters;
   immediate?: boolean;
@@ -391,7 +398,7 @@ export interface DocAPI {
   // is HEAD, the result will contain a copy of any rows added or updated.
   compareVersion(leftHash: string, rightHash: string): Promise<DocStateComparison>;
   getDownloadUrl(template?: boolean): string;
-  getDownloadXlsxUrl(): string;
+  getDownloadXlsxUrl(params?: DownloadXLSXParams): string;
   getDownloadCsvUrl(params: DownloadCsvParams): string;
   /**
    * Exports current document to the Google Drive as a spreadsheet file. To invoke this method, first
@@ -866,8 +873,8 @@ export class DocAPIImpl extends BaseAPI implements DocAPI {
     return this._url + `/download?template=${Number(template)}`;
   }
 
-  public getDownloadXlsxUrl() {
-    return this._url + '/download/xlsx';
+  public getDownloadXlsxUrl(params: DownloadXLSXParams) {
+    return this._url + '/download/xlsx?' + encodeQueryParams({...params});
   }
 
   public getDownloadCsvUrl(params: DownloadCsvParams) {

--- a/app/common/UserAPI.ts
+++ b/app/common/UserAPI.ts
@@ -346,20 +346,13 @@ export interface UserAPI {
 }
 
 /**
- * Parameters for the download CSV endpoint (/download/csv).
+ * Parameters for the download CSV and XLSX endpoint (/download/csv & /download/csv).
  */
- export interface DownloadCsvParams {
+ export interface DownloadDocParams {
   tableId: string;
   viewSection?: number;
   activeSortSpec?: string;
   filters?: string;
-}
-
-/**
- * Parameters for the download XLSX endpoint (/download/xlsx).
- */
- export interface DownloadXLSXParams extends DownloadCsvParams{
-  activeView?: string;
 }
 
 interface GetRowsParams {
@@ -398,8 +391,8 @@ export interface DocAPI {
   // is HEAD, the result will contain a copy of any rows added or updated.
   compareVersion(leftHash: string, rightHash: string): Promise<DocStateComparison>;
   getDownloadUrl(template?: boolean): string;
-  getDownloadXlsxUrl(params?: DownloadXLSXParams): string;
-  getDownloadCsvUrl(params: DownloadCsvParams): string;
+  getDownloadXlsxUrl(params?: DownloadDocParams): string;
+  getDownloadCsvUrl(params: DownloadDocParams): string;
   /**
    * Exports current document to the Google Drive as a spreadsheet file. To invoke this method, first
    * acquire "code" via Google Auth Endpoint (see ShareMenu.ts for an example).
@@ -873,11 +866,11 @@ export class DocAPIImpl extends BaseAPI implements DocAPI {
     return this._url + `/download?template=${Number(template)}`;
   }
 
-  public getDownloadXlsxUrl(params: DownloadXLSXParams) {
+  public getDownloadXlsxUrl(params: DownloadDocParams) {
     return this._url + '/download/xlsx?' + encodeQueryParams({...params});
   }
 
-  public getDownloadCsvUrl(params: DownloadCsvParams) {
+  public getDownloadCsvUrl(params: DownloadDocParams) {
     // We spread `params` to work around TypeScript being overly cautious.
     return this._url + '/download/csv?' + encodeQueryParams({...params});
   }

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -752,10 +752,9 @@ export class DocWorkerApi {
       // Query DB for doc metadata to get the doc title (to use as the filename).
       const {name: docTitle} = await this._dbManager.getDoc(req);
 
-      const params = ! _.isEmpty(req.query) ? parseExportParameters(req) : {tableId: '', activeView: false};
+      const params = !_.isEmpty(req.query) ? parseExportParameters(req) : {tableId: '', activeView: false};
 
-      const {activeView} = params;
-      const filename = !activeView ? docTitle : docTitle + (params.tableId === docTitle ? '' : '-' + params.tableId);
+      const filename = !_.isEmpty(req.query) ? docTitle + (params.tableId === docTitle ? '' : '-' + params.tableId) : docTitle;
 
       const options: DownloadXLSXOptions = buildDownloadXlsxOptions({...params, filename});
 

--- a/app/server/lib/Export.ts
+++ b/app/server/lib/Export.ts
@@ -78,7 +78,17 @@ export interface ExportParameters {
   viewSectionId: number | undefined;
   sortOrder: number[];
   filters: Filter[];
-  activeView?: boolean;
+}
+
+/**
+ * Options parameters for CSV and XLSX export functions.
+ */
+export interface DownloadOptions {
+  filename: string;
+  tableId: string;
+  viewSectionId: number | undefined;
+  filters: Filter[];
+  sortOrder: number[];
 }
 
 interface FilteredMetaTables {

--- a/app/server/lib/Export.ts
+++ b/app/server/lib/Export.ts
@@ -78,6 +78,7 @@ export interface ExportParameters {
   viewSectionId: number | undefined;
   sortOrder: number[];
   filters: Filter[];
+  activeView?: boolean;
 }
 
 interface FilteredMetaTables {
@@ -92,12 +93,14 @@ export function parseExportParameters(req: express.Request): ExportParameters {
   const viewSectionId = optIntegerParam(req.query.viewSection);
   const sortOrder = optJsonParam(req.query.activeSortSpec, []) as number[];
   const filters: Filter[] = optJsonParam(req.query.filters, []);
+  const activeView = stringParam(req.query.activeViewOnly, 'false') === 'true';
 
   return {
     tableId,
     viewSectionId,
     sortOrder,
-    filters
+    filters,
+    activeView
   };
 }
 

--- a/app/server/lib/Export.ts
+++ b/app/server/lib/Export.ts
@@ -14,7 +14,7 @@ import {MetaRowRecord, MetaTableData} from 'app/common/TableData';
 import {ActiveDoc} from 'app/server/lib/ActiveDoc';
 import {RequestWithLogin} from 'app/server/lib/Authorizer';
 import {docSessionFromRequest} from 'app/server/lib/DocSession';
-import {optIntegerParam, optJsonParam, stringParam} from 'app/server/lib/requestUtils';
+import {optIntegerParam, optJsonParam, stringParam, optStringParam} from 'app/server/lib/requestUtils';
 import {ServerColumnGetters} from 'app/server/lib/ServerColumnGetters';
 import * as express from 'express';
 import * as _ from 'underscore';
@@ -93,7 +93,7 @@ export function parseExportParameters(req: express.Request): ExportParameters {
   const viewSectionId = optIntegerParam(req.query.viewSection);
   const sortOrder = optJsonParam(req.query.activeSortSpec, []) as number[];
   const filters: Filter[] = optJsonParam(req.query.filters, []);
-  const activeView = stringParam(req.query.activeViewOnly, 'false') === 'true';
+  const activeView = optStringParam(req.query.activeViewOnly) === 'true';
 
   return {
     tableId,

--- a/app/server/lib/Export.ts
+++ b/app/server/lib/Export.ts
@@ -14,7 +14,7 @@ import {MetaRowRecord, MetaTableData} from 'app/common/TableData';
 import {ActiveDoc} from 'app/server/lib/ActiveDoc';
 import {RequestWithLogin} from 'app/server/lib/Authorizer';
 import {docSessionFromRequest} from 'app/server/lib/DocSession';
-import {optIntegerParam, optJsonParam, stringParam, optStringParam} from 'app/server/lib/requestUtils';
+import {optIntegerParam, optJsonParam, stringParam} from 'app/server/lib/requestUtils';
 import {ServerColumnGetters} from 'app/server/lib/ServerColumnGetters';
 import * as express from 'express';
 import * as _ from 'underscore';
@@ -93,14 +93,12 @@ export function parseExportParameters(req: express.Request): ExportParameters {
   const viewSectionId = optIntegerParam(req.query.viewSection);
   const sortOrder = optJsonParam(req.query.activeSortSpec, []) as number[];
   const filters: Filter[] = optJsonParam(req.query.filters, []);
-  const activeView = optStringParam(req.query.activeViewOnly) === 'true';
 
   return {
     tableId,
     viewSectionId,
     sortOrder,
     filters,
-    activeView
   };
 }
 

--- a/app/server/lib/ExportCSV.ts
+++ b/app/server/lib/ExportCSV.ts
@@ -1,20 +1,12 @@
 import {ApiError} from 'app/common/ApiError';
 import {createFormatter} from 'app/common/ValueFormatter';
 import {ActiveDoc} from 'app/server/lib/ActiveDoc';
-import {ExportData, exportSection, exportTable, Filter} from 'app/server/lib/Export';
+import {ExportData, exportSection, exportTable, Filter, DownloadOptions} from 'app/server/lib/Export';
 import log from 'app/server/lib/log';
 import * as bluebird from 'bluebird';
 import contentDisposition from 'content-disposition';
 import csv from 'csv';
 import * as express from 'express';
-
-export interface DownloadCSVOptions {
-  filename: string;
-  tableId: string;
-  viewSectionId: number | undefined;
-  filters: Filter[];
-  sortOrder: number[];
-}
 
 // promisify csv
 bluebird.promisifyAll(csv);
@@ -23,7 +15,7 @@ bluebird.promisifyAll(csv);
  * Converts `activeDoc` to a CSV and sends the converted data through `res`.
  */
 export async function downloadCSV(activeDoc: ActiveDoc, req: express.Request,
-                                  res: express.Response, options: DownloadCSVOptions) {
+                                  res: express.Response, options: DownloadOptions) {
   log.info('Generating .csv file...');
   const {filename, tableId, viewSectionId, filters, sortOrder} = options;
   const data = viewSectionId ?

--- a/app/server/lib/ExportXLSX.ts
+++ b/app/server/lib/ExportXLSX.ts
@@ -11,7 +11,14 @@ export interface DownloadXLSXOptions extends ExportParameters {
   filename: string;
 }
 
-export function buildDownloadXlsxOptions({filename, tableId, viewSectionId, filters, sortOrder, activeView}: any): DownloadXLSXOptions {
+export function buildDownloadXlsxOptions({
+  filename,
+  tableId,
+  viewSectionId,
+  filters,
+  sortOrder,
+  activeView,
+}: any): DownloadXLSXOptions {
   return {
     filename,
     tableId: tableId || '',
@@ -23,7 +30,7 @@ export function buildDownloadXlsxOptions({filename, tableId, viewSectionId, filt
 }
 
 /**
- * Converts `activeDoc` to CSV and sends the converted data through `res`.
+ * Converts `activeDoc` to XLSX and sends the converted data through `res`.
  */
 export async function downloadXLSX(activeDoc: ActiveDoc, req: express.Request,
                                    res: express.Response, options: DownloadXLSXOptions) {
@@ -41,24 +48,20 @@ export async function downloadXLSX(activeDoc: ActiveDoc, req: express.Request,
 }
 
 /**
- * Returns a csv stream of a view section that can be transformed or parsed.
- *
- * See https://github.com/wdavidw/node-csv for API details.
+ * Returns a XLSX stream of a view section that can be transformed or parsed.
  *
  * @param {Object} activeDoc - the activeDoc that the table being converted belongs to.
  * @param {Integer} viewSectionId - id of the viewsection to export.
  * @param {Integer[]} activeSortOrder (optional) - overriding sort order.
  * @param {Filter[]} filters (optional) - filters defined from ui.
- * @return {Promise<string>} Promise for the resulting CSV.
  */
  export async function makeXLSXFromViewSection(
   activeDoc: ActiveDoc,
   viewSectionId: number,
   sortOrder: number[],
   filters: Filter[],
-  req: express.Request) {
-
-  console.log("=============== Using makeXLSXFromViewSection ===============")
+  req: express.Request,
+) {
 
   const data = await exportSection(activeDoc, viewSectionId, sortOrder, filters, req);
   const xlsx = await convertToExcel([data], req.hostname === 'localhost');
@@ -66,19 +69,17 @@ export async function downloadXLSX(activeDoc: ActiveDoc, req: express.Request,
 }
 
 /**
- * Returns a csv stream of a table that can be transformed or parsed.
+ * Returns a XLSX stream of a table that can be transformed or parsed.
  *
  * @param {Object} activeDoc - the activeDoc that the table being converted belongs to.
  * @param {Integer} tableId - id of the table to export.
- * @return {Promise<string>} Promise for the resulting CSV.
  */
 export async function makeXLSXFromTable(
   activeDoc: ActiveDoc,
   tableId: string,
-  req: express.Request) {
-
-  console.log("=============== Using makeXLSXFromTable ===============")
-    if (!activeDoc.docData) {
+  req: express.Request
+) {
+  if (!activeDoc.docData) {
     throw new Error('No docData in active document');
   }
 
@@ -100,8 +101,8 @@ export async function makeXLSXFromTable(
  */
 export async function makeXLSX(
   activeDoc: ActiveDoc,
-  req: express.Request): Promise<ArrayBuffer> {
-  console.log("=============== Using makeXLSX ===============")
+  req: express.Request,
+): Promise<ArrayBuffer> {
   const content = await exportDoc(activeDoc, req);
   const data = await convertToExcel(content, req.hostname === 'localhost');
   return data;

--- a/app/server/lib/ExportXLSX.ts
+++ b/app/server/lib/ExportXLSX.ts
@@ -1,37 +1,17 @@
 import {ActiveDoc} from 'app/server/lib/ActiveDoc';
 import {createExcelFormatter} from 'app/server/lib/ExcelFormatter';
-import {ExportData, exportDoc, ExportParameters, exportSection, exportTable, Filter} from 'app/server/lib/Export';
+import {ExportData, exportDoc, DownloadOptions, exportSection, exportTable, Filter} from 'app/server/lib/Export';
 import {Alignment, Border, Fill, Workbook} from 'exceljs';
 import * as express from 'express';
 import log from 'app/server/lib/log';
 import contentDisposition from 'content-disposition';
 import { ApiError } from 'app/common/ApiError';
 
-export interface DownloadXLSXOptions extends ExportParameters {
-  filename: string;
-}
-
-export function buildDownloadXlsxOptions({
-  filename,
-  tableId,
-  viewSectionId,
-  filters,
-  sortOrder,
-}: any): DownloadXLSXOptions {
-  return {
-    filename,
-    tableId: tableId || '',
-    viewSectionId: viewSectionId || undefined,
-    filters: filters || [],
-    sortOrder: sortOrder || [],
-  }
-}
-
 /**
  * Converts `activeDoc` to XLSX and sends the converted data through `res`.
  */
 export async function downloadXLSX(activeDoc: ActiveDoc, req: express.Request,
-                                   res: express.Response, options: DownloadXLSXOptions) {
+                                   res: express.Response, options: DownloadOptions) {
   log.debug(`Generating .xlsx file`);
   const {filename, tableId, viewSectionId, filters, sortOrder} = options;
   // hanlding 3 cases : full XLSX export (full file), view xlsx export, table xlsx export

--- a/app/server/lib/ExportXLSX.ts
+++ b/app/server/lib/ExportXLSX.ts
@@ -17,7 +17,6 @@ export function buildDownloadXlsxOptions({
   viewSectionId,
   filters,
   sortOrder,
-  activeView,
 }: any): DownloadXLSXOptions {
   return {
     filename,
@@ -25,7 +24,6 @@ export function buildDownloadXlsxOptions({
     viewSectionId: viewSectionId || undefined,
     filters: filters || [],
     sortOrder: sortOrder || [],
-    activeView: activeView || false,
   }
 }
 
@@ -35,11 +33,11 @@ export function buildDownloadXlsxOptions({
 export async function downloadXLSX(activeDoc: ActiveDoc, req: express.Request,
                                    res: express.Response, options: DownloadXLSXOptions) {
   log.debug(`Generating .xlsx file`);
-  const {filename, tableId, viewSectionId, filters, sortOrder, activeView} = options;
+  const {filename, tableId, viewSectionId, filters, sortOrder} = options;
   // hanlding 3 cases : full XLSX export (full file), view xlsx export, table xlsx export
-  const data = !activeView ? await makeXLSX(activeDoc, req)
-              : viewSectionId ? await makeXLSXFromViewSection(activeDoc, viewSectionId, sortOrder, filters, req)
-              : await makeXLSXFromTable(activeDoc, tableId, req);
+  const data = viewSectionId ? await makeXLSXFromViewSection(activeDoc, viewSectionId, sortOrder, filters, req)
+              : tableId ? await makeXLSXFromTable(activeDoc, tableId, req)
+              : await makeXLSX(activeDoc, req);
 
   res.set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
   res.setHeader('Content-Disposition', contentDisposition(filename + '.xlsx'));

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -1805,27 +1805,27 @@ function testDocApi() {
   });
 
   it("GET /docs/{did}/download/xlsx serves XLSX-encoded document", async function() {
-    const resp = await axios.get(`${serverUrl}/api/docs/${docIds.Timesheets}/download/xlsx?activeViewOnly=true&tableId=Table1`, chimpy);
+    const resp = await axios.get(`${serverUrl}/api/docs/${docIds.Timesheets}/download/xlsx?tableId=Table1`, chimpy);
     assert.equal(resp.status, 200);
     assert.notEqual(resp.data, null);
   });
 
   it("GET /docs/{did}/download/xlsx respects permissions", async function() {
     // kiwi has no access to TestDoc
-    const resp = await axios.get(`${serverUrl}/api/docs/${docIds.TestDoc}/download/xlsx?activeViewOnly=true&tableId=Table1`, kiwi);
+    const resp = await axios.get(`${serverUrl}/api/docs/${docIds.TestDoc}/download/xlsx?tableId=Table1`, kiwi);
     assert.equal(resp.status, 403);
     assert.deepEqual(resp.data, { error: 'No view access' });
   });
 
   it("GET /docs/{did}/download/xlsx returns 404 if tableId is invalid", async function() {
-    const resp = await axios.get(`${serverUrl}/api/docs/${docIds.TestDoc}/download/xlsx?activeViewOnly=true&tableId=MissingTableId`, chimpy);
+    const resp = await axios.get(`${serverUrl}/api/docs/${docIds.TestDoc}/download/xlsx?tableId=MissingTableId`, chimpy);
     assert.equal(resp.status, 404);
     assert.deepEqual(resp.data, { error: 'Table MissingTableId not found.' });
   });
 
   it("GET /docs/{did}/download/xlsx returns 404 if viewSectionId is invalid", async function() {
     const resp = await axios.get(
-      `${serverUrl}/api/docs/${docIds.TestDoc}/download/xlsx?activeViewOnly=true&tableId=Table1&viewSection=9999`, chimpy);
+      `${serverUrl}/api/docs/${docIds.TestDoc}/download/xlsx?tableId=Table1&viewSection=9999`, chimpy);
     assert.equal(resp.status, 404);
     assert.deepEqual(resp.data, { error: 'No record 9999 in table _grist_Views_section' });
   });

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -1804,6 +1804,39 @@ function testDocApi() {
     assert.deepEqual(resp.data, { error: 'tableId parameter should be a string: undefined' });
   });
 
+  it("GET /docs/{did}/download/xlsx serves XLSX-encoded document", async function() {
+    const resp = await axios.get(`${serverUrl}/api/docs/${docIds.Timesheets}/download/xlsx?activeViewOnly=true&tableId=Table1`, chimpy);
+    assert.equal(resp.status, 200);
+    assert.notEqual(resp.data, null);
+  });
+
+  it("GET /docs/{did}/download/xlsx respects permissions", async function() {
+    // kiwi has no access to TestDoc
+    const resp = await axios.get(`${serverUrl}/api/docs/${docIds.TestDoc}/download/xlsx?activeViewOnly=true&tableId=Table1`, kiwi);
+    assert.equal(resp.status, 403);
+    assert.deepEqual(resp.data, { error: 'No view access' });
+  });
+
+  it("GET /docs/{did}/download/xlsx returns 404 if tableId is invalid", async function() {
+    const resp = await axios.get(`${serverUrl}/api/docs/${docIds.TestDoc}/download/xlsx?activeViewOnly=true&tableId=MissingTableId`, chimpy);
+    assert.equal(resp.status, 404);
+    assert.deepEqual(resp.data, { error: 'Table MissingTableId not found.' });
+  });
+
+  it("GET /docs/{did}/download/xlsx returns 404 if viewSectionId is invalid", async function() {
+    const resp = await axios.get(
+      `${serverUrl}/api/docs/${docIds.TestDoc}/download/xlsx?activeViewOnly=true&tableId=Table1&viewSection=9999`, chimpy);
+    assert.equal(resp.status, 404);
+    assert.deepEqual(resp.data, { error: 'No record 9999 in table _grist_Views_section' });
+  });
+
+  it("GET /docs/{did}/download/xlsx returns 200 if tableId is missing", async function() {
+    const resp = await axios.get(
+      `${serverUrl}/api/docs/${docIds.TestDoc}/download/xlsx`, chimpy);
+    assert.equal(resp.status, 200);
+    assert.notEqual(resp.data, null);
+  });
+
   it('POST /workspaces/{wid}/import handles empty filenames', async function() {
     if (!process.env.TEST_REDIS_URL) { this.skip(); }
     const worker1 = await userApi.getWorkerAPI('import');


### PR DESCRIPTION
Code related to [issue #256](https://github.com/gristlabs/grist-core/issues/256).

Enable user to export a view in XLSX instead of only CSV.

With the help of @vviers we were heavily inspired by the work done on the CSV export and tried to conserve legacy behavior.

As usual, we are open to improvement.

Here a demonstration of the behavior. I don't know if it's what you'd expect.

https://user-images.githubusercontent.com/11460746/189173109-bcc287be-2a20-413d-8415-65d61e3bd335.mov

