### PR TITLE
Adds in linkstate bubbles (no tooltips)

### DIFF
--- a/app/client/ui/WidgetTitle.ts
+++ b/app/client/ui/WidgetTitle.ts
@@ -269,7 +269,7 @@ const updateOnKey = {onInput: true};
 
 // Leave class for tests.
 const cssTitleContainer = styled('div', `
-  flex: 1 1 0px;
+  flex: 0 1 auto;  /* won't grow, starts at size of content, will shrink if needed */
   min-width: 0px;
   display: flex;
   .info_toggle_icon {

--- a/test/nbrowser/Views.ntest.js
+++ b/test/nbrowser/Views.ntest.js
@@ -36,7 +36,7 @@ describe('Views.ntest', function() {
     // Check that viewsection titles are correct and editable
     var recordTitle = recordSection.find('.test-viewsection-title');
     assert.equal(await recordTitle.text(), 'TABLE1');
-    await recordTitle.click();
+    await recordSection.find('.test-viewsection-blank').click(); //switch to recordSection without opening title widget
     await gu.renameActiveSection('foo');
     assert.equal(await recordTitle.text(), 'foo');
 


### PR DESCRIPTION
Adds bubbles to the tops of viewsections that show the current state of linking (i.e., indicating that the section has linking, and if it's filtered, showing the current filter value or values)

Also opens the rightPanel to the linking section when clicked