### PR TITLE
Fix server crash when client passes malformed JSON

### DIFF
--- a/app/server/lib/Client.ts
+++ b/app/server/lib/Client.ts
@@ -526,23 +526,20 @@ export class Client {
     }
   }
 
+  private async _onMessage(message: string): Promise<void> {
+    try {
+      await this._onMessageImpl(message);
+    } catch (err) {
+      this._log.warn(null, 'onMessage error received for message "%s": %s', shortDesc(message), err.stack);
+    }
+  }
+
   /**
    * Processes a request from a client. All requests from a client get a response, at least to
    * indicate success or failure.
    */
-  private async _onMessage(message: string): Promise<void> {
-    let request;
-    try {
-      request = JSON.parse(message);
-    } catch (err) {
-      this._log.warn(null, "failed to parse message: %s", err.toString());
-      if (!this._destroyed) {
-        this._sendToWebsocket(JSON.stringify({error: err.message}))
-          // Ignore error if we cannot send the error message.
-          .catch(() => {});
-      }
-      return;
-    }
+  private async _onMessageImpl(message: string): Promise<void> {
+    const request = JSON.parse(message);
     if (request.beat) {
       // this is a heart beat, to keep the websocket alive.  No need to reply.
       log.rawInfo('heartbeat', {

--- a/app/server/lib/Client.ts
+++ b/app/server/lib/Client.ts
@@ -531,7 +531,18 @@ export class Client {
    * indicate success or failure.
    */
   private async _onMessage(message: string): Promise<void> {
-    const request = JSON.parse(message);
+    let request;
+    try {
+      request = JSON.parse(message);
+    } catch (err) {
+      this._log.warn(null, "failed to parse message: %s", err.toString());
+      if (!this._destroyed) {
+        this._sendToWebsocket(JSON.stringify({error: err.message}))
+          // Ignore error if we cannot send the error message.
+          .catch(() => {});
+      }
+      return;
+    }
     if (request.beat) {
       // this is a heart beat, to keep the websocket alive.  No need to reply.
       log.rawInfo('heartbeat', {

--- a/test/server/Comm.ts
+++ b/test/server/Comm.ts
@@ -188,17 +188,21 @@ describe('Comm', function() {
       ]);
     });
 
-    it('should return error for malformed JSON data', async function () {
+    it('should only log warning for malformed JSON data', async function () {
       const logMessages  = await testUtils.captureLog('warn', async () => {
         ws.send('foobar');
-        const messages = await getMessages(ws, 1);
-        const resp = messages[0];
-        assert.equal(resp.data, undefined);
-        assert.equal(resp.reqId, undefined);
-        assert.include(resp.error, 'Unexpected token');
-      });
+      }, {waitForFirstLog: true});
       testUtils.assertMatchArray(logMessages, [
         /^warn: Client.* Unexpected token.*/
+      ]);
+    });
+
+    it('should log warning when null value is passed', async function () {
+      const logMessages  = await testUtils.captureLog('warn', async () => {
+        ws.send('null');
+      }, {waitForFirstLog: true});
+      testUtils.assertMatchArray(logMessages, [
+        /^warn: Client.*Cannot read properties of null*/
       ]);
     });
 

--- a/test/server/Comm.ts
+++ b/test/server/Comm.ts
@@ -188,6 +188,20 @@ describe('Comm', function() {
       ]);
     });
 
+    it('should return error for malformed JSON data', async function () {
+      const logMessages  = await testUtils.captureLog('warn', async () => {
+        ws.send('foobar');
+        const messages = await getMessages(ws, 1);
+        const resp = messages[0];
+        assert.equal(resp.data, undefined);
+        assert.equal(resp.reqId, undefined);
+        assert.include(resp.error, 'Unexpected token');
+      });
+      testUtils.assertMatchArray(logMessages, [
+        /^warn: Client.* Unexpected token.*/
+      ]);
+    });
+
     it("should support app-level events correctly", async function() {
       comm!.broadcastMessage('fooType' as any, 'hello');
       comm!.broadcastMessage('barType' as any, 'world');


### PR DESCRIPTION
## Context

The server crash when opening a WS connection and sending malformed JSON data.

## Proposed solution

Add a try/catch on JSON parse, and send an error through websocket if the parsing fails.