### PR TITLE
Change how a builtin custom widget bundle is found

### DIFF
--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1999,9 +1999,15 @@ export class FlexServer implements GristServer {
     const userRoot = path.resolve(process.env.GRIST_USER_ROOT || getAppPathTo(this.appRoot, '.grist'));
     this.info.push(['userRoot', userRoot]);
     // Some custom widgets may be included as an npm package called @gristlabs/grist-widget.
+    // The package doesn't actually  contain node code, but should be in the same vicinity
+    // as other packages that do, so we can use require.resolve on one of them to find it.
+    // This seems a little overcomplicated, but works well when grist-core is bundled within
+    // a larger project like grist-electron.
+    // TODO: maybe add a little node code to @gristlabs/grist-widget so it can be resolved
+    // directly?
+    const gristLabsModules = path.dirname(path.dirname(require.resolve('@gristlabs/express-session')));
     const bundledRoot = isAffirmative(process.env.GRIST_SKIP_BUNDLED_WIDGETS) ? undefined : path.join(
-      getAppPathTo(this.appRoot, 'node_modules'),
-      '@gristlabs', 'grist-widget', 'dist'
+      gristLabsModules, 'grist-widget', 'dist'
     );
     this.info.push(['bundledRoot', bundledRoot]);
     const pluginManager = new PluginManager(this.appRoot, userRoot, bundledRoot);


### PR DESCRIPTION
This change makes builtin custom widget bundles work on grist-electron, by finding the package in a slightly more flexible way.
    
It also includes a related change to make a widget manifest fetched from the network optional if a flag is present, with an error being logged rather than thrown. This could make it harder to track down why custom widgets aren't available, but makes it easier to make grist-electron work (including calendars) when the network is shut off. Ideally we'd do something fancier when we can.
