### PR TITLE
remove cached packages for pyodide when cleaning up

### DIFF
--- a/sandbox/pyodide/Makefile
+++ b/sandbox/pyodide/Makefile
@@ -21,6 +21,7 @@ save_packages:
 
 clean_packages:
 	rm -rf _build/packages
+	rm -rf _build/pyodide/grist-packages
 
 setup:
 	./setup.sh


### PR DESCRIPTION
If these get messed up, it is hard to track down the problem.