### PR TITLE
OIDC name for gitlab and authelia

### DIFF
--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -141,6 +141,10 @@ export class OIDCConfig {
   }
 
   public async getLogoutRedirectUrl(req: express.Request, redirectUrl: URL): Promise<string> {
+    // For IdPs that don't have end_session_endpoint, we just redirect to the logout page.
+    if (this._client.issuer.metadata.end_session_endpoint === undefined) {
+      return redirectUrl.href;
+    }
     return this._client.endSessionUrl({
       post_logout_redirect_uri: redirectUrl.href
     });

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -6,8 +6,9 @@
  *    IdP is the "Identity Provider", somewhere users log into, e.g. Okta or Google Apps.
  *
  * We also use optional attributes for the user's name, for which we accept any of:
- *    given_name
- *    family_name
+ *    given_name + family_name
+ *    display_name
+ *    name
  *
  * Expected environment variables:
  *    env GRIST_OIDC_SP_HOST=https://<your-domain>
@@ -171,9 +172,16 @@ export class OIDCConfig {
       const email = userInfo.email;
       const fname = userInfo.given_name ?? '';
       const lname = userInfo.family_name ?? '';
+
+      const fullname = `${fname} ${lname}`.trim() ||
+        // display_name is provided by Authelia for example.
+        userInfo.display_name ||
+        // name is provided by Gitlab for example.
+        userInfo.name;
+
       return {
         email,
-        name: `${fname} ${lname}`.trim(),
+        name: fullname,
       };
   }
 }

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -103,6 +103,10 @@ export class OIDCConfig {
       redirect_uris: [ this._redirectUrl ],
       response_types: [ 'code' ],
     });
+    if (this._client.issuer.metadata.end_session_endpoint === undefined && !this._skipEndSessionEndpoint) {
+      throw new Error('The Identity provider does not propose end_session_endpoint. ' +
+        'If that is expected, please set GRIST_OIDC_IDP_SKIP_END_SESSION_ENDPOINT=true');
+    }
     log.info(`OIDCConfig: initialized with issuer ${issuerUrl}`);
   }
 
@@ -168,11 +172,6 @@ export class OIDCConfig {
     // For IdPs that don't have end_session_endpoint, we just redirect to the logout page.
     if (this._skipEndSessionEndpoint) {
       return redirectUrl.href;
-    }
-    if (this._client.issuer.metadata.end_session_endpoint === undefined) {
-      log.error('The Identity provider does not propose end_session_endpoint. ' +
-        'If that is expected, please set GRIST_OIDC_IDP_SKIP_END_SESSION_ENDPOINT=true');
-      throw new Error('The identity provider does not propose end_session_endpoint.');
     }
     return this._client.endSessionUrl({
       post_logout_redirect_uri: redirectUrl.href


### PR DESCRIPTION
# Context

1. Nor Authelia (see #739) or Gitlab do provide `given_name` or `family_name` attributes in userinfo
1. Gitlab does not provide an `end_session_endpoint`, which led to an ugly error when disconnecting

# Solutions

 1. I propose to use `display_name` or `name` as alternative attributes for the `given_name` + `family_name` pair;
 1. I propose to just redirect to the logout page directly, the user won't be logged out in the IdP;