### PR TITLE
Added linux-specific fonts

### DIFF
--- a/app/client/ui2018/cssVars.ts
+++ b/app/client/ui2018/cssVars.ts
@@ -82,13 +82,13 @@ export const colors = {
 
 export const vars = {
   /* Fonts */
-  fontFamily: new CustomProp('font-family', `-apple-system,BlinkMacSystemFont,Segoe UI,
+  fontFamily: new CustomProp('font-family', `-apple-system,BlinkMacSystemFont,Segoe UI,DejaVu Sans,
     Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol`),
 
   // This is more monospace and looks better for data that should often align (e.g. to have 00000
   // take similar space to 11111). This is the main font for user data.
   fontFamilyData: new CustomProp('font-family-data',
-    `Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol`),
+    `Liberation Sans,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol`),
 
   /* Font sizes */
   xxsmallFontSize:  new CustomProp('xx-font-size',        '8px'),


### PR DESCRIPTION
Currently, ubuntu has a lot of issues with fonts.
Both the regular font-family and the data-font-family end up evaluating to NimbusSans on my system
  (ubuntu's fallback font from helvetica)

NimbusSans unfortunately is noticably too high, causes text in buttons, emoji on the left pane, and other vertical text alignment to be too high

This diff explicitly says to use DejaVu and Liberation Sans which should have no effect on windows/mac systems, but should significantly improve appearance on ubuntu (and hopefully other linuxes)

Both of these fonts are some of the more widely supported linux fonts, see:
https://www.webfx.com/blog/web-design/a-web-designers-guide-to-linux-fonts/

Here's some pictures:
- **Look At:** the "Add New" button, the whitespace around the compass emoji near "Venue Map", the filter bubbles for "RSVP" and "invitation", and the choicelist options "Bride", "Groom", "Invited"

Before (BAD)
![image](https://github.com/gristlabs/grist-core/assets/1192632/c5866814-e54b-41e3-bffb-9bc019d3f2e4)

After (BETTER)
![image](https://github.com/gristlabs/grist-core/assets/1192632/007a033c-c6d2-4c79-a6fe-256bc69d72da)
