### PR TITLE
REQUEST with unknown and undetectable encoding

### DIFF
--- a/sandbox/grist/functions/info.py
+++ b/sandbox/grist/functions/info.py
@@ -689,12 +689,12 @@ class Response(object):
   """
   Similar to the Response class from the `requests` library.
   """
-  def __init__(self, content, status, statusText, headers, encoding):
+  def __init__(self, content, status, statusText, headers, encoding=None):
     self.content = content  # raw bytes
     self.status_code = status  # e.g. 404
     self.reason = statusText  # e.g. "Not Found"
     self.headers = CaseInsensitiveDict(headers)
-    self.encoding = encoding or self.apparent_encoding
+    self.encoding = encoding or self.apparent_encoding or "utf-8"
 
   @property
   def text(self):

--- a/sandbox/grist/test_requests.py
+++ b/sandbox/grist/test_requests.py
@@ -72,11 +72,11 @@ class TestResponse(unittest.TestCase):
     self.assertEqual(r.content, content)
     self.assertEqual(r.text, text)
 
-  def test_unknown_undetectable_encoding_json(self):
+  def test_unknown_undetectable_encoding(self):
     content = b''
     r = Response(content, 200, "OK", {}, encoding=None)
 
-    # Not knowing the encoding should not break json() or text
+    # Not knowing the encoding should not break text
     self.assertEqual(r.text, "")
 
 

--- a/sandbox/grist/test_requests.py
+++ b/sandbox/grist/test_requests.py
@@ -72,6 +72,13 @@ class TestResponse(unittest.TestCase):
     self.assertEqual(r.content, content)
     self.assertEqual(r.text, text)
 
+  def test_unknown_undetectable_encoding_json(self):
+    content = b''
+    r = Response(content, 200, "OK", {}, encoding=None)
+
+    # Not knowing the encoding should not break json() or text
+    self.assertEqual(r.text, "")
+
 
 class TestRequestFunction(test_engine.EngineTestCase):
   sample = testutil.parse_test_sample({


### PR DESCRIPTION
This fixes issue #599 , where the `encoding` parameter was not always passed to Response.

It also includes a workaround for another issue, where the encoding cannot be determined by the existing JS implementation or the Python implementation. Since the most common case of this may be an empty response, with no useful response headers for determining the encoding, I figure that any encoding will do, so I used utf-8 as a default.