### PR TITLE
Fix GREP_TESTS unbound error in test_under_docker.sh

### DIFF
--- a/test/test_under_docker.sh
+++ b/test/test_under_docker.sh
@@ -64,4 +64,4 @@ TEST_ADD_SAMPLES=1 TEST_ACCOUNT_PASSWORD=not-needed \
   GRIST_SESSION_COOKIE=grist_test_cookie \
   GRIST_TEST_LOGIN=1 \
   NODE_PATH=_build:_build/stubs \
-  $MOCHA _build/test/deployment/*.js --slow 6000 -g "${GREP_TESTS}" "$@"
+  $MOCHA _build/test/deployment/*.js --slow 6000 -g "${GREP_TESTS:-}" "$@"


### PR DESCRIPTION
To fix what's reported here: https://github.com/gristlabs/grist-core/pull/535#issuecomment-1608908111