### PR TITLE
ignore order of languages in test

### DIFF
--- a/test/nbrowser/Localization.ts
+++ b/test/nbrowser/Localization.ts
@@ -116,7 +116,7 @@ describe("Localization", function() {
       await driver.navigate().refresh();
       assert.equal(await driver.findWait('.test-welcome-title', 3000).getText(), 'TestMessage');
       const gristConfig: any = await driver.executeScript("return window.gristConfig");
-      assert.deepEqual(gristConfig.supportedLngs, [...existingLocales, 'pl']);
+      assert.sameDeepMembers(gristConfig.supportedLngs, [...existingLocales, 'pl']);
     });
   });
 


### PR DESCRIPTION
A test was breaking because of order of languages, which isn't significant.