### PR TITLE
OIDC: Use 'sub' claim to identify the user #759

### DIFF
--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -348,10 +348,13 @@ export async function addRequestUser(
       // A user record will be created automatically for emails we've never seen before.
       if (profile && !mreq.userId) {
         const userOptions: UserOptions = {};
-        if (profile?.loginMethod === 'Email + Password') {
+        if (profile.loginMethod === 'Email + Password') {
           // Link the session authSubject, if present, to the user. This has no effect
           // if the user already has an authSubject set in the db.
           userOptions.authSubject = sessionUser.authSubject;
+        }
+        if (profile.connectId) {
+          await dbManager.ensureExternalUser(profile);
         }
         const user = await dbManager.getUserByLoginWithRetry(profile.email, {profile, userOptions});
         if (user) {

--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -203,8 +203,9 @@ export class OIDCConfig {
   private _makeUserProfileFromUserInfo(userInfo: UserinfoResponse): Partial<UserProfile> {
     return {
       email: String(userInfo[ this._emailPropertyKey ]),
-      name: this._extractName(userInfo)
-
+      name: this._extractName(userInfo),
+      connectId: userInfo.sub,
+      loginMethod: 'External',
     };
   }
 


### PR DESCRIPTION
# Context

Resolves #759 

When a user change their email in the OIDC Identity Provider and connect again to Grist, a new account is created and they cannot access to their workspace anymore.

# Technical considerations

Credits to @illode for the idea.

The [`sub` claim in OIDC spec](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) is used to uniquely identify a user, instead of their email (which can be changed).

We store it in the `connect_id` field of the `users` table [which seems to be made for that](https://github.com/gristlabs/grist-core/blob/c06828d35da0a8fe316aca14be508e3d4be886f5/app/common/LoginSessionAPI.ts#L9) and take advantage of it to update the email when required.

