### PR TITLE
improve how server.restart functions in tests

### DIFF
--- a/test/nbrowser/MultiColumn.ts
+++ b/test/nbrowser/MultiColumn.ts
@@ -877,11 +877,13 @@ async function testChoices(colA: string = 'Left', colB: string = 'Right') {
   if (await getColumnType() === 'Choice List') {
     await gu.sendKeys(Key.ENTER);
   }
+  await gu.waitForServer();
   await gu.getCell(colB, 1).click();
   await gu.sendKeys("one", Key.ENTER);
   if (await getColumnType() === 'Choice List') {
     await gu.sendKeys(Key.ENTER);
   }
+  await gu.waitForServer();
   // Rename one of the choices.
   await selectColumns(colA, colB);
   const undo = await gu.begin();

--- a/test/nbrowser/MultiColumn.ts
+++ b/test/nbrowser/MultiColumn.ts
@@ -1106,6 +1106,7 @@ async function alignment(value?: 'left' | 'right' | 'center') {
     if (value === 'right') {
       await buttons[2].click();
     }
+    await gu.waitForServer();
     return;
   }
   if (await buttons[0].matches('[class*=-selected]')) {

--- a/test/nbrowser/MultiColumn.ts
+++ b/test/nbrowser/MultiColumn.ts
@@ -1023,12 +1023,14 @@ async function wrap(state?: boolean) {
   if (await buttons[0].matches('[class*=-selected]')) {
     if (state === false) {
       await buttons[0].click();
+      await gu.waitForServer();
       return false;
     }
     return true;
   }
   if (state === true) {
     await buttons[0].click();
+    await gu.waitForServer();
     return true;
   }
   return false;
@@ -1294,6 +1296,7 @@ async function numMode(value?: 'currency' | 'percent' | 'exp' | 'decimal') {
         await driver.findContent('.test-numeric-mode .test-select-button', /Exp/).click();
       }
     }
+    await gu.waitForServer();
   }
   if (mode.length === 0) {
     return undefined;

--- a/test/nbrowser/MultiColumn.ts
+++ b/test/nbrowser/MultiColumn.ts
@@ -941,6 +941,7 @@ const choiceEditor = {
   },
   async save() {
     await driver.find(".test-choice-list-entry-save").click();
+    await gu.waitForServer();
   },
   async cancel() {
     await driver.find(".test-choice-list-entry-cancel").click();

--- a/test/nbrowser/testServer.ts
+++ b/test/nbrowser/testServer.ts
@@ -97,7 +97,6 @@ export class TestServerMerged implements IMochaServer {
     const serverLog = process.env.VERBOSE ? 'inherit' : nodeLogFd;
     const env: Record<string, string> = {
       TYPEORM_DATABASE: this._getDatabaseFile(),
-      TEST_CLEAN_DATABASE: reset ? 'true' : '',
       GRIST_DATA_DIR: this.testDocDir,
       GRIST_INST_DIR: this.testDir,
       // uses the test installed plugins folder as the user installed plugins.
@@ -129,6 +128,7 @@ export class TestServerMerged implements IMochaServer {
       // This skips type-checking when running server, but reduces startup time a lot.
       TS_NODE_TRANSPILE_ONLY: 'true',
       ...process.env,
+      TEST_CLEAN_DATABASE: reset ? 'true' : '',
     };
     if (!process.env.REDIS_URL) {
       // Multiple doc workers only possible when redis is available.


### PR DESCRIPTION
The server.restart functionality in tests uses `TEST_CLEAN_DATABASE`. Make sure the way it wants to set this variable takes precedence over the environment.