### PR TITLE
Webhook: Do not fetch table with formulas if no webhook is enabled

### DIFF
--- a/app/server/lib/Triggers.ts
+++ b/app/server/lib/Triggers.ts
@@ -174,7 +174,7 @@ export class DocTriggers {
     const triggersTable = docData.getMetaTable("_grist_Triggers");
     const getTableId = docData.getMetaTable("_grist_Tables").getRowPropFunc("tableId");
 
-    const triggersByTableRef = _.groupBy(triggersTable.getRecords(), "tableRef");
+    const triggersByTableRef = _.groupBy(triggersTable.getRecords().filter(t => t.enabled), "tableRef");
     const triggersByTableId: Array<[string, Trigger[]]> = [];
 
     // First we need a list of columns which must be included in full in the action summary
@@ -545,9 +545,7 @@ export class DocTriggers {
     tableDelta: TableDelta,
   ): boolean {
     let readyBefore: boolean;
-    if (!trigger.enabled) {
-      return false;
-    } else if (!trigger.isReadyColRef) {
+    if (!trigger.isReadyColRef) {
       // User hasn't configured a column, so all records are considered ready immediately
       readyBefore = recordDelta.existedBefore;
     } else {

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -3833,6 +3833,7 @@ function testDocApi() {
       eventTypes?: string[],
       name?: string,
       memo?: string,
+      enabled?: boolean,
     }) {
       // Subscribe helper that returns a method to unsubscribe.
       const {data, status} = await axios.post(
@@ -3841,7 +3842,7 @@ function testDocApi() {
           eventTypes: options?.eventTypes ?? ['add', 'update'],
           url: `${serving.url}/${endpoint}`,
           isReadyColumn: options?.isReadyColumn === undefined ? 'B' : options?.isReadyColumn,
-          ...pick(options, 'name', 'memo'),
+          ...pick(options, 'name', 'memo', 'enabled'),
         }, chimpy
       );
       assert.equal(status, 200);
@@ -3978,11 +3979,7 @@ function testDocApi() {
         ], chimpy);
 
         for (const eventTypes of eventTypesSet) {
-          const {data, status} = await axios.post(
-            `${serverUrl}/api/docs/${docId}/tables/${tableId}/_subscribe`,
-            {eventTypes, url: `${serving.url}/${eventTypes}`, isReadyColumn, enabled}, chimpy
-          );
-          assert.equal(status, 200);
+          const data = await subscribe(String(eventTypes), docId, {tableId, eventTypes, isReadyColumn, enabled});
           subscribeResponses.push(data);
           webhookIds[data.webhookId] = String(eventTypes);
         }


### PR DESCRIPTION
# Context

Some of our users have their document stuck at some point. My analysis is that it is related to webhooks, even when they are disabled.

For more details, see  #799

# Proposed solution

This solution does not fix  #799, but at least I propose to not fetching table data when all of the webhooks are disabled (unless I misunderstand something, that is unnecessary). With that patch, I could manage to make the document work on my local machine.