### PR TITLE
AI formula generation

### DIFF
--- a/app/client/components/DocComm.ts
+++ b/app/client/components/DocComm.ts
@@ -32,6 +32,7 @@ export class DocComm extends Disposable implements ActiveDocAPI {
   public addAttachments = this._wrapMethod("addAttachments");
   public findColFromValues = this._wrapMethod("findColFromValues");
   public getFormulaError = this._wrapMethod("getFormulaError");
+  public generateFormula = this._wrapMethod("generateFormula");
   public fetchURL = this._wrapMethod("fetchURL");
   public autocomplete = this._wrapMethod("autocomplete");
   public removeInstanceFromDoc = this._wrapMethod("removeInstanceFromDoc");

--- a/app/client/models/entities/ColumnRec.ts
+++ b/app/client/models/entities/ColumnRec.ts
@@ -39,6 +39,9 @@ export interface ColumnRec extends IRowModel<"_grist_Tables_column"> {
   // column being transformed and that column's transform column.
   isTransforming: ko.Observable<boolean>;
 
+  // Description used to generate formula with AI. Only stored temporarily in the client.
+  generateFormulaDescription: ko.Observable<string>;
+
   // Convenience observable to obtain and set the type with no suffix
   pureType: ko.Computed<string>;
 
@@ -102,6 +105,9 @@ export function createColumnRec(this: ColumnRec, docModel: DocModel): void {
   // Indicates whether a column is transforming. Manually set, but should be true in both the original
   // column being transformed and that column's transform column.
   this.isTransforming = ko.observable(false);
+
+  // Description used to generate formula with AI. Only stored temporarily in the client.
+  this.generateFormulaDescription = ko.observable('');
 
   // Convenience observable to obtain and set the type with no suffix
   this.pureType = ko.pureComputed(() => gristTypes.extractTypeFromColType(this.type()));

--- a/app/client/ui2018/modals.ts
+++ b/app/client/ui2018/modals.ts
@@ -95,7 +95,11 @@ export class ModalControl extends Disposable implements IModalControl {
           throw err;
         }
       } finally {
-        this._inProgress.set(this._inProgress.get() - 1);
+        try {
+          this._inProgress.set(this._inProgress.get() - 1);
+        } catch {
+          // Ignore errors from things being disposed.
+        }
         if (closePromise) {
           await closePromise;
         }

--- a/app/client/widgets/DiscussionEditor.ts
+++ b/app/client/widgets/DiscussionEditor.ts
@@ -11,6 +11,7 @@ import {labeledSquareCheckbox} from 'app/client/ui2018/checkbox';
 import {theme, vars} from 'app/client/ui2018/cssVars';
 import {icon} from 'app/client/ui2018/icons';
 import {menu, menuItem} from 'app/client/ui2018/menus';
+import {buildTextEditor} from 'app/client/widgets/TextArea';
 import {CellInfoType} from 'app/common/gristTypes';
 import {FullUser} from 'app/common/UserAPI';
 import {
@@ -890,54 +891,12 @@ export class DiscussionPanel extends Disposable implements IDomComponent {
   }
 }
 
-function buildTextEditor(text: Observable<string>, ...args: DomArg<HTMLTextAreaElement>[]) {
-  const textArea = cssTextArea(
-    bindProp(text),
-    autoFocus(),
-    autoGrow(text),
-    ...args
-  );
-  return textArea;
-}
-
-
 function buildAvatar(user: FullUser | null, ...args: DomElementArg[]) {
   return cssAvatar(user, 'small', ...args);
 }
 
 function buildNick(user: {name: string} | null, ...args: DomArg<HTMLElement>[]) {
   return cssNick(user?.name ?? 'Anonymous', ...args);
-}
-
-function bindProp(text: Observable<string>) {
-  return [
-    dom.prop('value', text),
-    dom.on('input', (_, el: HTMLTextAreaElement) => text.set(el.value)),
-  ];
-}
-
-function autoFocus() {
-  return (el: HTMLElement) => void setTimeout(() => el.focus(), 10);
-}
-
-function resize(el: HTMLTextAreaElement) {
-  el.style.height = '5px'; // hack for triggering style update.
-  const border = getComputedStyle(el, null).borderTopWidth || "0";
-  el.style.height = `calc(${el.scrollHeight}px + 2 * ${border})`;
-}
-
-function autoGrow(text: Observable<string>) {
-  return (el: HTMLTextAreaElement) => {
-    el.addEventListener('input', () => resize(el));
-    setTimeout(() => resize(el), 10);
-    dom.autoDisposeElem(el, text.addListener(val => {
-      // Changes to the text are not reflected by the input event (witch is used by the autoGrow)
-      // So we need to manually update the textarea when the text is cleared.
-      if (!val) {
-        el.style.height = '5px'; // there is a min-height css attribute, so this is only to trigger a style update.
-      }
-    }));
-  };
 }
 
 function buildPopup(

--- a/app/client/widgets/TextArea.ts
+++ b/app/client/widgets/TextArea.ts
@@ -1,0 +1,62 @@
+import {theme} from 'app/client/ui2018/cssVars';
+import {dom, DomArg, Observable, styled} from 'grainjs';
+
+const cssTextArea = styled('textarea', `
+  min-height: 5em;
+  border-radius: 3px;
+  padding: 4px 6px;
+  color: ${theme.inputFg};
+  background-color: ${theme.inputBg};
+  border: 1px solid ${theme.inputBorder};
+  outline: none;
+  width: 100%;
+  resize: none;
+  max-height: 10em;
+  &-comment, &-reply {
+    min-height: 28px;
+    height: 28px;
+  }
+  &::placeholder {
+    color: ${theme.inputPlaceholderFg};
+  }
+`);
+
+function bindProp(text: Observable<string>) {
+  return [
+    dom.prop('value', text),
+    dom.on('input', (_, el: HTMLTextAreaElement) => text.set(el.value)),
+  ];
+}
+
+function autoFocus() {
+  return (el: HTMLElement) => void setTimeout(() => el.focus(), 10);
+}
+
+function autoGrow(text: Observable<string>) {
+  return (el: HTMLTextAreaElement) => {
+    el.addEventListener('input', () => resize(el));
+    setTimeout(() => resize(el), 10);
+    dom.autoDisposeElem(el, text.addListener(val => {
+      // Changes to the text are not reflected by the input event (witch is used by the autoGrow)
+      // So we need to manually update the textarea when the text is cleared.
+      if (!val) {
+        el.style.height = '5px'; // there is a min-height css attribute, so this is only to trigger a style update.
+      }
+    }));
+  };
+}
+
+function resize(el: HTMLTextAreaElement) {
+  el.style.height = '5px'; // hack for triggering style update.
+  const border = getComputedStyle(el, null).borderTopWidth || "0";
+  el.style.height = `calc(${el.scrollHeight}px + 2 * ${border})`;
+}
+
+export function buildTextEditor(text: Observable<string>, ...args: DomArg<HTMLTextAreaElement>[]) {
+  return cssTextArea(
+    bindProp(text),
+    autoFocus(),
+    autoGrow(text),
+    ...args
+  );
+}

--- a/app/common/ActiveDocAPI.ts
+++ b/app/common/ActiveDocAPI.ts
@@ -281,6 +281,8 @@ export interface ActiveDocAPI {
    */
   getFormulaError(tableId: string, colId: string, rowId: number): Promise<CellValue>;
 
+  generateFormula(tableId: string, colId: string, description: string): Promise<void>;
+
   /**
    * Fetch content at a url.
    */

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -577,7 +577,9 @@ export interface GristLoadConfig {
   featureComments?: boolean;
 }
 
-export const HideableUiElements = StringUnion("helpCenter", "billing", "templates", "multiSite", "multiAccounts");
+export const HideableUiElements = StringUnion(
+  "helpCenter", "billing", "templates", "multiSite", "multiAccounts", "generateFormula"
+);
 export type IHideableUiElement = typeof HideableUiElements.type;
 
 export function shouldHideUiElement(elem: IHideableUiElement): boolean {

--- a/app/server/lib/DocWorker.ts
+++ b/app/server/lib/DocWorker.ts
@@ -110,6 +110,7 @@ export class DocWorker {
       applyUserActionsById:     activeDocMethod.bind(null, 'editors', 'applyUserActionsById'),
       findColFromValues:        activeDocMethod.bind(null, 'viewers', 'findColFromValues'),
       getFormulaError:          activeDocMethod.bind(null, 'viewers', 'getFormulaError'),
+      generateFormula:          activeDocMethod.bind(null, 'editors', 'generateFormula'),
       importFiles:              activeDocMethod.bind(null, 'editors', 'importFiles'),
       finishImportFiles:        activeDocMethod.bind(null, 'editors', 'finishImportFiles'),
       cancelImportFiles:        activeDocMethod.bind(null, 'editors', 'cancelImportFiles'),

--- a/app/server/lib/sendAppPage.ts
+++ b/app/server/lib/sendAppPage.ts
@@ -135,11 +135,15 @@ function shouldSupportAnon() {
 }
 
 function getHiddenUiElements(): IHideableUiElement[] {
+  const result: IHideableUiElement[] = [];
   const str = process.env.GRIST_HIDE_UI_ELEMENTS;
-  if (!str) {
-    return [];
+  if (str) {
+    result.push(...HideableUiElements.checkAll(str.split(",")));
   }
-  return HideableUiElements.checkAll(str.split(","));
+  if (!process.env.OPENAI_API_KEY && !process.env.HUGGINGFACE_API_KEY) {
+    result.push("generateFormula");
+  }
+  return result;
 }
 
 function configuredPageTitleSuffix() {

--- a/documentation/llm.md
+++ b/documentation/llm.md
@@ -1,0 +1,34 @@
+# Using Large Language Models with Grist
+
+In this experimental branch of Grist, originally developed by Alex Hall,
+you can hook up an AI model such as OpenAI's Codex to write formulas for
+you. Here's how.
+
+First, you need an API key. You'll have best results currently with an
+OpenAI model. Visit https://openai.com/api/ and prepare a key, then
+store it in an environment variable `OPENAI_API_KEY`.
+
+Alternatively, there are many non-proprietary models hosted on Hugging Face.
+At the time of writing, none can compare with OpenAI for use with Grist.
+Things can change quickly in the world of AI though. So instead of OpenAI,
+you can visit https://huggingface.co/ and prepare a key, then
+store it in an environment variable `HUGGINGFACE_API_KEY`.
+
+That's all the configuration needed! Run Grist as usual and there should
+be a new option to generate formulas, as in demo videos.
+
+## Trying other models
+
+The model used will default to `text-davinci-002` for OpenAI. You can
+get better results by setting an environment variable `COMPLETION_MODEL` to
+`code-davinci-002` if you have access to that model.
+
+The model used will default to `NovelAI/genji-python-6B` for
+Hugging Face. There's no particularly great model for this application,
+but you can try other models by setting an environment variable
+`COMPLETION_MODEL` to `codeparrot/codeparrot` or
+`NinedayWang/PolyCoder-2.7B` or similar.
+
+If you are hosting a model yourself, host it as Hugging Face does,
+and use `COMPLETION_URL` rather than `COMPLETION_MODEL` to
+point to the model on your own server rather than Hugging Face.

--- a/sandbox/grist/formula_prompt.py
+++ b/sandbox/grist/formula_prompt.py
@@ -1,0 +1,177 @@
+import ast
+import json
+import textwrap
+
+import asttokens.util
+from asttokens import ASTText
+
+import records
+from column import is_visible_column, BaseReferenceColumn
+from objtypes import RaisedException
+
+
+def column_type(engine, table_id, col_id):
+  col_rec = engine.docmodel.get_column_rec(table_id, col_id)
+  typ = col_rec.type
+  parts = typ.split(":")
+  if parts[0] == "Ref":
+    return parts[1]
+  elif parts[0] == "RefList":
+    return "List[{}]".format(parts[1])
+  elif typ == "Choice":
+    return choices(col_rec)
+  elif typ == "ChoiceList":
+    return "Tuple[{}, ...]".format(choices(col_rec))
+  elif typ == "Any":
+    table = engine.tables[table_id]
+    col = table.get_column(col_id)
+    values = [col.raw_get(row_id) for row_id in table.row_ids]
+    return values_type(values)
+  else:
+    return dict(
+      Text="str",
+      Numeric="float",
+      Int="int",
+      Bool="bool",
+      Date="datetime.date",
+      DateTime="datetime.datetime",
+      Any="Any",
+      Attachments="Any",
+    )[parts[0]]
+
+
+def choices(col_rec):
+  try:
+    widget_options = json.loads(col_rec.widgetOptions)
+    return "Literal{}".format(widget_options["choices"])
+  except (ValueError, KeyError):
+    return 'str'
+
+
+def values_type(values):
+  types = set(type(v) for v in values) - {RaisedException}
+  optional = type(None) in types
+  types.discard(type(None))
+
+  if types == {int, float}:
+    types = {float}
+
+  if len(types) != 1:
+    return "Any"
+
+  [typ] = types
+  val = next(v for v in values if isinstance(v, typ))
+
+  if isinstance(val, records.Record):
+    type_name = val._table.table_id
+  elif isinstance(val, records.RecordSet):
+    type_name = "List[{}]".format(val._table.table_id)
+  elif isinstance(val, list):
+    type_name = "List[{}]".format(values_type(val))
+  elif isinstance(val, set):
+    type_name = "Set[{}]".format(values_type(val))
+  elif isinstance(val, tuple):
+    type_name = "Tuple[{}, ...]".format(values_type(val))
+  elif isinstance(val, dict):
+    type_name = "Dict[{}, {}]".format(values_type(val.keys()), values_type(val.values()))
+  else:
+    type_name = typ.__name__
+
+  if optional:
+    type_name = "Optional[{}]".format(type_name)
+
+  return type_name
+
+
+def referenced_tables(engine, table_id):
+  result = set()
+  queue = [table_id]
+  while queue:
+    cur_table_id = queue.pop()
+    if cur_table_id in result:
+      continue
+    result.add(cur_table_id)
+    for col_id, col in visible_columns(engine, cur_table_id):
+      if isinstance(col, BaseReferenceColumn):
+        target_table_id = col._target_table.table_id
+        if not target_table_id.startswith("_"):
+          queue.append(target_table_id)
+  return result - {table_id}
+
+def all_other_tables(engine, table_id):
+  result = set(t for t in engine.tables.keys() if not t.startswith('_grist'))
+  return result - {table_id} - {'GristDocTour'}
+
+def visible_columns(engine, table_id):
+  return [
+    (col_id, col)
+    for col_id, col in engine.tables[table_id].all_columns.items()
+    if is_visible_column(col_id)
+  ]
+
+
+def class_schema(engine, table_id, exclude_col_id=None, lookups=False):
+  result = "@dataclass\nclass {}:\n".format(table_id)
+
+  if lookups:
+    tmp = []
+    tmp2 = []
+    for col_id, col in visible_columns(engine, table_id):
+      if col_id != exclude_col_id:
+        tmp.append(col_id + ' = None')
+        tmp2.append(f'{col_id}={col_id}')
+    tmp.append('sort_by = None')
+    tmp2.append('sort_by=sort_by')
+    args = ', '.join(tmp)
+    args2 = ', '.join(tmp2)
+    result += f"     def __len__(self):\n"
+    result += f"        return len({table_id}.lookupRecords())\n"
+    result += f"    @staticmethod\n"
+    result += f"    def lookupRecords({args}) -> List[{table_id}]:\n"
+    result += f"       # ...\n"
+    result += f"    @staticmethod\n"
+    result += f"    def lookupOne({args}) -> {table_id}:\n"
+    result += f"       '''\n"
+    result += f"       Filter for one result matching the keys provided.\n"
+    result += f"       To control order, use e.g. `sort_by='Key' or `sort_by='-Key'`.\n"
+    result += f"       '''\n"
+    result += f"       return {table_id}.lookupRecords({args2})[0]\n"
+    result += "\n"
+
+  for col_id, col in visible_columns(engine, table_id):
+    if col_id != exclude_col_id:
+      result += "    {}: {}\n".format(col_id, column_type(engine, table_id, col_id))
+  result += "\n"
+  return result
+
+
+def get_formula_prompt(engine, table_id, col_id, description,
+                       include_all_tables=True,
+                       lookups=True):
+  result = ""
+  other_tables = all_other_tables(engine, table_id) if include_all_tables else referenced_tables(engine, table_id)
+  for other_table_id in sorted(other_tables):
+    result += class_schema(engine, other_table_id, lookups)
+
+  result += class_schema(engine, table_id, col_id, lookups)
+
+  return_type = column_type(engine, table_id, col_id)
+  result += "    @property\n"
+  result += "    def {}(self) -> {}:\n".format(col_id, return_type)
+  result += '        """\n'
+  result += '{}\n'.format(textwrap.indent(description, "        "))
+  result += '        """\n'
+  return result
+
+
+def convert_completion(completion):
+  result = textwrap.dedent(completion)
+  replacements = []
+  atok = ASTText(result)
+  for node in ast.walk(atok.tree):
+    if isinstance(node, ast.Name) and node.id == "self":
+      start, end = atok.get_text_range(node)
+      # Avoid $ because of f-strings
+      replacements.append((start, end, "rec"))
+  result = asttokens.util.replace(result, replacements)
+  return result

--- a/sandbox/grist/main.py
+++ b/sandbox/grist/main.py
@@ -16,6 +16,7 @@ import six
 
 import actions
 import engine
+import formula_prompt
 import migrations
 import schema
 import useractions
@@ -134,6 +135,14 @@ def run(sandbox):
   @export
   def get_formula_error(table_id, col_id, row_id):
     return objtypes.encode_object(eng.get_formula_error(table_id, col_id, row_id))
+
+  @export
+  def get_formula_prompt(table_id, col_id, description):
+    return formula_prompt.get_formula_prompt(eng, table_id, col_id, description)
+
+  @export
+  def convert_formula_completion(completion):
+    return formula_prompt.convert_completion(completion)
 
   export(parse_acl_formula)
   export(eng.load_empty)

--- a/sandbox/grist/test_formula_prompt.py
+++ b/sandbox/grist/test_formula_prompt.py
@@ -1,0 +1,217 @@
+import test_engine
+import testutil
+from formula_prompt import (
+  values_type, column_type, referenced_tables, get_formula_prompt,
+  convert_completion,
+)
+from objtypes import RaisedException
+from records import Record, RecordSet
+
+
+class FakeTable:
+  table_id = "Table1"
+  _identity_relation = None
+
+
+class TestFormulaPrompt(test_engine.EngineTestCase):
+  def test_values_type(self):
+    self.assertEqual(values_type([1, 2, 3]), "int")
+    self.assertEqual(values_type([1.0, 2.0, 3.0]), "float")
+    self.assertEqual(values_type([1, 2, 3.0]), "float")
+
+    self.assertEqual(values_type([1, 2, None]), "Optional[int]")
+    self.assertEqual(values_type([1, 2, 3.0, None]), "Optional[float]")
+
+    self.assertEqual(values_type([1, RaisedException(None), 3]), "int")
+    self.assertEqual(values_type([1, RaisedException(None), None]), "Optional[int]")
+
+    self.assertEqual(values_type(["1", "2", "3"]), "str")
+    self.assertEqual(values_type([1, 2, "3"]), "Any")
+    self.assertEqual(values_type([1, 2, "3", None]), "Any")
+
+    self.assertEqual(values_type([
+      Record(FakeTable(), None),
+      Record(FakeTable(), None),
+    ]), "Table1")
+    self.assertEqual(values_type([
+      Record(FakeTable(), None),
+      Record(FakeTable(), None),
+      None,
+    ]), "Optional[Table1]")
+
+    self.assertEqual(values_type([
+      RecordSet(FakeTable(), None),
+      RecordSet(FakeTable(), None),
+    ]), "List[Table1]")
+    self.assertEqual(values_type([
+      RecordSet(FakeTable(), None),
+      RecordSet(FakeTable(), None),
+      None,
+    ]), "Optional[List[Table1]]")
+
+    self.assertEqual(values_type([[1, 2, 3]]), "List[int]")
+    self.assertEqual(values_type([[1, 2, 3], None]), "Optional[List[int]]")
+    self.assertEqual(values_type([[1, 2, None]]), "List[Optional[int]]")
+    self.assertEqual(values_type([[1, 2, None], None]), "Optional[List[Optional[int]]]")
+    self.assertEqual(values_type([[1, 2, "3"]]), "List[Any]")
+
+    self.assertEqual(values_type([{1, 2, 3}]), "Set[int]")
+    self.assertEqual(values_type([(1, 2, 3)]), "Tuple[int, ...]")
+    self.assertEqual(values_type([{1: ["2"]}]), "Dict[int, List[str]]")
+
+  def assert_column_type(self, col_id, expected_type):
+    self.assertEqual(column_type(self.engine, "Table2", col_id), expected_type)
+
+  def assert_prompt(self, table_name, col_id, expected_prompt):
+    prompt = get_formula_prompt(self.engine, table_name, col_id, "description here",
+                                include_all_tables=False, lookups=False)
+    # print(prompt)
+    self.assertEqual(prompt, expected_prompt)
+
+  def test_column_type(self):
+    sample = testutil.parse_test_sample({
+      "SCHEMA": [
+        [1, "Table2", [
+          [1, "text", "Text", False, "", "", ""],
+          [2, "numeric", "Numeric", False, "", "", ""],
+          [3, "int", "Int", False, "", "", ""],
+          [4, "bool", "Bool", False, "", "", ""],
+          [5, "date", "Date", False, "", "", ""],
+          [6, "datetime", "DateTime", False, "", "", ""],
+          [7, "attachments", "Attachments", False, "", "", ""],
+          [8, "ref", "Ref:Table2", False, "", "", ""],
+          [9, "reflist", "RefList:Table2", False, "", "", ""],
+          [10, "choice", "Choice", False, "", "", '{"choices": ["a", "b", "c"]}'],
+          [11, "choicelist", "ChoiceList", False, "", "", '{"choices": ["x", "y", "z"]}'],
+          [12, "ref_formula", "Any", True, "$ref or None", "", ""],
+          [13, "numeric_formula", "Any", True, "1 / $numeric", "", ""],
+          [14, "new_formula", "Numeric", True, "'to be generated...'", "", ""],
+        ]],
+      ],
+      "DATA": {
+        "Table2": [
+          ["id", "numeric", "ref"],
+          [1, 0, 0],
+          [2, 1, 1],
+        ],
+      },
+    })
+    self.load_sample(sample)
+
+    self.assert_column_type("text", "str")
+    self.assert_column_type("numeric", "float")
+    self.assert_column_type("int", "int")
+    self.assert_column_type("bool", "bool")
+    self.assert_column_type("date", "datetime.date")
+    self.assert_column_type("datetime", "datetime.datetime")
+    self.assert_column_type("attachments", "Any")
+    self.assert_column_type("ref", "Table2")
+    self.assert_column_type("reflist", "List[Table2]")
+    self.assert_column_type("choice", "Literal['a', 'b', 'c']")
+    self.assert_column_type("choicelist", "Tuple[Literal['x', 'y', 'z'], ...]")
+    self.assert_column_type("ref_formula", "Optional[Table2]")
+    self.assert_column_type("numeric_formula", "float")
+
+    self.assertEqual(referenced_tables(self.engine, "Table2"), set())
+
+    self.assert_prompt("Table2", "new_formula",
+      '''\
+@dataclass
+class Table2:
+    text: str
+    numeric: float
+    int: int
+    bool: bool
+    date: datetime.date
+    datetime: datetime.datetime
+    attachments: Any
+    ref: Table2
+    reflist: List[Table2]
+    choice: Literal['a', 'b', 'c']
+    choicelist: Tuple[Literal['x', 'y', 'z'], ...]
+    ref_formula: Optional[Table2]
+    numeric_formula: float
+
+    @property
+    def new_formula(self) -> float:
+        """
+        description here
+        """
+''')
+
+  def test_get_formula_prompt(self):
+    sample = testutil.parse_test_sample({
+      "SCHEMA": [
+        [1, "Table1", [
+          [1, "text", "Text", False, "", "", ""],
+        ]],
+        [2, "Table2", [
+          [2, "ref", "Ref:Table1", False, "", "", ""],
+        ]],
+        [3, "Table3", [
+          [3, "reflist", "RefList:Table2", False, "", "", ""],
+        ]],
+      ],
+      "DATA": {},
+    })
+    self.load_sample(sample)
+    self.assertEqual(referenced_tables(self.engine, "Table3"), {"Table1", "Table2"})
+    self.assertEqual(referenced_tables(self.engine, "Table2"), {"Table1"})
+    self.assertEqual(referenced_tables(self.engine, "Table1"), set())
+
+    self.assert_prompt("Table1", "text", '''\
+@dataclass
+class Table1:
+
+    @property
+    def text(self) -> str:
+        """
+        description here
+        """
+''')
+
+    self.assert_prompt("Table2", "ref", '''\
+@dataclass
+class Table1:
+    text: str
+
+@dataclass
+class Table2:
+
+    @property
+    def ref(self) -> Table1:
+        """
+        description here
+        """
+''')
+
+    self.assert_prompt("Table3", "reflist", '''\
+@dataclass
+class Table1:
+    text: str
+
+@dataclass
+class Table2:
+    ref: Table1
+
+@dataclass
+class Table3:
+
+    @property
+    def reflist(self) -> List[Table2]:
+        """
+        description here
+        """
+''')
+
+
+  def test_convert_completion(self):
+    completion = """
+# comment with self.foo
+return "self.foo: " + self.foo + self + self.bar + f'{self.baz}'
+    """
+    result = """
+# comment with self.foo
+return "self.foo: " + rec.foo + rec + rec.bar + f'{rec.baz}'
+"""
+    self.assertEqual(convert_completion(completion), result)

--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -1,7 +1,7 @@
 ### python 2 requirements, see requirements3.txt for python 3
 
 astroid==1.6.6
-asttokens==2.0.5
+asttokens==2.1.0
 backports.functools-lru-cache==1.6.4
 chardet==4.0.0
 enum34==1.1.10

--- a/sandbox/requirements3.txt
+++ b/sandbox/requirements3.txt
@@ -15,7 +15,7 @@ et-xmlfile==1.0.1
 astroid==2.5.7
 
 # Everything after this is the same for python 2 and 3
-asttokens==2.0.5
+asttokens==2.1.0
 backports.functools-lru-cache==1.6.4
 chardet==4.0.0
 enum34==1.1.10

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -199,6 +199,9 @@
     "ErrorHappened_unknown": "There was an unknown error."
   },
   "FieldConfig": {
+    "GenerateFormula": "Generate formula",
+    "Generate": "Generate",
+    "Cancel": "Cancel",
     "ColumnLabel": "COLUMN LABEL AND ID",
     "ColumnOptionsLimited": "Column options are limited in summary tables.",
     "ColumnType_formula_one": "Formula Column",


### PR DESCRIPTION
This is a placeholder for a demo @alexmojaki created using OpenAI's `text-davinci-002` model to write Grist formulas from plain text descriptions. It does pretty well!

[spooky-doggo.webm](https://user-images.githubusercontent.com/118367/203653415-3229d4c0-8c7b-49af-a7bf-4780fc4b7d2b.webm)

There's a docker image at `gristlabs/grist-llm` if you want to try it out:
```
docker run -p 8484:8484 -v /tmp/persist:/persist -e OPENAI_API_KEY=.... -it gristlabs/grist-llm
```

You will need an OpenAI key for best results, or a Hugging Face key for trying non-proprietary models. There are notes on usage and configuration at https://github.com/gristlabs/grist-core/blob/formula-prompt/documentation/llm.md

There are some examples of the kinds of formulas that can currently be handled or not at https://public.getgrist.com/n3jAtRYDSVWe/AI-Formula-dataset, along with the prompts generated for the AI. These examples were prepared with a slightly earlier version of this code.

Edit: there's a write-up of this experiment at https://www.getgrist.com/blog/ai-formula-generation-experiment/ - and there's a poll there where you can vote for this to be developed into a full-blown feature :pray:

