### PR TITLE
Use relative imports only in plugin folder

### DIFF
--- a/app/plugin/DocApiTypes.ts
+++ b/app/plugin/DocApiTypes.ts
@@ -1,4 +1,4 @@
-import { CellValue } from "app/plugin/GristData";
+import { CellValue } from "./GristData";
 
 /**
  * JSON schema for api /record endpoint. Used in POST method for adding new records.

--- a/app/plugin/TableOperations.ts
+++ b/app/plugin/TableOperations.ts
@@ -1,4 +1,4 @@
-import * as Types from 'app/plugin/DocApiTypes';
+import * as Types from './DocApiTypes';
 
 /**
  * Offer CRUD-style operations on a table.

--- a/app/plugin/TableOperationsImpl.ts
+++ b/app/plugin/TableOperationsImpl.ts
@@ -1,6 +1,6 @@
-import * as Types from "app/plugin/DocApiTypes";
-import { BulkColValues } from 'app/plugin/GristData';
-import { OpOptions, TableOperations, UpsertOptions } from 'app/plugin/TableOperations';
+import * as Types from "./DocApiTypes";
+import { BulkColValues } from './GristData';
+import { OpOptions, TableOperations, UpsertOptions } from './TableOperations';
 import { arrayRepeat } from './gutil';
 import flatMap = require('lodash/flatMap');
 import isEqual = require('lodash/isEqual');

--- a/app/plugin/objtypes.ts
+++ b/app/plugin/objtypes.ts
@@ -4,7 +4,7 @@
  */
 // tslint:disable:max-classes-per-file
 
-import { CellValue, GristObjCode } from 'app/plugin/GristData';
+import { CellValue, GristObjCode } from './GristData';
 import isPlainObject = require('lodash/isPlainObject');
 
 // The text to show on cells whose values are pending.


### PR DESCRIPTION
I'm working on exporting type definitions from the `app/plugin` folder in order to make it easier to write plugins thanks to IntelliSense.

Type definitions are available in the `_build` folder (`*.d.ts` files).

Thankfully, the folder is mostly self-contained: it has some external dependencies, but no dependency to other folders in grist-core.

Using relative imports within this folder makes it possible to use the definition files as a standalone package.

Right now, I'm copying those files manually where I need them.
As a second step, we could imagine having a routine to copy those definition files to a separate package. That package could possibly live in this repo using yarn workspaces 🤷🏻 
