### PR TITLE
add more docker label choices

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: |
             ${{ github.repository_owner }}/grist
@@ -23,6 +23,9 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            stable
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx


### PR DESCRIPTION
Make it easier for users to subscribe to monthly Grist releases using a `stable` docker tag, rather than the daily `latest`. Fixes https://github.com/gristlabs/grist-core/issues/569