### PR TITLE
Force test:docker to run with English language

### DIFF
--- a/test/test_under_docker.sh
+++ b/test/test_under_docker.sh
@@ -65,4 +65,5 @@ TEST_ADD_SAMPLES=1 TEST_ACCOUNT_PASSWORD=not-needed \
   GRIST_SESSION_COOKIE=grist_test_cookie \
   GRIST_TEST_LOGIN=1 \
   NODE_PATH=_build:_build/stubs \
+  LANGUAGE=en_US \
   $MOCHA _build/test/deployment/*.js --slow 6000 -g "${GREP_TESTS:-}" "$@"


### PR DESCRIPTION
Same as #776 but for test:docker

If not set, in a non-English environment, the tests fail :boom: 