### PR TITLE
Bidirectional Linking

### DIFF
--- a/app/client/components/BaseView.js
+++ b/app/client/components/BaseView.js
@@ -131,8 +131,8 @@ function BaseView(gristDoc, viewSectionModel, options) {
 
   // Update the cursor whenever linkedRowId() changes (but only if we have any linking).
   this.autoDispose(this.linkedRowId.subscribe(rowId => {
-    if (this.viewSection.linkingState.peek() && rowId != null) { //TODO JV: used to be that null meant "new", now it means "no cursor linking"
-      this.setCursorPos({rowId: rowId || 'new'}, true); //true b/c not a user-edit (caused by linking)
+    if (this.viewSection.linkingState.peek()) {
+      this.setCursorPos({rowId: rowId || 'new'}, true);
     }
   }));
 
@@ -282,14 +282,14 @@ BaseView.prototype.deleteRecords = function(source) {
 
 /**
  * Sets the cursor to the given position, deferring if necessary until the current query finishes
- * loading. silentUpdate will be set if updating as a result of cursor linking(see Cursor.setCursorPos for info)
+ * loading. isFromLink will be set when called as result of cursor linking(see Cursor.setCursorPos for info)
  */
-BaseView.prototype.setCursorPos = function(cursorPos, silentUpdate = false) {
+BaseView.prototype.setCursorPos = function(cursorPos, isFromLink = false) {
   if (this.isDisposed()) {
     return;
   }
   if (!this._isLoading.peek()) {
-    this.cursor.setCursorPos(cursorPos, silentUpdate);
+    this.cursor.setCursorPos(cursorPos, isFromLink);
   } else {
     // This is the first step; the second happens in onTableLoaded.
     this._pendingCursorPos = cursorPos;

--- a/app/client/components/BaseView.js
+++ b/app/client/components/BaseView.js
@@ -131,8 +131,8 @@ function BaseView(gristDoc, viewSectionModel, options) {
 
   // Update the cursor whenever linkedRowId() changes (but only if we have any linking).
   this.autoDispose(this.linkedRowId.subscribe(rowId => {
-    if (this.viewSection.linkingState.peek()) {
-      this.setCursorPos({rowId: rowId || 'new'});
+    if (this.viewSection.linkingState.peek() && rowId != null) { //TODO JV: used to be that null meant "new", now it means "no cursor linking"
+      this.setCursorPos({rowId: rowId || 'new'}, true); //true b/c not a user-edit (caused by linking)
     }
   }));
 
@@ -282,14 +282,14 @@ BaseView.prototype.deleteRecords = function(source) {
 
 /**
  * Sets the cursor to the given position, deferring if necessary until the current query finishes
- * loading.
+ * loading. silentUpdate will be set if updating as a result of cursor linking(see Cursor.setCursorPos for info)
  */
-BaseView.prototype.setCursorPos = function(cursorPos) {
+BaseView.prototype.setCursorPos = function(cursorPos, silentUpdate = false) {
   if (this.isDisposed()) {
     return;
   }
   if (!this._isLoading.peek()) {
-    this.cursor.setCursorPos(cursorPos);
+    this.cursor.setCursorPos(cursorPos, silentUpdate);
   } else {
     // This is the first step; the second happens in onTableLoaded.
     this._pendingCursorPos = cursorPos;

--- a/app/client/components/Cursor.ts
+++ b/app/client/components/Cursor.ts
@@ -125,8 +125,8 @@ export class Cursor extends Disposable {
 
     // Update the cursor edit time if either the row or column change
     // IMPORTANT: need to subscribe AFTER the properRowId->activeRowId subscription.
-    //  (Cursor-linking observables depend on edit-version, and only peek at activeRowId. Therefore, make sure
-    //   we set all values correctly, and only update version after that's been done)
+    //  (Cursor-linking observables depend on lastCursorEdit, but only peek at activeRowId. Therefore, updating the
+    //   edit time triggers a re-read of activeRowId, and swapping the order will read stale values for rowId)
     this.autoDispose(this._properRowId.subscribe(() => { this.cursorEdited(); }));
     this.autoDispose(this.fieldIndex.subscribe(() => { this.cursorEdited(); }));
 

--- a/app/client/components/Cursor.ts
+++ b/app/client/components/Cursor.ts
@@ -156,7 +156,8 @@ export class Cursor extends Disposable {
   public setCursorPos(cursorPos: CursorPos, silentUpdate: boolean = false): void {
     //If updating as a result of links, we want to NOT update lastEditedAt
     if(silentUpdate) { this._silentUpdatesFlag = true; }
-    //console.log(`CURSOR: ${silentUpdate}, silentUpdate=${this._silentUpdatesFlag}, lastUpdated = ${this.lastUpdated.peek()}`) //TODO JV DEBUG TEMP
+    //console.log(`CURSOR: ${silentUpdate}, silentUpdate=${this._silentUpdatesFlag},
+    //            lastUpdated = ${this.lastUpdated.peek()}`) //TODO JV DEBUG TEMP
 
     if (cursorPos.rowId !== undefined && this.viewData.getRowIndex(cursorPos.rowId) >= 0) {
       this.rowIndex(this.viewData.getRowIndex(cursorPos.rowId) );
@@ -170,7 +171,8 @@ export class Cursor extends Disposable {
       this.fieldIndex(cursorPos.fieldIndex);
     }
 
-    //console.log(`CURSOR-END: silentUpdate=${this._silentUpdatesFlag}, lastEditedAt = ${this._lastEditedAt.peek()}  `); //TODO JV DEBUG TEMP
+    //console.log(`CURSOR-END: silentUpdate=${this._silentUpdatesFlag},
+    //            lastEditedAt = ${this._lastEditedAt.peek()}  `); //TODO JV DEBUG TEMP
     this._silentUpdatesFlag = false;
   }
 

--- a/app/client/components/Cursor.ts
+++ b/app/client/components/Cursor.ts
@@ -183,6 +183,17 @@ export class Cursor extends Disposable {
         this.fieldIndex(cursorPos.fieldIndex);
       }
 
+      // NOTE: cursorEdited
+      // We primarily update cursorEdited counter from a this._properRowId.subscribe(), since that catches updates
+      //   from many sources (setCursorPos, arrowKeys, save/load, filter/sort-changes, etc)
+      // However, when deleting a row with several sections linked together, there can be a case where this fails:
+      //   When GridView.deleteRows calls setCursorPos to keep cursor from jumping after delete, the observable
+      //   doesn't trigger cursorEdited(), because (I think) _properRowId has already been updated that cycle.
+      //   This caused a bug when several viewSections were cursor-linked to each other and a row was deleted.
+      // We can explicitly call cursorEdited again here. It'll cause cursorEdited to be called twice sometimes,
+      //   but that shouldn't cause any problems, since we don't care about edit counts, just who was edited latest.
+      this.cursorEdited()
+
     } finally { // Make sure we reset this even on error
       this._silentUpdatesFlag = false;
     }

--- a/app/client/components/Cursor.ts
+++ b/app/client/components/Cursor.ts
@@ -136,8 +136,8 @@ export class Cursor extends Disposable {
     //       For determining priority, this cursor will become the latest edited whether we call it once or twice.
     //       For updating observables, the double-update might cause cursor-linking observables in LinkingState to
     //       double-update, but it should be transient and get resolved immediately.
-    this.autoDispose(this._properRowId.subscribe(() => { this.cursorEdited(); }));
-    this.autoDispose(this.fieldIndex.subscribe(() => { this.cursorEdited(); }));
+    this.autoDispose(this._properRowId.subscribe(() => { this._cursorEdited(); }));
+    this.autoDispose(this.fieldIndex.subscribe(() => { this._cursorEdited(); }));
 
     // On dispose, save the current cursor position to the section model.
     this.onDispose(() => { baseView.viewSection.lastCursorPos = this.getCursorPos(); });
@@ -183,7 +183,7 @@ export class Cursor extends Disposable {
         this.fieldIndex(cursorPos.fieldIndex);
       }
 
-      // NOTE: cursorEdited
+      // NOTE: _cursorEdited
       // We primarily update cursorEdited counter from a this._properRowId.subscribe(), since that catches updates
       //   from many sources (setCursorPos, arrowKeys, save/load, filter/sort-changes, etc)
       // However, when deleting a row with several sections linked together, there can be a case where this fails:
@@ -192,7 +192,7 @@ export class Cursor extends Disposable {
       //   This caused a bug when several viewSections were cursor-linked to each other and a row was deleted.
       // We can explicitly call cursorEdited again here. It'll cause cursorEdited to be called twice sometimes,
       //   but that shouldn't cause any problems, since we don't care about edit counts, just who was edited latest.
-      this.cursorEdited()
+      this._cursorEdited();
 
     } finally { // Make sure we reset this even on error
       this._silentUpdatesFlag = false;
@@ -211,7 +211,7 @@ export class Cursor extends Disposable {
   // _EXCEPT FOR: when cursor is set by linking
   // this is used to determine which widget/cursor has most recently been touched,
   // and therefore which one should be used to drive linking if there's a conflict
-  private cursorEdited(): void {
+  private _cursorEdited(): void {
     // If updating as a result of links, we want to NOT update lastEdited
     if (!this._silentUpdatesFlag)
       { this._lastEditedAt(nextSequenceNum()); }

--- a/app/client/components/GristDoc.ts
+++ b/app/client/components/GristDoc.ts
@@ -1185,12 +1185,10 @@ export class GristDoc extends DisposableWithEvents {
         if (!srcRowId || typeof srcRowId !== 'number') {
           throw new Error('cannot trace rowId');
         }
-
         await this.recursiveMoveToCursorPos({
           rowId: srcRowId,
           sectionId: srcSection.id.peek(),
         }, false, silent, visitedSections.concat([section.id.peek()]));
-
       }
       const view: ViewRec = section.view.peek();
       const docPage: ViewDocPage = section.isRaw.peek() ? "data" : view.getRowId();

--- a/app/client/components/GristDoc.ts
+++ b/app/client/components/GristDoc.ts
@@ -1120,7 +1120,8 @@ export class GristDoc extends DisposableWithEvents {
   public async recursiveMoveToCursorPos(
     cursorPos: CursorPos,
     setAsActiveSection: boolean,
-    silent: boolean = false): Promise<boolean> {
+    silent: boolean = false,
+    visitedSections: number[] = []): Promise<boolean> {
     try {
       if (!cursorPos.sectionId) {
         throw new Error('sectionId required');
@@ -1132,6 +1133,12 @@ export class GristDoc extends DisposableWithEvents {
       if (!section.id.peek()) {
         throw new Error(`Section ${cursorPos.sectionId} does not exist`);
       }
+
+      if (visitedSections.includes(section.id.peek())) {
+        //We've already been here (we hit a cycle), just return immediately
+        return true;
+      }
+
       const srcSection = section.linkSrcSection.peek();
       if (srcSection.id.peek()) {
         // We're in a linked section, so we need to recurse to make sure the row we want
@@ -1178,10 +1185,12 @@ export class GristDoc extends DisposableWithEvents {
         if (!srcRowId || typeof srcRowId !== 'number') {
           throw new Error('cannot trace rowId');
         }
+
         await this.recursiveMoveToCursorPos({
           rowId: srcRowId,
           sectionId: srcSection.id.peek(),
-        }, false, silent);
+        }, false, silent, visitedSections.concat([section.id.peek()]));
+
       }
       const view: ViewRec = section.view.peek();
       const docPage: ViewDocPage = section.isRaw.peek() ? "data" : view.getRowId();

--- a/app/client/components/GristDoc.ts
+++ b/app/client/components/GristDoc.ts
@@ -1135,7 +1135,7 @@ export class GristDoc extends DisposableWithEvents {
       }
 
       if (visitedSections.includes(section.id.peek())) {
-        //We've already been here (we hit a cycle), just return immediately
+        // We've already been here (we hit a cycle), just return immediately
         return true;
       }
 

--- a/app/client/components/LinkingState.ts
+++ b/app/client/components/LinkingState.ts
@@ -78,7 +78,6 @@ export class LinkingState extends Disposable {
 
   private _docModel: DocModel;
   private _srcSection: ViewSectionRec;
-  //private _tgtSection: ViewSectionRec;
   private _srcTableModel: DataTableModel;
   private _srcColId: string | undefined;
 
@@ -87,7 +86,6 @@ export class LinkingState extends Disposable {
     const {srcSection, srcCol, srcColId, tgtSection, tgtCol, tgtColId} = linkConfig;
     this._docModel = docModel;
     this._srcSection = srcSection;
-    //this._tgtSection = tgtSection;
     this._srcColId = srcColId;
     this._srcTableModel = docModel.dataTables[srcSection.table().tableId()];
     const srcTableData = this._srcTableModel.tableData;

--- a/app/client/components/LinkingState.ts
+++ b/app/client/components/LinkingState.ts
@@ -78,7 +78,7 @@ export class LinkingState extends Disposable {
 
   private _docModel: DocModel;
   private _srcSection: ViewSectionRec;
-  private _tgtSection: ViewSectionRec;
+  //private _tgtSection: ViewSectionRec;
   private _srcTableModel: DataTableModel;
   private _srcColId: string | undefined;
 
@@ -87,12 +87,13 @@ export class LinkingState extends Disposable {
     const {srcSection, srcCol, srcColId, tgtSection, tgtCol, tgtColId} = linkConfig;
     this._docModel = docModel;
     this._srcSection = srcSection;
-    this._tgtSection = tgtSection;
+    //this._tgtSection = tgtSection;
     this._srcColId = srcColId;
     this._srcTableModel = docModel.dataTables[srcSection.table().tableId()];
     const srcTableData = this._srcTableModel.tableData;
 
-    console.log(`============ LinkingState: Re-running constructor; tgtSec:${tgtSection.id()}: ${tgtSection.titleDef()}`); //TODO JV TEMP;
+    //TODO JV TEMP;
+    console.log(`======= LinkingState: Re-running constructor; tgtSec:${tgtSection.id()}: ${tgtSection.titleDef()}`);
 
 
     // === IMPORTANT NOTE! (this applies throughout this file)
@@ -221,7 +222,8 @@ export class LinkingState extends Disposable {
             (prevLink.linkTypeDescription() == "Cursor:Same-Table" ||
              prevLink.linkTypeDescription() == "Cursor:Reference");
 
-          const [prevLinkedPos, prevLinkedVersion] = prevLinkHasCursor ? prevLink.incomingCursorPos(): [null, SequenceNEVER];
+          const [prevLinkedPos, prevLinkedVersion] = prevLinkHasCursor ? prevLink.incomingCursorPos() :
+                                                                         [null, SequenceNEVER];
 
           const srcSecPos = this._srcSection.activeRowId.peek(); //we don't depend on this, only on its cursor version
           const srcSecVersion = this._srcSection.lastCursorEdit();
@@ -258,8 +260,7 @@ export class LinkingState extends Disposable {
         //This is the cursorPos that's directly applied to tgtSection, should be null if incoming link is outdated
         //where null means "cursorPos does not apply to tgtSection and should be ignored"
         this.cursorPos = this.autoDispose(ko.computed(() => {
-          const [incomingPos, _]: [UIRowId|null, SequenceNum] = this.incomingCursorPos();
-          return incomingPos;
+          return this.incomingCursorPos()[0]; //TODO JV: this is ugly and probably not needed
 
           // TODO JV: old code only accepted incomingPos if it was newer than tgtSec.
           //          However I think we'll be ok with always taking incomingPos. I think the only weird case

--- a/app/client/components/LinkingState.ts
+++ b/app/client/components/LinkingState.ts
@@ -258,16 +258,25 @@ export class LinkingState extends Disposable {
         //This is the cursorPos that's directly applied to tgtSection, should be null if incoming link is outdated
         //where null means "cursorPos does not apply to tgtSection and should be ignored"
         this.cursorPos = this.autoDispose(ko.computed(() => {
-          const [incomingPos, incomingVersion]: [UIRowId|null, SequenceNum] = this.incomingCursorPos();
-          const tgtSecVersion = this._tgtSection.lastCursorEdit();
+          const [incomingPos, _]: [UIRowId|null, SequenceNum] = this.incomingCursorPos();
+          return incomingPos;
 
-          //if(!tgtSecVersion) { return null; }
+          // TODO JV: old code only accepted incomingPos if it was newer than tgtSec.
+          //          However I think we'll be ok with always taking incomingPos. I think the only weird case
+          //          is if we cycle back to ourselves, in which case we might end up setCursorPos()-ing ourselves
+          //          thru the link. However, that's not actually an issue? so it's probably fine
 
-          if(incomingVersion > tgtSecVersion) { // if linked cursor newer that current sec, use it
-              return incomingPos;
-          } else { // else, there's no linked cursor, since current section is driving the linking
-            return null;
-          }
+          //const [incomingPos, incomingVersion]: [UIRowId|null, SequenceNum] = this.incomingCursorPos();
+          //const tgtSecVersion = this._tgtSection.lastCursorEdit();
+
+          //if(!tgtSecVersion) { return null; } //TODO JV
+
+          // if(incomingVersion > tgtSecVersion) { // if linked cursor newer that current sec, use it
+          //     return incomingPos;
+          // } else { // else, there's no linked cursor, since current section is driving the linking
+          //   return incomingPos; //TODO JV TEMP: let's try just always taking the incomingpos
+          //   //return null;
+          // }
 
         }));
       }

--- a/app/client/models/entities/ViewSectionRec.ts
+++ b/app/client/models/entities/ViewSectionRec.ts
@@ -1,4 +1,5 @@
 import BaseView from 'app/client/components/BaseView';
+import {SequenceNEVER, SequenceNum} from 'app/client/components/Cursor';
 import {EmptyFilterColValues, LinkingState} from 'app/client/components/LinkingState';
 import {KoArray} from 'app/client/lib/koArray';
 import {ColumnToMapImpl} from 'app/client/models/ColumnToMap';
@@ -154,6 +155,8 @@ export interface ViewSectionRec extends IRowModel<"_grist_Views_section">, RuleO
   linkingFilter: ko.Computed<FilterColValues>;
 
   activeRowId: ko.Observable<UIRowId | null>;     // May be null when there are no rows.
+
+  lastCursorEdit: ko.Observable<SequenceNum>;
 
   // If the view instance for section is instantiated, it will be accessible here.
   viewInstance: ko.Observable<BaseView | null>;
@@ -618,6 +621,7 @@ export function createViewSectionRec(this: ViewSectionRec, docModel: DocModel): 
   this.linkTargetCol = refRecord(docModel.columns, this.linkTargetColRef);
 
   this.activeRowId = ko.observable<UIRowId|null>(null);
+  this.lastCursorEdit = ko.observable<SequenceNum>(SequenceNEVER);
 
   this._linkingState = Holder.create(this);
   this.linkingState = this.autoDispose(ko.pureComputed(() => {

--- a/app/client/ui/RightPanel.ts
+++ b/app/client/ui/RightPanel.ts
@@ -644,14 +644,13 @@ export class RightPanel extends Disposable {
       const lstate = use(tgtSec.linkingState);
       const lfilter = lstate?.filterState ? use(lstate.filterState) : undefined;
 
-      //TODO JV TEMP DEBUG: srcLastUpdated is temporary
+      // Debug info for cursor linking
+      const inPos = lstate?.incomingCursorPos?.();
       const cursorPosStr = (lstate?.cursorPos ? `${tgtSec.tableId()}[${use(lstate.cursorPos)}]` : "N/A") +
-        `\n srclastEdited: ${use(srcSec.lastCursorEdit)} \n tgtLastEdited: ${use(tgtSec.lastCursorEdit)}` +
-        `\n incomingCursorPos: ${lstate?.incomingCursorPos ? `${lstate.incomingCursorPos()}` : "N/A"}` +
-        (() => {
-          //const;
-          return '';
-        })();
+      // TODO: the lastEdited and incomingCursorPos is kinda technical, to do with how bidirectional linking determines
+      //       priority for cyclical cursor links. Might be too technical even for the "advanced info" box
+        `\n srclastEdited: T+${use(srcSec.lastCursorEdit)} \n tgtLastEdited: T+${use(tgtSec.lastCursorEdit)}` +
+        `\n incomingCursorPos: ${inPos ? `${inPos[0]}@T+${inPos[1]}` : "N/A"}`;
 
       //Main link info as a big string, will be in a <pre></pre> block
       let preString = "No Incoming Link";

--- a/app/client/ui/RightPanel.ts
+++ b/app/client/ui/RightPanel.ts
@@ -645,8 +645,8 @@ export class RightPanel extends Disposable {
       const lfilter = lstate?.filterState ? use(lstate.filterState) : undefined;
 
       // Debug info for cursor linking
-      const inPos = lstate?.incomingCursorPos?.();
-      const cursorPosStr = (lstate?.cursorPos ? `${tgtSec.tableId()}[${use(lstate.cursorPos)}]` : "N/A") +
+      const inPos = lstate?.incomingCursorPos ? use(lstate.incomingCursorPos) : null;
+      const cursorPosStr = (lstate?.cursorPos ? `${use(tgtSec.tableId)}[${use(lstate.cursorPos)}]` : "N/A") +
       // TODO: the lastEdited and incomingCursorPos is kinda technical, to do with how bidirectional linking determines
       //       priority for cyclical cursor links. Might be too technical even for the "advanced info" box
         `\n srclastEdited: T+${use(srcSec.lastCursorEdit)} \n tgtLastEdited: T+${use(tgtSec.lastCursorEdit)}` +

--- a/app/client/ui/RightPanel.ts
+++ b/app/client/ui/RightPanel.ts
@@ -644,7 +644,14 @@ export class RightPanel extends Disposable {
       const lstate = use(tgtSec.linkingState);
       const lfilter = lstate?.filterState ? use(lstate.filterState) : undefined;
 
-      const cursorPosStr = lstate?.cursorPos ? `${tgtSec.tableId()}[${use(lstate.cursorPos)}]` : "N/A";
+      //TODO JV TEMP DEBUG: srcLastUpdated is temporary
+      const cursorPosStr = (lstate?.cursorPos ? `${tgtSec.tableId()}[${use(lstate.cursorPos)}]` : "N/A") +
+        `\n srclastEdited: ${use(srcSec.lastCursorEdit)} \n tgtLastEdited: ${use(tgtSec.lastCursorEdit)}` +
+        `\n incomingCursorPos: ${lstate?.incomingCursorPos ? `${lstate.incomingCursorPos()}` : "N/A"}` +
+        (() => {
+          //const;
+          return '';
+        })();
 
       //Main link info as a big string, will be in a <pre></pre> block
       let preString = "No Incoming Link";

--- a/app/client/ui/selectBy.ts
+++ b/app/client/ui/selectBy.ts
@@ -163,8 +163,8 @@ function isValidLink(source: LinkNode, target: LinkNode) {
     //    they would stop being ancestors of src)
     // NOTE: we're guaranteed to hit target before the end of the array (because of the `if(...includes...)` above)
     // ALSO NOTE: isAncestorSameTableCursorLink may be 1 shorter than ancestors, but it's accounted for by the above
-    let i = 0
-    while(true) {
+    let i = 0;
+    for (;;) {
       if (source.ancestors[i] == target.section.getRowId()) {
         // We made it! All is well
         break;

--- a/test/nbrowser/RightPanelSelectBy.ts
+++ b/test/nbrowser/RightPanelSelectBy.ts
@@ -63,9 +63,23 @@ describe('RightPanelSelectBy', function() {
   });
 
 
-  it('should disallow creating cycles', async function() {
+  it('should disallow creating cycles if not cursor-linked', async function() {
+
+    //Link "films record" by "performances record"
+    await gu.openSelectByForSection('FILMS RECORD');
+    await driver.findContent('.test-select-row', /Performances record.*Film/i).click();
+    await gu.waitForServer();
+
+    // this link should no longer be present, since it would create a cycle with a filter link in it
     await gu.openSelectByForSection('PERFORMANCES RECORD');
-    assert.equal(await driver.findContent('.test-select-row', /Performances detail/).isPresent(), false);
+    assert.equal(await driver.findContent('.test-select-row', /Performances record.*Film/i).isPresent(), false);
+  });
+
+  it('should allow creating cursor-linked-cycles', async function() {
+    assert.equal(await driver.findContent('.test-select-row', /Performances detail/).isPresent(), true);
+
+    // undo, link is expected to be unset for next test
+    await gu.undo();
   });
 
 

--- a/test/nbrowser/RightPanelSelectBy.ts
+++ b/test/nbrowser/RightPanelSelectBy.ts
@@ -78,7 +78,7 @@ describe('RightPanelSelectBy', function() {
   it('should allow creating cursor-linked-cycles', async function() {
     assert.equal(await driver.findContent('.test-select-row', /Performances detail/).isPresent(), true);
 
-    // undo, link is expected to be unset for next test
+    // undo, the operation from the previous test; link is expected to be unset for next test
     await gu.undo();
   });
 


### PR DESCRIPTION
Adds bidirectional linking (same-table cursor-links)

Allows linking sections in a cycle as long as all are same-table cursor links
(e.g. A->B->A,  A->B->C->A, etc)

Clicking/moving cursor in any of the linked sections updates them all.
Works correctly even if sections have differing filters

Tests now check that same-table cursor cycles are allowed in selectBy,
but others are forbidden.

No actual tests of behavior, though