### PR TITLE
Add option to skip Checksum verif between doc storage and Redis #751

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ COOKIE_MAX_AGE      | session cookie max age, defaults to 90 days; can be set to
 HOME_PORT           | port number to listen on for REST API server; if set to "share", add API endpoints to regular grist port.
 PORT                | port number to listen on for Grist server
 REDIS_URL           | optional redis server for browser sessions and db query caching
+GRIST_SKIP_REDIS_CHECKSUM_MISMATCH | Experimental. If set, only warn if the checksum in Redis differs with the one in your S3 backend storage. You may turn it on if your backend storage implements the [read-after-write consistency](https://aws.amazon.com/fr/blogs/aws/amazon-s3-update-strong-read-after-write-consistency/). Defaults to false.
 GRIST_SNAPSHOT_TIME_CAP       | optional. Define the caps for tracking buckets. Usage: {"hour": 25, "day": 32, "isoWeek": 12, "month": 96, "year": 1000}
 GRIST_SNAPSHOT_KEEP           | optional. Number of recent snapshots to retain unconditionally for a document, regardless of when they were made
 GRIST_PROMCLIENT_PORT         | optional. If set, serve the Prometheus metrics on the specified port number. ⚠️ Be sure to use a port which is not publicly exposed ⚠️.

--- a/app/server/lib/ExternalStorage.ts
+++ b/app/server/lib/ExternalStorage.ts
@@ -227,8 +227,9 @@ export class ChecksummedExternalStorage implements ExternalStorage {
           const expectedChecksum = await this._options.sharedHash.load(fromKey);
           // Let null docMD5s pass.  Otherwise we get stuck if redis is cleared.
           // Otherwise, make sure what we've got matches what we expect to get.
-          // S3 is eventually consistent - if you overwrite an object in it, and then read from it,
-          // you may get an old version for some time.
+          // S3 is eventually consistent. However, times ago, if you overwrote an object in it,
+          // and then read from it, you may have got an old version for some time.
+          // We are confident this should not be the case anymore, though this has to be studied carefully.
           // If a snapshotId was specified, we can skip this check.
           if (expectedChecksum && expectedChecksum !== checksum) {
             const message = `ext ${this.label} download: data for ${fromKey} has wrong checksum:` +

--- a/app/server/lib/ExternalStorage.ts
+++ b/app/server/lib/ExternalStorage.ts
@@ -1,7 +1,7 @@
+import {ObjMetadata, ObjSnapshot, ObjSnapshotWithMetadata} from 'app/common/DocSnapshot';
+import {isAffirmative} from 'app/common/gutil';
 import log from 'app/server/lib/log';
 import {createTmpDir} from 'app/server/lib/uploads';
-import {isAffirmative} from 'app/common/gutil';
-import {ObjMetadata, ObjSnapshot, ObjSnapshotWithMetadata} from 'app/common/DocSnapshot';
 
 import {delay} from 'bluebird';
 import * as fse from 'fs-extra';
@@ -239,8 +239,10 @@ export class ChecksummedExternalStorage implements ExternalStorage {
             const message = `ext ${this.label} download: data for ${fromKey} has wrong checksum:` +
               ` ${checksum} (expected ${expectedChecksum})`;
 
-            // Only warn if GRIST_SKIP_REDIS_CHECKSUM_MISMATCH is set. This flag is experimental
-            // and should be removed once we are confident that the checksums verification is useless.
+            // If GRIST_SKIP_REDIS_CHECKSUM_MISMATCH is set, issue a warning only and continue,
+            // rather than issuing an error and failing.
+            // This flag is experimental and should be removed once we are
+            // confident that the checksums verification is useless.
             if (isAffirmative(process.env.GRIST_SKIP_REDIS_CHECKSUM_MISMATCH)) {
               log.warn(message);
             } else {

--- a/app/server/lib/ExternalStorage.ts
+++ b/app/server/lib/ExternalStorage.ts
@@ -234,9 +234,9 @@ export class ChecksummedExternalStorage implements ExternalStorage {
             const message = `ext ${this.label} download: data for ${fromKey} has wrong checksum:` +
               ` ${checksum} (expected ${expectedChecksum})`;
 
-            // Only warn if GRIST_DISCARD_REDIS_CHECKSUM_MISMATCH is set. This flag is experimental
+            // Only warn if GRIST_SKIP_REDIS_CHECKSUM_MISMATCH is set. This flag is experimental
             // and should be removed once we are confident that the checksums verification is useless.
-            if (isAffirmative(process.env.GRIST_DISCARD_REDIS_CHECKSUM_MISMATCH)) {
+            if (isAffirmative(process.env.GRIST_SKIP_REDIS_CHECKSUM_MISMATCH)) {
               log.warn(message);
             } else {
               log.error(message);


### PR DESCRIPTION
# Context

See #751, we faced an issue where the checksum stored in Redis does not match the one of the document. This is due to the fact that the S3 upload finished but the server crashed before storing the checksum in redis.

So Redis had the checksum of the previous version of the document.

# Solution

As suggested in the issue, it should be wise to just log a warning telling that the checksum does not match.

However there is some uncertainty around this. I propose to offer an experimental flag until we are comfortable with just warning the user (if that may be of some help until then?).