### PR TITLE
TEXT() alternatives per #580

### DIFF
--- a/sandbox/grist/functions/text.py
+++ b/sandbox/grist/functions/text.py
@@ -657,8 +657,9 @@ def TASTEME(food):
 @unimplemented
 def TEXT(number, format_type):    # pylint: disable=unused-argument
   """
-  Converts a number into text according to a specified format. It is not yet implemented in
-  Grist.
+  Converts a number into text according to a specified format. It is not yet implemented in 
+  Grist. You can use the similar Python functions str() to convert numbers into strings, and
+  optionally format() to specify the number format. 
   """
   raise NotImplementedError()
 


### PR DESCRIPTION
#580 discusses the usefulness of recommending Python alternatives to the non-implemented Grist TEXT() function. This provides the recommendation.