### PR TITLE
bump pyodide version number

### DIFF
--- a/sandbox/pyodide/Makefile
+++ b/sandbox/pyodide/Makefile
@@ -1,6 +1,6 @@
 # This number should be bumped up if making a non-additive change
 # to python packages.
-GRIST_PYODIDE_VERSION = 2
+GRIST_PYODIDE_VERSION = 3
 
 default:
 	echo "Welcome to the pyodide sandbox"

--- a/sandbox/pyodide/package_filenames.json
+++ b/sandbox/pyodide/package_filenames.json
@@ -1,6 +1,6 @@
 [
   "astroid-2.14.2-cp311-none-any.whl",
-  "asttokens-2.2.1-cp311-none-any.whl",
+  "asttokens-2.4.0-cp311-none-any.whl",
   "chardet-5.1.0-cp311-none-any.whl",
   "et_xmlfile-1.0.1-cp311-none-any.whl",
   "executing-1.1.1-cp311-none-any.whl",


### PR DESCRIPTION
Pyodide packages needed rebuilding, and the pyodide project has moved on a bit so a new version number is needed (newly built packages cannot be intermingled with older ones). The new packages have already been built and pushed to S3.

To verify, go to `sandbox/pyodide` and follow the README there. Then at top level do `GRIST_SANDBOX_FLAVOR=pyodide`. Try to create and edit a document using formulas. It should work.

See https://github.com/gristlabs/grist-core/issues/734