### PR TITLE
Optimize a bit the SQL request to fetch workspace access

### DIFF
--- a/app/gen-server/lib/HomeDBManager.ts
+++ b/app/gen-server/lib/HomeDBManager.ts
@@ -2397,7 +2397,9 @@ export class HomeDBManager extends EventEmitter {
     .leftJoinAndSelect('workspace_group_users.logins', 'workspace_user_logins')
     // Join the org and groups/users.
     .leftJoinAndSelect('workspaces.org', 'org')
-    .leftJoinAndSelect('org.aclRules', 'org_acl_rules')
+    .leftJoinAndSelect('org.aclRules', 'org_acl_rules',
+      '("org_acl_rules"."permissions" <> "acl_rules"."permissions")'
+    )
     .leftJoinAndSelect('org_acl_rules.group', 'org_groups')
     .leftJoinAndSelect('org_groups.memberUsers', 'org_group_users')
     .leftJoinAndSelect('org_group_users.logins', 'org_user_logins');

--- a/test/gen-server/ApiServerAccess.ts
+++ b/test/gen-server/ApiServerAccess.ts
@@ -921,6 +921,21 @@ describe('ApiServerAccess', function() {
         isMember: true,
       }]
     });
+
+    const deltaOrg = {
+      users: {
+        [kiwiEmail]: "owners",
+      }
+    };
+    const respDeltaOrg = await axios.patch(`${homeUrl}/api/orgs/${oid}/access`, {delta: deltaOrg}, chimpy);
+    assert.equal(respDeltaOrg.status, 200);
+
+    const resp3 = await axios.get(`${homeUrl}/api/workspaces/${wid}/access`, chimpy);
+    assert.include(resp3.data.users.find((user: any) => user.email === kiwiEmail), {
+      access: "editors",
+      parentAccess: "owners"
+    });
+
     // Reset the access settings
     const resetDelta = {
       maxInheritedRole: "owners",
@@ -930,6 +945,13 @@ describe('ApiServerAccess', function() {
     };
     const resetResp = await axios.patch(`${homeUrl}/api/workspaces/${wid}/access`, {delta: resetDelta}, chimpy);
     assert.equal(resetResp.status, 200);
+    const resetOrgDelta = {
+      users: {
+        [kiwiEmail]: "members",
+      }
+    };
+    const resetOrgResp = await axios.patch(`${homeUrl}/api/orgs/${oid}/access`, {delta: resetOrgDelta}, chimpy);
+    assert.equal(resetOrgResp.status, 200);
 
     // Assert that ws guests are properly displayed.
     // Tests a minor bug that showed ws guests as having null access.


### PR DESCRIPTION
# Context

In our self-hosted instance, when we fetch the ACLs rules of a workspace, we get a gateway timeout error. This is due to the fact that with this workspace, the SQL request made in `getWorkspaceAccess` returns ~900 000 results, which not only is heavy for the database but also takes time for TypeORM to parse.

@vviers made an analysis here in this document: https://outline.incubateur.anct.gouv.fr/doc/grist-list-workspace-access-issue-rxer0X7e44 

# Proposed solution

We limit the number of results by changing the JOIN condition between the organization ACL rules and the workspace ones to only join lines with different permissions, assuming that it is not interesting to retrieve org permissions if they are the same as the workspace ones.