### PR TITLE
Issue 740 OIDC login redirect

### DIFF
--- a/app/server/lib/BrowserSession.ts
+++ b/app/server/lib/BrowserSession.ts
@@ -72,6 +72,8 @@ export interface SessionObj {
   oidc?: {
     // codeVerifier is used during OIDC authentication, to protect against attacks like CSRF.
     codeVerifier?: string;
+    state?: string;
+    targetUrl?: string;
   }
 }
 

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -85,15 +85,18 @@ export class OIDCConfig {
   }
 
   public async handleCallback(sessions: Sessions, req: express.Request, res: express.Response): Promise<void> {
+    const mreq = req as RequestWithLogin;
     try {
       const params = this._client.callbackParams(req);
-      const { state } = params;
+      const { state, targetUrl } = mreq.session?.oidc ?? {};
       if (!state) {
         throw new Error('Login or logout failed to complete');
       }
 
       const codeVerifier = await this._retrieveCodeVerifierFromSession(req);
 
+      // The callback function will compare the state present in the params and the one we retrieved from the session.
+      // If they don't match, it will throw an error.
       const tokenSet = await this._client.callback(
         this._redirectUrl,
         params,
@@ -108,17 +111,22 @@ export class OIDCConfig {
         profile,
       }));
 
-      res.redirect('/');
+      delete mreq.session.oidc;
+      res.redirect(targetUrl ?? '/');
     } catch (err) {
-      log.error(`OIDC callback failed: ${err.message}`);
-      res.status(500).send(`OIDC callback failed: ${err.message}`);
+      log.error(`OIDC callback failed: ${err.stack}`);
+      // Delete the session data even if the login failed.
+      // This way, we prevent several login attempts.
+      //
+      // Also session deletion must be done before sending the response.
+      delete mreq.session.oidc;
+      res.status(500).send(`OIDC callback failed.`);
     }
   }
 
-  public async getLoginRedirectUrl(req: express.Request): Promise<string> {
-    const codeVerifier = await this._generateAndStoreCodeVerifier(req);
+  public async getLoginRedirectUrl(req: express.Request, targetUrl: URL): Promise<string> {
+    const { codeVerifier, state } = await this._generateAndStoreConnectionInfo(req, targetUrl.href);
     const codeChallenge = generators.codeChallenge(codeVerifier);
-    const state = generators.state();
 
     const authUrl = this._client.authorizationUrl({
       scope: process.env.GRIST_OIDC_IDP_SCOPES || 'openid email profile',
@@ -135,15 +143,18 @@ export class OIDCConfig {
     });
   }
 
-  private async _generateAndStoreCodeVerifier(req: express.Request) {
+  private async _generateAndStoreConnectionInfo(req: express.Request, targetUrl: string) {
     const mreq = req as RequestWithLogin;
     if (!mreq.session) { throw new Error('no session available'); }
     const codeVerifier = generators.codeVerifier();
+    const state = generators.state();
     mreq.session.oidc = {
       codeVerifier,
+      state,
+      targetUrl
     };
 
-    return codeVerifier;
+    return { codeVerifier, state };
   }
 
   private async _retrieveCodeVerifierFromSession(req: express.Request) {
@@ -151,7 +162,6 @@ export class OIDCConfig {
     if (!mreq.session) { throw new Error('no session available'); }
     const codeVerifier = mreq.session.oidc?.codeVerifier;
     if (!codeVerifier) { throw new Error('Login is stale'); }
-    delete mreq.session.oidc?.codeVerifier;
     return codeVerifier;
   }
 

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -78,6 +78,7 @@ export class OIDCConfig {
       redirect_uris: [ this._redirectUrl ],
       response_types: [ 'code' ],
     });
+    log.info(`OIDCConfig: initialized with issuer ${issuerUrl}`);
   }
 
   public addEndpoints(app: express.Application, sessions: Sessions): void {
@@ -105,6 +106,7 @@ export class OIDCConfig {
 
       const userInfo = await this._client.userinfo(tokenSet);
       const profile = this._makeUserProfileFromUserInfo(userInfo);
+      log.info(`OIDCConfig: got OIDC response for ${profile.email} (${profile.name}) redirecting to ${targetUrl}`);
 
       const scopedSession = sessions.getOrCreateSessionFromRequest(req);
       await scopedSession.operateOnScopedSession(req, async (user) => Object.assign(user, {


### PR DESCRIPTION
# Context

Resolves #740

 - After being logged in, the user should be redirected to the URL s/he was consulting before the authentication process;

# Technical considerations

 - Store the `targetUrl` along with the `state` and the `codeVerifier` in the session;
 - Let the openid-client compare the state as stored in the session and as stored in the parameters (otherwise it will be useless [as pointed out by Dmitry here](https://github.com/gristlabs/grist-core/issues/740#issuecomment-1807012939);
 - Continue using the state, which I believe offers protection against CSRF that PKCE does not (cf [Daniel Fett this summary in the blog article](https://danielfett.de/2020/05/16/pkce-vs-nonce-equivalent-or-not/#csrf-summary));
 - Add more logs;
 - Also don't print error the full error message in the response, which could give attackers information;