### PR TITLE
Linux-specific fonts: Liberation Sans

### DIFF
--- a/app/client/ui2018/cssVars.ts
+++ b/app/client/ui2018/cssVars.ts
@@ -82,7 +82,7 @@ export const colors = {
 
 export const vars = {
   /* Fonts */
-  fontFamily: new CustomProp('font-family', `-apple-system,BlinkMacSystemFont,Segoe UI,DejaVu Sans,
+  fontFamily: new CustomProp('font-family', `-apple-system,BlinkMacSystemFont,Segoe UI,Liberation Sans,
     Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol`),
 
   // This is more monospace and looks better for data that should often align (e.g. to have 00000

--- a/app/client/ui2018/cssVars.ts
+++ b/app/client/ui2018/cssVars.ts
@@ -82,13 +82,13 @@ export const colors = {
 
 export const vars = {
   /* Fonts */
-  fontFamily: new CustomProp('font-family', `-apple-system,BlinkMacSystemFont,Segoe UI,
+  fontFamily: new CustomProp('font-family', `-apple-system,BlinkMacSystemFont,Segoe UI,DejaVu Sans,
     Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol`),
 
   // This is more monospace and looks better for data that should often align (e.g. to have 00000
   // take similar space to 11111). This is the main font for user data.
   fontFamilyData: new CustomProp('font-family-data',
-    `Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol`),
+    `Liberation Sans,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol`),
 
   /* Font sizes */
   xxsmallFontSize:  new CustomProp('xx-font-size',        '8px'),


### PR DESCRIPTION
Specified linux-specific font "Liberation Sans", fixes vertical alignment in buttons/pills/column headers/emoji. 

Previously we had Mac- and Windows-specific fonts, but Linux systems didn't have anything explicitly selected until they fell through to Helvetica, which by default got rendered in "Nimbus Sans" (at least on my ubuntu system). Unfortunately, Nimbus Sans is horribly vertically misaligned. 

The [previous iteration of this patch](https://github.com/gristlabs/grist-core/pull/568) used DejaVu Sans for most text and Liberation Sans only for data in grids. This version uses liberation sans for all fonts, which fixes the too-wide issue that DejaVu had)

Screenshot with Liberation Sans
![image](https://github.com/gristlabs/grist-core/assets/1192632/cbc6c5bc-ed22-4950-8a98-1ad840a1789a)

For comparison, old grist which defaulted to Nimbus Sans (BAD)
![image](https://github.com/gristlabs/grist-core/assets/1192632/a6ec543d-4b92-4e82-843a-a146b2b3a330)
