### PR TITLE
Fix deadlock with webhooks on document load #799

### DIFF
--- a/app/server/lib/Sharing.ts
+++ b/app/server/lib/Sharing.ts
@@ -337,8 +337,10 @@ export class Sharing {
       }
       await this._activeDoc.processActionBundle(ownActionBundle);
 
-      const isCalculate = userActions.length === 1 && userActions[0][0] === 'Calculate';
-      const actionSummary = !isCalculate ?
+      // Don't trigger webhooks for single Calculate actions, this causes a deadlock on document load.
+      // See gh issue #799
+      const isSingleCalculateAction = userActions.length === 1 && userActions[0][0] === 'Calculate';
+      const actionSummary = !isSingleCalculateAction ?
         await this._activeDoc.handleTriggers(localActionBundle) :
         summarizeAction(localActionBundle);
 

--- a/app/server/lib/Sharing.ts
+++ b/app/server/lib/Sharing.ts
@@ -22,6 +22,7 @@ import {ActionHistory, asActionGroup, getActionUndoInfo} from './ActionHistory';
 import {ActiveDoc} from './ActiveDoc';
 import {makeExceptionalDocSession, OptDocSession} from './DocSession';
 import {WorkCoordinator} from './WorkCoordinator';
+import {createEmptyActionSummary} from 'app/common/ActionSummary';
 
 // Describes the request to apply a UserActionBundle. It includes a Client (so that broadcast
 // message can set `.fromSelf` property), and methods to resolve or reject the promise for when
@@ -336,7 +337,9 @@ export class Sharing {
       }
       await this._activeDoc.processActionBundle(ownActionBundle);
 
-      const actionSummary = await this._activeDoc.handleTriggers(localActionBundle);
+      const actionSummary = !isCalculate ?
+        await this._activeDoc.handleTriggers(localActionBundle) :
+        createEmptyActionSummary();
 
       await this._activeDoc.updateRowCount(sandboxActionBundle.rowCount, docSession);
 


### PR DESCRIPTION
# Context

Resolves #799 

# Proposed solution

This deadlock occurs because we trigger the webhooks even on Calculate action. As suggested by @alexmojaki, webhooks can discard these actions.