### PR TITLE
Optimize sql query ws acl (version 2)

### DIFF
--- a/app/gen-server/lib/HomeDBManager.ts
+++ b/app/gen-server/lib/HomeDBManager.ts
@@ -2378,8 +2378,7 @@ export class HomeDBManager extends EventEmitter {
   public async getWorkspaceAccess(scope: Scope, wsId: number): Promise<QueryResult<PermissionData>> {
     // Run the query for the workspace and org in a transaction. This brings some isolation protection
     // against changes to the workspace or org while we are querying.
-    // As we deal with permission issues, use the highest isolation level.
-    const { workspace, org, queryFailure } = await this._connection.transaction('SERIALIZABLE', async manager => {
+    const { workspace, org, queryFailure } = await this._connection.transaction(async manager => {
       const wsQueryResult = await this._getWorkspaceWithACLRules(scope, wsId, { manager });
       if (wsQueryResult.status !== 200) {
         // If the query for the workspace failed, return the failure result.

--- a/app/gen-server/lib/HomeDBManager.ts
+++ b/app/gen-server/lib/HomeDBManager.ts
@@ -2378,9 +2378,8 @@ export class HomeDBManager extends EventEmitter {
   public async getWorkspaceAccess(scope: Scope, wsId: number): Promise<QueryResult<PermissionData>> {
     // Run the query for the workspace and org in a transaction. This brings some isolation protection
     // against changes to the workspace or org while we are querying.
-    // The default isolation level for postgres is "read committed" (which is a good tradeoff with performance),
-    // and the default one for sqlite is "serializable".
-    const { workspace, org, queryFailure } = await this._connection.transaction(async manager => {
+    // As we deal with permission issues, use the highest isolation level.
+    const { workspace, org, queryFailure } = await this._connection.transaction('SERIALIZABLE', async manager => {
       const wsQueryResult = await this._getWorkspaceWithACLRules(scope, wsId, { manager });
       if (wsQueryResult.status !== 200) {
         // If the query for the workspace failed, return the failure result.

--- a/app/gen-server/lib/HomeDBManager.ts
+++ b/app/gen-server/lib/HomeDBManager.ts
@@ -811,7 +811,7 @@ export class HomeDBManager extends EventEmitter {
         .leftJoinAndSelect('org_groups.memberUsers', 'org_member_users');
       const result = await orgQuery.getRawAndEntities();
       if (result.entities.length === 0) {
-        // If the query for the doc failed, return the failure result.
+        // If the query for the org failed, return the failure result.
         throw new ApiError('org not found', 404);
       }
       org = result.entities[0];
@@ -2378,7 +2378,7 @@ export class HomeDBManager extends EventEmitter {
   public async getWorkspaceAccess(scope: Scope, wsId: number): Promise<QueryResult<PermissionData>> {
     const wsQueryResult = await this._getWorkspaceWithACLRules(scope, wsId);
     if (wsQueryResult.status !== 200) {
-      // If the query for the doc failed, return the failure result.
+      // If the query for the workspace failed, return the failure result.
       return wsQueryResult;
     }
     const workspace: Workspace = wsQueryResult.data;
@@ -2388,7 +2388,7 @@ export class HomeDBManager extends EventEmitter {
     // Also fetch the organization ACLs so we can determine inherited rights.
     const orgQueryResult = await this._getOrgWithACLRules(scope, workspace.org.id);
     if (orgQueryResult.status !== 200) {
-      // If the query for the doc failed, return the failure result.
+      // If the query for the org failed, return the failure result.
       return orgQueryResult;
     }
     const org: Organization = orgQueryResult.data;

--- a/app/gen-server/lib/HomeDBManager.ts
+++ b/app/gen-server/lib/HomeDBManager.ts
@@ -1071,7 +1071,7 @@ export class HomeDBManager extends EventEmitter {
       needRealOrg: true
     });
     orgQuery = this._addFeatures(orgQuery);
-    const orgQueryResult = await verifyIsPermitted(orgQuery);
+    const orgQueryResult = await verifyEntity(orgQuery);
     const org: Organization = this.unwrapQueryResult(orgQueryResult);
     const productFeatures = org.billingAccount.product.features;
 
@@ -1556,7 +1556,7 @@ export class HomeDBManager extends EventEmitter {
         markPermissions,
         needRealOrg: true
       });
-      const queryResult = await verifyIsPermitted(orgQuery);
+      const queryResult = await verifyEntity(orgQuery);
       if (queryResult.status !== 200) {
         // If the query for the workspace failed, return the failure result.
         return queryResult;
@@ -1624,7 +1624,7 @@ export class HomeDBManager extends EventEmitter {
       .leftJoinAndSelect('docs.aclRules', 'doc_acl_rules')
       .leftJoinAndSelect('doc_acl_rules.group', 'doc_group')
       .leftJoinAndSelect('orgs.billingAccount', 'billing_accounts');
-      const queryResult = await verifyIsPermitted(orgQuery);
+      const queryResult = await verifyEntity(orgQuery);
       if (queryResult.status !== 200) {
         // If the query for the org failed, return the failure result.
         return queryResult;
@@ -1677,7 +1677,7 @@ export class HomeDBManager extends EventEmitter {
       .leftJoinAndSelect('acl_rules.group', 'org_group')
       .leftJoinAndSelect('orgs.workspaces', 'workspaces');  // we may want to count workspaces.
       orgQuery = this._addFeatures(orgQuery);  // add features to access optional workspace limit.
-      const queryResult = await verifyIsPermitted(orgQuery);
+      const queryResult = await verifyEntity(orgQuery);
       if (queryResult.status !== 200) {
         // If the query for the organization failed, return the failure result.
         return queryResult;
@@ -1717,7 +1717,7 @@ export class HomeDBManager extends EventEmitter {
         manager,
         markPermissions: Permissions.UPDATE
       });
-      const queryResult = await verifyIsPermitted(wsQuery);
+      const queryResult = await verifyEntity(wsQuery);
       if (queryResult.status !== 200) {
         // If the query for the workspace failed, return the failure result.
         return queryResult;
@@ -1749,7 +1749,7 @@ export class HomeDBManager extends EventEmitter {
       .leftJoinAndSelect('docs.aclRules', 'doc_acl_rules')
       .leftJoinAndSelect('doc_acl_rules.group', 'doc_groups')
       .leftJoinAndSelect('workspaces.org', 'orgs');
-      const queryResult = await verifyIsPermitted(wsQuery);
+      const queryResult = await verifyEntity(wsQuery);
       if (queryResult.status !== 200) {
         // If the query for the workspace failed, return the failure result.
         return queryResult;
@@ -1802,7 +1802,7 @@ export class HomeDBManager extends EventEmitter {
       .leftJoinAndSelect('workspaces.aclRules', 'acl_rules')
       .leftJoinAndSelect('acl_rules.group', 'workspace_group');
       wsQuery = this._addFeatures(wsQuery);
-      const queryResult = await verifyIsPermitted(wsQuery);
+      const queryResult = await verifyEntity(wsQuery);
       if (queryResult.status !== 200) {
         // If the query for the organization failed, return the failure result.
         return queryResult;
@@ -1976,7 +1976,7 @@ export class HomeDBManager extends EventEmitter {
           markPermissions,
         });
       }
-      const queryResult = await verifyIsPermitted(query);
+      const queryResult = await verifyEntity(query);
       if (queryResult.status !== 200) {
         // If the query for the doc or fork failed, return the failure result.
         return queryResult;
@@ -2029,7 +2029,7 @@ export class HomeDBManager extends EventEmitter {
           manager,
           allowSpecialPermit: true,
         });
-        const queryResult = await verifyIsPermitted(forkQuery);
+        const queryResult = await verifyEntity(forkQuery);
         if (queryResult.status !== 200) {
           // If the query for the fork failed, return the failure result.
           return queryResult;
@@ -2047,7 +2047,7 @@ export class HomeDBManager extends EventEmitter {
         // Join the workspace and org to get their ids.
         .leftJoinAndSelect('docs.aclRules', 'acl_rules')
         .leftJoinAndSelect('acl_rules.group', 'groups');
-        const queryResult = await verifyIsPermitted(docQuery);
+        const queryResult = await verifyEntity(docQuery);
         if (queryResult.status !== 200) {
           // If the query for the doc failed, return the failure result.
           return queryResult;
@@ -2185,7 +2185,7 @@ export class HomeDBManager extends EventEmitter {
       .leftJoinAndSelect('org_groups.memberUsers', 'org_member_users');
       orgQuery = this._addFeatures(orgQuery);
       orgQuery = this._withAccess(orgQuery, userId, 'orgs');
-      const queryResult = await verifyIsPermitted(orgQuery);
+      const queryResult = await verifyEntity(orgQuery);
       if (queryResult.status !== 200) {
         // If the query for the organization failed, return the failure result.
         return queryResult;
@@ -2246,7 +2246,7 @@ export class HomeDBManager extends EventEmitter {
       .leftJoinAndSelect('org_groups.memberUsers', 'org_users');
       wsQuery = this._addFeatures(wsQuery, 'org');
       wsQuery = this._withAccess(wsQuery, userId, 'workspaces');
-      const queryResult = await verifyIsPermitted(wsQuery);
+      const queryResult = await verifyEntity(wsQuery);
       if (queryResult.status !== 200) {
         // If the query for the workspace failed, return the failure result.
         return queryResult;
@@ -2386,7 +2386,8 @@ export class HomeDBManager extends EventEmitter {
     const wsMap = getMemberUserRoles(workspace, this.defaultCommonGroupNames);
 
     // Also fetch the organization ACLs so we can determine inherited rights.
-    const orgQueryResult = await this._getOrgWithACLRules(scope, workspace.org.id);
+    const orgQuery = this._buildOrgWithACLRulesQuery(scope, workspace.org.id);
+    const orgQueryResult = await verifyEntity(orgQuery, { discardPermissionsCheck: true });
     if (orgQueryResult.status !== 200) {
       // If the query for the org failed, return the failure result.
       return orgQueryResult;
@@ -2529,7 +2530,7 @@ export class HomeDBManager extends EventEmitter {
       .leftJoinAndSelect('orgs.aclRules', 'org_acl_rules')
       .leftJoinAndSelect('org_acl_rules.group', 'org_groups')
       .leftJoinAndSelect('org_groups.memberUsers', 'org_users');
-      const docQueryResult = await verifyIsPermitted(docQuery);
+      const docQueryResult = await verifyEntity(docQuery);
       if (docQueryResult.status !== 200) {
         // If the query for the doc failed, return the failure result.
         return docQueryResult;
@@ -2556,7 +2557,7 @@ export class HomeDBManager extends EventEmitter {
       .leftJoinAndSelect('org_acl_rules.group', 'org_groups')
       .leftJoinAndSelect('org_groups.memberUsers', 'org_users');
       wsQuery = this._addFeatures(wsQuery);
-      const wsQueryResult = await verifyIsPermitted(wsQuery);
+      const wsQueryResult = await verifyEntity(wsQuery);
       if (wsQueryResult.status !== 200) {
         // If the query for the organization failed, return the failure result.
         return wsQueryResult;
@@ -2634,7 +2635,7 @@ export class HomeDBManager extends EventEmitter {
         manager
       })
       .addSelect(this._markIsPermitted('orgs', scope.userId, 'open', permissions), 'is_permitted');
-      const docQueryResult = await verifyIsPermitted(docQuery);
+      const docQueryResult = await verifyEntity(docQuery);
       if (docQueryResult.status !== 200) {
         // If the query for the doc failed, return the failure result.
         return docQueryResult;
@@ -4571,7 +4572,7 @@ export class HomeDBManager extends EventEmitter {
       // SQL results are flattened, and multiplying the number of rows we have already
       // by the number of workspace users could get excessive.
       .leftJoinAndSelect('docs.workspace', 'workspace');
-      const queryResult = await verifyIsPermitted(docQuery);
+      const queryResult = await verifyEntity(docQuery);
       const doc: Document = this.unwrapQueryResult(queryResult);
 
       // Load the workspace's member groups/users.
@@ -4679,7 +4680,7 @@ export class HomeDBManager extends EventEmitter {
         manager,
         markPermissions: Permissions.REMOVE
       });
-      const workspace: Workspace = this.unwrapQueryResult(await verifyIsPermitted(wsQuery));
+      const workspace: Workspace = this.unwrapQueryResult(await verifyEntity(wsQuery));
       await manager.createQueryBuilder()
         .update(Workspace).set({removedAt}).where({id: workspace.id})
         .execute();
@@ -4697,7 +4698,7 @@ export class HomeDBManager extends EventEmitter {
       if (!removedAt) {
         docQuery = this._addFeatures(docQuery);  // pull in billing information for doc count limits
       }
-      const doc: Document = this.unwrapQueryResult(await verifyIsPermitted(docQuery));
+      const doc: Document = this.unwrapQueryResult(await verifyEntity(docQuery));
       if (!removedAt) {
         await this._checkRoomForAnotherDoc(doc.workspace, manager);
       }
@@ -4743,21 +4744,27 @@ export class HomeDBManager extends EventEmitter {
     .leftJoinAndSelect('workspace_groups.memberGroups', 'workspace_group_groups')
     .leftJoinAndSelect('workspace_group_users.logins', 'workspace_user_logins')
     .leftJoinAndSelect('workspaces.org', 'org');
-    return verifyIsPermitted(query);
+    return verifyEntity(query);
+  }
+
+  private _buildOrgWithACLRulesQuery(scope: Scope, org: number|string, opts: Partial<QueryOptions> = {}) {
+    return this.org(scope, org, {
+      needRealOrg: true,
+      ...opts
+    })
+      // Join the org's ACL rules (with 1st level groups/users listed).
+      .leftJoinAndSelect('orgs.aclRules', 'acl_rules')
+      .leftJoinAndSelect('acl_rules.group', 'org_groups')
+      .leftJoinAndSelect('org_groups.memberUsers', 'org_member_users')
+      .leftJoinAndSelect('org_member_users.logins', 'user_logins');
   }
 
   private _getOrgWithACLRules(scope: Scope, org: number|string) {
-    const orgQuery = this.org(scope, org, {
+    const orgQuery = this._buildOrgWithACLRulesQuery(scope, org, {
       markPermissions: Permissions.VIEW,
-      needRealOrg: true,
-      allowSpecialPermit: true
-    })
-    // Join the org's ACL rules (with 1st level groups/users listed).
-    .leftJoinAndSelect('orgs.aclRules', 'acl_rules')
-    .leftJoinAndSelect('acl_rules.group', 'org_groups')
-    .leftJoinAndSelect('org_groups.memberUsers', 'org_member_users')
-    .leftJoinAndSelect('org_member_users.logins', 'user_logins');
-    return verifyIsPermitted(orgQuery);
+      allowSpecialPermit: true,
+    });
+    return verifyEntity(orgQuery);
   }
 
 }
@@ -4766,10 +4773,12 @@ export class HomeDBManager extends EventEmitter {
 // Checks on the "is_permitted" field which select queries set on resources to
 // indicate whether the user has access.
 // If the output is empty, we signal that the desired resource does not exist.
+// If we retrieve more than 1 entity, we signal that the request is ambiguous.
 // If the "is_permitted" field is falsy, we signal that the resource is forbidden.
 // Returns the resource fetched by the queryBuilder.
-async function verifyIsPermitted(
-  queryBuilder: SelectQueryBuilder<any>
+async function verifyEntity(
+  queryBuilder: SelectQueryBuilder<any>,
+  options: { discardPermissionsCheck?: boolean } = {}
 ): Promise<QueryResult<any>> {
   const results = await queryBuilder.getRawAndEntities();
   if (results.entities.length === 0) {
@@ -4782,7 +4791,7 @@ async function verifyIsPermitted(
       status: 400,
       errMessage: `ambiguous ${getFrom(queryBuilder)} request`
     };
-  } else if (!results.raw[0].is_permitted) {
+  } else if (!options.discardPermissionsCheck && !results.raw[0].is_permitted) {
     return {
       status: 403,
       errMessage: "access denied"

--- a/app/gen-server/lib/HomeDBManager.ts
+++ b/app/gen-server/lib/HomeDBManager.ts
@@ -2397,7 +2397,9 @@ export class HomeDBManager extends EventEmitter {
     .leftJoinAndSelect('workspace_group_users.logins', 'workspace_user_logins')
     // Join the org and groups/users.
     .leftJoinAndSelect('workspaces.org', 'org')
-    .leftJoinAndSelect('org.aclRules', 'org_acl_rules')
+    .leftJoinAndSelect('org.aclRules', 'org_acl_rules',
+      '("org_acl_rules"."permissions" <> "acl_rules"."permissions")'
+    )
     .leftJoinAndSelect('org_acl_rules.group', 'org_groups')
     .leftJoinAndSelect('org_groups.memberUsers', 'org_group_users')
     .leftJoinAndSelect('org_group_users.logins', 'org_user_logins');

--- a/test/gen-server/ApiServerAccess.ts
+++ b/test/gen-server/ApiServerAccess.ts
@@ -921,6 +921,21 @@ describe('ApiServerAccess', function() {
         isMember: true,
       }]
     });
+
+    const deltaOrg = {
+      users: {
+        [kiwiEmail]: "owners",
+      }
+    };
+    const respDeltaOrg = await axios.patch(`${homeUrl}/api/orgs/${oid}/access`, {delta: deltaOrg}, chimpy);
+    assert.equal(respDeltaOrg.status, 200);
+
+    const resp3 = await axios.get(`${homeUrl}/api/workspaces/${wid}/access`, chimpy);
+    assert.include(resp3.data.users.find((user: any) => user.email === kiwiEmail), {
+      access: "editors",
+      parentAccess: "owners"
+    });
+
     // Reset the access settings
     const resetDelta = {
       maxInheritedRole: "owners",
@@ -930,6 +945,13 @@ describe('ApiServerAccess', function() {
     };
     const resetResp = await axios.patch(`${homeUrl}/api/workspaces/${wid}/access`, {delta: resetDelta}, chimpy);
     assert.equal(resetResp.status, 200);
+    const resetOrgDelta = {
+      users: {
+        [kiwiEmail]: "members",
+      }
+    };
+    const resetOrgResp = await axios.patch(`${homeUrl}/api/orgs/${oid}/access`, {delta: resetOrgDelta}, chimpy);
+    assert.equal(resetOrgResp.status, 200);
 
     // Assert that ws guests are properly displayed.
     // Tests a minor bug that showed ws guests as having null access.

--- a/test/gen-server/ApiServerAccess.ts
+++ b/test/gen-server/ApiServerAccess.ts
@@ -846,6 +846,7 @@ describe('ApiServerAccess', function() {
     const oid = await dbManager.testGetId('Chimpyland');
     const wid = await dbManager.testGetId('Public');
     const resp1 = await axios.get(`${homeUrl}/api/workspaces/${wid}/access`, chimpy);
+    console.log('resp1.data = ', resp1.data);
     assert.equal(resp1.status, 200);
     assert.deepEqual(resp1.data, {
       maxInheritedRole: "owners",

--- a/test/gen-server/ApiServerAccess.ts
+++ b/test/gen-server/ApiServerAccess.ts
@@ -846,7 +846,6 @@ describe('ApiServerAccess', function() {
     const oid = await dbManager.testGetId('Chimpyland');
     const wid = await dbManager.testGetId('Public');
     const resp1 = await axios.get(`${homeUrl}/api/workspaces/${wid}/access`, chimpy);
-    console.log('resp1.data = ', resp1.data);
     assert.equal(resp1.status, 200);
     assert.deepEqual(resp1.data, {
       maxInheritedRole: "owners",

--- a/test/gen-server/apiUtils.ts
+++ b/test/gen-server/apiUtils.ts
@@ -22,6 +22,7 @@ import * as path from 'path';
 import {createInitialDb, removeConnection, setUpDB} from 'test/gen-server/seed';
 import {setPlan} from 'test/gen-server/testUtils';
 import {fixturesRoot} from 'test/server/testUtils';
+import {isAffirmative} from 'app/common/gutil';
 
 export class TestServer {
   public serverUrl: string;
@@ -36,7 +37,7 @@ export class TestServer {
   public async start(servers: ServerType[] = ["home"],
                      options: FlexServerOptions = {}): Promise<string> {
     await createInitialDb();
-    this.server = await mergedServerMain(0, servers, {logToConsole: true,
+    this.server = await mergedServerMain(0, servers, {logToConsole: isAffirmative(process.env.DEBUG),
                                                       externalStorage: false,
                                                       ...options});
     this.serverUrl = this.server.getOwnUrl();

--- a/test/gen-server/apiUtils.ts
+++ b/test/gen-server/apiUtils.ts
@@ -36,7 +36,7 @@ export class TestServer {
   public async start(servers: ServerType[] = ["home"],
                      options: FlexServerOptions = {}): Promise<string> {
     await createInitialDb();
-    this.server = await mergedServerMain(0, servers, {logToConsole: false,
+    this.server = await mergedServerMain(0, servers, {logToConsole: true,
                                                       externalStorage: false,
                                                       ...options});
     this.serverUrl = this.server.getOwnUrl();


### PR DESCRIPTION
## Context

In our self-hosted instance, when we fetch the ACLs rules of a workspace, we get a gateway timeout error. This is due to the fact that with this workspace, the SQL request made in getWorkspaceAccess returns ~900 000 results, which not only is heavy for the database but also takes time for TypeORM to parse.

@vviers made an analysis here in this document: https://outline.incubateur.anct.gouv.fr/doc/grist-list-workspace-access-issue-rxer0X7e44

## Proposed solution

Here is another proposal than the one in #818 

@vviers also suggested to rework the function so it does two separate queries. 

I changed my mind as it seemed like:
1. The risk for regressions of the patch in #818 also seem high (and maybe higher);
2. There are benefits for this rework, as a much better performance and a better clarity (2 queries for two types of resources requested);
3. I would say we gain control over the logic, hence we lower the risk for regressions (especially in the future).

I hope this goes in the right way.