### PR TITLE
tweak a date test that can occasionally fail

### DIFF
--- a/test/nbrowser/Dates.ntest.js
+++ b/test/nbrowser/Dates.ntest.js
@@ -391,6 +391,7 @@ describe('Dates.ntest', function() {
     await gu.clickCellRC(0, 1);
     await gu.sendKeys([$.ALT, '=']);
     await gu.waitForServer();
+    await gu.waitAppFocus(false);
     await gu.sendKeys("Diff", $.ENTER);
     await gu.waitForServer();
     await gu.sendKeys('=');


### PR DESCRIPTION
A date test was noted to fail, with a formula intended for a cell ending up in the column header. This may help. Entering formulas reliably requires waiting for a particular focus state.