### PR TITLE
Ubuntu fontfix liberation

### DIFF
--- a/app/client/ui2018/cssVars.ts
+++ b/app/client/ui2018/cssVars.ts
@@ -82,7 +82,7 @@ export const colors = {
 
 export const vars = {
   /* Fonts */
-  fontFamily: new CustomProp('font-family', `-apple-system,BlinkMacSystemFont,Segoe UI,DejaVu Sans,
+  fontFamily: new CustomProp('font-family', `-apple-system,BlinkMacSystemFont,Segoe UI,Liberation Sans,
     Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol`),
 
   // This is more monospace and looks better for data that should often align (e.g. to have 00000

--- a/app/client/ui2018/cssVars.ts
+++ b/app/client/ui2018/cssVars.ts
@@ -82,13 +82,13 @@ export const colors = {
 
 export const vars = {
   /* Fonts */
-  fontFamily: new CustomProp('font-family', `-apple-system,BlinkMacSystemFont,Segoe UI,
+  fontFamily: new CustomProp('font-family', `-apple-system,BlinkMacSystemFont,Segoe UI,DejaVu Sans,
     Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol`),
 
   // This is more monospace and looks better for data that should often align (e.g. to have 00000
   // take similar space to 11111). This is the main font for user data.
   fontFamilyData: new CustomProp('font-family-data',
-    `Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol`),
+    `Liberation Sans,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol`),
 
   /* Font sizes */
   xxsmallFontSize:  new CustomProp('xx-font-size',        '8px'),


### PR DESCRIPTION
See https://github.com/gristlabs/grist-core/pull/568

Switched font so that all things are in Liberation Sans, should look better and be less wide
(Previously was DejaVu Sans for most text and Liberation Sans only for data)

![image](https://github.com/gristlabs/grist-core/assets/1192632/cbc6c5bc-ed22-4950-8a98-1ad840a1789a)