### PR TITLE
getHostType: consider APP_DOC_INTERNAL_URL as native

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Variable | Purpose
 -------- | -------
 ALLOWED_WEBHOOK_DOMAINS | comma-separated list of permitted domains to use in webhooks (e.g. webhook.site,zapier.com). You can set this to `*` to allow all domains, but if doing so, we recommend using a carefully locked-down proxy (see `GRIST_HTTPS_PROXY`) if you do not entirely trust users. Otherwise services on your internal network may become vulnerable to manipulation.
 APP_DOC_URL | doc worker url, set when starting an individual doc worker (other servers will find doc worker urls via redis)
-APP_DOC_INTERNAL_URL | like `APP_DOC_URL` but used by the home server to join the server using an internal domain name resolution (like in a docker environment). Defaults to APP_DOC_URL
+APP_DOC_INTERNAL_URL | like `APP_DOC_URL` but used by the home server to reach the server using an internal domain name resolution (like in a docker environment). Defaults to `APP_DOC_URL`
 APP_HOME_URL | url prefix for home api (home and doc servers need this)
 APP_STATIC_URL | url prefix for static resources
 APP_STATIC_INCLUDE_CUSTOM_CSS | set to "true" to include custom.css (from APP_STATIC_URL) in static pages

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Variable | Purpose
 -------- | -------
 ALLOWED_WEBHOOK_DOMAINS | comma-separated list of permitted domains to use in webhooks (e.g. webhook.site,zapier.com). You can set this to `*` to allow all domains, but if doing so, we recommend using a carefully locked-down proxy (see `GRIST_HTTPS_PROXY`) if you do not entirely trust users. Otherwise services on your internal network may become vulnerable to manipulation.
 APP_DOC_URL | doc worker url, set when starting an individual doc worker (other servers will find doc worker urls via redis)
+APP_DOC_INTERNAL_URL | like `APP_DOC_URL` but used by the home server to join the server using an internal domain name resolution (like in a docker environment). Defaults to APP_DOC_URL
 APP_HOME_URL | url prefix for home api (home and doc servers need this)
 APP_STATIC_URL | url prefix for static resources
 APP_STATIC_INCLUDE_CUSTOM_CSS | set to "true" to include custom.css (from APP_STATIC_URL) in static pages

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -166,8 +166,7 @@ export interface OrgUrlInfo {
 function isDocInternalUrl(host: string) {
   if (!process.env.APP_DOC_INTERNAL_URL) { return false; }
   const internalUrl = new URL('/', process.env.APP_DOC_INTERNAL_URL);
-  const internalHostnameAndMaybePort = internalUrl.hostname + (internalUrl.port ? `:${internalUrl.port}` : '');
-  return internalHostnameAndMaybePort === host;
+  return internalUrl.host === host;
 }
 
 /**

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -163,6 +163,13 @@ export interface OrgUrlInfo {
   orgInPath?: string;     // If /o/{orgInPath} should be used to access the requested org.
 }
 
+function isDocInternalUrl(host: string) {
+  if (!process.env.APP_DOC_INTERNAL_URL) { return false; }
+  const internalUrl = new URL('/', process.env.APP_DOC_INTERNAL_URL);
+  const internalHostnameAndMaybePort = internalUrl.hostname + (internalUrl.port ? `:${internalUrl.port}` : '');
+  return internalHostnameAndMaybePort === host;
+}
+
 /**
  * Given host (optionally with port), baseDomain, and pluginUrl, determine whether to interpret host
  * as a custom domain, a native domain, or a plugin domain.
@@ -180,8 +187,10 @@ export function getHostType(host: string, options: {
 
   const hostname = host.split(":")[0];
   if (!options.baseDomain) { return 'native'; }
-  if (hostname !== 'localhost' && !hostname.endsWith(options.baseDomain)) { return 'custom'; }
-  return 'native';
+  if (hostname === 'localhost' || isDocInternalUrl(host) || hostname.endsWith(options.baseDomain)) {
+    return 'native';
+  }
+  return 'custom';
 }
 
 export function getOrgUrlInfo(newOrg: string, currentHost: string, options: OrgUrlOptions): OrgUrlInfo {

--- a/test/common/gristUrls.ts
+++ b/test/common/gristUrls.ts
@@ -1,5 +1,6 @@
 import {decodeUrl, getHostType, IGristUrlState, parseFirstUrlPart} from 'app/common/gristUrls';
 import {assert} from 'chai';
+import * as testUtils from 'test/server/testUtils';
 
 describe('gristUrls', function() {
 
@@ -68,29 +69,36 @@ describe('gristUrls', function() {
   describe('getHostType', function() {
     const defaultOptions = {
       baseDomain: 'getgrist.com',
-      pluginUrl: 'https://plugin.getgrist.com/path',
+      pluginUrl: 'https://plugin.getgrist.com',
     };
+
+    const oldEnv = new testUtils.EnvironmentSnapshot();
     afterEach(function () {
-      delete process.env.APP_DOC_INTERNAL_URL;
+      oldEnv.restore();
     });
+
     it('should interpret localhost as "native"', function() {
       assert.equal(getHostType('localhost', defaultOptions), 'native');
       assert.equal(getHostType('localhost:8080', defaultOptions), 'native');
     });
+
     it('should interpret base domain as "native"', function() {
       assert.equal(getHostType('getgrist.com', defaultOptions), 'native');
       assert.equal(getHostType('www.getgrist.com', defaultOptions), 'native');
       assert.equal(getHostType('foo.getgrist.com', defaultOptions), 'native');
       assert.equal(getHostType('foo.getgrist.com:8080', defaultOptions), 'native');
     });
+
     it('should interpret plugin domain as "plugin"', function() {
       assert.equal(getHostType('plugin.getgrist.com', defaultOptions), 'plugin');
       assert.equal(getHostType('PLUGIN.getgrist.com', { pluginUrl: 'https://pLuGin.getgrist.com' }), 'plugin');
     });
+
     it('should interpret other domains as "custom"', function() {
       assert.equal(getHostType('foo.com', defaultOptions), 'custom');
       assert.equal(getHostType('foo.bar.com', defaultOptions), 'custom');
     });
+
     it('should interpret doc internal url as "native"', function() {
       process.env.APP_DOC_INTERNAL_URL = 'https://doc-worker-123.internal/path';
       assert.equal(getHostType('doc-worker-123.internal', defaultOptions), 'native');

--- a/test/common/gristUrls.ts
+++ b/test/common/gristUrls.ts
@@ -1,4 +1,4 @@
-import {decodeUrl, IGristUrlState, parseFirstUrlPart} from 'app/common/gristUrls';
+import {decodeUrl, getHostType, IGristUrlState, parseFirstUrlPart} from 'app/common/gristUrls';
 import {assert} from 'chai';
 
 describe('gristUrls', function() {
@@ -62,6 +62,46 @@ describe('gristUrls', function() {
       assert.deepEqual(parseFirstUrlPart('o', '/o/?x#y'), {path: '/o/?x#y'});
       assert.deepEqual(parseFirstUrlPart('o', '/#y'), {path: '/#y'});
       assert.deepEqual(parseFirstUrlPart('o', ''), {path: ''});
+    });
+  });
+
+  describe('getHostType', function() {
+    const defaultOptions = {
+      baseDomain: 'getgrist.com',
+      pluginUrl: 'https://plugin.getgrist.com/path',
+    };
+    afterEach(function () {
+      delete process.env.APP_DOC_INTERNAL_URL;
+    });
+    it('should interpret localhost as "native"', function() {
+      assert.equal(getHostType('localhost', defaultOptions), 'native');
+      assert.equal(getHostType('localhost:8080', defaultOptions), 'native');
+    });
+    it('should interpret base domain as "native"', function() {
+      assert.equal(getHostType('getgrist.com', defaultOptions), 'native');
+      assert.equal(getHostType('www.getgrist.com', defaultOptions), 'native');
+      assert.equal(getHostType('foo.getgrist.com', defaultOptions), 'native');
+      assert.equal(getHostType('foo.getgrist.com:8080', defaultOptions), 'native');
+    });
+    it('should interpret plugin domain as "plugin"', function() {
+      assert.equal(getHostType('plugin.getgrist.com', defaultOptions), 'plugin');
+      assert.equal(getHostType('PLUGIN.getgrist.com', { pluginUrl: 'https://pLuGin.getgrist.com' }), 'plugin');
+    });
+    it('should interpret other domains as "custom"', function() {
+      assert.equal(getHostType('foo.com', defaultOptions), 'custom');
+      assert.equal(getHostType('foo.bar.com', defaultOptions), 'custom');
+    });
+    it('should interpret doc internal url as "native"', function() {
+      process.env.APP_DOC_INTERNAL_URL = 'https://doc-worker-123.internal/path';
+      assert.equal(getHostType('doc-worker-123.internal', defaultOptions), 'native');
+      assert.equal(getHostType('doc-worker-123.internal:8080', defaultOptions), 'custom');
+      assert.equal(getHostType('doc-worker-124.internal', defaultOptions), 'custom');
+
+      process.env.APP_DOC_INTERNAL_URL = 'https://doc-worker-123.internal:8080/path';
+      assert.equal(getHostType('doc-worker-123.internal:8080', defaultOptions), 'native');
+      assert.equal(getHostType('doc-worker-123.internal', defaultOptions), 'custom');
+      assert.equal(getHostType('doc-worker-124.internal:8080', defaultOptions), 'custom');
+      assert.equal(getHostType('doc-worker-123.internal:8079', defaultOptions), 'custom');
     });
   });
 });

--- a/test/common/gristUrls.ts
+++ b/test/common/gristUrls.ts
@@ -72,7 +72,12 @@ describe('gristUrls', function() {
       pluginUrl: 'https://plugin.getgrist.com',
     };
 
-    const oldEnv = new testUtils.EnvironmentSnapshot();
+    let oldEnv: testUtils.EnvironmentSnapshot;
+
+    beforeEach(function () {
+      oldEnv = new testUtils.EnvironmentSnapshot();
+    });
+
     afterEach(function () {
       oldEnv.restore();
     });

--- a/test/server/lib/DocApi2.ts
+++ b/test/server/lib/DocApi2.ts
@@ -17,9 +17,10 @@ describe('DocApi2', function() {
   let owner: UserAPI;
   let wsId: number;
   testUtils.setTmpLogLevel('error');
-  const oldEnv = new testUtils.EnvironmentSnapshot();
+  let oldEnv: testUtils.EnvironmentSnapshot;
 
   before(async function() {
+    oldEnv = new testUtils.EnvironmentSnapshot();
     const tmpDir = await createTmpDir();
     process.env.GRIST_DATA_DIR = tmpDir;
     process.env.STRIPE_ENDPOINT_SECRET = 'TEST_WITHOUT_ENDPOINT_SECRET';


### PR DESCRIPTION
# Context

While trying to scale, we faced some issue where we have a different internal and public URL for doc workers, and having configured the org to be specified in the path (`GRIST_ORG_IN_PATH=true`).
We saw that we can set `APP_DOC_INTERNAL_URL` in the doc worker so the home worker knows how to contact to the doc workers through a private network.

However, without this patch, when the home workers attempts to contact the doc worker, the latter responds a 404 error and with a `Domain not recognized: ${hostname}` error message. That's because of the code below which rely on the result of the `getHostType()` function. I am not sure of what how the machinery works here when the `getHostType()` equals to custom though.

https://github.com/gristlabs/grist-core/blob/9557f8c4e4c61b434ee508d4fedcec063209d900/app/server/lib/extractOrg.ts#L94-L121

# Proposed solution

If we tell `getHostType()` to return `"native"` when the host corresponds to the value of `APP_DOC_INTERNAL_URL`, the rest works.
As I said, I am not very certain of the implications though. Feedback welcome :pray: