### PR TITLE
Add native OIDC support in Grist #707

### DIFF
--- a/app/server/lib/BrowserSession.ts
+++ b/app/server/lib/BrowserSession.ts
@@ -68,6 +68,11 @@ export interface SessionObj {
                           // anonymous editing (e.g. to allow the user to edit
                           // something they just added, without allowing the suer
                           // to edit other people's contributions).
+
+  oidc?: {
+    // codeVerifier is used during OIDC authentication, to protect against attacks like CSRF.
+    codeVerifier?: string;
+  }
 }
 
 // Make an artificial change to a session to encourage express-session to set a cookie.

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -36,12 +36,12 @@
  */
 
 import * as express from 'express';
-import {GristLoginSystem, GristServer} from './GristServer';
+import { GristLoginSystem, GristServer } from './GristServer';
 import { Client, generators, Issuer, UserinfoResponse } from 'openid-client';
-import {Sessions} from './Sessions';
+import { Sessions } from './Sessions';
 import log from 'app/server/lib/log';
-import {appSettings} from './AppSettings';
-import {RequestWithLogin} from './Authorizer';
+import { appSettings } from './AppSettings';
+import { RequestWithLogin } from './Authorizer';
 
 const CALLBACK_URL = '/oauth2/callback';
 
@@ -74,7 +74,7 @@ export class OIDCConfig {
       client_id: clientId,
       client_secret: clientSecret,
       redirect_uris: [ this._redirectUrl ],
-      response_types: ['code'],
+      response_types: [ 'code' ],
     });
   }
 

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -1,0 +1,145 @@
+/**
+ * Configuration for OpenID Connect (OIDC), useful for enterprise single-sign-on logins.
+ * A good informative overview of SAML is at https://developer.okta.com/blog/2019/10/21/illustrated-guide-to-oauth-and-oidc
+ * Note:
+ *    SP is "Service Provider", in our case, the Grist application.
+ *    IdP is the "Identity Provider", somewhere users log into, e.g. Okta or Google Apps.
+ *
+ * We also use optional attributes for the user's name, for which we accept any of:
+ *    given_name
+ *    family_name
+ *
+ * Expected environment variables:
+ *    env GRIST_OIDC_SP_HOST=https://<your-domain>
+ *        Host at which our /oidc endpoint will live; identifies our application.
+ *    env GRIST_OIDC_IDP_ISSUER
+ *        The issuer URL for the IdP.
+ *    env GRIST_OIDC_IDP_CLIENT_ID
+ *        The client ID for the application, as registered with the IdP.
+ *    env GRIST_OIDC_IDP_CLIENT_SECRET
+ *        The client secret for the application, as registered with the IdP.
+ *    env GRIST_OIDC_IDP_SCOPES
+ *        The scopes to request from the IdP, as a space-separated list. Defaults to "openid email profile".
+ *    env GRIST_OIDC_IDP_CODE_CHALLENGE_METHOD
+ *        The method to use for code challenge. Defaults to "S256".
+ *
+ * This version of OIDCConfig has been tested with Keycloak OIDC IdP following the instructions
+ * at:
+ *   https://www.keycloak.org/getting-started/getting-started-docker
+ * When running on localhost and http, the settings tested were with:
+ *   - GRIST_OIDC_SP_HOST=http://localhost:8484 (or whatever port you use for Grist)
+ *   - GRIST_OIDC_IDP_ISSUER=http://localhost:8080/realms/myrealm (replace 8080 by the port you use for keycloak)
+ *   - GRIST_OIDC_IDP_CLIENT_ID=myclient
+ *   - GRIST_OIDC_IDP_CLIENT_SECRET=YOUR_SECRET (as set in keycloak)
+ *   - GRIST_OIDC_IDP_SCOPES="openid email profile"
+ */
+
+import * as express from 'express';
+import {GristLoginSystem, GristServer} from './GristServer';
+import { Client, generators, Issuer } from 'openid-client';
+import {Sessions} from './Sessions';
+const CALLBACK_URL = '/oauth2/callback';
+const LOGIN_URL = '/oauth2/login';
+
+export class OIDCConfig {
+  private _client: Client;
+  private _nonce: string;
+  private _codeVerifier: string;
+  private _codeChallenge: string;
+
+  public constructor() {
+    this._nonce = generators.nonce();
+    this._codeVerifier = generators.codeVerifier();
+    this._codeChallenge = generators.codeChallenge(this._codeVerifier);
+  }
+
+  public async initOIDC(): Promise<void> {
+    if (!process.env.GRIST_OIDC_SP_HOST) { throw new Error('initConfig requires GRIST_OIDC_SP_HOST to be set'); }
+    if (!process.env.GRIST_OIDC_IDP_ISSUER) { throw new Error('initConfig requires GRIST_OIDC_IDP_ISSUER to be set'); }
+    if (!process.env.GRIST_OIDC_IDP_CLIENT_ID) {
+      throw new Error('initConfig requires GRIST_OIDC_IDP_CLIENT_ID to be set');
+    }
+    if (!process.env.GRIST_OIDC_IDP_CLIENT_SECRET) {
+      throw new Error('initConfig requires GRIST_OIDC_IDP_CLIENT_SECRET to be set');
+    }
+    const spHost: string = process.env.GRIST_OIDC_SP_HOST;
+    const issuer = await Issuer.discover(process.env.GRIST_OIDC_IDP_ISSUER);
+    this._client = new issuer.Client({
+      client_id: process.env.GRIST_OIDC_IDP_CLIENT_ID,
+      client_secret: process.env.GRIST_OIDC_IDP_CLIENT_SECRET,
+      redirect_uris: [ new URL(CALLBACK_URL, spHost).href ],
+      response_types: ['code'],
+    });
+  }
+
+  public addEndpoints(app: express.Application, sessions: Sessions): void {
+    app.get(LOGIN_URL, this.handleLogin.bind(this));
+    app.get(CALLBACK_URL, this.handleCallback.bind(this, sessions));
+  }
+
+  public async handleCallback(sessions: Sessions, req: express.Request, res: express.Response): Promise<void> {
+
+    const params = this._client.callbackParams(req);
+    const { state } = params;
+    const tokenSet = await this._client.callback(
+      new URL(CALLBACK_URL, process.env.GRIST_OIDC_SP_HOST).href,
+      params,
+      { nonce: this._nonce, state, code_verifier: this._codeVerifier }
+    );
+    const userInfo = await this._client.userinfo(tokenSet);
+    const email = userInfo.email;
+    const fname = userInfo.given_name ?? '';
+    const lname = userInfo.family_name ?? '';
+    const profile = {
+      email,
+      name: `${fname} ${lname}`.trim(),
+    };
+    const scopedSession = sessions.getOrCreateSessionFromRequest(req);
+    await scopedSession.operateOnScopedSession(req, async (user) => Object.assign(user, {
+      profile,
+    }));
+    res.redirect('/');
+  }
+
+  public async handleLogin(req: express.Request, res: express.Response): Promise<void> {
+    res.redirect(await this.getLoginRedirectUrl());
+  }
+
+  public async getLoginRedirectUrl(): Promise<string> {
+    const state = generators.state();
+    const authUrl = this._client.authorizationUrl({
+      scope: process.env.GRIST_OIDC_IDP_SCOPES || 'openid email profile',
+      code_challenge: this._codeChallenge,
+      code_challenge_method: process.env.GRIST_OIDC_IDP_CODE_CHALLENGE_METHOD || 'S256',
+      nonce: this._nonce,
+      state,
+    });
+    return authUrl;
+  }
+
+  public async getLogoutRedirectUrl(req: express.Request, redirectUrl: URL): Promise<string> {
+    return this._client.endSessionUrl({
+      post_logout_redirect_uri: redirectUrl.href
+    });
+  }
+}
+
+export async function getOIDCLoginSystem(): Promise<GristLoginSystem|undefined> {
+  if (!process.env.GRIST_OIDC_SP_HOST) { return undefined; }
+  return {
+    async getMiddleware(gristServer: GristServer) {
+      const config = new OIDCConfig();
+      await config.initOIDC();
+      return {
+        getLoginRedirectUrl: config.getLoginRedirectUrl.bind(config),
+        getSignUpRedirectUrl: config.getLoginRedirectUrl.bind(config),
+        getLogoutRedirectUrl: config.getLogoutRedirectUrl.bind(config),
+        async addEndpoints(app: express.Express) {
+          config.addEndpoints(app, gristServer.getSessions());
+          return 'oidc';
+        },
+      };
+    },
+    async deleteUser() {},
+  };
+}

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -24,7 +24,10 @@
  * This version of OIDCConfig has been tested with Keycloak OIDC IdP following the instructions
  * at:
  *   https://www.keycloak.org/getting-started/getting-started-docker
- * When running on localhost and http, the settings tested were with:
+ *
+ * /!\ CAUTION: For production, be sure to use https for all URLs. /!\
+ *
+ * For development of this module on localhost, these settings should work:
  *   - GRIST_OIDC_SP_HOST=http://localhost:8484 (or whatever port you use for Grist)
  *   - GRIST_OIDC_IDP_ISSUER=http://localhost:8080/realms/myrealm (replace 8080 by the port you use for keycloak)
  *   - GRIST_OIDC_IDP_CLIENT_ID=my_grist_instance

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -168,7 +168,7 @@ export class OIDCConfig {
 }
 
 export async function getOIDCLoginSystem(): Promise<GristLoginSystem|undefined> {
-  if (!process.env.GRIST_OIDC_SP_HOST) { return undefined; }
+  if (!process.env.GRIST_OIDC_IDP_ISSUER) { return undefined; }
   return {
     async getMiddleware(gristServer: GristServer) {
       const config = new OIDCConfig();

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -1,6 +1,6 @@
 /**
  * Configuration for OpenID Connect (OIDC), useful for enterprise single-sign-on logins.
- * A good informative overview of SAML is at https://developer.okta.com/blog/2019/10/21/illustrated-guide-to-oauth-and-oidc
+ * A good informative overview of OIDC is at https://developer.okta.com/blog/2019/10/21/illustrated-guide-to-oauth-and-oidc
  * Note:
  *    SP is "Service Provider", in our case, the Grist application.
  *    IdP is the "Identity Provider", somewhere users log into, e.g. Okta or Google Apps.
@@ -36,31 +36,31 @@
 
 import * as express from 'express';
 import {GristLoginSystem, GristServer} from './GristServer';
-import { Client, generators, Issuer } from 'openid-client';
+import { Client, generators, Issuer, UserinfoResponse } from 'openid-client';
 import {Sessions} from './Sessions';
+import log from 'app/server/lib/log';
+import {Permit} from './Permit';
+
 const CALLBACK_URL = '/oauth2/callback';
 const LOGIN_URL = '/oauth2/login';
 
+const LOGIN_ACTION = 'oidc-login';
+const WAIT_IN_MINUTES = 20;
+
 export class OIDCConfig {
   private _client: Client;
-  private _nonce: string;
-  private _codeVerifier: string;
-  private _codeChallenge: string;
 
-  public constructor() {
-    this._nonce = generators.nonce();
-    this._codeVerifier = generators.codeVerifier();
-    this._codeChallenge = generators.codeChallenge(this._codeVerifier);
+  public constructor(private _gristServer: GristServer) {
   }
 
   public async initOIDC(): Promise<void> {
-    if (!process.env.GRIST_OIDC_SP_HOST) { throw new Error('initConfig requires GRIST_OIDC_SP_HOST to be set'); }
-    if (!process.env.GRIST_OIDC_IDP_ISSUER) { throw new Error('initConfig requires GRIST_OIDC_IDP_ISSUER to be set'); }
+    if (!process.env.GRIST_OIDC_SP_HOST) { throw new Error('initOIDC requires GRIST_OIDC_SP_HOST to be set'); }
+    if (!process.env.GRIST_OIDC_IDP_ISSUER) { throw new Error('initOIDC requires GRIST_OIDC_IDP_ISSUER to be set'); }
     if (!process.env.GRIST_OIDC_IDP_CLIENT_ID) {
-      throw new Error('initConfig requires GRIST_OIDC_IDP_CLIENT_ID to be set');
+      throw new Error('initOIDC requires GRIST_OIDC_IDP_CLIENT_ID to be set');
     }
     if (!process.env.GRIST_OIDC_IDP_CLIENT_SECRET) {
-      throw new Error('initConfig requires GRIST_OIDC_IDP_CLIENT_SECRET to be set');
+      throw new Error('initOIDC requires GRIST_OIDC_IDP_CLIENT_SECRET to be set');
     }
     const spHost: string = process.env.GRIST_OIDC_SP_HOST;
     const issuer = await Issuer.discover(process.env.GRIST_OIDC_IDP_ISSUER);
@@ -79,39 +79,50 @@ export class OIDCConfig {
 
   public async handleCallback(sessions: Sessions, req: express.Request, res: express.Response): Promise<void> {
 
-    const params = this._client.callbackParams(req);
-    const { state } = params;
-    const tokenSet = await this._client.callback(
-      new URL(CALLBACK_URL, process.env.GRIST_OIDC_SP_HOST).href,
-      params,
-      { nonce: this._nonce, state, code_verifier: this._codeVerifier }
-    );
-    const userInfo = await this._client.userinfo(tokenSet);
-    const email = userInfo.email;
-    const fname = userInfo.given_name ?? '';
-    const lname = userInfo.family_name ?? '';
-    const profile = {
-      email,
-      name: `${fname} ${lname}`.trim(),
-    };
-    const scopedSession = sessions.getOrCreateSessionFromRequest(req);
-    await scopedSession.operateOnScopedSession(req, async (user) => Object.assign(user, {
-      profile,
-    }));
-    res.redirect('/');
+    try {
+      const params = this._client.callbackParams(req);
+      const { state } = params;
+      if (!state) {
+        throw new Error('Login or logout failed to complete');
+      }
+      const codeVerifier = await this._retrieveCodeVerifierFromPermit(state);
+      const tokenSet = await this._client.callback(
+        new URL(CALLBACK_URL, process.env.GRIST_OIDC_SP_HOST).href,
+        params,
+        { state, code_verifier: codeVerifier }
+      );
+      const userInfo = await this._client.userinfo(tokenSet);
+      const profile = this._makeUserProfileFromUserInfo(userInfo);
+      const scopedSession = sessions.getOrCreateSessionFromRequest(req);
+      await scopedSession.operateOnScopedSession(req, async (user) => Object.assign(user, {
+        profile,
+        accessToken: tokenSet.access_token,
+        refreshToken: tokenSet.refresh_token,
+      }));
+      res.redirect('/');
+    } catch (err) {
+      log.error(`OIDC callback failed: ${err.message}`);
+      res.status(500).send(`Cannot connect to OIDC provider: ${err.message}`);
+    }
   }
 
   public async handleLogin(req: express.Request, res: express.Response): Promise<void> {
-    res.redirect(await this.getLoginRedirectUrl());
+    try {
+      res.redirect(await this.getLoginRedirectUrl(req));
+    } catch (ex) {
+      log.error(`OIDC login failed: ${ex.message}`);
+      res.status(500).send(`Cannot connect to OIDC provider: ${ex.message}`);
+    }
   }
 
-  public async getLoginRedirectUrl(): Promise<string> {
-    const state = generators.state();
+  public async getLoginRedirectUrl(req: express.Request): Promise<string> {
+    const { state, codeVerifier } = await this._generateAndStoreCodeVerifier(req, this._gristServer.getSessions());
+    const codeChallenge = generators.codeChallenge(codeVerifier);
+
     const authUrl = this._client.authorizationUrl({
       scope: process.env.GRIST_OIDC_IDP_SCOPES || 'openid email profile',
-      code_challenge: this._codeChallenge,
+      code_challenge: codeChallenge,
       code_challenge_method: process.env.GRIST_OIDC_IDP_CODE_CHALLENGE_METHOD || 'S256',
-      nonce: this._nonce,
       state,
     });
     return authUrl;
@@ -122,13 +133,51 @@ export class OIDCConfig {
       post_logout_redirect_uri: redirectUrl.href
     });
   }
+
+  private async _generateAndStoreCodeVerifier(req: express.Request, sessions: Sessions) {
+    const permitStore = this._gristServer.getExternalPermitStore();
+    const sessionId = sessions.getSessionIdFromRequest(req);
+    if (!sessionId) { throw new Error('no session available'); }
+    const codeVerifier = generators.codeVerifier();
+    const permit: Permit = {
+      action: LOGIN_ACTION,
+      sessionId,
+      codeVerifier,
+    };
+    const state = await permitStore.setPermit(permit, WAIT_IN_MINUTES * 60 * 1000);
+    return { codeVerifier, state };
+  }
+
+  private async _retrieveCodeVerifierFromPermit(state: string) {
+    const permitStore = this._gristServer.getExternalPermitStore();
+    const permit = await permitStore.getPermit(state);
+    if (!permit || !permit.codeVerifier) {
+      throw new Error('Login or logout is stale');
+    }
+    if (permit.action !== LOGIN_ACTION) {
+      throw new Error(`Unexpected action: "${permit.action}"`);
+    }
+    const { codeVerifier } = permit;
+    await permitStore.removePermit(state);
+    return codeVerifier;
+  }
+
+  private _makeUserProfileFromUserInfo(userInfo: UserinfoResponse) {
+      const email = userInfo.email;
+      const fname = userInfo.given_name ?? '';
+      const lname = userInfo.family_name ?? '';
+      return {
+        email,
+        name: `${fname} ${lname}`.trim(),
+      };
+  }
 }
 
 export async function getOIDCLoginSystem(): Promise<GristLoginSystem|undefined> {
   if (!process.env.GRIST_OIDC_SP_HOST) { return undefined; }
   return {
     async getMiddleware(gristServer: GristServer) {
-      const config = new OIDCConfig();
+      const config = new OIDCConfig(gristServer);
       await config.initOIDC();
       return {
         getLoginRedirectUrl: config.getLoginRedirectUrl.bind(config),

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -11,9 +11,10 @@
  *
  * Expected environment variables:
  *    env GRIST_OIDC_SP_HOST=https://<your-domain>
- *        Host at which our /oauth2 endpoint will live, usually the same value as `APP_HOME_URL`.
+ *        Host at which our /oauth2 endpoint will live. Optional, defaults to `APP_HOME_URL`.
  *    env GRIST_OIDC_IDP_ISSUER
  *        The issuer URL for the IdP, passed to node-openid-client, see: https://github.com/panva/node-openid-client/blob/a84d022f195f82ca1c97f8f6b2567ebcef8738c3/docs/README.md#issuerdiscoverissuer.
+ *        This variable turns on the OIDC login system.
  *    env GRIST_OIDC_IDP_CLIENT_ID
  *        The client ID for the application, as registered with the IdP.
  *    env GRIST_OIDC_IDP_CLIENT_SECRET
@@ -66,6 +67,7 @@ export class OIDCConfig {
     });
     const clientSecret = section.flag('clientSecret').requireString({
       envVar: 'GRIST_OIDC_IDP_CLIENT_SECRET',
+      censor: true,
     });
 
     const issuer = await Issuer.discover(issuerUrl);
@@ -140,7 +142,6 @@ export class OIDCConfig {
     mreq.session.oidc = {
       codeVerifier,
     };
-    console.log('mreq.session = ', mreq.session);
 
     return codeVerifier;
   }
@@ -150,9 +151,7 @@ export class OIDCConfig {
     if (!mreq.session) { throw new Error('no session available'); }
     const codeVerifier = mreq.session.oidc?.codeVerifier;
     if (!codeVerifier) { throw new Error('Login is stale'); }
-    console.log('mreq.session = ', mreq.session);
     delete mreq.session.oidc?.codeVerifier;
-    console.log('zzzz mreq.session = ', mreq.session);
     return codeVerifier;
   }
 

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -20,8 +20,6 @@
  *        The client secret for the application, as registered with the IdP.
  *    env GRIST_OIDC_IDP_SCOPES
  *        The scopes to request from the IdP, as a space-separated list. Defaults to "openid email profile".
- *    env GRIST_OIDC_IDP_CODE_CHALLENGE_METHOD
- *        The method to use for code challenge. Defaults to "S256".
  *
  * This version of OIDCConfig has been tested with Keycloak OIDC IdP following the instructions
  * at:
@@ -122,7 +120,7 @@ export class OIDCConfig {
     const authUrl = this._client.authorizationUrl({
       scope: process.env.GRIST_OIDC_IDP_SCOPES || 'openid email profile',
       code_challenge: codeChallenge,
-      code_challenge_method: process.env.GRIST_OIDC_IDP_CODE_CHALLENGE_METHOD || 'S256',
+      code_challenge_method: 'S256',
       state,
     });
     return authUrl;

--- a/app/server/lib/Permit.ts
+++ b/app/server/lib/Permit.ts
@@ -32,6 +32,7 @@ export interface Permit {
   sessionId?: string;   // A particular session.
   url?: string;         // A particular url.
   action?: string;      // A string denoting what kind of action the permit applies to.
+  codeVerifier?: string;
 }
 
 /* A store of permits */

--- a/app/server/lib/Permit.ts
+++ b/app/server/lib/Permit.ts
@@ -32,7 +32,6 @@ export interface Permit {
   sessionId?: string;   // A particular session.
   url?: string;         // A particular url.
   action?: string;      // A string denoting what kind of action the permit applies to.
-  codeVerifier?: string;
 }
 
 /* A store of permits */

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "multiparty": "4.2.2",
     "node-abort-controller": "3.0.1",
     "node-fetch": "2.6.7",
+    "openid-client": "^5.6.1",
     "pg": "8.6.0",
     "piscina": "3.2.0",
     "plotly.js-basic-dist": "2.13.2",

--- a/stubs/app/server/lib/logins.ts
+++ b/stubs/app/server/lib/logins.ts
@@ -1,10 +1,12 @@
 import { getForwardAuthLoginSystem } from 'app/server/lib/ForwardAuthLogin';
 import { GristLoginSystem } from 'app/server/lib/GristServer';
 import { getMinimalLoginSystem } from 'app/server/lib/MinimalLogin';
+import {getOIDCLoginSystem} from 'app/server/lib/OIDCConfig';
 import { getSamlLoginSystem } from 'app/server/lib/SamlConfig';
 
 export async function getLoginSystem(): Promise<GristLoginSystem> {
   return await getSamlLoginSystem() ||
+    await getOIDCLoginSystem() ||
     await getForwardAuthLoginSystem() ||
     await getMinimalLoginSystem();
 }

--- a/stubs/app/server/lib/logins.ts
+++ b/stubs/app/server/lib/logins.ts
@@ -1,7 +1,7 @@
 import { getForwardAuthLoginSystem } from 'app/server/lib/ForwardAuthLogin';
 import { GristLoginSystem } from 'app/server/lib/GristServer';
 import { getMinimalLoginSystem } from 'app/server/lib/MinimalLogin';
-import {getOIDCLoginSystem} from 'app/server/lib/OIDCConfig';
+import { getOIDCLoginSystem } from 'app/server/lib/OIDCConfig';
 import { getSamlLoginSystem } from 'app/server/lib/SamlConfig';
 
 export async function getLoginSystem(): Promise<GristLoginSystem> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4918,6 +4918,11 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+jose@^4.15.1:
+  version "4.15.4"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.4.tgz#02a9a763803e3872cf55f29ecef0dfdcc218cc03"
+  integrity sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==
+
 joycon@^3.0.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz"
@@ -6062,6 +6067,11 @@ object-assign@^4.0.1, object-assign@^4.1.1:
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
+object-hash@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
+
 object-inspect@^1.9.0:
   version "1.9.0"
   resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz"
@@ -6081,6 +6091,11 @@ object.assign@^4.0.4:
     define-properties "^1.1.4"
     has-symbols "^1.0.3"
     object-keys "^1.1.1"
+
+oidc-token-hash@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz#9a229f0a1ce9d4fc89bcaee5478c97a889e7b7b6"
+  integrity sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==
 
 on-finished@2.4.1:
   version "2.4.1"
@@ -6107,6 +6122,16 @@ once@^1.3.0, once@^1.3.1, once@^1.3.2, once@^1.4.0:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
+
+openid-client@^5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.6.1.tgz#8f7526a50c290a5e28a7fe21b3ece3107511bc73"
+  integrity sha512-PtrWsY+dXg6y8mtMPyL/namZSYVz8pjXz3yJiBNZsEdCnu9miHLB4ELVC85WvneMKo2Rg62Ay7NkuCpM0bgiLQ==
+  dependencies:
+    jose "^4.15.1"
+    lru-cache "^6.0.0"
+    object-hash "^2.2.0"
+    oidc-token-hash "^5.0.3"
 
 optionator@^0.8.1:
   version "0.8.3"


### PR DESCRIPTION
Resolves #707

# Proposed implementation

We use the `openid-client` package, which is certified as [openid compliant](https://www.npmjs.com/package/openid-client#certification).
Also the code is heavily inspired from [SamlConfig](https://github.com/gristlabs/grist-core/blob/d29e23efe83d71f0e3daf921898cac2efcdce8cc/app/server/lib/SamlConfig.ts)
