### PR TITLE
Visually identify that a field is a drop-down list (single choice) #491

### DIFF
--- a/app/client/widgets/ChoiceEditor.js
+++ b/app/client/widgets/ChoiceEditor.js
@@ -22,7 +22,9 @@ function ChoiceEditor(options) {
   this.choiceOptions = options.field.widgetOptionsJson.peek().choiceOptions || {};
   if (!options.readonly) {
     this.cellEditorDiv.classList.add(cssChoiceEditor.className);
-    this.cellEditorDiv.appendChild(cssChoiceEditIcon('Dropdown'));
+    if (options.field.viewSection().parentKey() === "single") {
+      this.cellEditorDiv.appendChild(cssChoiceEditIcon('Dropdown'));
+    }
   }
   // Whether to include a button to show a new choice.
   // TODO: Disable when the user cannot change column configuration.

--- a/app/client/widgets/ChoiceEditor.js
+++ b/app/client/widgets/ChoiceEditor.js
@@ -20,11 +20,9 @@ function ChoiceEditor(options) {
 
   this.choices = options.field.widgetOptionsJson.peek().choices || [];
   this.choiceOptions = options.field.widgetOptionsJson.peek().choiceOptions || {};
-  if (!options.readonly) {
+  if (!options.readonly && options.field.viewSection().parentKey() === "single") {
     this.cellEditorDiv.classList.add(cssChoiceEditor.className);
-    if (options.field.viewSection().parentKey() === "single") {
-      this.cellEditorDiv.appendChild(cssChoiceEditIcon('Dropdown'));
-    }
+    this.cellEditorDiv.appendChild(cssChoiceEditIcon('Dropdown'));
   }
   // Whether to include a button to show a new choice.
   // TODO: Disable when the user cannot change column configuration.

--- a/app/client/widgets/ChoiceEditor.js
+++ b/app/client/widgets/ChoiceEditor.js
@@ -7,9 +7,10 @@ const {ACIndexImpl, buildHighlightedDom} = require('app/client/lib/ACIndex');
 const {ChoiceItem, cssChoiceList, cssMatchText, cssPlusButton,
        cssPlusIcon} = require('app/client/widgets/ChoiceListEditor');
 const {menuCssClass} = require('app/client/ui2018/menus');
-const {testId} = require('app/client/ui2018/cssVars');
+const {testId, colors} = require('app/client/ui2018/cssVars');
 const {choiceToken, cssChoiceACItem} = require('app/client/widgets/ChoiceToken');
-const {dom} = require('grainjs');
+const {dom, styled} = require('grainjs');
+const {icon} = require('../ui2018/icons');
 
 /**
  * ChoiceEditor - TextEditor with a dropdown for possible choices.
@@ -19,7 +20,10 @@ function ChoiceEditor(options) {
 
   this.choices = options.field.widgetOptionsJson.peek().choices || [];
   this.choiceOptions = options.field.widgetOptionsJson.peek().choiceOptions || {};
-
+  if (!options.readonly) {
+    this.cellEditorDiv.classList.add(cssChoiceEditor.className);
+    this.cellEditorDiv.appendChild(cssChoiceEditIcon('Dropdown'));
+  }
   // Whether to include a button to show a new choice.
   // TODO: Disable when the user cannot change column configuration.
   this.enableAddNew = true;
@@ -106,5 +110,19 @@ ChoiceEditor.prototype.maybeShowAddNew = function(result, text) {
 
   return result;
 }
+
+const cssChoiceEditIcon = styled(icon, `
+  background-color: ${colors.slate};
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin: 3px 3px 0 3px;
+`);
+
+const cssChoiceEditor = styled('div', `
+  & > .celleditor_text_editor, & > .celleditor_content_measure {
+    padding-left: 18px;
+  }
+`);
 
 module.exports = ChoiceEditor;

--- a/app/client/widgets/ChoiceTextBox.ts
+++ b/app/client/widgets/ChoiceTextBox.ts
@@ -4,7 +4,8 @@ import {ViewFieldRec} from 'app/client/models/entities/ViewFieldRec';
 import {KoSaveableObservable} from 'app/client/models/modelUtil';
 import {Style} from 'app/client/models/Styles';
 import {cssLabel, cssRow} from 'app/client/ui/RightPanelStyles';
-import {testId} from 'app/client/ui2018/cssVars';
+import {colors, testId} from 'app/client/ui2018/cssVars';
+import {icon} from 'app/client/ui2018/icons';
 import {ChoiceListEntry} from 'app/client/widgets/ChoiceListEntry';
 import {choiceToken, DEFAULT_FILL_COLOR, DEFAULT_TEXT_COLOR} from 'app/client/widgets/ChoiceToken';
 import {NTextBox} from 'app/client/widgets/NTextBox';
@@ -48,6 +49,8 @@ export class ChoiceTextBox extends NTextBox {
     return cssChoiceField(
       cssChoiceTextWrapper(
         dom.style('justify-content', (use) => use(this.alignment) === 'right' ? 'flex-end' : use(this.alignment)),
+        // FIXME ensure right access
+        cssChoiceEditIcon('Dropdown'),
         dom.domComputed((use) => {
           if (this.isDisposed() || use(row._isAddRow)) { return null; }
 
@@ -61,7 +64,7 @@ export class ChoiceTextBox extends NTextBox {
               invalid: !use(this._choiceValuesSet).has(formattedValue),
             },
             dom.cls(cssChoiceText.className),
-            testId('choice-token')
+            testId('choice-token'),
           );
         }),
       ),
@@ -85,6 +88,7 @@ export class ChoiceTextBox extends NTextBox {
       cssRow(
         dom.autoDispose(disabled),
         dom.autoDispose(mixed),
+        cssChoiceEditIcon('Dropdown'),
         dom.create(
           ChoiceListEntry,
           this._choiceValues,
@@ -149,4 +153,13 @@ const cssChoiceText = styled('div', `
   margin: 2px;
   height: min-content;
   line-height: 16px;
+`);
+
+const cssChoiceEditIcon = styled(icon, `
+  background-color: ${colors.slate};
+  display: none;
+  .g_record_detail_value & {
+    display: block;
+    height: inherit;
+  }
 `);

--- a/app/client/widgets/ChoiceTextBox.ts
+++ b/app/client/widgets/ChoiceTextBox.ts
@@ -46,10 +46,13 @@ export class ChoiceTextBox extends NTextBox {
 
   public buildDom(row: DataRowModel) {
     const value = row.cells[this.field.colId()];
+    const isSingle = this.field.viewSection().parentKey() === "single";
+    const maybeDropDownCssChoiceEditIcon = isSingle ? cssChoiceEditIcon('Dropdown') : null;
+
     return cssChoiceField(
       cssChoiceTextWrapper(
         dom.style('justify-content', (use) => use(this.alignment) === 'right' ? 'flex-end' : use(this.alignment)),
-        cssChoiceEditIcon('Dropdown'),
+        maybeDropDownCssChoiceEditIcon,
         dom.domComputed((use) => {
           if (this.isDisposed() || use(row._isAddRow)) { return null; }
 
@@ -156,9 +159,6 @@ const cssChoiceText = styled('div', `
 
 const cssChoiceEditIcon = styled(icon, `
   background-color: ${colors.slate};
-  display: none;
-  .g_record_detail_value & {
-    display: block;
-    height: inherit;
-  }
+  display: block;
+  height: inherit;
 `);

--- a/app/client/widgets/ChoiceTextBox.ts
+++ b/app/client/widgets/ChoiceTextBox.ts
@@ -49,7 +49,6 @@ export class ChoiceTextBox extends NTextBox {
     return cssChoiceField(
       cssChoiceTextWrapper(
         dom.style('justify-content', (use) => use(this.alignment) === 'right' ? 'flex-end' : use(this.alignment)),
-        // FIXME ensure right access
         cssChoiceEditIcon('Dropdown'),
         dom.domComputed((use) => {
           if (this.isDisposed() || use(row._isAddRow)) { return null; }
@@ -64,7 +63,7 @@ export class ChoiceTextBox extends NTextBox {
               invalid: !use(this._choiceValuesSet).has(formattedValue),
             },
             dom.cls(cssChoiceText.className),
-            testId('choice-token'),
+            testId('choice-token')
           );
         }),
       ),

--- a/app/client/widgets/ChoiceTextBox.ts
+++ b/app/client/widgets/ChoiceTextBox.ts
@@ -90,7 +90,6 @@ export class ChoiceTextBox extends NTextBox {
       cssRow(
         dom.autoDispose(disabled),
         dom.autoDispose(mixed),
-        cssChoiceEditIcon('Dropdown'),
         dom.create(
           ChoiceListEntry,
           this._choiceValues,

--- a/app/client/widgets/TextEditor.js
+++ b/app/client/widgets/TextEditor.js
@@ -39,7 +39,7 @@ function TextEditor(options) {
 
   this.dom = dom('div.default_editor',
     kd.toggleClass("readonly_editor", options.readonly),
-    dom('div.celleditor_cursor_editor', dom.testId('TextEditor_editor'),
+    this.cellEditorDiv = dom('div.celleditor_cursor_editor', dom.testId('TextEditor_editor'),
       testId('widget-text-editor'),   // new-style testId matches NTextEditor, for more uniform tests.
       this.contentSizer = dom('div.celleditor_content_measure'),
       this.textInput = dom('textarea.celleditor_text_editor',


### PR DESCRIPTION
Fix #491, for single choice lists only.

## Remaining TODO:
 - [x] Ensure it works well when the user only has read-only rights (seems to work just like the reference field);
 - [x] Deduplicate code when relevant (lots of copy-paste from ReferenceEditor ⇒ is this relevant to deduplicate?);
 - [x] Remove the chevron icon when editing from the table view (it should only appear in the detail view);

## Help welcome for these questions :pray::
 - Does this enhancement deserve to write unit tests? I would say no, as it does not introduce new feature per se.
 - Is it relevant to deduplicate the code from the Reference? It is mostly copy/paste of styles
 - Currently the chevron icon is even shown in the Grid when triggering the editor. How would you do that? I am not sure how to manage to remove it:
   - That seems not being doable through CSS, as the editor does not descent from the GridView's HTML element;
   - That seems not being doable through JS, the editor instance is not aware of the view (DetailView, GridView, ...) from which the user has triggered it (and I would not think relevant storing the view in the editor);


Here is how it is rendered as of the current state of the PR:

https://github.com/gristlabs/grist-core/assets/371705/85e20bd5-e42b-4ef3-b1d9-f94dfcb08748.mov