### PR TITLE
Option to export colId as header in CSV / XSLX instead of label (#688)

### DIFF
--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -1211,6 +1211,7 @@ export class DocWorkerApi {
         viewSectionId: undefined,
         filters: [],
         sortOrder: [],
+        colIdAsHeader: false
       };
       await downloadXLSX(activeDoc, req, res, options);
     }));

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -1205,13 +1205,13 @@ export class DocWorkerApi {
     this._app.get('/api/docs/:docId/download/xlsx', canView, withDoc(async (activeDoc, req, res) => {
       // Query DB for doc metadata to get the doc title (to use as the filename).
       const {name: docTitle} = await this._dbManager.getDoc(req);
-      const options = !_.isEmpty(req.query) ? this._getDownloadOptions(req, docTitle) : {
+      const options: DownloadOptions = !_.isEmpty(req.query) ? this._getDownloadOptions(req, docTitle) : {
         filename: docTitle,
         tableId: '',
         viewSectionId: undefined,
         filters: [],
         sortOrder: [],
-        colIdAsHeader: false
+        header: 'label'
       };
       await downloadXLSX(activeDoc, req, res, options);
     }));

--- a/app/server/lib/Export.ts
+++ b/app/server/lib/Export.ts
@@ -17,7 +17,7 @@ import {BaseFormatter, createFullFormatterFromDocData} from 'app/common/ValueFor
 import {ActiveDoc} from 'app/server/lib/ActiveDoc';
 import {RequestWithLogin} from 'app/server/lib/Authorizer';
 import {docSessionFromRequest} from 'app/server/lib/DocSession';
-import {optIntegerParam, optJsonParam, stringParam} from 'app/server/lib/requestUtils';
+import {optIntegerParam, optJsonParam, optStringParam, stringParam} from 'app/server/lib/requestUtils';
 import {ServerColumnGetters} from 'app/server/lib/ServerColumnGetters';
 import * as express from 'express';
 import * as _ from 'underscore';
@@ -90,6 +90,8 @@ export interface ExportData {
   docSettings: DocumentSettings;
 }
 
+export type ExportHeader = 'colId' | 'label';
+
 /**
  * Export parameters that identifies a section, filters, sort order.
  */
@@ -99,7 +101,7 @@ export interface ExportParameters {
   sortOrder?: number[];
   filters?: Filter[];
   linkingFilter?: FilterColValues;
-  colIdAsHeader?: boolean;
+  header?: ExportHeader;
 }
 
 /**
@@ -118,7 +120,7 @@ export function parseExportParameters(req: express.Request): ExportParameters {
   const sortOrder = optJsonParam(req.query.activeSortSpec, []) as number[];
   const filters: Filter[] = optJsonParam(req.query.filters, []);
   const linkingFilter: FilterColValues = optJsonParam(req.query.linkingFilter, null);
-  const colIdAsHeader = gutil.isAffirmative(req.query.colIdAsHeader);
+  const header = optStringParam(req.query.header, 'header', {allowed: ['label', 'colId']}) as ExportHeader | undefined;
 
   return {
     tableId,
@@ -126,7 +128,7 @@ export function parseExportParameters(req: express.Request): ExportParameters {
     sortOrder,
     filters,
     linkingFilter,
-    colIdAsHeader,
+    header,
   };
 }
 

--- a/app/server/lib/Export.ts
+++ b/app/server/lib/Export.ts
@@ -99,6 +99,7 @@ export interface ExportParameters {
   sortOrder?: number[];
   filters?: Filter[];
   linkingFilter?: FilterColValues;
+  colIdAsHeader?: boolean;
 }
 
 /**
@@ -117,6 +118,7 @@ export function parseExportParameters(req: express.Request): ExportParameters {
   const sortOrder = optJsonParam(req.query.activeSortSpec, []) as number[];
   const filters: Filter[] = optJsonParam(req.query.filters, []);
   const linkingFilter: FilterColValues = optJsonParam(req.query.linkingFilter, null);
+  const colIdAsHeader = gutil.isAffirmative(req.query.colIdAsHeader);
 
   return {
     tableId,
@@ -124,6 +126,7 @@ export function parseExportParameters(req: express.Request): ExportParameters {
     sortOrder,
     filters,
     linkingFilter,
+    colIdAsHeader,
   };
 }
 

--- a/app/server/lib/ExportCSV.ts
+++ b/app/server/lib/ExportCSV.ts
@@ -1,7 +1,7 @@
 import {ApiError} from 'app/common/ApiError';
 import {ActiveDoc} from 'app/server/lib/ActiveDoc';
 import {FilterColValues} from "app/common/ActiveDocAPI";
-import {DownloadOptions, ExportData, exportSection, exportTable, Filter} from 'app/server/lib/Export';
+import {DownloadOptions, ExportData, ExportHeader, exportSection, exportTable, Filter} from 'app/server/lib/Export';
 import log from 'app/server/lib/log';
 import * as bluebird from 'bluebird';
 import contentDisposition from 'content-disposition';
@@ -17,13 +17,13 @@ bluebird.promisifyAll(csv);
 export async function downloadCSV(activeDoc: ActiveDoc, req: express.Request,
                                   res: express.Response, options: DownloadOptions) {
   log.info('Generating .csv file...');
-  const {filename, tableId, viewSectionId, filters, sortOrder, linkingFilter, colIdAsHeader} = options;
+  const {filename, tableId, viewSectionId, filters, sortOrder, linkingFilter, header} = options;
   const data = viewSectionId ?
     await makeCSVFromViewSection({
       activeDoc, viewSectionId, sortOrder: sortOrder || null, filters: filters || null,
-      linkingFilter: linkingFilter || null, colIdAsHeader, req
+      linkingFilter: linkingFilter || null, header, req
     }) :
-    await makeCSVFromTable({activeDoc, tableId, colIdAsHeader, req});
+    await makeCSVFromTable({activeDoc, tableId, header, req});
   res.set('Content-Type', 'text/csv');
   res.setHeader('Content-Disposition', contentDisposition(filename + '.csv'));
   res.send(data);
@@ -40,25 +40,25 @@ export async function downloadCSV(activeDoc: ActiveDoc, req: express.Request,
  * @param {Integer[]} options.activeSortOrder (optional) - overriding sort order.
  * @param {Filter[]} options.filters (optional) - filters defined from ui.
  * @param {FilterColValues} options.linkingFilter (optional) - linking filter defined from ui.
- * @param {boolean} [options.colIdAsHeader] - whether to use column id as header.
+ * @param {string} options.header (optional) - which field of the column to use as header
  * @param {express.Request} options.req - the request object.
  *
  * @return {Promise<string>} Promise for the resulting CSV.
  */
 export async function makeCSVFromViewSection({
-  activeDoc, viewSectionId, sortOrder = null, filters = null, linkingFilter = null, colIdAsHeader, req
+  activeDoc, viewSectionId, sortOrder = null, filters = null, linkingFilter = null, header, req
 }: {
   activeDoc: ActiveDoc,
   viewSectionId: number,
   sortOrder: number[] | null,
   filters: Filter[] | null,
   linkingFilter: FilterColValues | null,
-  colIdAsHeader?: boolean,
+  header?: ExportHeader,
   req: express.Request
 }) {
 
   const data = await exportSection(activeDoc, viewSectionId, sortOrder, filters, linkingFilter, req);
-  const file = convertToCsv(data, { colIdAsHeader });
+  const file = convertToCsv(data, { header });
   return file;
 }
 
@@ -68,15 +68,15 @@ export async function makeCSVFromViewSection({
  * @param {Object} options - options for the export.
  * @param {Object} options.activeDoc - the activeDoc that the table being converted belongs to.
  * @param {Integer} options.tableId - id of the table to export.
- * @param {boolean} [options.colIdAsHeader] - whether to use column id as header.
+ * @param {string} options.header (optional) - which field of the column to use as header
  * @param {express.Request} options.req - the request object.
  *
  * @return {Promise<string>} Promise for the resulting CSV.
  */
-export async function makeCSVFromTable({ activeDoc, tableId, colIdAsHeader, req }: {
+export async function makeCSVFromTable({ activeDoc, tableId, header, req }: {
   activeDoc: ActiveDoc,
   tableId: string,
-  colIdAsHeader?: boolean,
+  header?: ExportHeader,
   req: express.Request
 }) {
 
@@ -93,7 +93,7 @@ export async function makeCSVFromTable({ activeDoc, tableId, colIdAsHeader, req 
   }
 
   const data = await exportTable(activeDoc, tableRef, req);
-  const file = convertToCsv(data, { colIdAsHeader });
+  const file = convertToCsv(data, { header });
   return file;
 }
 
@@ -101,12 +101,12 @@ function convertToCsv({
   rowIds,
   access,
   columns: viewColumns,
-}: ExportData, options: { colIdAsHeader?: boolean }) {
+}: ExportData, options: { header?: ExportHeader }) {
 
   // create formatters for columns
   const formatters = viewColumns.map(col => col.formatter);
   // Arrange the data into a row-indexed matrix, starting with column headers.
-  const colPropertyAsHeader = options.colIdAsHeader ? 'colId' : 'label';
+  const colPropertyAsHeader = options.header ?? 'label';
   const csvMatrix = [viewColumns.map(col => col[colPropertyAsHeader])];
   // populate all the rows with values as strings
   rowIds.forEach(row => {

--- a/app/server/lib/workerExporter.ts
+++ b/app/server/lib/workerExporter.ts
@@ -91,12 +91,18 @@ export async function doMakeXLSXFromOptions(
 }
 
 /**
+ * @async
  * Returns a XLSX stream of a view section that can be transformed or parsed.
  *
- * @param {Object} activeDoc - the activeDoc that the table being converted belongs to.
- * @param {Integer} viewSectionId - id of the viewsection to export.
- * @param {Integer[]} activeSortOrder (optional) - overriding sort order.
- * @param {Filter[]} filters (optional) - filters defined from ui.
+ * @param {Object} options - options for the export.
+ * @param {Object} options.activeDocSource - the activeDoc that the table being converted belongs to.
+ * @param {Integer} options.viewSectionId - id of the viewsection to export.
+ * @param {Integer[]} options.activeSortOrder (optional) - overriding sort order.
+ * @param {Filter[]} options.filters (optional) - filters defined from ui.
+ * @param {FilterColValues} options.linkingFilter (optional)
+ * @param {Stream} options.stream - the stream to write to.
+ * @param {boolean} options.testDates - whether to use static dates for testing.
+ * @param {boolean} [options.colIdAsHeader] - whether to use column id as header.
  */
 async function doMakeXLSXFromViewSection({
   activeDocSource, testDates, stream, viewSectionId, sortOrder, filters, linkingFilter, colIdAsHeader
@@ -117,10 +123,16 @@ async function doMakeXLSXFromViewSection({
 }
 
 /**
+ * @async
  * Returns a XLSX stream of a table that can be transformed or parsed.
  *
- * @param {Object} activeDoc - the activeDoc that the table being converted belongs to.
- * @param {Integer} tableId - id of the table to export.
+ * @param {Object} options - options for the export.
+ * @param {Object} options.activeDocSource - the activeDoc that the table being converted belongs to.
+ * @param {Integer} options.tableId - id of the table to export.
+ * @param {Stream} options.stream - the stream to write to.
+ * @param {boolean} options.testDates - whether to use static dates for testing.
+ * @param {boolean} [options.colIdAsHeader] - whether to use column id as header.
+ *
  */
 async function doMakeXLSXFromTable({activeDocSource, testDates, stream, tableId, colIdAsHeader}: {
   activeDocSource: ActiveDocSource,

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -2592,7 +2592,7 @@ function testDocApi() {
     assert.equal(resp2.data, 'A,B\nSanta,1\nBob,11\nAlice,2\nFelix,22\n');
   });
 
-  it('GET /docs/{did}/download/csv with colIdAsHeader shows columns id in the header instead of their name',
+  it('GET /docs/{did}/download/csv with header=colId shows columns id in the header instead of their name',
     async function () {
       const { docUrl } = await generateDocAndUrl('csvWithColIdAsHeader');
       const AColRef = 2;
@@ -2606,7 +2606,7 @@ function testDocApi() {
       ];
       const resp = await axios.post(`${docUrl}/apply`, userActions, chimpy);
       assert.equal(resp.status, 200);
-      const csvResp = await axios.get(`${docUrl}/download/csv?tableId=Table1&colIdAsHeader=true`, chimpy);
+      const csvResp = await axios.get(`${docUrl}/download/csv?tableId=Table1&header=colId`, chimpy);
       assert.equal(csvResp.status, 200);
       assert.equal(csvResp.data, 'AColId,B,C\na1,b1,\n');
     });

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -230,6 +230,14 @@ describe('DocApi', function () {
 
 // Contains the tests. This is where you want to add more test.
 function testDocApi() {
+  async function generateDocAndUrl(docName: string = "Dummy") {
+    const wid = (await userApi.getOrgWorkspaces('current')).find((w) => w.name === 'Private')!.id;
+    const docId = await userApi.newDoc({name: docName}, wid);
+    const docUrl = `${serverUrl}/api/docs/${docId}`;
+    const tableUrl = `${serverUrl}/api/docs/${docId}/tables/Table1`;
+    return { docUrl, tableUrl, docId };
+  }
+
   it("creator should be owner of a created ws", async () => {
     const kiwiEmail = 'kiwi@getgrist.com';
     const ws1 = (await userApi.getOrgWorkspaces('current'))[0].id;
@@ -1055,13 +1063,13 @@ function testDocApi() {
   });
 
   describe("/docs/{did}/tables/{tid}/columns", function () {
-    async function generateDocAndUrl(docName: string = "Dummy") {
-      const wid = (await userApi.getOrgWorkspaces('current')).find((w) => w.name === 'Private')!.id;
-      const docId = await userApi.newDoc({name: docName}, wid);
-      const url = `${serverUrl}/api/docs/${docId}/tables/Table1/columns`;
-      return { url, docId };
+    async function generateDocAndUrlForColumns(name: string) {
+      const { tableUrl, docId } = await generateDocAndUrl(name);
+      return {
+        docId,
+        url: `${tableUrl}/columns`,
+      };
     }
-
     describe("PUT /docs/{did}/tables/{tid}/columns", function () {
       async function getColumnFieldsMapById(url: string, params: any) {
         const result = await axios.get(url, {...chimpy, params});
@@ -1079,7 +1087,7 @@ function testDocApi() {
         expectedFieldsByColId: Record<string, object>,
         opts?: { getParams?: any }
       ) {
-        const {url} = await generateDocAndUrl('ColumnsPut');
+        const {url} = await generateDocAndUrlForColumns('ColumnsPut');
         const body: ColumnsPut = { columns };
         const resp = await axios.put(url, body, {...chimpy, params});
         assert.equal(resp.status, 200);
@@ -1150,7 +1158,7 @@ function testDocApi() {
 
       it('should forbid update by viewers', async function () {
         // given
-        const { url, docId } = await generateDocAndUrl('ColumnsPut');
+        const { url, docId } = await generateDocAndUrlForColumns('ColumnsPut');
         await userApi.updateDocPermissions(docId, {users: {'kiwi@getgrist.com': 'viewers'}});
 
         // when
@@ -1162,7 +1170,7 @@ function testDocApi() {
 
       it("should return 404 when table is not found", async function() {
         // given
-        const { url } = await generateDocAndUrl('ColumnsPut');
+        const { url } = await generateDocAndUrlForColumns('ColumnsPut');
         const notFoundUrl = url.replace("Table1", "NonExistingTable");
 
         // when
@@ -1176,7 +1184,7 @@ function testDocApi() {
 
     describe("DELETE /docs/{did}/tables/{tid}/columns/{colId}", function () {
       it('should delete some column', async function() {
-        const {url} = await generateDocAndUrl('ColumnDelete');
+        const {url} = await generateDocAndUrlForColumns('ColumnDelete');
         const deleteUrl = url + '/A';
         const resp = await axios.delete(deleteUrl, chimpy);
 
@@ -1190,7 +1198,7 @@ function testDocApi() {
       });
 
       it('should return 404 if table not found', async function() {
-        const {url} = await generateDocAndUrl('ColumnDelete');
+        const {url} = await generateDocAndUrlForColumns('ColumnDelete');
         const deleteUrl = url.replace("Table1", "NonExistingTable") + '/A';
         const resp = await axios.delete(deleteUrl, chimpy);
 
@@ -1199,7 +1207,7 @@ function testDocApi() {
       });
 
       it('should return 404 if column not found', async function() {
-        const {url} = await generateDocAndUrl('ColumnDelete');
+        const {url} = await generateDocAndUrlForColumns('ColumnDelete');
         const deleteUrl = url + '/NonExistingColId';
         const resp = await axios.delete(deleteUrl, chimpy);
 
@@ -1208,7 +1216,7 @@ function testDocApi() {
       });
 
       it('should forbid column deletion by viewers', async function() {
-        const {url, docId} = await generateDocAndUrl('ColumnDelete');
+        const {url, docId} = await generateDocAndUrlForColumns('ColumnDelete');
         await userApi.updateDocPermissions(docId, {users: {'kiwi@getgrist.com': 'viewers'}});
         const deleteUrl = url + '/A';
         const resp = await axios.delete(deleteUrl, kiwi);
@@ -2583,6 +2591,25 @@ function testDocApi() {
     assert.equal(resp2.status, 200);
     assert.equal(resp2.data, 'A,B\nSanta,1\nBob,11\nAlice,2\nFelix,22\n');
   });
+
+  it('GET /docs/{did}/download/csv with colIdAsHeader shows columns id in the header instead of their name',
+    async function () {
+      const { docUrl } = await generateDocAndUrl('csvWithColIdAsHeader');
+      const AColRef = 2;
+      const userActions = [
+        ['AddRecord', 'Table1', null, {A: 'a1', B: 'b1'}],
+        ['UpdateRecord', '_grist_Tables_column', AColRef, { untieColIdFromLabel: true }],
+        ['UpdateRecord', '_grist_Tables_column', AColRef, {
+          label: 'Column label for A',
+          colId: 'AColId'
+        }]
+      ];
+      const resp = await axios.post(`${docUrl}/apply`, userActions, chimpy);
+      assert.equal(resp.status, 200);
+      const csvResp = await axios.get(`${docUrl}/download/csv?tableId=Table1&colIdAsHeader=true`, chimpy);
+      assert.equal(csvResp.status, 200);
+      assert.equal(csvResp.data, 'AColId,B,C\na1,b1,\n');
+    });
 
   it("GET /docs/{did}/download/csv respects permissions", async function () {
     // kiwi has no access to TestDoc


### PR DESCRIPTION
# Context

Quoting @vviers in #688 : 

> We do a lot of downloading CSV from Grist in order to integrate data tables to a downstream data platform, and it's a little painful that the column names are human-friendly labels instead of the more machine-friendly `colId`.
>
> This also defeats the purpose of disconnecting the column label from colId since any renaming of a column in a Grist doc breaks our ETL system if we forget / aren't told to update it as well (this would not happen if we relied on colId and disconnected them from labels*).
> 
> My idea is to add a new option to the `download/csv` endpoint (and to `download/xlsx` as well if you wish though I think less developers / automated systems would be impacted by this) in order to add the option of getting the file with colId instead of labels.

# Solution

Add a `?colIdAsHeader=true|false` option to both CSV and XLSX exports for that purpose. 

resolves #688 

