### PR TITLE
Skip tests involving f-strings for Python 3.9

### DIFF
--- a/sandbox/grist/test_codebuilder.py
+++ b/sandbox/grist/test_codebuilder.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-import codebuilder
 import six
+from asttokens.util import fstring_positions_work
+
+import codebuilder
 import test_engine
 
 unicode_prefix = 'u' if six.PY2 else ''
@@ -72,7 +74,7 @@ class TestCodeBuilder(test_engine.EngineTestCase):
     self.assertEqual(make_body("'''test1'''\n\"\"\"test2\"\"\""),
                      "'''test1'''\nreturn \"\"\"test2\"\"\"")
 
-    if six.PY3:
+    if fstring_positions_work():
       self.assertEqual(
         make_body("f'{$foo + 1 + $bar} 2 {3 + $baz}' + $foo2 + f'{4 + $bar2}!'"),
         "return f'{rec.foo + 1 + rec.bar} 2 {3 + rec.baz}' + rec.foo2 + f'{4 + rec.bar2}!'"

--- a/sandbox/grist/test_formula_prompt.py
+++ b/sandbox/grist/test_formula_prompt.py
@@ -1,5 +1,6 @@
 import unittest
 import six
+from asttokens.util import fstring_positions_work
 
 import test_engine
 import testutil
@@ -219,6 +220,7 @@ class Table3:
 def reflist(rec: Table3) -> list[Table2]:
 ''')
 
+  @unittest.skipUnless(fstring_positions_work(), "Needs Python 3.10+")
   def test_convert_completion(self):
     completion = """
 Here's some code:

--- a/sandbox/grist/test_renames.py
+++ b/sandbox/grist/test_renames.py
@@ -2,7 +2,7 @@
 import logging
 import unittest
 
-import six
+from asttokens.util import fstring_positions_work
 
 import testutil
 import test_engine
@@ -81,7 +81,7 @@ class TestRenames(test_engine.EngineTestCase):
       }]
     ]})
 
-  @unittest.skipUnless(six.PY3, "Python 3 only")
+  @unittest.skipUnless(fstring_positions_work(), "Python 3.10+ only")
   def test_rename_inside_fstring(self):
     self.load_sample(self.sample)
     self.add_column("People", "CityUpper", formula="f'{$city.upper()}'")


### PR DESCRIPTION
Tests are failing for Python 3.9, this PR makes them pass again. The underlying problem is https://github.com/gristlabs/asttokens/pull/104. So basically Python 3.9 won't support using `$` or table/column names inside f-strings.