### PR TITLE
give parseDate test more time

### DIFF
--- a/test/common/parseDate.ts
+++ b/test/common/parseDate.ts
@@ -331,6 +331,7 @@ describe('parseDate', function() {
   });
 
   it('should handle datetimes as formatted by moment', function() {
+    this.timeout(10000);  // there may be a LOT of timezone names.
     for (const date of ['2020-02-03', '2020-06-07', '2020-10-11']) {  // different months for daylight savings
       const dateTime = date + ' 12:34:56';
       const utcMoment = moment.tz(dateTime, 'UTC');


### PR DESCRIPTION
The time it takes parseDate to run depends on how many timezone names moment knows about. It has been timing out sporadically in CI, so this PR gives it more time to run. An alternative could be to sample some timezone names rather than testing them all.