### PR TITLE
only offer languages that have been marked as substantially complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ GRIST_LIST_PUBLIC_SITES | if set to true, sites shared with the public will be l
 GRIST_MANAGED_WORKERS | if set, Grist can assume that if a url targeted at a doc worker returns a 404, that worker is gone
 GRIST_MAX_UPLOAD_ATTACHMENT_MB | max allowed size for attachments (0 or empty for unlimited).
 GRIST_MAX_UPLOAD_IMPORT_MB | max allowed size for imports (except .grist files) (0 or empty for unlimited).
+GRIST_OFFER_ALL_LANGUAGES | if set, all translated langauages are offered to the user (by default, only languages with a special 'good enough' key set are offered to user).
 GRIST_ORG_IN_PATH | if true, encode org in path rather than domain
 GRIST_PAGE_TITLE_SUFFIX | a string to append to the end of the `<title>` in HTML documents. Defaults to `" - Grist"`. Set to `_blank` for no suffix at all.
 GRIST_PROXY_AUTH_HEADER | header which will be set by a (reverse) proxy webserver with an authorized users' email. This can be used as an alternative to a SAML service. See also GRIST_FORWARD_AUTH_HEADER.

--- a/app/server/localization.ts
+++ b/app/server/localization.ts
@@ -72,7 +72,7 @@ export function setupLocale(appRoot: string): i18n {
     // If the "Translators: please ..." key in "App" has not been translated,
     // ignore this language for this and later namespaces.
     if (!offerAll && ns === 'client' &&
-      !Object.keys(data.App || []).some(key => key.includes('Translators: please'))) {
+      !Object.keys(data.App || {}).some(key => key.includes('Translators: please'))) {
       shouldIgnoreLng.add(lng);
       log.debug(`skipping incomplete language ${lng} (set GRIST_OFFER_ALL_LANGUAGES if you want it)`);
     }


### PR DESCRIPTION
This checks for languages that have a special key translated. Any that don't have the key translated, are not offered to the user (unless GRIST_OFFER_ALL_LANGUAGES=1 is set). This gives a bit more room for translators to give it a go without immediate time pressure.