### PR TITLE
Restoring default ports for webhook tests

### DIFF
--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -4359,7 +4359,7 @@ async function getWorkspaceId(api: UserAPIImpl, name: string) {
   return workspaces.find((w) => w.name === name)!.id;
 }
 
-const webhooksTestPort = Number(process.env.WEBHOOK_TEST_PORT);
+const webhooksTestPort = Number(process.env.WEBHOOK_TEST_PORT || 34365);
 
 async function setupDataDir(dir: string) {
   // we'll be serving Hello.grist content for various document ids, so let's make copies of it in

--- a/test/server/lib/Webhooks-Proxy.ts
+++ b/test/server/lib/Webhooks-Proxy.ts
@@ -51,8 +51,8 @@ function backupEnvironmentVariables() {
   });
 }
 
-const webhooksTestPort = Number(process.env.WEBHOOK_TEST_PORT);
-const webhooksTestProxyPort = Number(process.env.WEBHOOK_TEST_PROXY_PORT);
+const webhooksTestPort = Number(process.env.WEBHOOK_TEST_PORT || 34365);
+const webhooksTestProxyPort = Number(process.env.WEBHOOK_TEST_PROXY_PORT || 22335);
 
 describe('Webhooks-Proxy', function () {
   // A testDir of the form grist_test_{USER}_{SERVER_NAME}


### PR DESCRIPTION
Recently ports used in WebHook tests were extracted to an internal `autopicker` tool, which is not need in grist-core. 