### PR TITLE
allow bundled widgets to be hidden from dropdown, and nested

### DIFF
--- a/app/client/ui/CustomSectionConfig.ts
+++ b/app/client/ui/CustomSectionConfig.ts
@@ -551,10 +551,12 @@ export class CustomSectionConfig extends Disposable {
     // Options for the select-box (all widgets definitions and Custom URL)
     const options = Computed.create(holder, use => [
       {label: 'Custom URL', value: 'custom'},
-      ...(use(this._widgets) || []).map(w => ({
-        label: w.source?.name ? `${w.name} (${w.source.name})` : w.name,
-        value: (w.source?.pluginId || '') + ':' + w.widgetId,
-      })),
+      ...(use(this._widgets) || [])
+           .filter(w => w?.published !== false)
+           .map(w => ({
+             label: w.source?.name ? `${w.name} (${w.source.name})` : w.name,
+             value: (w.source?.pluginId || '') + ':' + w.widgetId,
+           })),
     ]);
     function buildPrompt(level: AccessLevel|null) {
       if (!level) {

--- a/app/common/CustomWidget.ts
+++ b/app/common/CustomWidget.ts
@@ -32,6 +32,11 @@ export interface ICustomWidget {
   renderAfterReady?: boolean;
 
   /**
+   * If set to false, do not offer to user in UI.
+   */
+  published?: boolean;
+
+  /**
    * If the widget came from a plugin, we track that here.
    */
   source?: {

--- a/app/server/lib/WidgetRepository.ts
+++ b/app/server/lib/WidgetRepository.ts
@@ -267,7 +267,7 @@ export function getWidgetsInPlugins(gristServer: GristServer,
         gristServer.getTag() + '/widgets/' + plugin.id + '/';
     places.push({
       urlBase,
-      dir: plugin.path,
+      dir: path.resolve(plugin.path, path.dirname(components.widgets)),
       file: path.join(plugin.path, components.widgets),
       name: plugin.manifest.name || plugin.id,
       pluginId: plugin.id,


### PR DESCRIPTION
This makes a few refinements to bundling widgets:

  * A widget with `published: false` is not shown in the custom widget dropdown in the UI. This is so widgets can be bundled with the app for "native" use (like the calendar widget) without immediately resulting in an extra listing in the UI. (There are improvements we'd like to make to the UI to better communicate widget provenance and quality eventually, which would be a helpful alternative to just a binary flag.)

  * A relative path to the custom widget manifest is respected. This will make the bundling process marginally neater.