### PR TITLE
style: ACL rules has no max-width

### DIFF
--- a/app/client/aclui/ACLFormulaEditor.ts
+++ b/app/client/aclui/ACLFormulaEditor.ts
@@ -133,6 +133,9 @@ const cssConditionInputAce = styled('div', `
   & .ace-chrome, & .ace-dracula {
     background-color: ${theme.accessRulesFormulaEditorBg};
   }
+  & .ace-chrome .ace_print-margin, & .ace-dracula .ace_print-margin {
+    width: 0px;
+  }
   &-disabled .ace-chrome, &-disabled .ace-dracula {
     background-color: ${theme.accessRulesFormulaEditorBgDisabled};
   }

--- a/app/client/aclui/ACLFormulaEditor.ts
+++ b/app/client/aclui/ACLFormulaEditor.ts
@@ -133,7 +133,7 @@ const cssConditionInputAce = styled('div', `
   & .ace-chrome, & .ace-dracula {
     background-color: ${theme.accessRulesFormulaEditorBg};
   }
-  & .ace-chrome .ace_print-margin, & .ace-dracula .ace_print-margin {
+  &:not(:focus-within) .ace_print-margin {
     width: 0px;
   }
   &-disabled .ace-chrome, &-disabled .ace-dracula {

--- a/app/client/aclui/AccessRules.ts
+++ b/app/client/aclui/AccessRules.ts
@@ -1906,7 +1906,7 @@ const cssOuter = styled('div', `
   flex: auto;
   height: 100%;
   width: 100%;
-  max-width: 800px;
+  max-width: 1500px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
#674

There were a glitch on the ACL formula Editor, so add style to hide this glitch.
![Screenshot from 2024-01-09 11-59-40](https://github.com/gristlabs/grist-core/assets/19594405/8977a277-22cd-4c5c-8859-fa4d304d7595)