### PR TITLE
Fixes bug 'this.valueFormatter is not a function'

### DIFF
--- a/app/client/widgets/DateTextBox.js
+++ b/app/client/widgets/DateTextBox.js
@@ -83,7 +83,7 @@ DateTextBox.prototype.buildDom = function(row) {
   let value = row[this.field.colId()];
   return dom('div.field_clip',
     kd.style('text-align', this.alignment),
-    kd.text(() => row._isAddRow() ? '' : this.valueFormatter().format(value()))
+    kd.text(() => row._isAddRow() || this.isDisposed() ? '' : this.valueFormatter().format(value()))
   );
 };
 

--- a/app/client/widgets/NTextBox.ts
+++ b/app/client/widgets/NTextBox.ts
@@ -63,7 +63,7 @@ export class NTextBox extends NewAbstractWidget {
     return dom('div.field_clip',
       dom.style('text-align', this.alignment),
       dom.cls('text_wrapping', this.wrapping),
-      dom.domComputed((use) => use(row._isAddRow) ? null : makeLinks(use(this.valueFormatter).formatAny(use(value), t)))
+      dom.domComputed((use) => use(row._isAddRow) || this.isDisposed() ? null : makeLinks(use(this.valueFormatter).formatAny(use(value), t)))
     );
   }
 }

--- a/app/client/widgets/NTextBox.ts
+++ b/app/client/widgets/NTextBox.ts
@@ -63,7 +63,9 @@ export class NTextBox extends NewAbstractWidget {
     return dom('div.field_clip',
       dom.style('text-align', this.alignment),
       dom.cls('text_wrapping', this.wrapping),
-      dom.domComputed((use) => use(row._isAddRow) || this.isDisposed() ? null : makeLinks(use(this.valueFormatter).formatAny(use(value), t)))
+      dom.domComputed((use) => use(row._isAddRow) || this.isDisposed() ?
+        null :
+        makeLinks(use(this.valueFormatter).formatAny(use(value), t)))
     );
   }
 }


### PR DESCRIPTION
Bug, 'this.valueFormatter is not a function' showed up when deleting a page
(https://grist.slack.com/archives/C069RUP71/p1692034396980779)


Other widgets (e.g. choiceTextBox) had isDisposed checks that dodged this issue, but DateTextBox didn't check for that.
Fixed it for DateTextBox, and also for NTextBox which had a near-identical function