### PR TITLE
Add command to debug the server (with Chrome devtools)

### DIFF
--- a/documentation/develop.md
+++ b/documentation/develop.md
@@ -101,6 +101,16 @@ Lost on what you can do to help? If you are new to Grist, you may just pick one 
 
 https://github.com/gristlabs/grist-core/labels/good%20first%20issue
 
+## Debug the server
+
+You can debug the NodeJS application using this command:
+
+```bash
+$ yarn start:debug
+```
+
+And start using your nodejs debugger client (like the Chrome Devtools). See https://nodejs.org/en/docs/guides/debugging-getting-started#inspector-clients
+
 ## Run tests
 
 You may run the tests using one of these commands:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": "git://github.com/gristlabs/grist-core.git",
   "scripts": {
     "start": "sandbox/watch.sh",
+    "start:debug": "NODE_INSPECT=1 sandbox/watch.sh",
     "install:python": "buildtools/prepare_python.sh",
     "install:python2": "buildtools/prepare_python2.sh",
     "install:python3": "buildtools/prepare_python3.sh",

--- a/sandbox/watch.sh
+++ b/sandbox/watch.sh
@@ -17,6 +17,6 @@ fi
 
 tsc --build -w --preserveWatchOutput $PROJECT &
 catw app/client/*.css app/client/*/*.css -o static/bundle.css -v & webpack --config $WEBPACK_CONFIG --mode development --watch &
-NODE_PATH=_build:_build/stubs:_build/ext nodemon --delay 1 -w _build/app/server -w _build/app/common _build/stubs/app/server/server.js &
+NODE_PATH=_build:_build/stubs:_build/ext nodemon ${NODE_INSPECT:+--inspect} --delay 1 -w _build/app/server -w _build/app/common _build/stubs/app/server/server.js &
 
 wait


### PR DESCRIPTION
I propose to introduce the `yarn debug` command in order to allow debugging the server using the Chrome Devtools.

To run the debugger, run `yarn debug` and then open a Chrome-based browser. Then in the URL bar, enter `chrome://inspect` and then in the `Remote Target` inspect the corresponding server.

TODO: 
 - [x] Run locally and trigger a breakpoint;
 - [x] Document it in the CONTRIBUTE guide (if merged);