### PR TITLE
Remove unused GRIST_EXT env variable #531

### DIFF
--- a/buildtools/build.sh
+++ b/buildtools/build.sh
@@ -3,7 +3,6 @@
 set -e
 
 PROJECT=""
-export GRIST_EXT=stubs
 if [[ -e ext/app ]]; then
   PROJECT="tsconfig-ext.json"
 fi

--- a/sandbox/watch.sh
+++ b/sandbox/watch.sh
@@ -3,7 +3,6 @@
 set -x
 
 PROJECT=""
-export GRIST_EXT=stubs
 if [[ -e ext/app ]]; then
   PROJECT="tsconfig-ext.json"
 fi


### PR DESCRIPTION
As per remark from @paulfitz in #531, I propose to remove the use of `GRIST_EXT` env variable.