### PR TITLE
fix a node-sqlite3-ism that breaks record removal in grist-static

### DIFF
--- a/app/server/lib/DocStorage.ts
+++ b/app/server/lib/DocStorage.ts
@@ -1093,7 +1093,7 @@ export class DocStorage implements ISQLiteDB, OnDemandStorage {
   public _process_RemoveRecord(tableId: string, rowId: string): Promise<RunResult> {
     const sql = "DELETE FROM " + quoteIdent(tableId) + " WHERE id=?";
     debuglog("RemoveRecord SQL: " + sql, [rowId]);
-    return this.run(sql, [rowId]);
+    return this.run(sql, rowId);
   }
 
 

--- a/app/server/lib/DocStorage.ts
+++ b/app/server/lib/DocStorage.ts
@@ -378,7 +378,7 @@ export class DocStorage implements ISQLiteDB, OnDemandStorage {
           const colListSql = newCols.map(c => `${quoteIdent(c.colId)}=?`).join(', ');
           const types = newCols.map(c => c.type);
           const sqlParams = DocStorage._encodeColumnsToRows(types, newCols.map(c => [PENDING_VALUE]));
-          await db.run(`UPDATE ${quoteIdent(tableId)} SET ${colListSql}`, sqlParams[0]);
+          await db.run(`UPDATE ${quoteIdent(tableId)} SET ${colListSql}`, ...sqlParams[0]);
         }
       },
 
@@ -1130,7 +1130,7 @@ export class DocStorage implements ISQLiteDB, OnDemandStorage {
       const stmt = await this.prepare(preSql + chunkParams + postSql);
       for (const index of _.range(0, numChunks * chunkSize, chunkSize)) {
         debuglog("DocStorage.BulkRemoveRecord: chunk delete " + index + "-" + (index + chunkSize - 1));
-        await stmt.run(rowIds.slice(index, index + chunkSize));
+        await stmt.run(...rowIds.slice(index, index + chunkSize));
       }
       await stmt.finalize();
     }
@@ -1139,7 +1139,7 @@ export class DocStorage implements ISQLiteDB, OnDemandStorage {
       debuglog("DocStorage.BulkRemoveRecord: leftover delete " + (numChunks * chunkSize) + "-" + (rowIds.length - 1));
       const leftoverParams = _.range(numLeftovers).map(q).join(',');
       await this.run(preSql + leftoverParams + postSql,
-                     rowIds.slice(numChunks * chunkSize, rowIds.length));
+                     ...rowIds.slice(numChunks * chunkSize, rowIds.length));
     }
   }
 


### PR DESCRIPTION
Grist by default uses node-sqlite3 to manipulate data in an SQLite database. If a single parameter is passed to `run` and it is a list, the list is unpacked and its contents treated as the actual parameters. In grist-static, we use other SQLite interfaces that don't have that automatic unpacking. Most calls like this have been reworked during the creation of grist-static, but at least one was missed, and was causing symptoms such as https://github.com/gristlabs/grist-static/issues/5

This change should make no difference to regular Grist, but resolves the grist-static problems.