### PR TITLE
Return 403 error when origin is not trusted

### DIFF
--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1,3 +1,4 @@
+import {ApiError} from 'app/common/ApiError';
 import {delay} from 'app/common/delay';
 import {DocCreationInfo} from 'app/common/DocListAPI';
 import {encodeUrl, getSlugIfNeeded, GristLoadConfig, IGristUrlState, isOrgInPathOnly,
@@ -1753,7 +1754,7 @@ function trustOriginHandler(req: express.Request, res: express.Response, next: e
     res.header("Access-Control-Allow-Methods", "GET, PATCH, PUT, POST, DELETE, OPTIONS");
     res.header("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Requested-With");
   } else {
-    throw new Error('Unrecognized origin');
+    throw new ApiError('Unrecognized origin', 403);
   }
   if ('OPTIONS' === req.method) {
     res.sendStatus(200);

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -2800,9 +2800,9 @@ function testDocApi() {
         error && assert.deepEqual(resp.data, {error});
         assert.equal(resp.status, status);
       }
-      await checkOrigin("https://www.toto.com", 500, "Unrecognized origin");
-      await checkOrigin("https://badexample.com", 500, "Unrecognized origin");
-      await checkOrigin("https://bad.com/example.com/toto", 500, "Unrecognized origin");
+      await checkOrigin("https://www.toto.com", 403, "Unrecognized origin");
+      await checkOrigin("https://badexample.com", 403, "Unrecognized origin");
+      await checkOrigin("https://bad.com/example.com/toto", 403, "Unrecognized origin");
       await checkOrigin("https://example.com/path", 200);
       await checkOrigin("https://good.example.com/toto", 200);
     });


### PR DESCRIPTION
As discussed [here](https://github.com/gristlabs/grist-core/commit/bd6a54e90198a7117fa4ebdcbb6d87b7d54c809e#r86576310)