### PR TITLE
Fix condition to check that a translation key exists

### DIFF
--- a/app/client/lib/localization.ts
+++ b/app/client/lib/localization.ts
@@ -71,7 +71,7 @@ export async function setupLocale() {
  * Resolves the translation of the given key, using the given options.
  */
 export function t(key: string, args?: any): string {
-  if (!i18next.exists(key)) {
+  if (!i18next.exists(key, args)) {
     const error = new Error(`Missing translation for key: ${key} and language: ${i18next.language}`);
     reportError(error);
   }


### PR DESCRIPTION
The `exists` function from i18next takes the same arguments as `t`, and it fails when it tries to look for translation keys with the count or the context missing. This PR adds the options object when calling `i18next.exists`.