### PR TITLE
tweak XLSX export worker to make Piscina happy under Electon

### DIFF
--- a/app/server/lib/workerExporter.ts
+++ b/app/server/lib/workerExporter.ts
@@ -224,3 +224,14 @@ export function sanitizeWorksheetName(tableName: string): string {
     .replace(/^['\s]+/, '')
     .replace(/['\s]+$/, '');
 }
+
+// This method exists only to make Piscina happier. With it,
+// Piscina will load this file using a regular require(),
+// which under Electron will deal fine with Electron's ASAR
+// app bundle. Without it, Piscina will try fancier methods
+// that aren't at the time of writing correctly patched to
+// deal with an ASAR app bundle, and so report that this
+// file doesn't exist instead of exporting an XLSX file.
+//   https://github.com/gristlabs/grist-electron/issues/9
+export default function doNothing() {
+}


### PR DESCRIPTION
Adds a dummy default export to the worker exporter script used for producing XLSX. This method exists only to make Piscina happier. With it, Piscina will load this file using a regular require(), which under Electron will deal fine with Electron's ASAR app bundle. Without it, Piscina will try fancier methods that aren't at the time of writing correctly patched to deal with an ASAR app bundle, and so report that this file doesn't exist instead of exporting an XLSX file.

I tried various other solutions such as upgrading Electron, unpacking various files, patching Piscina, and this was overall the simplest.

See https://github.com/gristlabs/grist-electron/issues/9