### PR TITLE
remove a log message about fetching URLs

### DIFF
--- a/app/common/ACLRuleCollection.ts
+++ b/app/common/ACLRuleCollection.ts
@@ -1,12 +1,13 @@
 import {parsePermissions, permissionSetToText, splitSchemaEditPermissionSet} from 'app/common/ACLPermissions';
 import {AclRuleProblem} from 'app/common/ActiveDocAPI';
-import {ILogger} from 'app/common/BaseAPI';
 import {DocData} from 'app/common/DocData';
 import {AclMatchFunc, ParsedAclFormula, RulePart, RuleSet, UserAttributeRule} from 'app/common/GranularAccessClause';
 import {getSetMapValue, isNonNullish} from 'app/common/gutil';
 import {MetaRowRecord} from 'app/common/TableData';
 import {decodeObject} from 'app/plugin/objtypes';
 import sortBy = require('lodash/sortBy');
+
+export type ILogger = Pick<Console, 'log'|'debug'|'info'|'warn'|'error'>;
 
 const defaultMatchFunc: AclMatchFunc = () => true;
 

--- a/app/common/BaseAPI.ts
+++ b/app/common/BaseAPI.ts
@@ -2,13 +2,10 @@ import {ApiError, ApiErrorDetails} from 'app/common/ApiError';
 import axios, {AxiosRequestConfig, AxiosResponse} from 'axios';
 import {tbind} from './tbind';
 
-export type ILogger = Pick<Console, 'log'|'debug'|'info'|'warn'|'error'>;
-
 export interface IOptions {
   headers?: Record<string, string>;
   fetch?: typeof fetch;
   newFormData?: () => FormData;  // constructor for FormData depends on platform.
-  logger?: ILogger;
   extraParameters?: Map<string, string>;  // if set, add query parameters to requests.
 }
 
@@ -54,13 +51,11 @@ export class BaseAPI {
   protected fetch: typeof fetch;
   protected newFormData: () => FormData;
   private _headers: Record<string, string>;
-  private _logger: ILogger;
   private _extraParameters?: Map<string, string>;
 
   constructor(options: IOptions = {}) {
     this.fetch = options.fetch || tbind(window.fetch, window);
     this.newFormData = options.newFormData || (() => new FormData());
-    this._logger = options.logger || console;
     this._headers = {
       'Content-Type': 'application/json',
       'X-Requested-With': 'XMLHttpRequest',
@@ -116,7 +111,6 @@ export class BaseAPI {
       }
     }
     const resp = await this.fetch(input, init);
-    this._logger.log("Fetched", input);
     if (resp.status !== 200) {
       const body = await resp.json().catch(() => ({}));
       throwApiError(input, resp, body);

--- a/test/gen-server/apiUtils.ts
+++ b/test/gen-server/apiUtils.ts
@@ -14,7 +14,6 @@ import {getDocWorkerMap} from 'app/gen-server/lib/DocWorkerMap';
 import {HomeDBManager} from 'app/gen-server/lib/HomeDBManager';
 import * as docUtils from 'app/server/lib/docUtils';
 import {FlexServer, FlexServerOptions} from 'app/server/lib/FlexServer';
-import log from 'app/server/lib/log';
 import {main as mergedServerMain, ServerType} from 'app/server/mergedServerMain';
 import axios from 'axios';
 import FormData from 'form-data';
@@ -287,7 +286,6 @@ export class TestSession {
       fetch: fetch as any,
       headers,
       newFormData: () => new FormData() as any,
-      logger: log,
     });
     // Make sure api is functioning, and create user if this is their first time to hit API.
     if (checkAccess) { await api.getOrg('current'); }

--- a/test/nbrowser/homeUtil.ts
+++ b/test/nbrowser/homeUtil.ts
@@ -13,7 +13,6 @@ import {UserProfile} from 'app/common/LoginSessionAPI';
 import {BehavioralPrompt, UserPrefs, WelcomePopup} from 'app/common/Prefs';
 import {DocWorkerAPI, UserAPI, UserAPIImpl} from 'app/common/UserAPI';
 import {HomeDBManager} from 'app/gen-server/lib/HomeDBManager';
-import log from 'app/server/lib/log';
 import {TestingHooksClient} from 'app/server/lib/TestingHooks';
 import EventEmitter = require('events');
 
@@ -445,7 +444,7 @@ export class HomeUtil {
       headers,
       fetch: fetch as any,
       newFormData: () => new FormData() as any,  // form-data isn't quite type compatible
-      logger: log});
+    });
   }
 
   private async _toggleTips(enabled: boolean, email: string) {

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -14,7 +14,6 @@ import {
   getDocApiUsageKeysToIncr,
   WebhookSubscription
 } from 'app/server/lib/DocApi';
-import log from 'app/server/lib/log';
 import {delayAbort} from 'app/server/lib/serverUtils';
 import axios, {AxiosRequestConfig, AxiosResponse} from 'axios';
 import {delay} from 'bluebird';
@@ -2441,7 +2440,6 @@ function testDocApi() {
       headers: {Authorization: 'Bearer api_key_for_kiwi'},
       fetch: fetch as any,
       newFormData: () => new FormData() as any,
-      logger: log
     });
     // upload something for Chimpy and something else for Kiwi.
     const worker1 = await userApi.getWorkerAPI('import');
@@ -2549,7 +2547,6 @@ function testDocApi() {
       headers: {Authorization: 'Bearer api_key_for_chimpy'},
       fetch: fetch as any,
       newFormData: () => new FormData() as any,
-      logger: log
     });
     const ws2 = (await nasaApi.getOrgWorkspaces('current'))[0].id;
     const doc2 = await nasaApi.newDoc({name: 'testdoc2', urlId: 'urlid'}, ws2);
@@ -2581,7 +2578,6 @@ function testDocApi() {
       headers: {Authorization: 'Bearer api_key_for_chimpy'},
       fetch: fetch as any,
       newFormData: () => new FormData() as any,
-      logger: log
     });
     const ws2 = (await nasaApi.getOrgWorkspaces('current'))[0].id;
     const doc2 = await nasaApi.newDoc({name: 'testdoc2'}, ws2);

--- a/test/server/lib/helpers/TestServer.ts
+++ b/test/server/lib/helpers/TestServer.ts
@@ -137,7 +137,6 @@ export class TestServer {
       headers: {Authorization: `Bearer api_key_for_${user}`},
       fetch: fetch as unknown as typeof globalThis.fetch,
       newFormData: () => new FormData() as any,
-      logger: log
     });
   }
 


### PR DESCRIPTION
Every fetch made from the client is logged to the console. But this isn't really necessary, and is particularly confusing in grist-static, where those fetches are virtualized.

Tests in grist-saas may need adjusting to remove the logger.