### PR TITLE
support other SQLite wrappers, and various hooks needed by grist-static

### DIFF
--- a/app/client/DefaultHooks.ts
+++ b/app/client/DefaultHooks.ts
@@ -9,4 +9,4 @@ export interface IHooks {
 }
 
 export const defaultHooks: IHooks = {
-}
+};

--- a/app/client/DefaultHooks.ts
+++ b/app/client/DefaultHooks.ts
@@ -4,7 +4,6 @@ export interface IHooks {
   iframeAttributes?: Record<string, any>,
   fetch?: typeof fetch,
   baseURI?: string,
-  nominalUrl?: string,
   urlTweaks?: UrlTweaks,
 }
 

--- a/app/client/DefaultHooks.ts
+++ b/app/client/DefaultHooks.ts
@@ -1,0 +1,12 @@
+import { UrlTweaks } from 'app/common/gristUrls';
+
+export interface IHooks {
+  iframeAttributes?: Record<string, any>,
+  fetch?: typeof fetch,
+  baseURI?: string,
+  nominalUrl?: string,
+  urlTweaks?: UrlTweaks,
+}
+
+export const defaultHooks: IHooks = {
+}

--- a/app/client/Hooks.ts
+++ b/app/client/Hooks.ts
@@ -1,0 +1,3 @@
+import {defaultHooks} from 'app/client/DefaultHooks';
+
+export const hooks = defaultHooks;

--- a/app/client/components/GristWSConnection.ts
+++ b/app/client/components/GristWSConnection.ts
@@ -1,11 +1,12 @@
 import {get as getBrowserGlobals} from 'app/client/lib/browserGlobals';
 import {guessTimezone} from 'app/client/lib/guessTimezone';
 import {getSessionStorage} from 'app/client/lib/storage';
+import {newUserAPIImpl} from 'app/client/models/AppModel';
 import {getWorker} from 'app/client/models/gristConfigCache';
 import {CommResponseBase} from 'app/common/CommTypes';
 import * as gutil from 'app/common/gutil';
 import {addOrgToPath, docUrl, getGristConfig} from 'app/common/urlUtils';
-import {UserAPI, UserAPIImpl} from 'app/common/UserAPI';
+import {UserAPI} from 'app/common/UserAPI';
 import {Events as BackboneEvents} from 'backbone';
 import {Disposable} from 'grainjs';
 
@@ -25,7 +26,7 @@ async function getDocWorkerUrl(assignmentId: string|null): Promise<string|null> 
   // never changes.
   if (assignmentId === null) { return docUrl(null); }
 
-  const api: UserAPI = new UserAPIImpl(getGristConfig().homeUrl!);
+  const api: UserAPI = newUserAPIImpl();
   return getWorker(api, assignmentId);
 }
 

--- a/app/client/components/WidgetFrame.ts
+++ b/app/client/components/WidgetFrame.ts
@@ -1,5 +1,6 @@
 import BaseView from 'app/client/components/BaseView';
 import {GristDoc} from 'app/client/components/GristDoc';
+import {hooks} from 'app/client/Hooks';
 import {get as getBrowserGlobals} from 'app/client/lib/browserGlobals';
 import {ColumnRec, ViewSectionRec} from 'app/client/models/DocModel';
 import {AccessLevel, isSatisfied} from 'app/common/CustomWidget';
@@ -157,6 +158,7 @@ export class WidgetFrame extends DisposableWithEvents {
     return onElem(
       (this._iframe = dom('iframe', dom.cls('clipboard_focus'), dom.cls('custom_view'), {
         src: fullUrl,
+        ...hooks.iframeAttributes,
       }))
     );
   }

--- a/app/client/exposeModulesForTests.js
+++ b/app/client/exposeModulesForTests.js
@@ -6,7 +6,7 @@ Object.assign(window.exposedModules, {
   grainjs: require('grainjs'),
   ko: require('knockout'),
   moment: require('moment-timezone'),
-  Comm: require('./components/Comm'),
+  Comm: require('app/client/components/Comm'),
   _loadScript: require('./lib/loadScript'),
   ConnectState: require('./models/ConnectState'),
 });

--- a/app/client/lib/localization.ts
+++ b/app/client/lib/localization.ts
@@ -1,3 +1,4 @@
+import {hooks} from 'app/client/Hooks';
 import {getGristConfig} from 'app/common/urlUtils';
 import {DomContents} from 'grainjs';
 import i18next from 'i18next';
@@ -34,7 +35,7 @@ export async function setupLocale() {
     // Detect what is resolved languages to load.
     const languages = i18next.languages;
     // Fetch all json files (all of which should be already preloaded);
-    const loadPath = `${document.baseURI}locales/{{lng}}.{{ns}}.json`;
+    const loadPath = `${hooks.baseURI || document.baseURI}locales/{{lng}}.{{ns}}.json`;
     const pathsToLoad: Promise<any>[] = [];
     async function load(lang: string, n: string) {
       const resourceUrl = loadPath.replace('{{lng}}', lang.replace("-", "_")).replace('{{ns}}', n);

--- a/app/client/models/AppModel.ts
+++ b/app/client/models/AppModel.ts
@@ -1,4 +1,5 @@
 import {BehavioralPromptsManager} from 'app/client/components/BehavioralPromptsManager';
+import {hooks} from 'app/client/Hooks';
 import {get as getBrowserGlobals} from 'app/client/lib/browserGlobals';
 import {makeT} from 'app/client/lib/localization';
 import {sessionStorageObs} from 'app/client/lib/localStorageObs';
@@ -131,7 +132,7 @@ export class TopAppModelImpl extends Disposable implements TopAppModel {
 
   constructor(
     window: {gristConfig?: GristLoadConfig},
-    public readonly api: UserAPI = new UserAPIImpl(getHomeUrl()),
+    public readonly api: UserAPI = newUserAPIImpl(),
   ) {
     super();
     setErrorNotifier(this.notifier);
@@ -434,6 +435,12 @@ export function getHomeUrl(): string {
   const {host, protocol} = window.location;
   const gristConfig: any = (window as any).gristConfig;
   return (gristConfig && gristConfig.homeUrl) || `${protocol}//${host}`;
+}
+
+export function newUserAPIImpl(): UserAPIImpl {
+  return new UserAPIImpl(getHomeUrl(), {
+    fetch: hooks.fetch,
+  });
 }
 
 export function getOrgNameOrGuest(org: Organization|null, user: FullUser|null) {

--- a/app/client/models/gristUrlState.ts
+++ b/app/client/models/gristUrlState.ts
@@ -23,6 +23,7 @@
  * Note that the form of URLs depends on the settings in window.gristConfig object.
  */
 import {unsavedChanges} from 'app/client/components/UnsavedChanges';
+import {hooks} from 'app/client/Hooks';
 import {UrlState} from 'app/client/lib/UrlState';
 import {decodeUrl, encodeUrl, getSlugIfNeeded, GristLoadConfig, IGristUrlState,
         parseFirstUrlPart} from 'app/common/gristUrls';
@@ -134,7 +135,9 @@ export class UrlStateImpl {
    */
   public encodeUrl(state: IGristUrlState, baseLocation: Location | URL): string {
     const gristConfig = this._window.gristConfig || {};
-    return encodeUrl(gristConfig, state, baseLocation);
+    return encodeUrl(gristConfig, state, baseLocation, {
+      tweaks: hooks.urlTweaks,
+    });
   }
 
   /**
@@ -142,7 +145,9 @@ export class UrlStateImpl {
    */
   public decodeUrl(location: Location | URL): IGristUrlState {
     const gristConfig = this._window.gristConfig || {};
-    return decodeUrl(gristConfig, location);
+    return decodeUrl(gristConfig, location, {
+      tweaks: hooks.urlTweaks,
+    });
   }
 
   /**

--- a/app/client/ui/App.ts
+++ b/app/client/ui/App.ts
@@ -84,7 +84,7 @@ export class App extends DisposableWithEvents {
 
     const isHelpPaneVisible = ko.observable(false);
 
-    G.document.querySelector('#grist-logo-wrapper').remove();
+    G.document.querySelector('#grist-logo-wrapper')?.remove();
 
     // Help pop-up pane
     const helpDiv = document.body.appendChild(

--- a/app/gen-server/entity/AclRule.ts
+++ b/app/gen-server/entity/AclRule.ts
@@ -13,7 +13,7 @@ export class AclRule extends BaseEntity {
   @PrimaryGeneratedColumn()
   public id: number;
 
-  @Column()
+  @Column({type: Number})
   public permissions: number;
 
   @OneToOne(type => Group, group => group.aclRule)

--- a/app/gen-server/entity/Alias.ts
+++ b/app/gen-server/entity/Alias.ts
@@ -5,13 +5,13 @@ import {Organization} from './Organization';
 
 @Entity({name: 'aliases'})
 export class Alias extends BaseEntity {
-  @PrimaryColumn({name: 'org_id'})
+  @PrimaryColumn({name: 'org_id', type: Number})
   public orgId: number;
 
-  @PrimaryColumn({name: 'url_id'})
+  @PrimaryColumn({name: 'url_id', type: String})
   public urlId: string;
 
-  @Column({name: 'doc_id'})
+  @Column({name: 'doc_id', type: String})
   public docId: string;
 
   @ManyToOne(type => Document)

--- a/app/gen-server/entity/BillingAccount.ts
+++ b/app/gen-server/entity/BillingAccount.ts
@@ -34,14 +34,14 @@ export class BillingAccount extends BaseEntity {
   @JoinColumn({name: 'product_id'})
   public product: Product;
 
-  @Column()
+  @Column({type: Boolean})
   public individual: boolean;
 
   // A flag for when all is well with the user's subscription.
   // Probably shouldn't use this to drive whether service is provided or not.
   // Strip recommends updating an end-of-service datetime every time payment
   // is received, adding on a grace period of some days.
-  @Column({name: 'in_good_standing', default: nativeValues.trueValue})
+  @Column({name: 'in_good_standing', type: Boolean, default: nativeValues.trueValue})
   public inGoodStanding: boolean;
 
   @Column({type: nativeValues.jsonEntityType, nullable: true})

--- a/app/gen-server/entity/BillingAccountManager.ts
+++ b/app/gen-server/entity/BillingAccountManager.ts
@@ -10,14 +10,14 @@ export class BillingAccountManager extends BaseEntity {
   @PrimaryGeneratedColumn()
   public id: number;
 
-  @Column({name: 'billing_account_id'})
+  @Column({name: 'billing_account_id', type: Number})
   public billingAccountId: number;
 
   @ManyToOne(type => BillingAccount, { onDelete: 'CASCADE' })
   @JoinColumn({name: 'billing_account_id'})
   public billingAccount: BillingAccount;
 
-  @Column({name: 'user_id'})
+  @Column({name: 'user_id', type: Number})
   public userId: number;
 
   @ManyToOne(type => User, { onDelete: 'CASCADE' })

--- a/app/gen-server/entity/Document.ts
+++ b/app/gen-server/entity/Document.ts
@@ -24,7 +24,7 @@ function isValidUrlId(urlId: string) {
 @Entity({name: 'docs'})
 export class Document extends Resource {
 
-  @PrimaryColumn()
+  @PrimaryColumn({type: String})
   public id: string;
 
   @ManyToOne(type => Workspace)
@@ -35,7 +35,7 @@ export class Document extends Resource {
   public aclRules: AclRuleDoc[];
 
   // Indicates whether the doc is pinned to the org it lives in.
-  @Column({name: 'is_pinned', default: false})
+  @Column({name: 'is_pinned', type: Boolean, default: false})
   public isPinned: boolean;
 
   // Property that may be returned when the doc is fetched to indicate the access the

--- a/app/gen-server/entity/Group.ts
+++ b/app/gen-server/entity/Group.ts
@@ -9,7 +9,7 @@ export class Group extends BaseEntity {
   @PrimaryGeneratedColumn()
   public id: number;
 
-  @Column()
+  @Column({type: String})
   public name: string;
 
   @ManyToMany(type => User)

--- a/app/gen-server/entity/Login.ts
+++ b/app/gen-server/entity/Login.ts
@@ -5,18 +5,18 @@ import {User} from "./User";
 @Entity({name: 'logins'})
 export class Login extends BaseEntity {
 
-  @PrimaryColumn()
+  @PrimaryColumn({type: Number})
   public id: number;
 
   // This is the normalized email address we use for equality and indexing.
-  @Column()
+  @Column({type: String})
   public email: string;
 
   // This is how the user's email address should be displayed.
-  @Column({name: 'display_email'})
+  @Column({name: 'display_email', type: String})
   public displayEmail: string;
 
-  @Column({name: 'user_id'})
+  @Column({name: 'user_id', type: Number})
   public userId: number;
 
   @ManyToOne(type => User)

--- a/app/gen-server/entity/Organization.ts
+++ b/app/gen-server/entity/Organization.ts
@@ -29,6 +29,7 @@ export class Organization extends Resource {
   public id: number;
 
   @Column({
+    type: String,
     nullable: true
   })
   public domain: string;
@@ -46,7 +47,7 @@ export class Organization extends Resource {
   @OneToMany(type => AclRuleOrg, aclRule => aclRule.organization)
   public aclRules: AclRuleOrg[];
 
-  @Column({name: 'billing_account_id'})
+  @Column({name: 'billing_account_id', type: Number})
   public billingAccountId: number;
 
   @ManyToOne(type => BillingAccount)

--- a/app/gen-server/entity/Pref.ts
+++ b/app/gen-server/entity/Pref.ts
@@ -11,10 +11,10 @@ export class Pref {
   // one, but we haven't marked them as so in the DB since the SQL standard frowns
   // on nullable primary keys (and Postgres doesn't support them).  We could add
   // another primary key, but we don't actually need one.
-  @PrimaryColumn({name: 'user_id'})
+  @PrimaryColumn({name: 'user_id', type: Number})
   public userId: number|null;
 
-  @PrimaryColumn({name: 'org_id'})
+  @PrimaryColumn({name: 'org_id', type: Number})
   public orgId: number|null;
 
   @ManyToOne(type => User)

--- a/app/gen-server/entity/Product.ts
+++ b/app/gen-server/entity/Product.ts
@@ -169,7 +169,7 @@ export class Product extends BaseEntity {
   @PrimaryGeneratedColumn()
   public id: number;
 
-  @Column()
+  @Column({type: String})
   public name: string;
 
   @Column({type: nativeValues.jsonEntityType})

--- a/app/gen-server/entity/Resource.ts
+++ b/app/gen-server/entity/Resource.ts
@@ -3,13 +3,13 @@ import {ApiError} from 'app/common/ApiError';
 import {CommonProperties} from "app/common/UserAPI";
 
 export class Resource extends BaseEntity {
-  @Column()
+  @Column({type: String})
   public name: string;
 
-  @Column({name: 'created_at', default: () => "CURRENT_TIMESTAMP"})
+  @Column({name: 'created_at', type: Date, default: () => "CURRENT_TIMESTAMP"})
   public createdAt: Date;
 
-  @Column({name: 'updated_at', default: () => "CURRENT_TIMESTAMP"})
+  @Column({name: 'updated_at', type: Date, default: () => "CURRENT_TIMESTAMP"})
   public updatedAt: Date;
 
   // a computed column which, when present, means the entity should be filtered out

--- a/app/gen-server/entity/Secret.ts
+++ b/app/gen-server/entity/Secret.ts
@@ -3,10 +3,10 @@ import {Document} from "./Document";
 
 @Entity({name: 'secrets'})
 export class Secret extends BaseEntity {
-  @PrimaryColumn()
+  @PrimaryColumn({type: String})
   public id: string;  // generally a UUID
 
-  @Column({name: 'value'})
+  @Column({name: 'value', type: String})
   public value: string;
 
   @ManyToOne(_type => Document, { onDelete: 'CASCADE' })

--- a/app/gen-server/entity/User.ts
+++ b/app/gen-server/entity/User.ts
@@ -15,7 +15,7 @@ export class User extends BaseEntity {
   @PrimaryGeneratedColumn()
   public id: number;
 
-  @Column()
+  @Column({type: String})
   public name: string;
 
   @Column({name: 'api_key', type: String, nullable: true})
@@ -46,7 +46,7 @@ export class User extends BaseEntity {
   })
   public groups: Group[];
 
-  @Column({name: 'is_first_time_user', default: false})
+  @Column({name: 'is_first_time_user', type: Boolean, default: false})
   public isFirstTimeUser: boolean;
 
   @Column({name: 'options', type: nativeValues.jsonEntityType, nullable: true})

--- a/app/server/lib/ActionHistoryImpl.ts
+++ b/app/server/lib/ActionHistoryImpl.ts
@@ -314,7 +314,7 @@ export class ActionHistoryImpl implements ActionHistory {
     } finally {
       if (tip) {
         await this._db.run(`UPDATE _gristsys_ActionHistoryBranch SET actionRef = ?
-                              WHERE name = "local_sent"`,
+                              WHERE name = 'local_sent'`,
                            tip);
       }
     }
@@ -336,7 +336,7 @@ export class ActionHistoryImpl implements ActionHistory {
       }
     }
     await this._db.run(`UPDATE _gristsys_ActionHistoryBranch SET actionRef = ?
-                          WHERE name = "shared"`,
+                          WHERE name = 'shared'`,
                        candidate.id);
     if (candidates.length === 1) {
       this._haveLocalSent = false;
@@ -405,9 +405,10 @@ export class ActionHistoryImpl implements ActionHistory {
   }
 
   public async getActions(actionNums: number[]): Promise<Array<LocalActionBundle|undefined>> {
-    const actions = await this._db.all(`SELECT actionHash, actionNum, body FROM _gristsys_ActionHistory
-                                         where actionNum in (${actionNums.map(x => '?').join(',')})`,
-                                       actionNums);
+    const actions = await this._db.all(
+      `SELECT actionHash, actionNum, body FROM _gristsys_ActionHistory
+       where actionNum in (${actionNums.map(x => '?').join(',')})`,
+      ...actionNums);
     return reportTimeTaken("getActions", () => {
       const actionsByActionNum = keyBy(actions, 'actionNum');
       return actionNums
@@ -516,7 +517,7 @@ export class ActionHistoryImpl implements ActionHistory {
                                        FROM _gristsys_ActionHistoryBranch as Branch
                                        LEFT JOIN _gristsys_ActionHistory as History
                                          ON History.id = Branch.actionRef
-                                       WHERE name in ("shared", "local_sent", "local_unsent")`);
+                                       WHERE name in ('shared', 'local_sent', 'local_unsent')`);
     const bits = mapValues(keyBy(rows, 'name'), this._asActionIdentifiers);
     const missing = { actionHash: null, actionRef: null, actionNum: null } as ActionIdentifiers;
     return {

--- a/app/server/lib/GranularAccess.ts
+++ b/app/server/lib/GranularAccess.ts
@@ -1879,11 +1879,10 @@ export class GranularAccess implements GranularAccessForBundle {
    * tables or examples.
    */
   private async _getViewAsUser(linkParameters: Record<string, string>): Promise<UserOverride> {
-    // Look up user information in database.
-    if (!this._homeDbManager) { throw new Error('database required'); }
+    // Look up user information in database, if available
     const dbUser = linkParameters.aclAsUserId ?
-      (await this._homeDbManager.getUser(integerParam(linkParameters.aclAsUserId, 'aclAsUserId'))) :
-      (await this._homeDbManager.getExistingUserByLogin(linkParameters.aclAsUser));
+      (await this._homeDbManager?.getUser(integerParam(linkParameters.aclAsUserId, 'aclAsUserId'))) :
+      (await this._homeDbManager?.getExistingUserByLogin(linkParameters.aclAsUser));
     // If this is one of example users we will pretend that it doesn't exist, otherwise we would
     // end up using permissions of the real user.
     const isExampleUser = this.getExampleViewAsUsers().some(e => e.email === dbUser?.loginEmail);
@@ -1905,13 +1904,13 @@ export class GranularAccess implements GranularAccessForBundle {
         };
       }
     }
-    const docAuth = userExists ? await this._homeDbManager.getDocAuthCached({
+    const docAuth = userExists ? await this._homeDbManager?.getDocAuthCached({
       urlId: this._docId,
       userId: dbUser.id
     }) : null;
     const access = docAuth?.access || null;
-    const user = userExists ? this._homeDbManager.makeFullUser(dbUser) : null;
-    return { access, user };
+    const user = userExists ? this._homeDbManager?.makeFullUser(dbUser) : null;
+    return { access, user: user || null };
   }
 
   /**

--- a/app/server/lib/ICreate.ts
+++ b/app/server/lib/ICreate.ts
@@ -7,7 +7,8 @@ import {IBilling} from 'app/server/lib/IBilling';
 import {INotifier} from 'app/server/lib/INotifier';
 import {ISandbox, ISandboxCreationOptions} from 'app/server/lib/ISandbox';
 import {IShell} from 'app/server/lib/IShell';
-import {createSandbox} from 'app/server/lib/NSandbox';
+import {createSandbox, SpawnFn} from 'app/server/lib/NSandbox';
+import {SqliteVariant} from 'app/server/lib/SqliteCommon';
 
 export interface ICreate {
 
@@ -31,6 +32,8 @@ export interface ICreate {
   // static page.
   getExtraHeadHtml?(): string;
   getStorageOptions?(name: string): ICreateStorageOptions|undefined;
+  getSqliteVariant?(): SqliteVariant;
+  getSandboxVariants?(): Record<string, SpawnFn>;
 }
 
 export interface ICreateActiveDocOptions {
@@ -62,6 +65,8 @@ export function makeSimpleCreator(opts: {
   sandboxFlavor?: string,
   shell?: IShell,
   getExtraHeadHtml?: () => string,
+  getSqliteVariant?: () => SqliteVariant,
+  getSandboxVariants?: () => Record<string, SpawnFn>,
 }): ICreate {
   const {sessionSecret, storage, notifier, billing} = opts;
   return {
@@ -121,6 +126,8 @@ export function makeSimpleCreator(opts: {
     },
     getStorageOptions(name: string) {
       return storage?.find(s => s.name === name);
-    }
+    },
+    getSqliteVariant: opts.getSqliteVariant,
+    getSandboxVariants: opts.getSandboxVariants,
   };
 }

--- a/app/server/lib/SqliteCommon.ts
+++ b/app/server/lib/SqliteCommon.ts
@@ -9,8 +9,8 @@ import { OpenMode, quoteIdent } from 'app/server/lib/SQLiteDB';
  * It is important that Statement exists - but we don't expect
  * anything of it.
  */
-export interface Statement {
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Statement {}
 
 export interface MinDB {
   exec(sql: string): Promise<void>;

--- a/app/server/lib/SqliteCommon.ts
+++ b/app/server/lib/SqliteCommon.ts
@@ -1,0 +1,126 @@
+import { Marshaller } from 'app/common/marshal';
+import { OpenMode, quoteIdent } from 'app/server/lib/SQLiteDB';
+
+/**
+ * Code common to SQLite wrappers.
+ */
+
+/**
+ * It is important that Statement exists - but we don't expect
+ * anything of it.
+ */
+export interface Statement {
+}
+
+export interface MinDB {
+  exec(sql: string): Promise<void>;
+  run(sql: string, ...params: any[]): Promise<MinRunResult>;
+  get(sql: string, ...params: any[]): Promise<ResultRow|undefined>;
+  all(sql: string, ...params: any[]): Promise<ResultRow[]>;
+  prepare(sql: string, ...params: any[]): Promise<PreparedStatement>;
+  runAndGetId(sql: string, ...params: any[]): Promise<number>;
+  close(): Promise<void>;
+  allMarshal(sql: string, ...params: any[]): Promise<Buffer>;
+
+  /**
+   * Limit the number of ATTACHed databases permitted.
+   */
+  limitAttach(maxAttach: number): Promise<void>;
+}
+
+export interface MinRunResult {
+  changes: number;
+}
+
+// Describes the result of get() and all() database methods.
+export interface ResultRow {
+  [column: string]: any;
+}
+
+export interface PreparedStatement {
+  run(...params: any[]): Promise<MinRunResult>;
+  finalize(): Promise<void>;
+  columns(): string[];
+}
+
+export interface SqliteVariant {
+  opener(dbPath: string, mode: OpenMode): Promise<MinDB>;
+}
+
+/**
+ * A crude implementation of Grist marshalling.
+ * There is a fork of node-sqlite3 that has Grist
+ * marshalling built in, at:
+ *   https://github.com/gristlabs/node-sqlite3
+ * If using a version of SQLite without this built
+ * in, another option is to add custom functions
+ * to do it. This object has the initialize, step,
+ * and finalize callbacks typically needed to add
+ * a custom aggregration function.
+ */
+export const gristMarshal = {
+  initialize(): GristMarshalIntermediateValue {
+    return {};
+  },
+  step(accum: GristMarshalIntermediateValue, ...row: any[]) {
+    if (!accum.names || !accum.values) {
+      accum.names = row.map(value => String(value));
+      accum.values = row.map(() => []);
+    } else {
+      for (const [i, v] of row.entries()) {
+        accum.values[i].push(v);
+      }
+    }
+    return accum;
+  },
+  finalize(accum: GristMarshalIntermediateValue) {
+    const marshaller = new Marshaller({version: 2, keysAreBuffers: true});
+    const result: Record<string, Array<any>> = {};
+    if (accum.names && accum.values) {
+      for (const [i, name] of accum.names.entries()) {
+        result[name] = accum.values[i];
+      }
+    }
+    marshaller.marshal(result);
+    return marshaller.dumpAsBuffer();
+  }
+};
+
+/**
+ * An intermediate value used during an aggregation.
+ */
+interface GristMarshalIntermediateValue {
+  // The names of the columns, once known.
+  names?: string[];
+  // Values stored in the columns.
+  // There is one element in the outermost array per column.
+  // That element contains a list of values stored in that column.
+  values?: Array<Array<any>>;
+}
+
+/**
+ * Run Grist marshalling as a SQLite query, assuming
+ * a custom aggregation has been added as "grist_marshal".
+ * The marshalled result needs to contain the column
+ * identifiers embedded in it. This is a little awkward
+ * to organize - hence the hacky UNION here. This is
+ * for compatibility with the existing marshalling method,
+ * which could be replaced instead.
+ */
+export async function allMarshalQuery(db: MinDB, sql: string, ...params: any[]): Promise<Buffer> {
+  const statement = await db.prepare(sql);
+  const columns = statement.columns();
+  const quotedColumnList = columns.map(quoteIdent).join(',');
+  const query = await db.all(`select grist_marshal(${quotedColumnList}) as buf FROM ` +
+    `(select ${quotedColumnList} UNION ALL select * from (` + sql + '))', ..._fixParameters(params));
+  return query[0].buf;
+}
+
+/**
+ * Booleans need to be cast to 1 or 0 for SQLite.
+ * The node-sqlite3 wrapper does this automatically, but other
+ * wrappers do not.
+ */
+function _fixParameters(params: any[]) {
+  return params.map(p => p === true ? 1 : (p === false ? 0 : p));
+}

--- a/app/server/lib/SqliteNode.ts
+++ b/app/server/lib/SqliteNode.ts
@@ -4,7 +4,7 @@ import { MinDB, PreparedStatement, ResultRow, SqliteVariant } from 'app/server/l
 import { OpenMode, RunResult } from 'app/server/lib/SQLiteDB';
 
 export class NodeSqliteVariant implements SqliteVariant {
-  opener(dbPath: string, mode: OpenMode): Promise<MinDB> {
+  public opener(dbPath: string, mode: OpenMode): Promise<MinDB> {
     return NodeSqlite3DatabaseAdapter.opener(dbPath, mode);
   }
 }

--- a/app/server/lib/SqliteNode.ts
+++ b/app/server/lib/SqliteNode.ts
@@ -1,0 +1,104 @@
+import * as sqlite3 from '@gristlabs/sqlite3';
+import { fromCallback } from 'app/server/lib/serverUtils';
+import { MinDB, PreparedStatement, ResultRow, SqliteVariant } from 'app/server/lib/SqliteCommon';
+import { OpenMode, RunResult } from 'app/server/lib/SQLiteDB';
+
+export class NodeSqliteVariant implements SqliteVariant {
+  opener(dbPath: string, mode: OpenMode): Promise<MinDB> {
+    return NodeSqlite3DatabaseAdapter.opener(dbPath, mode);
+  }
+}
+
+export class NodeSqlite3PreparedStatement implements PreparedStatement {
+  public constructor(private _statement: sqlite3.Statement) {
+  }
+
+  public async run(...params: any[]): Promise<RunResult> {
+    return fromCallback(cb => this._statement.run(...params, cb));
+  }
+
+  public async finalize() {
+    await fromCallback(cb => this._statement.finalize(cb));
+  }
+
+  public columns(): string[] {
+    // This method is only needed if marshalling is not built in -
+    // and node-sqlite3 has marshalling built in.
+    throw new Error('not available (but should not be needed)');
+  }
+}
+
+export class NodeSqlite3DatabaseAdapter implements MinDB {
+  public static async opener(dbPath: string, mode: OpenMode): Promise<any> {
+    const sqliteMode: number =
+      // tslint:disable-next-line:no-bitwise
+      (mode === OpenMode.OPEN_READONLY ? sqlite3.OPEN_READONLY : sqlite3.OPEN_READWRITE) |
+      (mode === OpenMode.OPEN_CREATE || mode === OpenMode.CREATE_EXCL ? sqlite3.OPEN_CREATE : 0);
+    let _db: sqlite3.Database;
+    await fromCallback(cb => { _db = new sqlite3.Database(dbPath, sqliteMode, cb); });
+    const result = new NodeSqlite3DatabaseAdapter(_db!);
+    await result.limitAttach(0);  // Outside of VACUUM, we don't allow ATTACH.
+    return result;
+  }
+
+  public constructor(protected _db: sqlite3.Database) {
+    // Default database to serialized execution. See https://github.com/mapbox/node-sqlite3/wiki/Control-Flow
+    // This isn't enough for transactions, which we serialize explicitly.
+    this._db.serialize();
+  }
+
+  public async exec(sql: string): Promise<void> {
+    return fromCallback(cb => this._db.exec(sql, cb));
+  }
+
+  public async run(sql: string, ...params: any[]): Promise<RunResult> {
+    return new Promise((resolve, reject) => {
+      function callback(this: RunResult, err: Error | null) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(this);
+        }
+      }
+      this._db.run(sql, ...params, callback);
+    });
+  }
+
+  public async get(sql: string, ...params: any[]): Promise<ResultRow|undefined> {
+    return fromCallback(cb => this._db.get(sql, ...params, cb));
+  }
+
+  public async all(sql: string, ...params: any[]): Promise<ResultRow[]> {
+    return fromCallback(cb => this._db.all(sql, params, cb));
+  }
+
+  public async prepare(sql: string): Promise<PreparedStatement> {
+    let stmt: sqlite3.Statement|undefined;
+    // The original interface is a little strange; we resolve to Statement if prepare() succeeded.
+    await fromCallback(cb => { stmt = this._db.prepare(sql, cb); }).then(() => stmt);
+    if (!stmt) { throw new Error('could not prepare statement'); }
+    return new NodeSqlite3PreparedStatement(stmt);
+  }
+
+  public async close() {
+    this._db.close();
+  }
+
+  public async allMarshal(sql: string, ...params: any[]): Promise<Buffer> {
+    // allMarshal isn't in the typings, because it is our addition to our fork of sqlite3 JS lib.
+    return fromCallback(cb => (this._db as any).allMarshal(sql, ...params, cb));
+
+  }
+
+  public async runAndGetId(sql: string, ...params: any[]): Promise<number> {
+    const result = await this.run(sql, ...params);
+    return (result as any).lastID;
+  }
+
+  public async limitAttach(maxAttach: number) {
+    const SQLITE_LIMIT_ATTACHED = (sqlite3 as any).LIMIT_ATTACHED;
+    // Cast because types out of date.
+    (this._db as any).configure('limit', SQLITE_LIMIT_ATTACHED, maxAttach);
+  }
+}
+

--- a/app/server/lib/WorkCoordinator.ts
+++ b/app/server/lib/WorkCoordinator.ts
@@ -60,7 +60,12 @@ export class WorkCoordinator {
 
   private _maybeSchedule() {
     if (this._isStepScheduled && !this._isStepRunning) {
-      setImmediate(this._tryNextStepCB);
+      try {
+        setImmediate(this._tryNextStepCB);
+      } catch (e) {
+        // setImmediate may not be available outside node.
+        setTimeout(this._tryNextStepCB, 0);
+      }
     }
   }
 }

--- a/app/server/lib/requestUtils.ts
+++ b/app/server/lib/requestUtils.ts
@@ -8,7 +8,6 @@ import {RequestWithGrist} from 'app/server/lib/GristServer';
 import log from 'app/server/lib/log';
 import {Permit} from 'app/server/lib/Permit';
 import {Request, Response} from 'express';
-import {URL} from 'url';
 import _ from 'lodash';
 
 // log api details outside of dev environment (when GRIST_HOSTED_VERSION is set)

--- a/app/server/lib/shutdown.js
+++ b/app/server/lib/shutdown.js
@@ -3,8 +3,8 @@
  */
 
 
+var log = require('app/server/lib/log');
 var Promise = require('bluebird');
-var log = require('./log');
 
 var cleanupHandlers = [];
 

--- a/buildtools/build.sh
+++ b/buildtools/build.sh
@@ -7,11 +7,17 @@ export GRIST_EXT=stubs
 if [[ -e ext/app ]]; then
   PROJECT="tsconfig-ext.json"
 fi
+WEBPACK_CONFIG=buildtools/webpack.config.js
+if [[ -e ext/buildtools/webpack.config.js ]]; then
+  # Allow webpack config file to be replaced (useful
+  # for grist-static)
+  WEBPACK_CONFIG=ext/buildtools/webpack.config.js
+fi
 
 set -x
 tsc --build $PROJECT
 buildtools/update_type_info.sh app
-webpack --config buildtools/webpack.config.js --mode production
+webpack --config $WEBPACK_CONFIG --mode development
 webpack --config buildtools/webpack.check.js --mode production
 webpack --config buildtools/webpack.api.config.js --mode production
 cat app/client/*.css app/client/*/*.css > static/bundle.css

--- a/buildtools/build.sh
+++ b/buildtools/build.sh
@@ -17,7 +17,7 @@ fi
 set -x
 tsc --build $PROJECT
 buildtools/update_type_info.sh app
-webpack --config $WEBPACK_CONFIG --mode development
+webpack --config $WEBPACK_CONFIG --mode production
 webpack --config buildtools/webpack.check.js --mode production
 webpack --config buildtools/webpack.api.config.js --mode production
 cat app/client/*.css app/client/*/*.css > static/bundle.css

--- a/sandbox/MANIFEST.in
+++ b/sandbox/MANIFEST.in
@@ -1,0 +1,3 @@
+# see bundle_as_wheel.sh
+
+include grist/tzdata.data

--- a/sandbox/bundle_as_wheel.sh
+++ b/sandbox/bundle_as_wheel.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Package up Grist code as a stand-alone wheel.
+# This is useful for grist-static.
+# It is the reason why MANIFEST.in and setup.py are present.
+
+set -e
+
+# Clean up any previous packaging.
+rm -rf dist foo.egg-info grist.egg-info build
+
+# Go ahead and run packaging again.
+python setup.py bdist_wheel
+
+echo ""
+echo "Result is in the dist directory:"
+ls dist

--- a/sandbox/setup.py
+++ b/sandbox/setup.py
@@ -1,0 +1,15 @@
+# see bundle_as_wheel.sh
+
+from distutils.core import setup
+import glob
+
+files = glob.glob('grist/*.py') + glob.glob('grist/**/*.py')
+names = [f.split('.py')[0] for f in files]
+
+setup(name='grist',
+      version='1.0',
+      include_package_data=True,
+      packages=['grist', 'grist/functions', 'grist/imports'],
+      package_data={
+          'grist': ['grist/tzdata.data'],
+      })

--- a/sandbox/watch.sh
+++ b/sandbox/watch.sh
@@ -7,13 +7,17 @@ export GRIST_EXT=stubs
 if [[ -e ext/app ]]; then
   PROJECT="tsconfig-ext.json"
 fi
+WEBPACK_CONFIG=buildtools/webpack.config.js
+if [[ -e ext/buildtools/webpack.config.js ]]; then
+  WEBPACK_CONFIG=ext/buildtools/webpack.config.js
+fi
 
 if [ ! -e _build ]; then
   buildtools/build.sh
 fi
 
 tsc --build -w --preserveWatchOutput $PROJECT &
-catw app/client/*.css app/client/*/*.css -o static/bundle.css -v & webpack --config buildtools/webpack.config.js --mode development --watch &
+catw app/client/*.css app/client/*/*.css -o static/bundle.css -v & webpack --config $WEBPACK_CONFIG --mode development --watch &
 NODE_PATH=_build:_build/stubs:_build/ext nodemon --delay 1 -w _build/app/server -w _build/app/common _build/stubs/app/server/server.js &
 
 wait

--- a/test/server/lib/HostedStorageManager.ts
+++ b/test/server/lib/HostedStorageManager.ts
@@ -15,7 +15,6 @@ import {
   HostedStorageOptions
 } from 'app/server/lib/HostedStorageManager';
 import log from 'app/server/lib/log';
-import {fromCallback} from 'app/server/lib/serverUtils';
 import {SQLiteDB} from 'app/server/lib/SQLiteDB';
 import * as bluebird from 'bluebird';
 import {assert} from 'chai';
@@ -931,9 +930,9 @@ describe('backupSqliteDatabase', async function() {
         // Silly code to make a long random string to insert.
         // We can make a big db faster this way.
         const str = (new Array(100)).fill(1).map((_: any) => Math.random().toString(2)).join();
-        stmt.run(str, str, str);
+        await stmt.run(str, str, str);
       }
-      await fromCallback(cb => stmt.finalize(cb));
+      await stmt.finalize();
     });
     const stat = await fse.stat(src);
     assert(stat.size > 150 * 1000 * 1000);


### PR DESCRIPTION
[grist-static](https://github.com/gristlabs/grist-static) currently uses a hacky patched version of grist-core. In this PR, I'm working on cleaning up the changes, and consolidating them in general-purpose hooks.
 * Introduces new front-end hooks to:
   - add attributes to iframes (`credentialless` is useful in some situations)
   - allow intercepting API calls (handy when there is no back end)
   - allow overriding the base URI for grist-related assets (handy when not in full control of the page HTML)
 * Introduces new back-end hooks to:
   - add alternate sandbox variants (grist-static uses pyodide in the browser, in a particular way)
   - allows sandbox variants where the communication pipe is in-process via callbacks rather than a discrete process (grist-static uses this to communicate with a web worker)
   - add alternate SQLite wrappers (grist-static uses sqlite.js)
  * Supports overriding the webpack configuration (grist-static goes very much its own way there, but still benefits from the rest of the build system)
  * Adds a small script for bundling the Grist data engine python code as a wheel (simplifies using it from pyodide in the browser)
  * Makes Grist a little more forgiving in a few ways:
    - allows "View As" feature to operate without a home database
    - tolerates lack of implementation of a `realpath` function or `setImmediate` function
  * Adds some type annotations to make TypeORM happy in a slightly different build