### PR TITLE
Add createSite feature so user can disable site creation #813

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ GRIST_DEFAULT_LOCALE  | Locale to use as fallback when Grist cannot honour the b
 GRIST_DOMAIN        | in hosted Grist, Grist is served from subdomains of this domain.  Defaults to "getgrist.com".
 GRIST_EXPERIMENTAL_PLUGINS | enables experimental plugins
 GRIST_ENABLE_REQUEST_FUNCTION | enables the REQUEST function. This function performs HTTP requests in a similar way to `requests.request`. This function presents a significant security risk, since it can let users call internal endpoints when Grist is available publicly. This function can also cause performance issues. Unset by default.
-GRIST_HIDE_UI_ELEMENTS | comma-separated list of UI features to disable. Allowed names of parts: `helpCenter,billing,templates,multiSite,multiAccounts,sendToDrive,tutorials`. If a part also exists in GRIST_UI_FEATURES, it will still be disabled.
+GRIST_HIDE_UI_ELEMENTS | comma-separated list of UI features to disable. Allowed names of parts: `helpCenter,billing,templates,createSite,multiSite,multiAccounts,sendToDrive,tutorials`. If a part also exists in GRIST_UI_FEATURES, it will still be disabled.
 GRIST_HOME_INCLUDE_STATIC | if set, home server also serves static resources
 GRIST_HOST          | hostname to use when listening on a port.
 GRIST_HTTPS_PROXY   | if set, use this proxy for webhook payload delivery.
@@ -269,7 +269,7 @@ GRIST_TELEMETRY_LEVEL | the telemetry level. Can be set to: `off` (default), `li
 GRIST_THROTTLE_CPU | if set, CPU throttling is enabled
 GRIST_TRUST_PLUGINS | if set, plugins are expect to be served from the same host as the rest of the Grist app, rather than from a distinct host. Ordinarily, plugins are served from a distinct host so that the cookies used by the Grist app are not automatically available to them. Enable this only if you understand the security implications.
 GRIST_USER_ROOT     | an extra path to look for plugins in - Grist will scan for plugins in `$GRIST_USER_ROOT/plugins`.
-GRIST_UI_FEATURES | comma-separated list of UI features to enable. Allowed names of parts: `helpCenter,billing,templates,multiSite,multiAccounts,sendToDrive,tutorials`. If a part also exists in GRIST_HIDE_UI_ELEMENTS, it won't be enabled.
+GRIST_UI_FEATURES | comma-separated list of UI features to enable. Allowed names of parts: `helpCenter,billing,templates,createSite,multiSite,multiAccounts,sendToDrive,tutorials`. If a part also exists in GRIST_HIDE_UI_ELEMENTS, it won't be enabled.
 GRIST_UNTRUSTED_PORT | if set, plugins will be served from the given port. This is an alternative to setting APP_UNTRUSTED_URL.
 GRIST_WIDGET_LIST_URL | a url pointing to a widget manifest, by default `https://github.com/gristlabs/grist-widget/releases/download/latest/manifest.json` is used
 COOKIE_MAX_AGE      | session cookie max age, defaults to 90 days; can be set to "none" to make it a session cookie

--- a/app/client/ui/SiteSwitcher.ts
+++ b/app/client/ui/SiteSwitcher.ts
@@ -42,12 +42,14 @@ export function buildSiteSwitcher(appModel: AppModel) {
         testId('org'),
       )
     ),
-    menuItem(
-      () => appModel.showNewSiteModal(),
-      menuIcon('Plus'),
-      t("Create new team site"),
-      testId('create-new-site'),
-    ),
+    dom.maybe(() => isFeatureEnabled("createSite"), () => [
+      menuItem(
+        () => appModel.showNewSiteModal(),
+        menuIcon('Plus'),
+        t("Create new team site"),
+        testId('create-new-site'),
+      )
+    ]),
   ];
 }
 

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -739,6 +739,7 @@ export const Features = StringUnion(
   "helpCenter",
   "billing",
   "templates",
+  "createSite",
   "multiSite",
   "multiAccounts",
   "sendToDrive",

--- a/stubs/app/server/server.ts
+++ b/stubs/app/server/server.ts
@@ -31,7 +31,7 @@ if (!process.env.GRIST_SINGLE_ORG) {
   setDefaultEnv('GRIST_ORG_IN_PATH', 'true');
 }
 
-setDefaultEnv('GRIST_UI_FEATURES', 'helpCenter,billing,templates,multiSite,multiAccounts,sendToDrive');
+setDefaultEnv('GRIST_UI_FEATURES', 'helpCenter,billing,templates,multiSite,multiAccounts,sendToDrive,createSite');
 setDefaultEnv('GRIST_WIDGET_LIST_URL', commonUrls.gristLabsWidgetRepository);
 import {updateDb} from 'app/server/lib/dbUtils';
 import {main as mergedServerMain, parseServerTypes} from 'app/server/mergedServerMain';


### PR DESCRIPTION
# Context

On self-hosted grist instances, users who attempt to create a new site through the UI are redirected to https://www.getgrist.com/pricing/

# Proposed solution

[As suggested by @vviers](https://github.com/gristlabs/grist-core/issues/786#issuecomment-1875544798), we may let the administrator disallow the site creation through the UI.

Resolves #813 