### PR TITLE
TASTEME deobfuscate, comment, and add non-ascii behavior

### DIFF
--- a/sandbox/grist/functions/text.py
+++ b/sandbox/grist/functions/text.py
@@ -646,13 +646,19 @@ def T(value):
           value if isinstance(value, six.text_type) else
           six.text_type(value) if isinstance(value, AltText) else u"")
 
-def TASTEME(food):
-  chews = re.findall(r'\b[A-Z]+\b', food.upper())
-  claw = slice(2, None)
-  spit = lambda chow: chow[claw]
-  return (chews or None) and not all(fang != snap
-    for bite in chews for fang, snap in zip(bite, spit(bite)))
-
+def TASTEME(value):
+  """
+  Returns a Boolean stating whether the input has three identical items in a row.
+  """
+  inarow=1
+  for index, char in enumerate(thestring):
+    if thestring[index-1]==char:
+      inarow+=1
+      if inarow==3:
+        return True
+      else:
+        inarow=1
+  return False
 
 @unimplemented
 def TEXT(number, format_type):    # pylint: disable=unused-argument


### PR DESCRIPTION
An obfuscated meme function called TASTEME() [was introduced](https://github.com/gristlabs/grist-core/commit/a8b4a67b9f6300893a2482bfc369243174d004a6) ~5mo ago with [no documentation](https://support.getgrist.com/newsletters/2023-03/#tasteme). It appears to check for 3 sequential characters in a string; however its behavior is irregular for non-ascii strings, and could be dangerous depending on user implementation. For example, if used for hyperlink validation, it would be vulnerable to [IDN homograph attacks](https://en.wikipedia.org/wiki/IDN_homograph_attack).

For example:

| input             | actual result | expected result |
| ----------------- | ------------- | --------------- |
|  `abcddd`           | True          | True            |
| `aabbcc`            | False         | False           |
| `https://www`       | True          | True            |
| `://`               | None          | False           |
| `abcçççddd`         | None          | True            |
| `100700070006c0065` | None          | True            |

This PR de-obfuscates the code, and uses enumerate() and the == operator to make comparisons. This results in more sane/safe behavior.

Since this function was introduced as a meme, it should probably just be removed. But that's like, just my opinion, man. 