### PR TITLE
Set friendly traceback language based on document locale

### DIFF
--- a/sandbox/grist/docmodel.py
+++ b/sandbox/grist/docmodel.py
@@ -6,6 +6,7 @@ which exist only in the sandbox and are not communicated to the client.
 It is similar in purpose to DocModel.js on the client side.
 """
 import itertools
+import json
 
 import six
 
@@ -57,6 +58,22 @@ class MetaTableExtras(object):
         return moment.tzinfo(rec.timezone)
       except KeyError:
         return moment.TZ_UTC
+
+    def parsed_settings(rec, table):
+      try:
+        return json.loads(rec.documentSettings)
+      except ValueError:
+        return {}
+
+    def locale(rec, table):
+      return rec.parsed_settings.get("locale", "en-US")
+
+    def friendly_traceback_set_lang(rec, table):
+      try:
+        import friendly_traceback
+        friendly_traceback.set_lang(rec.locale)
+      except Exception:
+        pass
 
   class _grist_Tables(object):
     columns = _record_set('_grist_Tables_column', 'parentId', sort_by='parentPos')

--- a/sandbox/grist/docmodel.py
+++ b/sandbox/grist/docmodel.py
@@ -16,7 +16,7 @@ import usertypes
 import relabeling
 import table
 import moment
-from schema import RecalcWhen
+from schema import RecalcWhen, DEFAULT_LOCALE
 
 # pylint:disable=redefined-outer-name
 
@@ -66,7 +66,7 @@ class MetaTableExtras(object):
         return {}
 
     def locale(rec, table):
-      return rec.parsed_settings.get("locale", "en-US")
+      return rec.parsed_settings.get("locale", DEFAULT_LOCALE)
 
     def friendly_traceback_set_lang(rec, table):
       try:

--- a/sandbox/grist/migrations.py
+++ b/sandbox/grist/migrations.py
@@ -802,7 +802,7 @@ def migration22(tdset):
 def migration23(tdset):
   return tdset.apply_doc_actions([
     add_column('_grist_DocInfo', 'documentSettings', 'Text'),
-    actions.UpdateRecord('_grist_DocInfo', 1, {'documentSettings': '{"locale":"en-US"}'})
+    actions.UpdateRecord('_grist_DocInfo', 1, {'documentSettings': '{"locale":"' + schema.DEFAULT_LOCALE + '"}'})
   ])
 
 

--- a/sandbox/grist/schema.py
+++ b/sandbox/grist/schema.py
@@ -16,6 +16,7 @@ import six
 import actions
 
 SCHEMA_VERSION = 33
+DEFAULT_LOCALE = "en-US"
 
 def make_column(col_id, col_type, formula='', isFormula=False):
   return {


### PR DESCRIPTION
Adds a simple private formula `friendly_traceback_set_lang` to `_grist_DocInfo`, which sets the language based on the locale in the document settings. Updating the locale in the UI automatically updates this formula as usual, so tracebacks are always shown in the current language if possible.

The friendly-traceback library has been translated into several languages. Currently, the main other languages are Spanish, Tamil, Russian, and Hebrew. The full list of languages can always be seen at https://github.com/friendly-traceback/friendly-traceback/tree/main/friendly_traceback/locales.

Also adds a couple of other simple formulas parsed_settings and locale which are used by friendly_traceback_set_lang and may be useful for other purposes in the future.

This change was proposed and prepared by @alexmojaki 