### PR TITLE
DocApi: Introduce includeHidden option for GET on records

### DIFF
--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -241,7 +241,7 @@ export class DocWorkerApi {
     this._app.get('/api/docs/:docId/tables/:tableId/records', canView,
       withDoc(async (activeDoc, req, res) => {
         const records = await getTableRecords(activeDoc, req,
-          { includeHidden: isAffirmative(req.query.includeHidden) }
+          { includeHidden: isAffirmative(req.query.hidden) }
         );
         res.json({records});
       })
@@ -373,7 +373,7 @@ export class DocWorkerApi {
     this._app.get('/api/docs/:docId/tables/:tableId/columns', canView,
       withDoc(async (activeDoc, req, res) => {
         const tableId = req.params.tableId;
-        const includeHidden = isAffirmative(req.query.includeHidden);
+        const includeHidden = isAffirmative(req.query.hidden);
         const columns = await handleSandboxError('', [],
           activeDoc.getTableCols(docSessionFromRequest(req), tableId, includeHidden));
         res.json({columns});

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -209,7 +209,7 @@ export class DocWorkerApi {
           return false;
         }
         if (
-          !isAffirmative(opts?.includeHidden) &&
+          !opts?.includeHidden &&
           (k === "manualSort" || k.startsWith("gristHelper_"))
         ) {
           return false;

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -443,8 +443,8 @@ function testDocApi() {
       });
   });
 
-  it("GET /docs/{did}/tables/{tid}/records honors includeHidden", async function () {
-    const params = { includeHidden: true };
+  it("GET /docs/{did}/tables/{tid}/records honors the \"hidden\" param", async function () {
+    const params = { hidden: true };
     const resp = await axios.get(
       `${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1/records`,
       {...chimpy, params }
@@ -630,8 +630,8 @@ function testDocApi() {
     );
   });
 
-  it("GET /docs/{did}/tables/{tid}/columns retrieves hidden columns when includeHidden is set", async function () {
-    const params = { includeHidden: true };
+  it("GET /docs/{did}/tables/{tid}/columns retrieves hidden columns when \"hidden\" is set", async function () {
+    const params = { hidden: true };
     const resp = await axios.get(
       `${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1/columns`,
       { ...chimpy, params }

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -443,6 +443,26 @@ function testDocApi() {
       });
   });
 
+  it("GET /docs/{did}/tables/{tid}/records honors includeHidden", async function () {
+    const params = { includeHidden: true };
+    const resp = await axios.get(
+      `${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1/records`,
+      {...chimpy, params }
+    );
+    assert.equal(resp.status, 200);
+    assert.deepEqual(resp.data.records[0], {
+      id: 1,
+      fields: {
+        manualSort: 1,
+        A: 'hello',
+        B: '',
+        C: '',
+        D: null,
+        E: 'HELLO',
+      },
+    });
+  });
+
   it("GET /docs/{did}/tables/{tid}/records handles errors and hidden columns", async function () {
     let resp = await axios.get(`${serverUrl}/api/docs/${docIds.ApiDataRecordsTest}/tables/Table1/records`, chimpy);
     assert.equal(resp.status, 200);

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -443,7 +443,7 @@ function testDocApi() {
       });
   });
 
-  it("GET /docs/{did}/tables/{tid}/records honors the \"hidden\" param", async function () {
+  it('GET /docs/{did}/tables/{tid}/records honors the "hidden" param', async function () {
     const params = { hidden: true };
     const resp = await axios.get(
       `${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1/records`,
@@ -630,7 +630,7 @@ function testDocApi() {
     );
   });
 
-  it("GET /docs/{did}/tables/{tid}/columns retrieves hidden columns when \"hidden\" is set", async function () {
+  it('GET /docs/{did}/tables/{tid}/columns retrieves hidden columns when "hidden" is set', async function () {
     const params = { hidden: true };
     const resp = await axios.get(
       `${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1/columns`,


### PR DESCRIPTION
## Context

For issue #416, I want to fetch all the table data, including hidden fields of records, such as:
 - `manualSort`
 - `gristHelper_DisplayX`

So when putting records in the synchronized table, we keep the display fields and the sorting.

## Technical considerations

Not much stuffs, except that I change the signature of `getTableRecords` a bit to move the `optTableId` argument to an option parameter along with the new `includeHidden`.