### PR TITLE
Use url.hostname instead of url.host to allow host from environment variable

### DIFF
--- a/app/server/lib/requestUtils.ts
+++ b/app/server/lib/requestUtils.ts
@@ -117,7 +117,7 @@ export function matchesBaseDomain(domain: string, baseDomain: string) {
 }
 
 export function isEnvironmentAllowedHost(url: string|URL) {
-  const urlHost = (typeof url === 'string') ? url : url.host;
+  const urlHost = (typeof url === 'string') ? url : url.hostname;
   return (process.env.GRIST_ALLOWED_HOSTS || "").split(",").some(domain =>
     domain && matchesBaseDomain(urlHost, domain)
   );

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -3035,6 +3035,7 @@ function testDocApi() {
       await checkOrigin("https://www.toto.com", 403, "Unrecognized origin");
       await checkOrigin("https://badexample.com", 403, "Unrecognized origin");
       await checkOrigin("https://bad.com/example.com/toto", 403, "Unrecognized origin");
+      await checkOrigin("https://example.com:3000/path", 200);
       await checkOrigin("https://example.com/path", 200);
       await checkOrigin("https://good.example.com/toto", 200);
     });
@@ -3133,7 +3134,7 @@ class TestServer {
       REDIS_URL: process.env.TEST_REDIS_URL,
       APP_HOME_URL: _homeUrl,
       ALLOWED_WEBHOOK_DOMAINS: `example.com,localhost:${webhooksTestPort}`,
-      GRIST_ALLOWED_HOSTS: `example.com,localhost:${webhooksTestPort}`,
+      GRIST_ALLOWED_HOSTS: `example.com,localhost`,
       ...process.env
     };
 


### PR DESCRIPTION
Co-authored-by <yohan.boniface@free.fr>

Hello, we had an issue where we could not make request to our instance from our local applications.
We propose to drop the port in the configuration of the allowed hosts.


Do you have any concern regarding this change ?

cc @yohanboniface 