### PR TITLE
avoid test files importing other test files

### DIFF
--- a/test/nbrowser/RightPanelSelectBy.ts
+++ b/test/nbrowser/RightPanelSelectBy.ts
@@ -12,9 +12,6 @@ describe('RightPanelSelectBy', function() {
     const doc = await gu.importFixturesDoc('chimpy', 'nasa', 'Horizon', 'Favorite_Films_With_Linked_Ref.grist', false);
     await driver.get(`${server.getHost()}/o/nasa/doc/${doc.id}`);
     await gu.waitForDocToLoad();
-
-    await gu.toggleSidePanel('right', 'open');
-    await driver.find('.test-config-data').click();
   }
 
   it('should allow linking section with same table', async function() {
@@ -24,7 +21,7 @@ describe('RightPanelSelectBy', function() {
     await driver.findContentWait('.test-treeview-itemHeader', /All/, 2000).click();
     await gu.waitForDocToLoad();
 
-    await openSelectByForSection('PERFORMANCES DETAIL');
+    await gu.openSelectByForSection('PERFORMANCES DETAIL');
 
     // the dollar in /...record$/ makes sure we match against the table main node and not a ref
     // columns such as '...record.Film'
@@ -52,7 +49,7 @@ describe('RightPanelSelectBy', function() {
   });
 
   it('should allow to remove link', async function() {
-    await openSelectByForSection('PERFORMANCES DETAIL');
+    await gu.openSelectByForSection('PERFORMANCES DETAIL');
     await driver.findContent('.test-select-row', /Select Widget/).click();
     await gu.waitForServer();
 
@@ -67,7 +64,7 @@ describe('RightPanelSelectBy', function() {
 
 
   it('should disallow creating cycles', async function() {
-    await openSelectByForSection('PERFORMANCES RECORD');
+    await gu.openSelectByForSection('PERFORMANCES RECORD');
     assert.equal(await driver.findContent('.test-select-row', /Performances detail/).isPresent(), false);
   });
 
@@ -81,7 +78,7 @@ describe('RightPanelSelectBy', function() {
     await gu.addNewSection(/Chart/, /Films/);
 
     // open `SELECT BY`
-    await openSelectByForSection('FILMS');
+    await gu.openSelectByForSection('FILMS');
 
     // check that there is a chart and we cannot link from it
     assert.equal(await gu.getSection('FILMS CHART').isPresent(), true);
@@ -96,7 +93,7 @@ describe('RightPanelSelectBy', function() {
     await gu.getPageItem('Friends').click();
     await gu.waitForServer();
     await gu.addNewSection(/Table/, /Performances/);
-    await openSelectByForSection('Performances');
+    await gu.openSelectByForSection('Performances');
     assert.equal(await driver.findContent('.test-select-row', /FRIENDS.*Favorite Film/).isPresent(), true);
     await driver.findContent('.test-select-row', /FRIENDS.*Favorite Film/).click();
     await gu.waitForServer();
@@ -135,7 +132,7 @@ describe('RightPanelSelectBy', function() {
     await gu.getPageItem('Friends').click();
     await gu.waitForServer();
     await gu.addNewSection(/Card/, /Films/);
-    await openSelectByForSection('Films Card');
+    await gu.openSelectByForSection('Films Card');
     assert.equal(await driver.findContent('.test-select-row', /FRIENDS.*Favorite Film/).isPresent(), true);
     await driver.findContent('.test-select-row', /FRIENDS.*Favorite Film/).click();
     await gu.waitForServer();
@@ -194,8 +191,3 @@ describe('RightPanelSelectBy', function() {
   });
 
 });
-
-export async function openSelectByForSection(section: string) {
-  await gu.getSection(section).click();
-  await driver.find('.test-right-select-by').click();
-}

--- a/test/nbrowser/SelectByRefList.ts
+++ b/test/nbrowser/SelectByRefList.ts
@@ -2,7 +2,6 @@ import * as _ from 'lodash';
 import {addToRepl, assert, driver} from 'mocha-webdriver';
 import * as gu from 'test/nbrowser/gristUtils';
 import {server, setupTestSuite} from 'test/nbrowser/testUtils';
-import {openSelectByForSection} from "./RightPanelSelectBy";
 
 describe('SelectByRefList', function() {
   this.timeout(60000);
@@ -16,9 +15,6 @@ describe('SelectByRefList', function() {
       'SelectByRefList.grist', false);
     await driver.get(`${server.getHost()}/o/nasa/doc/${doc.id}`);
     await gu.waitForDocToLoad();
-
-    await gu.toggleSidePanel('right');
-    await driver.find('.test-config-data').click();
   }
 
   it('should filter a table selected by ref and reflist columns', async function() {
@@ -182,7 +178,7 @@ describe('SelectByRefList', function() {
  * The values will depend on the link and the last row selected in the driving table.
  */
 async function checkSelectingRecords(selectBy: string, sourceData: string[][], newRow: string[]) {
-  await openSelectByForSection('LINKTARGET');
+  await gu.openSelectByForSection('LINKTARGET');
   await driver.findContent('.test-select-row', new RegExp(selectBy + '$')).click();
   await gu.waitForServer();
 

--- a/test/nbrowser/SelectBySummary.ts
+++ b/test/nbrowser/SelectBySummary.ts
@@ -3,7 +3,6 @@ import {addToRepl, assert, driver} from 'mocha-webdriver';
 import {enterRulePart, findDefaultRuleSet} from 'test/nbrowser/aclTestUtils';
 import * as gu from 'test/nbrowser/gristUtils';
 import {server, setupTestSuite} from 'test/nbrowser/testUtils';
-import {openSelectByForSection} from "./RightPanelSelectBy";
 
 describe('SelectBySummary', function() {
   this.timeout(50000);
@@ -17,9 +16,6 @@ describe('SelectBySummary', function() {
       'SelectBySummary.grist', false);
     await driver.get(`${server.getHost()}/o/nasa/doc/${doc.id}`);
     await gu.waitForDocToLoad();
-
-    await gu.toggleSidePanel('right', 'open');
-    await driver.find('.test-config-data').click();
   });
 
   it('should filter a source table selected by a summary table', async function() {
@@ -219,7 +215,7 @@ async function checkSelectingRecords(
 ) {
   const summarySection = `TABLE1 [by ${groubyColumns.join(', ')}]`;
 
-  await openSelectByForSection(targetSection);
+  await gu.openSelectByForSection(targetSection);
   await driver.findContent('.test-select-row', summarySection).click();
   await gu.waitForServer();
 

--- a/test/nbrowser/SelectBySummaryRef.ts
+++ b/test/nbrowser/SelectBySummaryRef.ts
@@ -1,7 +1,6 @@
 import {addToRepl, assert, driver, Key} from 'mocha-webdriver';
 import * as gu from 'test/nbrowser/gristUtils';
 import {server, setupTestSuite} from 'test/nbrowser/testUtils';
-import {openSelectByForSection} from "./RightPanelSelectBy";
 
 describe('SelectBySummaryRef', function() {
   this.timeout(20000);
@@ -14,9 +13,6 @@ describe('SelectBySummaryRef', function() {
       'SelectBySummaryRef.grist', false);
     await driver.get(`${server.getHost()}/o/nasa/doc/${doc.id}`);
     await gu.waitForDocToLoad();
-
-    await gu.toggleSidePanel('right', 'open');
-    await driver.find('.test-config-data').click();
   });
 
   it('should give correct options when linking with a summary table with ref/reflist columns', async () => {
@@ -174,7 +170,7 @@ describe('SelectBySummaryRef', function() {
 
 // Check that the 'Select by' menu in the right panel for the section has the expected options
 async function checkRightPanelSelectByOptions(section: string, expected: string[]) {
-  await openSelectByForSection(section);
+  await gu.openSelectByForSection(section);
 
   const actual = await driver.findAll('.test-select-menu .test-select-row', (e) => e.getText());
   assert.deepEqual(actual, ['Select Widget', ...expected]);

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -1759,6 +1759,16 @@ export async function openAccessRulesDropdown(): Promise<void> {
   await driver.findWait('.grist-floating-menu', 1000);
 }
 
+/**
+ * Open "Select By" area in creator panel.
+ */
+export async function openSelectByForSection(section: string) {
+  await toggleSidePanel('right', 'open');
+  await driver.find('.test-config-data').click();
+  await getSection(section).click();
+  await driver.find('.test-right-select-by').click();
+}
+
 export async function editOrgAcls(): Promise<void> {
   // To prevent a common flakiness problem, wait for a potentially open modal dialog
   // to close before attempting to open the account menu.


### PR DESCRIPTION
There's a little nest of SelectBy tests that sometimes fail. They are also the only browser tests with an import of a helper function from another file that contains tests. Such imports have caused trouble with mocha in the past. I'm not sure if that is the case now, but I'd like to eliminate it as a possibility.