### PR TITLE
tweak translation key collection to be weblate-friendly

### DIFF
--- a/buildtools/generate_translation_keys.js
+++ b/buildtools/generate_translation_keys.js
@@ -11,6 +11,7 @@ const fs = require("fs");
 const path = require("path");
 const Parser = require("i18next-scanner").Parser;
 const englishKeys = require("../static/locales/en.client.json");
+const _ = require("lodash");
 
 const parser = new Parser({
   keySeparator: "/",
@@ -67,31 +68,63 @@ const getKeysFromFile = (filePath, fileName) => {
 // It is highly desirable to retain existing order, to not generate
 // unnecessary merges/conflicts, so we do a specialized merge.
 function merge(target, scanned) {
+  let merges = 0;
   for (const key of Object.keys(scanned)) {
     if (!(key in target)) {
+      console.log("Merging key", {key});
       target[key] = scanned[key];
+      merges++;
     } else if (typeof target[key] === 'object') {
-      merge(target[key], scanned[key]);
-    } else {
-      scanned[key] = target[key];
+      merges += merge(target[key], scanned[key]);
+    } else if (scanned[key] !== target[key]) {
+      if (!key.endsWith('_one')) {
+        console.log("Value difference", {key, value: target[key]});
+      }
     }
   }
+  return merges;
+}
+
+// Look for keys that are listed in json file but not found in source
+// code. These may be stale and need deleting in weblate.
+function reportUnrecognizedKeys(originalKeys, foundKeys) {
+  let unknowns = 0;
+  for (const section of Object.keys(originalKeys)) {
+    if (!(section in foundKeys)) {
+      console.log("Unknown section found", {section});
+      unknowns++;
+    } else {
+      for (const key of Object.keys(originalKeys[section])) {
+        if (!(key in foundKeys[section])) {
+          console.log("Unknown key found", {section, key});
+          unknowns++;
+        }
+      }
+    }
+  }
+  return unknowns;
 }
 
 async function walkTranslation(dirs) {
+  const originalKeys = _.cloneDeep(englishKeys);
   for await (const p of walk(dirs)) {
     const { name } = path.parse(p);
     if (p.endsWith('.map')) { continue; }
     getKeysFromFile(p, name);
   }
   const keys = parser.get({ sort: true });
-  merge(englishKeys, sort(keys.en.translation));
+  const foundKeys = _.cloneDeep(keys.en.translation);
+  const mergeCount = merge(englishKeys, sort(keys.en.translation));
   await fs.promises.writeFile(
     "static/locales/en.client.json",
     JSON.stringify(englishKeys, null, 4) + '\n',  // match weblate's default
     "utf-8"
   );
-  return keys;
+  // Now, print a report of unrecognized keys - candidates
+  // for deletion in weblate.
+  const unknownCount = reportUnrecognizedKeys(originalKeys, foundKeys);
+  console.log(`Found ${unknownCount} unknown key(s).`);
+  console.log(`Make ${mergeCount} merge(s).`);
 }
 
 walkTranslation(["_build/app/client", ...process.argv.slice(2)]);

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -36,7 +36,9 @@
         "Special Rules": "Special Rules",
         "Type a message...": "Type a message...",
         "User Attributes": "User Attributes",
-        "View As": "View As"
+        "View As": "View As",
+        "Seed rules": "Seed rules",
+        "When adding table rules, automatically add a rule to grant OWNER full access.": "When adding table rules, automatically add a rule to grant OWNER full access."
     },
     "AccountPage": {
         "API": "API",
@@ -332,7 +334,8 @@
         "Add Column": "Add Column"
     },
     "FilterBar": {
-        "SearchColumns": "Search columns"
+        "SearchColumns": "Search columns",
+        "Search Columns": "Search Columns"
     },
     "GridOptions": {
         "Grid Options": "Grid Options",
@@ -761,5 +764,17 @@
     "NTextBox": {
         "false": "false",
         "true": "true"
+    },
+    "ACLUsers": {
+        "Example Users": "Example Users",
+        "Users from table": "Users from table",
+        "View As": "View As"
+    },
+    "TypeTransform": {
+        "Apply": "Apply",
+        "Cancel": "Cancel",
+        "Preview": "Preview",
+        "Revise": "Revise",
+        "Update formula (Shift+Enter)": "Update formula (Shift+Enter)"
     }
 }


### PR DESCRIPTION
This tweaks the script for collecting translation keys so that it changes the existing file minimally, and matches the formatting output by weblate.

I'm not sure what is the best way to handle keys that are no longer needed. I think it may be best to delete these within weblate, but will need to experiment to see (I'm a weblate newbie). I think I saw keys reappear from weblate if not deleted there.

cc @LouisDelbosc 