### PR TITLE
Issue #601: implement PUT on columns

### DIFF
--- a/app/plugin/DocApiTypes-ti.ts
+++ b/app/plugin/DocApiTypes-ti.ts
@@ -68,6 +68,10 @@ export const ColumnsPatch = t.iface([], {
   "columns": t.tuple("RecordWithStringId", t.rest(t.array("RecordWithStringId"))),
 });
 
+export const ColumnsPut = t.iface([], {
+  "columns": t.tuple("RecordWithStringId", t.rest(t.array("RecordWithStringId"))),
+});
+
 export const TablePost = t.iface(["ColumnsPost"], {
   "id": t.opt("string"),
 });
@@ -93,6 +97,7 @@ const exportedTypeSuite: t.ITypeSuite = {
   MinimalRecord,
   ColumnsPost,
   ColumnsPatch,
+  ColumnsPut,
   TablePost,
   TablesPost,
   TablesPatch,

--- a/app/plugin/DocApiTypes.ts
+++ b/app/plugin/DocApiTypes.ts
@@ -88,6 +88,10 @@ export interface ColumnsPatch {
   columns: [RecordWithStringId, ...RecordWithStringId[]]; // at least one column is required
 }
 
+export interface ColumnsPut {
+  columns: [RecordWithStringId, ...RecordWithStringId[]]; // at least one column is required
+}
+
 /**
  * Creating tables requires a list of columns.
  * `fields` is not accepted because it's not generally sensible to set the metadata fields on new tables.

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -684,7 +684,6 @@ export class DocWorkerApi {
     // Add or update records given in records format
     this._app.put('/api/docs/:docId/tables/:tableId/columns', canEdit, validate(ColumnsPut),
       withDoc(async (activeDoc, req, res) => {
-        console.log("HOY");
         const tablesTable = activeDoc.docData!.getMetaTable("_grist_Tables");
         const columnsTable = activeDoc.docData!.getMetaTable("_grist_Tables_column");
         const {tableId} = req.params;
@@ -704,12 +703,12 @@ export class DocWorkerApi {
             columnsToUpdate: [...acc.columnsToUpdate, ...(id ? [{ ...col, id }] : [])]
           };
         }, { columnsToAdd: [], columnsToUpdate: [] });
-        const addActions = columnsToAdd.map(
+        const addActions = !isAffirmative(req.query.noadd) ? columnsToAdd.map(
           ({id, fields}) => ['AddVisibleColumn', tableId, id, fields || {}]
-        );
-        const updateActions = columnsToUpdate.map(
+        ) : [];
+        const updateActions = !isAffirmative(req.query.noupdate) ? columnsToUpdate.map(
           ({id: colId, fields}) => ['UpdateRecord', '_grist_Tables_column', colId, fields || {}]
-        );
+        ) : [];
         await handleSandboxError(tableId, [],
           activeDoc.applyUserActions(docSessionFromRequest(req), [...updateActions, ...addActions])
         );

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -716,7 +716,7 @@ export class DocWorkerApi {
 
         const getRemoveAction = async () => {
           const columns = await handleSandboxError('', [],
-            activeDoc.getTableCols(docSessionFromRequest(req), tableId, true));
+            activeDoc.getTableCols(docSessionFromRequest(req), tableId));
           const columnsToRemove = columns
             .map(col => col.fields.colRef as number)
             .filter(colRef => !updatedColumnsIds.has(colRef));

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -705,7 +705,7 @@ export class DocWorkerApi {
         for (const col of body.columns) {
           const id = columnsTable.findMatchingRowId({parentId: tableRef, colId: col.id});
           if (id) {
-            updateActions.push( ['UpdateRecord', '_grist_Tables_column', id, col.fields || {}] )
+            updateActions.push( ['UpdateRecord', '_grist_Tables_column', id, col.fields || {}] );
           } else {
             addActions.push( ['AddVisibleColumn', tableId, col.id, col.fields || {}] );
           }

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -364,8 +364,9 @@ export class DocWorkerApi {
     this._app.get('/api/docs/:docId/tables/:tableId/columns', canView,
       withDoc(async (activeDoc, req, res) => {
         const tableId = req.params.tableId;
+        const includeHidden = isAffirmative(req.query.includeHidden);
         const columns = await handleSandboxError('', [],
-          activeDoc.getTableCols(docSessionFromRequest(req), tableId));
+          activeDoc.getTableCols(docSessionFromRequest(req), tableId, includeHidden));
         res.json({columns});
       })
     );

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -925,6 +925,8 @@ function testDocApi() {
       const newColFields = fieldsByColId.get(COLUMN_TO_ADD.id);
       assert.exists(newColFields, `Column with id "${COLUMN_TO_ADD.id}" should have been added`);
       assert.deepInclude(newColFields, COLUMN_TO_ADD.fields);
+
+      assert.equal(fieldsByColId.size, 4, "Should have kept the 3 existing columns + added the new one");
     });
 
     it('should only update existing columns when noadd is set', async function () {
@@ -989,6 +991,34 @@ function testDocApi() {
         `Expecting to have added the column with id "${COLUMN_TO_ADD.id}"`
       );
       assert.deepInclude(addedColFields, COLUMN_TO_ADD.fields, "Expecting to have the fields set for the added column");
+    });
+
+    it('should remove existing columns if replaceall is set', async function () {
+      // given
+      const { url } = await generateDocAndUrl();
+      const submittedColumns: ColumnsPut = {
+        columns: [COLUMN_TO_ADD, COLUMN_TO_UPDATE]
+      };
+      const params = { replaceall: "1" };
+
+      // when
+      const resp = await axios.put(url, submittedColumns, {...chimpy, params });
+
+      // then
+      assert.equal(resp.status, 200);
+      const fieldsByColId = await getColumnFieldsMapById(url);
+
+      assert.isTrue(
+        fieldsByColId.has(COLUMN_TO_UPDATE.fields.colId),
+        `Expecting to have the column with id "${COLUMN_TO_UPDATE.id}" changed`
+      );
+
+      assert.isTrue(
+        fieldsByColId.has(COLUMN_TO_ADD.id),
+        `Expecting to have added the column with id "${COLUMN_TO_ADD.id}"`
+      );
+
+      assert.equal(fieldsByColId.size, 2, "Expecting to have removed the other columns");
     });
 
     it('should forbid update by viewers', async function () {

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -5,7 +5,7 @@ import {arrayRepeat} from 'app/common/gutil';
 import {WebhookSummary} from 'app/common/Triggers';
 import {DocAPI, DocState, UserAPIImpl} from 'app/common/UserAPI';
 import {testDailyApiLimitFeatures} from 'app/gen-server/entity/Product';
-import {AddOrUpdateRecord, Record as ApiRecord} from 'app/plugin/DocApiTypes';
+import {AddOrUpdateRecord, ColumnsPut, Record as ApiRecord} from 'app/plugin/DocApiTypes';
 import {CellValue, GristObjCode} from 'app/plugin/GristData';
 import {
   applyQueryParameters,
@@ -840,6 +840,37 @@ function testDocApi() {
     resp = await axios.post(`${serverUrl}/api/docs/${docIds.Timesheets}/tables/_grist_Tables/data/delete`,
       [2, 3, 4, 5, 6], chimpy);
     assert.equal(resp.status, 200);
+  });
+
+  describe("PUT /docs/{did}/columns", function () {
+
+    it('should create new columns and update existing ones', async function () {
+      // given
+      const wid = (await userApi.getOrgWorkspaces('current')).find((w) => w.name === 'Private')!.id;
+      const docId = await userApi.newDoc({name: 'ColumnsPut'}, wid);
+      const url = `${serverUrl}/api/docs/${docId}/tables/Table1/columns`;
+
+      {
+        const body: ColumnsPut = {
+          columns: [{
+            id: "Foo",
+            fields: {
+              type: "Text",
+              colId: "Foo",
+              label: "Foo"
+            }
+          }]
+        }
+        // when
+        const resp = await axios.put(url, body, chimpy);
+
+        // then
+        console.log("resp.statusText = ", resp.statusText);
+        console.log("url = ", url);
+        console.log("resp.data = ", resp.data);
+        assert.equal(resp.status, 200);
+      }
+    });
   });
 
   it("GET /docs/{did}/tables/{tid}/data returns 404 for non-existent doc", async function () {

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -848,7 +848,7 @@ function testDocApi() {
       const wid = (await userApi.getOrgWorkspaces('current')).find((w) => w.name === 'Private')!.id;
       const docId = await userApi.newDoc({name: 'ColumnsPut'}, wid);
       const url = `${serverUrl}/api/docs/${docId}/tables/Table1/columns`;
-      return { url, docId }
+      return { url, docId };
     }
 
     async function getColumnFieldsMapById(url: string) {
@@ -858,7 +858,7 @@ function testDocApi() {
           result.data.columns.map(
             ({id, fields}: {id: string, fields: object}) => [id, fields]
           )
-      )
+      );
     }
 
     const COLUMN_TO_ADD = {
@@ -988,7 +988,7 @@ function testDocApi() {
         addedColFields,
         `Expecting to have added the column with id "${COLUMN_TO_ADD.id}"`
       );
-      assert.deepInclude(addedColFields, COLUMN_TO_ADD.fields, "Expecting to have the fields set for the added column")
+      assert.deepInclude(addedColFields, COLUMN_TO_ADD.fields, "Expecting to have the fields set for the added column");
     });
 
     it('should forbid update by viewers', async function () {

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -1036,6 +1036,22 @@ function testDocApi() {
       // then
       assert.equal(resp.status, 403);
     });
+
+    it("should return 404 when table is not found", async function() {
+      // given
+      const { url } = await generateDocAndUrl();
+      const notFoundUrl = url.replace("Table1", "NonExistingTable");
+      const submittedColumns: ColumnsPut = {
+        columns: [COLUMN_TO_ADD, COLUMN_TO_UPDATE]
+      };
+
+      // when
+      const resp = await axios.put(notFoundUrl, submittedColumns, chimpy);
+
+      // then
+      assert.equal(resp.status, 404);
+      assert.equal(resp.data.error, 'Table not found "NonExistingTable"');
+    });
   });
 
   it("GET /docs/{did}/tables/{tid}/data returns 404 for non-existent doc", async function () {

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -610,6 +610,21 @@ function testDocApi() {
     );
   });
 
+  it("GET /docs/{did}/tables/{tid}/columns retrieves hidden columns when includeHidden is set", async function () {
+    const params = { includeHidden: true };
+    const resp = await axios.get(
+      `${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1/columns`,
+      { ...chimpy, params }
+    );
+    assert.equal(resp.status, 200);
+    const columnsMap = new Map(resp.data.columns.map(({id, fields}: {id: string, fields: object}) => [id, fields]));
+    assert.include([...columnsMap.keys()], "manualSort");
+    assert.deepInclude(columnsMap.get("manualSort"), {
+      colRef: 1,
+      type: 'ManualSortPos',
+    });
+  });
+
   it("GET/POST/PATCH /docs/{did}/tables and /columns", async function () {
     // POST /tables: Create new tables
     let resp = await axios.post(`${serverUrl}/api/docs/${docIds.Timesheets}/tables`, {

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -870,7 +870,6 @@ function testDocApi() {
       const body: ColumnsPut = { columns };
       const resp = await axios.put(url, body, {...chimpy, params});
       assert.equal(resp.status, 200);
-      console.log("resp.data = ", resp.data);
       const fieldsByColId = await getColumnFieldsMapById(url);
 
       assert.deepEqual(


### PR DESCRIPTION
## Context

For issue #416, I want to create a POC. It would be a command-line tool that would synchronize the columns from an external table to a synchronized table, and replace all the records with the new ones.

## Implementation

I introduced a new endpoint PUT on columns. It behaves much like PUT on records:
 - in the body, we pass the id and the fields of a column;
 - if a column of the same id exists, we update it with the provided fields;
 - otherwise we add the column as a new one;

## Issues

It implements the issue #601, but without the DELETE endpoint

See also this PR to update the API documentation accordingly: https://github.com/gristlabs/grist-help/pull/256