### PR TITLE
Replace disabled attribute by readonly attribute

### DIFF
--- a/app/client/ui/FieldConfig.ts
+++ b/app/client/ui/FieldConfig.ts
@@ -50,7 +50,7 @@ export function buildNameConfig(owner: MultiHolder, origColumn: ColumnRec, curso
         ),
         cssInput(editableColId,
           saveColId,
-          dom.boolAttr('disabled', use => use(origColumn.disableModify) || !use(origColumn.untieColIdFromLabel)),
+          dom.boolAttr(`readonly`, use => use(origColumn.disableModify) || !use(origColumn.untieColIdFromLabel)),
           cssCodeBlock.cls(''),
           {style: 'margin-top: 8px'},
           testId('field-col-id'),
@@ -396,7 +396,7 @@ const cssInput = styled(textInput, `
     color: ${theme.inputPlaceholderFg};
   }
 
-  &:disabled {
+  &[readonly] {
     background-color: ${theme.inputDisabledBg};
     color: ${theme.inputDisabledFg};
   }


### PR DESCRIPTION
Related to #275

We decided to go with readonly attribute because we could not select any label or text inside div or span.

I'd love to hear what how to solve it but unless the text is inside an input, it does not seems selectable.

https://user-images.githubusercontent.com/11460746/190451551-6445d038-35f0-4cf3-be62-e7ac3d8655a0.mov
