### PR TITLE
Change error message on documents for non-owner users

### DIFF
--- a/app/client/models/DocPageModel.ts
+++ b/app/client/models/DocPageModel.ts
@@ -294,7 +294,8 @@ Recovery mode opens the document to be fully accessible to owners, and inaccessi
 It also disables formulas. [{{error}}]", {error: err.message})
             : isDenied
               ? t('Sorry, access to this document has been denied. [{{error}}]', {error: err.message})
-              : t("Document owners can attempt to recover the document. [{{error}}]", {error: err.message})
+              : t("Please reload the document and if the error persist, "+
+                "contact the document owners to attempt a document recovery. [{{error}}]", {error: err.message})
         ),
         hideCancel: true,
         extraButtons: !(isDocOwner && !isDenied) ? null : bigBasicButton(


### PR DESCRIPTION
The error can often be fixed by just reloading the document with no need to worry the document owners

For example, when the error message is: "interrupted by reconnect"