### PR TITLE
Fixing typo in translation files

### DIFF
--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -659,7 +659,7 @@
     },
     "CodeEditorPanel": {
       "AccessDenied":"Access denied",
-      "CodeViewOnlyFullAccess.":"Code View is available only when you have full document access."
+      "CodeViewOnlyFullAccess":"Code View is available only when you have full document access."
     },
     "DataTables": {
       "RawDataTables":"Raw Data Tables",

--- a/static/locales/fr.client.json
+++ b/static/locales/fr.client.json
@@ -657,7 +657,7 @@
     },
     "CodeEditorPanel": {
       "AccessDenied": "Accès refusé",
-      "CodeViewOnlyFullAccess.": "La vue code n’est disponible que lorsque vous avez un accès complet au document."
+      "CodeViewOnlyFullAccess": "La vue code n’est disponible que lorsque vous avez un accès complet au document."
     },
     "DataTables": {
       "RawDataTables": "Données sources",


### PR DESCRIPTION
Fixing the `CodeViewOnlyFullAccess` translation key in resource files.