### PR TITLE
feat: add `overflowTooltip` to `editableLabel`

### DIFF
--- a/app/client/lib/koForm.js
+++ b/app/client/lib/koForm.js
@@ -26,6 +26,8 @@ var koArray  = require('./koArray');
 
 var modelUtil = require('../models/modelUtil');
 
+const { overflowTooltip } = require("app/client/ui/tooltips");
+
 var setSaveValue = modelUtil.setSaveValue;
 
 
@@ -902,7 +904,8 @@ exports.editableLabel = function(valueObservable, optToggleObservable) {
   return dom('div.kf_editable_label',
     dom('div.kf_elabel_text',
       kd.text(valueObservable),
-      kd.hide(isEditing)
+      kd.hide(isEditing),
+      overflowTooltip({placement: 'top'})
     ),
     contentSizer = dom('div.elabel_content_measure'),
     (!optToggleObservable ? dom.on('click', () => isEditing(true)) : null),

--- a/test/client/lib/koForm.js
+++ b/test/client/lib/koForm.js
@@ -189,6 +189,19 @@ describe('koForm', function() {
     });
   });
 
+  describe("editableLabel", function() {
+    it("should bind an observable", function () {
+      var obs = ko.observable("Tools, projects, things and others");
+      var el = kf.editableLabel(obs).querySelector("div.kf_elabel_text");
+
+      assert.equal(el.textContent, "Tools, projects, things and others");
+    });
+
+    it("should show a tooltip when textContent overflows", function () {
+      // How to test this? Should it be tested here?
+    });
+  });
+
   describe("select", function() {
     it("should bind an observable", function() {
       var obs = ko.observable("b");


### PR DESCRIPTION
Resolves: #543 

# Description

The objective was to add a tooltip to column names when their content overflows. This PR adds `overflowTooltip({placement: 'top'})` to `editableLabel` in `koForm`, which achieves this results:


https://github.com/gristlabs/grist-core/assets/20607294/aee7d696-0006-4b43-9480-5c94b14364d8

# Questions

I opened this as draft because of testing.

I noticed there was no test case for `editableLabel`, I added one following what was present for the other `koForm` entities. However, i am not sure how to test the rendering of a tooltip.

I assume that I need to trigger a `mouseenter` event and then select the test classname `'info-tooltip-popup'` from the DOM, but I'm not sure how to do this.

I'm also unsure if this is where we want to test this, or if it should be etsted in the end-to-end tests.