### PR TITLE
do not count unready translations in localization test

### DIFF
--- a/app/client/components/GristDoc.ts
+++ b/app/client/components/GristDoc.ts
@@ -1317,7 +1317,7 @@ export class GristDoc extends DisposableWithEvents {
     const options = section.options();
     const colIds = section.viewFields().all().map((f) => f.column().colId());
     const chartType = section.chartType();
-    const theme = section.theme();
+    const sectionTheme = section.theme();
 
     // we must read the current layout from the view layout because it can override the one in
     // `section.layoutSpec` (in particular it provides a default layout when missing from the
@@ -1351,7 +1351,7 @@ export class GristDoc extends DisposableWithEvents {
     }
 
     // update theme, and chart type
-    await newSection.theme.saveOnly(theme);
+    await newSection.theme.saveOnly(sectionTheme);
     await newSection.chartType.saveOnly(chartType);
 
     // The newly-added section should be given focus.

--- a/test/nbrowser/Localization.ts
+++ b/test/nbrowser/Localization.ts
@@ -41,14 +41,23 @@ describe("Localization", function() {
     const namespaces: Set<string> = new Set();
     for (const file of fs.readdirSync(localeDirectory)) {
       if (file.endsWith(".json")) {
-        const lang = file.split('.')[0]?.replace(/_/g, '-');
+        const langRaw = file.split('.')[0];
+        const lang = langRaw?.replace(/_/g, '-');
         const ns = file.split('.')[1];
+        const clientFile = path.join(localeDirectory,
+                                     `${langRaw}.client.json`);
+        const clientText = fs.readFileSync(clientFile, { encoding: 'utf8' });
+        if (!clientText.includes('Translators: please translate this only when')) {
+          // Translation not ready if this key is not present.
+          continue;
+        }
         langs.add(lang);
         namespaces.add(ns);
       }
     }
     assert.deepEqual(gristConfig.supportedLngs.sort(), [...langs].sort());
     assert.deepEqual(gristConfig.namespaces.sort(), [...namespaces].sort());
+    assert.isAbove(gristConfig.supportedLngs.length, 9);
   });
 
   // Now make a uz-UZ language file, and test that it is used.


### PR DESCRIPTION
This updates the expected count of languages in a localization test to omit translations that have been started but are not yet ready to be offered to users by default.