### PR TITLE
OIDC: Rename `endSessionEndpoint` flag to `skipEndSessionEndpoint`

### DIFF
--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -94,7 +94,7 @@ export class OIDCConfig {
       defaultValue: 'email',
     });
 
-    this._skipEndSessionEndpoint = section.flag('endSessionEndpoint').readBool({
+    this._skipEndSessionEndpoint = section.flag('skipEndSessionEndpoint').readBool({
       envVar: 'GRIST_OIDC_IDP_SKIP_END_SESSION_ENDPOINT',
       defaultValue: false,
     })!;


### PR DESCRIPTION
This renames the `endSessionEndpoint` flag to `skipEndSessionEndpoint`, to match `OIDCConfig._skipEndSessionEndpoint`, as discussed in [#782](https://github.com/gristlabs/grist-core/issues/782#issuecomment-1852029143).