### PR TITLE
rename variable to avoid shadowing another

### DIFF
--- a/app/server/lib/WidgetRepository.ts
+++ b/app/server/lib/WidgetRepository.ts
@@ -209,8 +209,8 @@ class CachedWidgetRepository extends WidgetRepositoryImpl {
     return list;
   }
 
-  public testOverrideUrl(url: string) {
-    super.testOverrideUrl(url);
+  public testOverrideUrl(overrideUrl: string) {
+    super.testOverrideUrl(overrideUrl);
     this._cache.reset();
   }
 }


### PR DESCRIPTION
This fixes a small lint issue in some widget bundling code.