### PR TITLE
Fixes linking "srcSection disposed" bug

### DIFF
--- a/app/client/components/LinkingState.ts
+++ b/app/client/components/LinkingState.ts
@@ -308,10 +308,17 @@ export class LinkingState extends Disposable {
     //(we autodispose/return it at the end of the function) is this right? TODO JV
     return owner.autoDispose(ko.computed(() => {
 
+      if (this._srcSection.isDisposed()) {
+        //happened transiently in test: "RawData should remove all tables except one (...)"
+        console.warn("LinkingState._makeFilterObs: srcSectionDisposed");
+        return EmptyFilterState;
+      }
+
       //Get selector-rowId
       const srcRowId = this._srcSection.activeRowId();
+
       if (srcRowId === null) {
-        console.warn("_makeFilterObs activeRowId is null");
+        console.warn("LinkingState._makeFilterObs activeRowId is null");
         return EmptyFilterState;
       }
 


### PR DESCRIPTION
The test case  "RawData should remove all tables except one (including referenced summary table)"

was failing with error: "this._srcSection.activeRowId is not a function" 

This adds an extra isDisposed check to catch it