### PR TITLE
skip building test harness in docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,8 @@ jobs:
           MOCHA_WEBDRIVER_SKIP_CLEANUP=1 MOCHA_WEBDRIVER_HEADLESS=1 yarn run test:nbrowser --parallel --jobs 3
         env:
           TESTS: ${{ matrix.tests }}
-          MOCHA_WEBDRIVER_LOGDIR: ${{ runner.temp }}/mocha-webdriver-logs
+          MOCHA_WEBDRIVER_LOGDIR: ${{ runner.temp }}/test-logs/webdriver
+          TESTDIR: ${{ runner.temp }}/test-logs
 
       - name: Prepare a safe artifact name
         if: failure()
@@ -119,7 +120,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          path: ${{ runner.temp }}/mocha-webdriver-logs  # only exists for webdriver tests
+          path: ${{ runner.temp }}/test-logs  # only exists for webdriver tests
 
     services:
       # https://github.com/bitnami/bitnami-docker-minio/issues/16

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,14 +106,16 @@ jobs:
           MOCHA_WEBDRIVER_LOGDIR: ${{ runner.temp }}/test-logs/webdriver
           TESTDIR: ${{ runner.temp }}/test-logs
 
-      - name: Prepare a safe artifact name
+      - name: Prepare for saving artifact
         if: failure()
         run: |
           ARTIFACT_NAME=logs-$(echo $TESTS | sed 's/[^-a-zA-Z0-9]/_/g')
           echo "Artifact name is '$ARTIFACT_NAME'"
           echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+          find $TESTDIR -iname "*.socket" -exec rm {} \;
         env:
           TESTS: ${{ matrix.tests }}
+          TESTDIR: ${{ runner.temp }}/test-logs
 
       - name: Save artifacts on failure
         if: failure()

--- a/buildtools/webpack.config.js
+++ b/buildtools/webpack.config.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 const { ProvidePlugin } = require('webpack');
 const path = require('path');
@@ -15,7 +16,11 @@ module.exports = {
     account: "app/client/accountMain",
     billing: "app/client/billingMain",
     activation: "app/client/activationMain",
-    test: "test/client-harness/client",
+    // Include client test harness if it is present (it won't be in
+    // docker image).
+    ...(fs.existsSync("test/client-harness/client.js") ? {
+      test: "test/client-harness/client",
+    } : {}),
   },
   output: {
     filename: "[name].bundle.js",

--- a/test/fixtures/sites/config/page.js
+++ b/test/fixtures/sites/config/page.js
@@ -4,27 +4,29 @@
 const urlParams = new URLSearchParams(window.location.search);
 const ready = urlParams.get('ready') ? JSON.parse(urlParams.get('ready')) : undefined;
 
-if (ready && ready.onEditOptions) {
-  ready.onEditOptions = () => {
-    document.getElementById('configure').innerHTML = 'called';
-  };
+function setup() {
+  if (ready && ready.onEditOptions) {
+    ready.onEditOptions = () => {
+      document.getElementById('configure').innerHTML = 'called';
+    };
+  }
+
+  grist.ready(ready);
+
+  grist.onOptions(data => {
+    document.getElementById('onOptions').innerHTML = JSON.stringify(data);
+  });
+
+  grist.onRecord((data, mappings) => {
+    document.getElementById('onRecord').innerHTML = JSON.stringify(data);
+    document.getElementById('onRecordMappings').innerHTML = JSON.stringify(mappings);
+  });
+
+  grist.onRecords((data, mappings) => {
+    document.getElementById('onRecords').innerHTML = JSON.stringify(data);
+    document.getElementById('onRecordsMappings').innerHTML = JSON.stringify(mappings);
+  });
 }
-
-grist.ready(ready);
-
-grist.onOptions(data => {
-  document.getElementById('onOptions').innerHTML = JSON.stringify(data);
-});
-
-grist.onRecord((data, mappings) => {
-  document.getElementById('onRecord').innerHTML = JSON.stringify(data);
-  document.getElementById('onRecordMappings').innerHTML = JSON.stringify(mappings);
-});
-
-grist.onRecords((data, mappings) => {
-  document.getElementById('onRecords').innerHTML = JSON.stringify(data);
-  document.getElementById('onRecordsMappings').innerHTML = JSON.stringify(mappings);
-});
 
 async function run(handler) {
   try {
@@ -66,6 +68,7 @@ async function configure() {
 }
 
 window.onload = () => {
+  setup();
   document.getElementById('ready').innerText = 'ready';
   document.getElementById('access').innerHTML = urlParams.get('access');
   document.getElementById('readonly').innerHTML = urlParams.get('readonly');

--- a/test/nbrowser/Localization.ts
+++ b/test/nbrowser/Localization.ts
@@ -116,8 +116,7 @@ describe("Localization", function() {
       // But only uz code is preloaded.
       notPresent(uzResponse, "uz-UZ");
 
-      // For Portuguese we have only en.
-      notPresent(ptResponse, "pt", "pt-PR", "uz", "en-US");
+      notPresent(ptResponse, "pt-PR", "uz", "en-US");
     });
 
     it("loads correct languages from file system", async function() {

--- a/test/nbrowser/testServer.ts
+++ b/test/nbrowser/testServer.ts
@@ -65,14 +65,14 @@ export class TestServerMerged extends EventEmitter implements IMochaServer {
       await this.stop();
     }
     this._starts++;
+    const workerIdText = process.env.MOCHA_WORKER_ID || '0';
     if (reset) {
       if (process.env.TESTDIR) {
-        this.testDir = process.env.TESTDIR;
+        this.testDir = path.join(process.env.TESTDIR, workerIdText);
       } else {
-        const workerId = process.env.MOCHA_WORKER_ID || '0';
         // Create a testDir of the form grist_test_{USER}_{SERVER_NAME}_{WORKER_ID}, removing any previous one.
         const username = process.env.USER || "nobody";
-        this.testDir = path.join(tmpdir(), `grist_test_${username}_${this._name}_${workerId}`);
+        this.testDir = path.join(tmpdir(), `grist_test_${username}_${this._name}_${workerIdText}`);
         await fse.remove(this.testDir);
       }
     }
@@ -99,7 +99,7 @@ export class TestServerMerged extends EventEmitter implements IMochaServer {
     // logging. Server code uses a global logger, so it's hard to separate out (especially so if
     // we ever run different servers for different tests).
     const serverLog = process.env.VERBOSE ? 'inherit' : nodeLogFd;
-    const workerId = parseInt(process.env.MOCHA_WORKER_ID || '0', 10);
+    const workerId = parseInt(workerIdText, 10);
     const corePort = String(8295 + workerId * 2);
     const untrustedPort = String(8295 + workerId * 2 + 1);
     const env: Record<string, string> = {


### PR DESCRIPTION
A small test harness bundle was recently added that is breaking the docker image build. It could be added to the docker image, but that would introduce a bunch of extraneous test file dependencies. So this tweaks the build to simply skip the test bundle if its primary source file is not found.

Also added some other test fixes along the way:
  * make a custom widget test more reliable
  * update a localization test now that `pt` exists
  * store more log info in artifact on error
