### PR TITLE
update node version used for generating translation keys

### DIFF
--- a/.github/workflows/translation_keys.yml
+++ b/.github/workflows/translation_keys.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
 
       - name: Install Node.js packages
         run: yarn install


### PR DESCRIPTION
We now use a package that relies on node >= 18.