### PR TITLE
Fixing scoped translation helper - it should ignore namespace and key separators.

### DIFF
--- a/app/client/lib/localization.ts
+++ b/app/client/lib/localization.ts
@@ -150,7 +150,7 @@ function isLikeDomContents(value: any): boolean {
  * namespace and a key prefix (a scope).
  */
 export function makeT(scope: string, instance?: typeof i18next) {
-  // Can create the scopedInstance yet as it might not be initialized.
+  // Can't create the scopedInstance yet as it might not be initialized.
   let scopedInstance: null|typeof i18next = null;
   let scopedResolver: null|typeof i18next.t = null;
   return function<T extends Record<string, any>>(key: string, args?: T|null) {

--- a/test/client/lib/localization.ts
+++ b/test/client/lib/localization.ts
@@ -19,6 +19,7 @@ describe('localization', function() {
             'Argument_variant': 'Variant {{arg1}} {{arg2}}{{end}}',
             'Parent': {
               'Child': 'Translated child {{arg}}',
+              'Not.Valid:Characters': 'Works',
             }
           }
         }
@@ -93,8 +94,8 @@ describe('localization', function() {
   });
 
   it('supports scoping through makeT', function() {
-    const scoped = makeT('Parent');
-    assert.equal(scoped('Child', { arg : 'Arg'}, instance), 'Translated child Arg');
+    const scoped = makeT('Parent', instance);
+    assert.equal(scoped('Child', { arg : 'Arg'}), 'Translated child Arg');
   });
 
   it('infers result from parameters', function() {
@@ -108,17 +109,22 @@ describe('localization', function() {
     typeString = t('Argument', {arg1: 'argument 1', arg2: 'argument 2'}, instance);
     typeString = t('Argument', {arg1: 1, arg2: true}, instance);
     typeString = t('Argument', undefined,  instance);
-    const scoped = makeT('Parent');
-    typeString = scoped('Child', {arg: 'argument 1'}, instance);
-    typeString = scoped('Child', {arg: 1}, instance);
-    typeString = scoped('Child', undefined, instance);
+    const scoped = makeT('Parent', instance);
+    typeString = scoped('Child', {arg: 'argument 1'});
+    typeString = scoped('Child', {arg: 1});
+    typeString = scoped('Child', undefined);
 
     let domContent: DomContents = null; void domContent;
 
     domContent = t('Argument', {arg1: 'argument 1', arg2: dom('span')}, instance);
     domContent = t('Argument', {arg1: 1, arg2: dom.domComputed(observable('test'))}, instance);
     domContent = t('Argument', undefined, instance);
-    domContent = scoped('Child', {arg: dom.create(Component)}, instance);
-    domContent = scoped('Child', {arg: dom.maybe(observable(true), () => dom('span'))}, instance);
+    domContent = scoped('Child', {arg: dom.create(Component)});
+    domContent = scoped('Child', {arg: dom.maybe(observable(true), () => dom('span'))});
+  });
+
+  it('supports : and . characters in scoped function', function() {
+    const scoped = makeT('Parent', instance);
+    assert.equal(scoped('Not.Valid:Characters'), 'Works');
   });
 });

--- a/test/nbrowser/ActionLog.ts
+++ b/test/nbrowser/ActionLog.ts
@@ -29,6 +29,13 @@ describe('ActionLog', function() {
     await gu.dismissWelcomeTourIfNeeded();
   });
 
+  after(async function() {
+    // If were are debugging the browser won't be reloaded, so we need to close the right panel.
+    if (process.env.NO_CLEANUP) {
+      await driver.find(".test-right-tool-close").click();
+    }
+  });
+
   it("should cross out undone actions", async function() {
     // Open the action-log tab.
     await driver.findWait('.test-tools-log', 1000).click();

--- a/test/nbrowser/CustomView.ts
+++ b/test/nbrowser/CustomView.ts
@@ -268,6 +268,8 @@ describe('CustomView', function() {
     const mainSession = await gu.session().teamSite.login();
     await mainSession.tempDoc(cleanup, 'TypeEncoding.grist');
     await gu.toggleSidePanel('right', 'open');
+    await driver.find('.test-right-tab-pagewidget').click();
+    await gu.waitForServer();
     await driver.find('.test-config-data').click();
 
     // The test doc already has a Custom View widget. It just needs to

--- a/test/nbrowser/CustomWidgets.ts
+++ b/test/nbrowser/CustomWidgets.ts
@@ -188,7 +188,9 @@ describe('CustomWidgets', function () {
   const reject = () => driver.find(".test-config-widget-access-reject").click();
 
   it('should show widgets in dropdown', async () => {
-    await gu.toggleSidePanel('right');
+    await gu.toggleSidePanel('right', 'open');
+    await driver.find('.test-right-tab-pagewidget').click();
+    await gu.waitForServer();
     await driver.find('.test-config-widget').click();
     await gu.waitForServer(); // Wait for widgets to load.
 


### PR DESCRIPTION
- Translation helper `makeT` was still sensitive for namespace and key separator, which didn't allow us to use natural scoped keys.
- Scoped translation doesn't check if a key is missing if the key is a simple text. With this, there is no need to maintain default resources for simple labels. The key is still checked if it contains an interpolation marker.
- Fixing some tests that were not passing with DEBUG flag.