### PR TITLE
REQUEST now supports POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ GRIST_DEFAULT_PRODUCT  | if set, this controls enabled features and limits of ne
 GRIST_DEFAULT_LOCALE  | Locale to use as fallback when Grist cannot honour the browser locale.
 GRIST_DOMAIN        | in hosted Grist, Grist is served from subdomains of this domain.  Defaults to "getgrist.com".
 GRIST_EXPERIMENTAL_PLUGINS | enables experimental plugins
+GRIST_ENABLE_REQUEST_FUNCTION | enables the REQUEST function. This function performs HTTP requests in a similar way to `requests.request`. This function presents a significant security risk, since it can let users call internal endpoints when Grist is available publicly. This function can also cause performance issues. Unset by default.
 GRIST_HIDE_UI_ELEMENTS | comma-separated list of UI features to disable. Allowed names of parts: `helpCenter,billing,templates,multiSite,multiAccounts,sendToDrive,tutorials`. If a part also exists in GRIST_UI_FEATURES, it will still be disabled.
 GRIST_HOME_INCLUDE_STATIC | if set, home server also serves static resources
 GRIST_HOST          | hostname to use when listening on a port.

--- a/app/common/ActionBundle.ts
+++ b/app/common/ActionBundle.ts
@@ -72,8 +72,8 @@ export interface SandboxActionBundle {
 // Represents a unique call to the Python REQUEST function
 export interface SandboxRequest {
   url: string;
-  method: string;
-  body: string;
+  method?: string;
+  body?: string;
   params: Record<string, string> | null;
   headers: Record<string, string> | null;
   deps: unknown;  // pass back to the sandbox unchanged in the response

--- a/app/common/ActionBundle.ts
+++ b/app/common/ActionBundle.ts
@@ -72,6 +72,8 @@ export interface SandboxActionBundle {
 // Represents a unique call to the Python REQUEST function
 export interface SandboxRequest {
   url: string;
+  method: string;
+  body: string;
   params: Record<string, string> | null;
   headers: Record<string, string> | null;
   deps: unknown;  // pass back to the sandbox unchanged in the response

--- a/app/common/ActionBundle.ts
+++ b/app/common/ActionBundle.ts
@@ -72,7 +72,7 @@ export interface SandboxActionBundle {
 // Represents a unique call to the Python REQUEST function
 export interface SandboxRequest {
   url: string;
-  method?: string;
+  method: string;
   body?: string;
   params: Record<string, string> | null;
   headers: Record<string, string> | null;

--- a/app/server/devServerMain.ts
+++ b/app/server/devServerMain.ts
@@ -66,6 +66,11 @@ export async function main() {
     process.env.GRIST_EXPERIMENTAL_PLUGINS = "1";
   }
 
+  // Experimental plugins are enabled by default for devs
+  if (!process.env.GRIST_ENABLE_REQUEST_FUNCTION) {
+    process.env.GRIST_ENABLE_REQUEST_FUNCTION = "1";
+  }
+
   // For tests, it is useful to start with the database in a known state.
   // If TEST_CLEAN_DATABASE is set, we reset the database before starting.
   if (process.env.TEST_CLEAN_DATABASE) {

--- a/app/server/lib/Requests.ts
+++ b/app/server/lib/Requests.ts
@@ -93,7 +93,7 @@ export class DocRequests {
         headers: headers || {},
         agent: proxyAgent(urlObj),
         method: method || "GET",
-        body: body
+        body
       });
       const content = await response.buffer();
       const {status, statusText} = response;

--- a/app/server/lib/Requests.ts
+++ b/app/server/lib/Requests.ts
@@ -83,13 +83,18 @@ export class DocRequests {
       if (process.env.GRIST_EXPERIMENTAL_PLUGINS != '1') {
         throw new Error("REQUEST is not enabled");
       }
-      const {url, params, headers} = request;
+      const {url, method, body, params, headers} = request;
       const urlObj = new URL(url);
       log.rawInfo("Handling sandbox request", {host: urlObj.host, docId: this._activeDoc.docName});
       for (const [param, value] of Object.entries(params || {})) {
         urlObj.searchParams.append(param, value);
       }
-      const response = await fetch(urlObj.toString(), {headers: headers || {}, agent: proxyAgent(urlObj)});
+      const response = await fetch(urlObj.toString(), {
+        headers: headers || {},
+        agent: proxyAgent(urlObj),
+        method: method || "GET",
+        body: body
+      });
       const content = await response.buffer();
       const {status, statusText} = response;
       const encoding = httpEncoding(response.headers.get('content-type'), content);

--- a/app/server/lib/Requests.ts
+++ b/app/server/lib/Requests.ts
@@ -80,7 +80,7 @@ export class DocRequests {
 
   private async _handleSingleRequestRaw(request: SandboxRequest): Promise<Response> {
     try {
-      if (process.env.GRIST_EXPERIMENTAL_PLUGINS != '1' || process.env.GRIST_ENABLE_REQUEST_FUNCTION != '1') {
+      if (process.env.GRIST_ENABLE_REQUEST_FUNCTION != '1') {
         throw new Error("REQUEST is not enabled");
       }
       const {url, method, body, params, headers} = request;
@@ -92,7 +92,7 @@ export class DocRequests {
       const response = await fetch(urlObj.toString(), {
         headers: headers || {},
         agent: proxyAgent(urlObj),
-        method: method || "GET",
+        method,
         body
       });
       const content = await response.buffer();

--- a/app/server/lib/Requests.ts
+++ b/app/server/lib/Requests.ts
@@ -80,7 +80,7 @@ export class DocRequests {
 
   private async _handleSingleRequestRaw(request: SandboxRequest): Promise<Response> {
     try {
-      if (process.env.GRIST_EXPERIMENTAL_PLUGINS != '1') {
+      if (process.env.GRIST_EXPERIMENTAL_PLUGINS != '1' || process.env.GRIST_ENABLE_REQUEST_FUNCTION != '1') {
         throw new Error("REQUEST is not enabled");
       }
       const {url, method, body, params, headers} = request;

--- a/sandbox/grist/functions/info.py
+++ b/sandbox/grist/functions/info.py
@@ -707,15 +707,11 @@ def REQUEST(url, params=None, headers=None, method="GET", data=None, json=None):
   #   - `args` as other types: Form encoded and used as the request body. The correct header is also set.
   #   - `json` as str: Used as the request body. The correct header is also set.
   #   - `json` as other types: JSON encoded and set as the request body. The correct header is also set.
-  body, extra_headers = _replicate_requests_body_args(data=data, json=json)
+  body, _headers = _replicate_requests_body_args(data=data, json=json)
 
   # Extra headers that make us consistent with requests.post must not override
   # user-supplied headers.
-  _headers = {}
-  _headers.update(extra_headers)
-
-  if headers is not None:
-    _headers.update(headers)
+  _headers.update(headers or {})
 
   # Requests are identified by a string key in various places.
   # The same arguments should produce the same key so the request is only made once.

--- a/sandbox/grist/functions/info.py
+++ b/sandbox/grist/functions/info.py
@@ -664,7 +664,7 @@ def _replicate_requests_body_args(data=None, json=None):
   if data is None and json is None:
       return None, {}
 
-  elif data is not None:
+  elif data is not None and json is None:
     if isinstance(data, str):
       body = data
       extra_headers = {}
@@ -675,7 +675,7 @@ def _replicate_requests_body_args(data=None, json=None):
       }
     return body, extra_headers
 
-  elif json is not None:
+  elif json is not None and data is None:
     if isinstance(json, str):
       body = json
     else:
@@ -685,7 +685,7 @@ def _replicate_requests_body_args(data=None, json=None):
     }
     return body, extra_headers
 
-  else:
+  elif data is not None and json is not None:
     # From testing manually with requests 2.28.2, data overrides json if both
     # supplied. However, this is probably a mistake on behalf of the caller, so
     # we choose to throw an error instead

--- a/sandbox/grist/functions/info.py
+++ b/sandbox/grist/functions/info.py
@@ -715,13 +715,7 @@ def REQUEST(url, params=None, headers=None, method="GET", data=None, json=None):
 
   # Requests are identified by a string key in various places.
   # The same arguments should produce the same key so the request is only made once.
-  args = dict(url=url, params=params, headers=_headers)
-
-  if method != "GET":
-    args["method"] = method
-
-  if body is not None:
-    args["body"] = body
+  args = dict(url=url, params=params, headers=_headers, method=method, body=body)
 
   args_json = json_module.dumps(args, sort_keys=True)
   key = hashlib.sha256(args_json.encode()).hexdigest()

--- a/sandbox/grist/functions/info.py
+++ b/sandbox/grist/functions/info.py
@@ -659,8 +659,6 @@ def _replicate_requests_body_args(data=None, json=None):
   Replicate some of the behaviour of requests.post, specifically the data and 
   json args.
 
-  From testing manually with requests 2.28.2, data overrides json if both supplied.
-
   Returns a tuple of (body, extra_headers)
   """
   if data is None and json is None:
@@ -688,6 +686,9 @@ def _replicate_requests_body_args(data=None, json=None):
     return body, extra_headers
 
   else:
+    # From testing manually with requests 2.28.2, data overrides json if both
+    # supplied. However, this is probably a mistake on behalf of the caller, so
+    # we choose to throw an error instead
     raise ValueError("`data` and `json` cannot be supplied to REQUEST at the same time")
 
 
@@ -701,8 +702,7 @@ def REQUEST(url, params=None, headers=None, method="GET", data=None, json=None):
   # Actually jumps through hoops internally to make the request asynchronously (usually)
   # while feeling synchronous to the formula writer.
 
-  # REQUEST also has a similar interfact to requests.post, if you change method to be POST.
-  # Support requests `data` and `json` args:
+  # When making a POST or PUT request, REQUEST supports `data` and `json` args, from `requests.request`:
   #   - `args` as str: Used as the request body
   #   - `args` as other types: Form encoded and used as the request body. The correct header is also set.
   #   - `json` as str: Used as the request body. The correct header is also set.

--- a/sandbox/grist/functions/info.py
+++ b/sandbox/grist/functions/info.py
@@ -719,7 +719,7 @@ def REQUEST(url, params=None, headers=None, method="GET", data=None, json=None):
 
   # Requests are identified by a string key in various places.
   # The same arguments should produce the same key so the request is only made once.
-  args = dict(url=url, params=params, headers=headers)
+  args = dict(url=url, params=params, headers=_headers)
 
   if method != "GET":
     args["method"] = method

--- a/sandbox/grist/test_requests.py
+++ b/sandbox/grist/test_requests.py
@@ -138,14 +138,17 @@ r = REQUEST('my_url', headers={'foo': 'bar'}, params={'b': 1, 'a': 2})
 r.__dict__
 """
     out_actions = self.modify_column("Table1", "Request", formula=formula)
-    key = '9d305be9664924aaaf7ebb0bab2e4155d1fa1b9dcde53e417f1a9f9a2c7e09b9'
+    key = 'd7f8cedf177ab538bf7dadf66e77a525486a29a41ce4520b2c89a33e39095fed'
     deps = {'Table1': {'Request': [1, 2]}}
     args = {
       'url': 'my_url',
       'headers': {'foo': 'bar'},
       'params': {'a': 2, 'b': 1},
+      'method': 'GET',
+      'body': None,
       'deps': deps,
     }
+    print(out_actions.requests)
     self.assertEqual(out_actions.requests, {key: args})
     self.assertTableData("Table1", cols="subset", data=[
       ["id", "Request"],

--- a/sandbox/grist/test_requests.py
+++ b/sandbox/grist/test_requests.py
@@ -148,7 +148,6 @@ r.__dict__
       'body': None,
       'deps': deps,
     }
-    print(out_actions.requests)
     self.assertEqual(out_actions.requests, {key: args})
     self.assertTableData("Table1", cols="subset", data=[
       ["id", "Request"],

--- a/sandbox/grist/test_requests.py
+++ b/sandbox/grist/test_requests.py
@@ -105,14 +105,12 @@ class TestRequestsPostInterface(unittest.TestCase):
         assert body == "invalid_but_ignored"
         assert headers == {"Content-Type": "application/json"}
 
-    def test_data_overrides_json(self):
-        body, headers = _replicate_requests_body_args(
-            json={"foo": "bar"},
-            data={"quux": "jazz"}
-        )
-
-        assert body == 'quux=jazz'
-        assert headers == {"Content-Type": "application/x-www-form-urlencoded"}
+    def test_data_and_json_together(self):
+        with self.assertRaises(ValueError):
+            body, headers = _replicate_requests_body_args(
+                json={"foo": "bar"},
+                data={"quux": "jazz"}
+            )
 
 
 class TestRequestFunction(test_engine.EngineTestCase):


### PR DESCRIPTION
The experimental REQUEST function now supports any HTTP method.

This makes sense if
  - Your formula is idempotent, taking actions that make external state consistent with the data in your document
  - You have an endpoint with GET behaviour, but it actually requires a POST/PUT method