### PR TITLE
update pyodide package list

### DIFF
--- a/sandbox/pyodide/package_filenames.json
+++ b/sandbox/pyodide/package_filenames.json
@@ -1,7 +1,7 @@
 [
   "astroid-2.14.2-cp311-none-any.whl",
   "asttokens-2.2.1-cp311-none-any.whl",
-  "chardet-4.0.0-cp311-none-any.whl",
+  "chardet-5.1.0-cp311-none-any.whl",
   "et_xmlfile-1.0.1-cp311-none-any.whl",
   "executing-1.1.1-cp311-none-any.whl",
   "friendly_traceback-0.7.48-cp311-none-any.whl",


### PR DESCRIPTION
A chardet dependency had changed, breaking a grist-electron upgrade. So I reran the pyodide script to build the new one, and pushed it to our CDN. This file changed. I don't see exactly where it plays a role, but I thought I'd better commit it anyway.