### PR TITLE
adapt tests after switch to parallel runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,13 +106,16 @@ jobs:
           MOCHA_WEBDRIVER_LOGDIR: ${{ runner.temp }}/mocha-webdriver-logs
 
       - name: Prepare a safe artifact name
-        run:
-          ARTIFACT_NAME="logs-${{ matrix.tests }}"
-          ARTIFACT_NAME=$(echo $ARTIFACT_NAME | sed 's/[^-a-zA-Z0-9]/_/g')
+        if: failure()
+        run: |
+          ARTIFACT_NAME=logs-$(echo $TESTS | sed 's/[^-a-zA-Z0-9]/_/g')
+          echo "Artifact name is '$ARTIFACT_NAME'"
           echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+        env:
+          TESTS: ${{ matrix.tests }}
 
       - name: Save artifacts on failure
-        if: ${{ failure() }}
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT_NAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,10 +98,19 @@ jobs:
       - name: Run main tests without minio and redis
         if: contains(matrix.tests, ':nbrowser-')
         run: |
+          mkdir -p $MOCHA_WEBDRIVER_LOGDIR
           export GREP_TESTS=$(echo $TESTS | sed "s/.*:nbrowser-\([^:]*\).*/\1/")
           MOCHA_WEBDRIVER_SKIP_CLEANUP=1 MOCHA_WEBDRIVER_HEADLESS=1 yarn run test:nbrowser --parallel --jobs 3
         env:
           TESTS: ${{ matrix.tests }}
+          MOCHA_WEBDRIVER_LOGDIR: ${{ runner.temp }}/mocha-webdriver-logs
+
+      - name: Save artifacts on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: mocha-webdriver-logs ${{ matrix.tests }}
+          path: ${{ runner.temp }}/mocha-webdriver-logs  # only exists for webdriver tests
 
     services:
       # https://github.com/bitnami/bitnami-docker-minio/issues/16

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,11 +105,17 @@ jobs:
           TESTS: ${{ matrix.tests }}
           MOCHA_WEBDRIVER_LOGDIR: ${{ runner.temp }}/mocha-webdriver-logs
 
+      - name: Prepare a safe artifact name
+        run:
+          ARTIFACT_NAME="logs-${{ matrix.tests }}"
+          ARTIFACT_NAME=$(echo $ARTIFACT_NAME | sed 's/[^-a-zA-Z0-9]/_/g')
+          echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+
       - name: Save artifacts on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
-          name: mocha-webdriver-logs ${{ matrix.tests }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: ${{ runner.temp }}/mocha-webdriver-logs  # only exists for webdriver tests
 
     services:

--- a/test/nbrowser/ColumnOps.ntest.js
+++ b/test/nbrowser/ColumnOps.ntest.js
@@ -7,7 +7,6 @@ describe('ColumnOps.ntest', function() {
   const cleanup = test.setupTestSuite(this);
 
   before(async function() {
-    this.timeout(Math.max(this.timeout(), 30000)); // Long-running test, unfortunately
     await gu.supportOldTimeyTestCode();
     await gu.useFixtureDoc(cleanup, "World.grist", true);
     await gu.toggleSidePanel('left', 'close');

--- a/test/nbrowser/CustomWidgetsConfig.ts
+++ b/test/nbrowser/CustomWidgetsConfig.ts
@@ -223,10 +223,10 @@ describe('CustomWidgetsConfig', function () {
     constructor(public frameSelector = 'iframe') {}
     // Wait for a frame.
     public async waitForFrame() {
-      await driver.wait(() => driver.find(this.frameSelector).isPresent(), 1000);
+      await driver.wait(() => driver.find(this.frameSelector).isPresent(), 3000);
       const iframe = driver.find(this.frameSelector);
       await driver.switchTo().frame(iframe);
-      await driver.wait(async () => (await driver.find('#ready').getText()) === 'ready', 1000);
+      await driver.wait(async () => (await driver.find('#ready').getText()) === 'ready', 3000);
       await driver.switchTo().defaultContent();
     }
     public async content() {
@@ -254,7 +254,7 @@ describe('CustomWidgetsConfig', function () {
     }
     // Wait for frame to close.
     public async waitForClose() {
-      await driver.wait(async () => !(await driver.find(this.frameSelector).isPresent()), 1000);
+      await driver.wait(async () => !(await driver.find(this.frameSelector).isPresent()), 3000);
     }
     // Wait for the onOptions event, and return its value.
     public async onOptions() {
@@ -262,7 +262,7 @@ describe('CustomWidgetsConfig', function () {
       await driver.switchTo().frame(iframe);
       // Wait for options to get filled, initially this div is empty,
       // as first message it should get at least null as an options.
-      await driver.wait(async () => await driver.find('#onOptions').getText(), 1000);
+      await driver.wait(async () => await driver.find('#onOptions').getText(), 3000);
       const text = await driver.find('#onOptions').getText();
       await driver.switchTo().defaultContent();
       return JSON.parse(text);

--- a/test/nbrowser/gristUtil-nbrowser.js
+++ b/test/nbrowser/gristUtil-nbrowser.js
@@ -53,7 +53,7 @@ async function applyPatchesToJquerylikeObject($) {
 // Adapt common old setup.
 const test = {
   setupTestSuite(self, ...args) {
-    self.timeout(20000);
+    self.timeout(40000);
     return setupTestSuite(...args);
   },
 };


### PR DESCRIPTION
Some browser tests are now run in parallel, and a new collection of tests have been ported to grist-core. Some tests are unreliable, and need some tweaks.