### PR TITLE
set TEST_CLEAN_DATABASE when running server tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:nbrowser": "TEST_SUITE=nbrowser TEST_SUITE_FOR_TIMINGS=nbrowser TIMINGS_FILE=test/timings/nbrowser.txt GRIST_SESSION_COOKIE=grist_test_cookie GRIST_TEST_LOGIN=1 TEST_SUPPORT_API_KEY=api_key_for_support TEST_CLEAN_DATABASE=true LANGUAGE=en_US mocha ${DEBUG:+-b --no-exit} $([ -z $DEBUG ] && echo --forbid-only) -g \"${GREP_TESTS}\" --slow 8000 -R test/xunit-file '_build/test/nbrowser/**/*.js'",
     "test:client": "GRIST_SESSION_COOKIE=grist_test_cookie mocha ${DEBUG:+'-b'} '_build/test/client/**/*.js'",
     "test:common": "GRIST_SESSION_COOKIE=grist_test_cookie mocha ${DEBUG:+'-b'} '_build/test/common/**/*.js'",
-    "test:server": "TEST_SUITE=server TEST_SUITE_FOR_TIMINGS=server TIMINGS_FILE=test/timings/server.txt GRIST_SESSION_COOKIE=grist_test_cookie mocha ${DEBUG:+'-b'} -g \"${GREP_TESTS}\" -R test/xunit-file '_build/test/server/**/*.js' '_build/test/gen-server/**/*.js'",
+    "test:server": "TEST_CLEAN_DATABASE=true TEST_SUITE=server TEST_SUITE_FOR_TIMINGS=server TIMINGS_FILE=test/timings/server.txt GRIST_SESSION_COOKIE=grist_test_cookie mocha ${DEBUG:+'-b'} -g \"${GREP_TESTS}\" -R test/xunit-file '_build/test/server/**/*.js' '_build/test/gen-server/**/*.js'",
     "test:smoke": "mocha _build/test/nbrowser/Smoke.js",
     "test:docker": "./test/test_under_docker.sh",
     "test:python": "sandbox_venv3/bin/python sandbox/grist/runtests.py ${GREP_TESTS:+discover -p \"test*${GREP_TESTS}*.py\"}",

--- a/test/gen-server/migrations.ts
+++ b/test/gen-server/migrations.ts
@@ -5,6 +5,7 @@ import {HomeDBManager} from 'app/gen-server/lib/HomeDBManager';
 import {Permissions} from 'app/gen-server/lib/Permissions';
 import {assert} from 'chai';
 import {addSeedData, createInitialDb, removeConnection, setUpDB} from 'test/gen-server/seed';
+import {EnvironmentSnapshot} from 'test/server/testUtils';
 
 import {Initial1536634251710 as Initial} from 'app/gen-server/migration/1536634251710-Initial';
 import {Login1539031763952 as Login} from 'app/gen-server/migration/1539031763952-Login';
@@ -63,9 +64,18 @@ function assertMembersGroup(org: Organization, exists: boolean) {
 }
 
 describe('migrations', function() {
+  let oldEnv: EnvironmentSnapshot;
 
   before(function() {
+    oldEnv = new EnvironmentSnapshot();
+    // This test is incompatible with TEST_CLEAN_DATABASE, and also
+    // does not need it.
+    delete process.env.TEST_CLEAN_DATABASE;
     setUpDB(this);
+  });
+
+  after(function() {
+    oldEnv.restore();
   });
 
   beforeEach(async function() {

--- a/test/gen-server/migrations.ts
+++ b/test/gen-server/migrations.ts
@@ -5,7 +5,6 @@ import {HomeDBManager} from 'app/gen-server/lib/HomeDBManager';
 import {Permissions} from 'app/gen-server/lib/Permissions';
 import {assert} from 'chai';
 import {addSeedData, createInitialDb, removeConnection, setUpDB} from 'test/gen-server/seed';
-import {EnvironmentSnapshot} from 'test/server/testUtils';
 
 import {Initial1536634251710 as Initial} from 'app/gen-server/migration/1536634251710-Initial';
 import {Login1539031763952 as Login} from 'app/gen-server/migration/1539031763952-Login';
@@ -64,18 +63,9 @@ function assertMembersGroup(org: Organization, exists: boolean) {
 }
 
 describe('migrations', function() {
-  let oldEnv: EnvironmentSnapshot;
 
   before(function() {
-    oldEnv = new EnvironmentSnapshot();
-    // This test is incompatible with TEST_CLEAN_DATABASE, and also
-    // does not need it.
-    delete process.env.TEST_CLEAN_DATABASE;
     setUpDB(this);
-  });
-
-  after(function() {
-    oldEnv.restore();
   });
 
   beforeEach(async function() {

--- a/test/gen-server/migrations.ts
+++ b/test/gen-server/migrations.ts
@@ -5,6 +5,7 @@ import {HomeDBManager} from 'app/gen-server/lib/HomeDBManager';
 import {Permissions} from 'app/gen-server/lib/Permissions';
 import {assert} from 'chai';
 import {addSeedData, createInitialDb, removeConnection, setUpDB} from 'test/gen-server/seed';
+import {EnvironmentSnapshot} from 'test/server/testUtils';
 
 import {Initial1536634251710 as Initial} from 'app/gen-server/migration/1536634251710-Initial';
 import {Login1539031763952 as Login} from 'app/gen-server/migration/1539031763952-Login';
@@ -63,9 +64,17 @@ function assertMembersGroup(org: Organization, exists: boolean) {
 }
 
 describe('migrations', function() {
+  let oldEnv: EnvironmentSnapshot;
 
   before(function() {
+    oldEnv = new EnvironmentSnapshot();
+    // This test is incompatible with TEST_CLEAN_DATABASE.
+    delete process.env.TEST_CLEAN_DATABASE;
     setUpDB(this);
+  });
+
+  after(function() {
+    oldEnv.restore();
   });
 
   beforeEach(async function() {

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -37,7 +37,6 @@ import {signal} from 'test/server/lib/helpers/Signal';
 import {TestServer} from 'test/server/lib/helpers/TestServer';
 import * as testUtils from 'test/server/testUtils';
 import {waitForIt} from 'test/server/wait';
-import clone = require('lodash/clone');
 import defaultsDeep = require('lodash/defaultsDeep');
 import pick = require('lodash/pick');
 
@@ -71,9 +70,11 @@ let userApi: UserAPIImpl;
 describe('DocApi', function () {
   this.timeout(30000);
   testUtils.setTmpLogLevel('error');
-  const oldEnv = clone(process.env);
+  let oldEnv: testUtils.EnvironmentSnapshot;
 
   before(async function () {
+    oldEnv = new testUtils.EnvironmentSnapshot();
+
     // Clear redis test database if redis is in use.
     if (process.env.TEST_REDIS_URL) {
       const cli = createClient(process.env.TEST_REDIS_URL);
@@ -94,7 +95,7 @@ describe('DocApi', function () {
   });
 
   after(() => {
-    Object.assign(process.env, oldEnv);
+    oldEnv.restore();
   });
 
   /**

--- a/test/server/lib/UnhandledErrors.ts
+++ b/test/server/lib/UnhandledErrors.ts
@@ -1,6 +1,7 @@
 import {prepareDatabase} from 'test/server/lib/helpers/PrepareDatabase';
 import {TestServer} from 'test/server/lib/helpers/TestServer';
 import {createTestDir, setTmpLogLevel} from 'test/server/testUtils';
+import * as testUtils from 'test/server/testUtils';
 import {waitForIt} from 'test/server/wait';
 import {assert} from 'chai';
 import fetch from 'node-fetch';
@@ -17,10 +18,16 @@ describe('UnhandledErrors', function() {
   setTmpLogLevel('warn');
 
   let testDir: string;
+  let oldEnv: testUtils.EnvironmentSnapshot;
 
   before(async function() {
+    oldEnv = new testUtils.EnvironmentSnapshot();
     testDir = await createTestDir('UnhandledErrors');
     await prepareDatabase(testDir);
+  });
+
+  after(function() {
+    oldEnv.restore();
   });
 
   for (const errType of ['exception', 'rejection', 'error-event']) {

--- a/test/server/lib/Webhooks-Proxy.ts
+++ b/test/server/lib/Webhooks-Proxy.ts
@@ -14,7 +14,6 @@ import {signal} from 'test/server/lib/helpers/Signal';
 import {TestProxyServer} from 'test/server/lib/helpers/TestProxyServer';
 import {TestServer} from 'test/server/lib/helpers/TestServer';
 import * as testUtils from 'test/server/testUtils';
-import clone = require('lodash/clone');
 
 const chimpy = configForUser('Chimpy');
 
@@ -39,12 +38,12 @@ async function cleanRedisDatabase() {
 }
 
 function backupEnvironmentVariables() {
-  let oldEnv: NodeJS.ProcessEnv;
+  let oldEnv: testUtils.EnvironmentSnapshot;
   before(() => {
-    oldEnv = clone(process.env);
+    oldEnv = new testUtils.EnvironmentSnapshot();
   });
   after(() => {
-    Object.assign(process.env, oldEnv);
+    oldEnv.restore();
   });
 }
 


### PR DESCRIPTION
After adding a batch of new server tests, some interactions between tests have shown up via a shared database. This sets an existing flag for dealing with this problem, that is used during browser tests but hadn't been needed before for server tests.