### PR TITLE
Make server take into account GRIST_SERVERS

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ GRIST_PAGE_TITLE_SUFFIX | a string to append to the end of the `<title>` in HTML
 GRIST_PROXY_AUTH_HEADER | header which will be set by a (reverse) proxy webserver with an authorized users' email. This can be used as an alternative to a SAML service. See also GRIST_FORWARD_AUTH_HEADER.
 GRIST_ROUTER_URL | optional url for an api that allows servers to be (un)registered with a load balancer
 GRIST_SERVE_SAME_ORIGIN | set to "true" to access home server and doc workers on the same protocol-host-port as the top-level page, same as for custom domains (careful, host header should be trustworthy)
+GRIST_SERVERS | the types of server to setup. Comma separated values which may contain "home", "docs", static" and/or "app". Defaults to "home,docs,static".
 GRIST_SESSION_COOKIE | if set, overrides the name of Grist's cookie
 GRIST_SESSION_DOMAIN | if set, associates the cookie with the given domain - otherwise defaults to GRIST_DOMAIN
 GRIST_SESSION_SECRET | a key used to encode sessions

--- a/app/server/mergedServerMain.ts
+++ b/app/server/mergedServerMain.ts
@@ -15,7 +15,7 @@ export type ServerType = "home" | "docs" | "static" | "app";
 const allServerTypes: ServerType[] = ["home", "docs", "static", "app"];
 
 // Parse a comma-separate list of server types into an array, with validation.
-function parseServerTypes(serverTypes: string|undefined): ServerType[] {
+export function parseServerTypes(serverTypes: string|undefined): ServerType[] {
   // Split and filter out empty strings (including the one we get when splitting "").
   const types = (serverTypes || "").trim().split(',').filter(part => Boolean(part));
 


### PR DESCRIPTION
## Context

We are willing to scale Grist with a similar way to what is explained in the [architecture document](https://github.com/gristlabs/grist-core/blob/6d6d325eaa14d2feca65595f76d7fac1534894c6/documentation/overview.md), and using Docker.

I attempted to create a home server and a doc server using `GRIST_SERVERS`, with no success. Indeed, the stub server hard coded the server types.

Also doc workers failed due to the fact that the database has already been initialized.

## Solution

- I export the `parseServerTypes` from `mergedMainServer` so the user can make use of it;
- I ensure that only a home server will setup the database. In case of serveral home servers, I introduced the `GRIST_SKIP_DB _SETUP` so the administrator can let only one server to handle this task.
- Also I document `GRIST_SERVERS` in the README page.

resolves #654