### PR TITLE
Setting main grist-widget repository as a default 

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ GRIST_SUPPORT_EMAIL | if set, give a user with the specified email support power
 GRIST_THROTTLE_CPU | if set, CPU throttling is enabled
 GRIST_USER_ROOT     | an extra path to look for plugins in.
 GRIST_UI_FEATURES | comma-separated list of UI features to enable. Allowed names of parts: `helpCenter,billing,templates,multiSite,multiAccounts,sendToDrive,tutorials`. If a part also exists in GRIST_HIDE_UI_ELEMENTS, it won't be enabled.
-GRIST_WIDGET_LIST_URL | a url pointing to a widget manifest
+GRIST_WIDGET_LIST_URL | a url pointing to a widget manifest, by default `https://github.com/gristlabs/grist-widget/releases/download/latest/manifest.json` is used
 COOKIE_MAX_AGE      | session cookie max age, defaults to 90 days; can be set to "none" to make it a session cookie
 HOME_PORT           | port number to listen on for REST API server; if set to "share", add API endpoints to regular grist port.
 PORT                | port number to listen on for Grist server

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -78,6 +78,7 @@ export const commonUrls = {
   basicTutorial: 'https://templates.getgrist.com/woXtXUBmiN5T/Grist-Basics',
   basicTutorialImage: 'https://www.getgrist.com/wp-content/uploads/2021/08/lightweight-crm.png',
   gristLabsCustomWidgets: 'https://gristlabs.github.io/grist-widget/',
+  gristLabsWidgetRepository: 'https://github.com/gristlabs/grist-widget/releases/download/latest/manifest.json',
 };
 
 /**

--- a/stubs/app/server/server.ts
+++ b/stubs/app/server/server.ts
@@ -31,7 +31,8 @@ if (!process.env.GRIST_SINGLE_ORG) {
 }
 
 setDefaultEnv('GRIST_UI_FEATURES', 'helpCenter,billing,templates,multiSite,multiAccounts,sendToDrive');
-
+setDefaultEnv('GRIST_WIDGET_LIST_URL',
+  'https://github.com/gristlabs/grist-widget/releases/download/latest/manifest.json');
 import {updateDb} from 'app/server/lib/dbUtils';
 import {main as mergedServerMain} from 'app/server/mergedServerMain';
 import * as fse from 'fs-extra';

--- a/stubs/app/server/server.ts
+++ b/stubs/app/server/server.ts
@@ -4,6 +4,7 @@
  * By default, starts up on port 8484.
  */
 
+import {commonUrls} from 'app/common/gristUrls';
 import {isAffirmative} from 'app/common/gutil';
 import {HomeDBManager} from 'app/gen-server/lib/HomeDBManager';
 import {TEAM_FREE_PLAN} from 'app/common/Features';
@@ -31,8 +32,7 @@ if (!process.env.GRIST_SINGLE_ORG) {
 }
 
 setDefaultEnv('GRIST_UI_FEATURES', 'helpCenter,billing,templates,multiSite,multiAccounts,sendToDrive');
-setDefaultEnv('GRIST_WIDGET_LIST_URL',
-  'https://github.com/gristlabs/grist-widget/releases/download/latest/manifest.json');
+setDefaultEnv('GRIST_WIDGET_LIST_URL', commonUrls.gristLabsWidgetRepository);
 import {updateDb} from 'app/server/lib/dbUtils';
 import {main as mergedServerMain} from 'app/server/mergedServerMain';
 import * as fse from 'fs-extra';


### PR DESCRIPTION
GRIST_WIDGET_LIST_URL by default points to https://github.com/gristlabs/grist-widget/releases/download/latest/manifest.json