### PR TITLE
Fixing widget selection

### DIFF
--- a/test/nbrowser/FillLinkedRecords.ntest.js
+++ b/test/nbrowser/FillLinkedRecords.ntest.js
@@ -28,19 +28,19 @@ describe('FillLinkedRecords.ntest', function() {
 
     // Link the sections first since the sample document start with no links.
     // Connect Friends -> Films
-    await gu.getSection('Films record').click();
+    await gu.actions.viewSection('Films record').selectSection();
     await $('.test-right-select-by').click();
     await $('.test-select-row:contains(Friends record)').click();
     await gu.waitForServer();
 
     // Connect Films -> Performances grid
-    await gu.getSection('Performances record').click();
+    await gu.actions.viewSection('Performances record').selectSection();
     await $('.test-right-select-by').click();
     await $('.test-select-row:contains(Films record)').click();
     await gu.waitForServer();
 
     // Connect Films -> Performances detail
-    await gu.getSection('Performances detail').click();
+    await gu.actions.viewSection('Performances detail').selectSection();
     await $('.test-right-select-by').click();
     await $('.test-select-row:contains(Films record)').click();
     await gu.waitForServer();

--- a/test/nbrowser/SavePosition.ntest.js
+++ b/test/nbrowser/SavePosition.ntest.js
@@ -25,7 +25,7 @@ describe('SavePosition.ntest', function() {
     await $('.test-config-data').click();
 
     // Connect CITY -> CITY Card List
-    await gu.getSection('CITY Card List').click();
+    await gu.actions.viewSection('CITY Card List').selectSection();
     await $('.test-right-select-by').click();
     await $('.test-select-row:contains(CITY)').click();
     await gu.waitForServer();

--- a/test/nbrowser/TypeChange.ntest.js
+++ b/test/nbrowser/TypeChange.ntest.js
@@ -291,12 +291,12 @@ describe('TypeChange.ntest', function() {
 
   it('should trigger a transform when reference table is changed', async function() {
     // Set up conditions for the test
-    await gu.getSection('Table1').click();
+    await gu.actions.viewSection('Table1').selectSection();
     await gu.enterGridValues(2, 3, [['red', 'yellow']]);
     await gu.actions.addNewSection('New', 'Table');
-    await gu.getSection('TABLE3').click();
+    await gu.actions.viewSection('TABLE3').selectSection();
     await gu.enterGridValues(0, 1, [['yellow', 'red', 'green', 'blue']]);
-    await gu.getSection('Table1').click();
+    await gu.actions.viewSection('Table1').selectSection();
     await gu.clickCellRC(0, 3);
     await gu.openSidePane('field');
     await gu.setType('Reference');
@@ -365,7 +365,7 @@ describe('TypeChange.ntest', function() {
   //  column were mistaken for row ids and converted to row values instead of AltText values.
   it('should properly convert from integer to reference', async function() {
     // Set up conditions for the test
-    await gu.getSection('TABLE3').click();
+    await gu.actions.viewSection('TABLE3').selectSection();
     await gu.enterGridValues(0, 2, [['3', '3', '4', '1']]);
     await gu.waitForServer();
     await gu.setType('Integer');

--- a/test/nbrowser/Views.ntest.js
+++ b/test/nbrowser/Views.ntest.js
@@ -111,7 +111,7 @@ describe('Views.ntest', function() {
     // Reference: https://phab.getgrist.com/T327
     await gu.actions.addNewSection('New', 'Table');
     await gu.waitForServer();
-    await gu.getSection('TABLE4').click();
+    await gu.actions.viewSection('TABLE4').selectSection();
     // Delete the section
     await gu.actions.viewSection('TABLE4').selectMenuOption('viewLayout', 'Delete widget');
     await gu.waitForServer();


### PR DESCRIPTION
Some tests were switching sections by clicking at the middle of the screen, which opened the detail card popup in some cases. 