### PR TITLE
introduce a workflow for keeping translation keys fresh

### DIFF
--- a/.github/workflows/translation_keys.yml
+++ b/.github/workflows/translation_keys.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository_owner == 'gristlabs'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -20,7 +21,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 14
 
       - name: Install Node.js packages
         run: yarn install

--- a/.github/workflows/translation_keys.yml
+++ b/.github/workflows/translation_keys.yml
@@ -1,0 +1,60 @@
+name: Translation keys
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Let's get all the branches
+
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      - name: Install Node.js packages
+        run: yarn install
+
+      - name: Build code
+        run: yarn run build:prod
+
+      - name: Scan for keys
+        id: scan-keys
+        run: |
+          git checkout -b translation-keys
+          yarn run generate:translation
+          git status --porcelain
+          if [[ $(git status --porcelain | wc -l) -eq "0" ]]; then
+            echo "No changes"
+            echo "CHANGED=false" >> $GITHUB_ENV
+          else
+            echo "Changes detected"
+            echo "CHANGED=true" >> $GITHUB_ENV
+          fi
+
+      - name: setup git config
+        run: |
+          git config user.name "Paul's Grist Bot"
+          git config user.email "<paul+bot@getgrist.com>"
+
+      - name: Prepare PR
+        if: env.CHANGED == 'true'
+        run: |
+          git commit -m "automated update to translation keys" -a
+          git push --set-upstream origin HEAD:translation-keys -f
+          num=$(gh pr list --search "automated update to translation keys" --json number -q ".[].number")
+          if [[ "$num" = "" ]]; then
+            gh pr create --fill
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a workflow that runs once the main branch is updated, and checks for new translation keys. If there are some, in makes a pull request. It is a bit crude but it seems to do the job - tested on a fork.
