### PR TITLE
Fix docker graceful shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,4 +142,4 @@ ENV \
 
 EXPOSE 8484
 
-CMD ./sandbox/run.sh
+CMD ["./sandbox/run.sh"]

--- a/app/server/lib/shutdown.js
+++ b/app/server/lib/shutdown.js
@@ -81,7 +81,7 @@ function signalExit(signal) {
     log.info("Server %s exiting on %s", prog, signal);
     process.removeListener(signal, dup);
     delete signalsHandled[signal];
-    process.kill(process.pid, signal);
+    process.exit(0);
   });
 }
 

--- a/app/server/lib/shutdown.js
+++ b/app/server/lib/shutdown.js
@@ -81,7 +81,7 @@ function signalExit(signal) {
     log.info("Server %s exiting on %s", prog, signal);
     process.removeListener(signal, dup);
     delete signalsHandled[signal];
-    process.exit(0);
+    process.kill(process.pid, signal);
   });
 }
 

--- a/sandbox/run.sh
+++ b/sandbox/run.sh
@@ -16,4 +16,4 @@ if [[ "$GRIST_SANDBOX_FLAVOR" = "gvisor" ]]; then
   ./sandbox/gvisor/update_engine_checkpoint.sh
 fi
 
-NODE_PATH=_build:_build/stubs:_build/ext node _build/stubs/app/server/server.js
+exec env NODE_PATH=_build:_build/stubs:_build/ext node _build/stubs/app/server/server.js


### PR DESCRIPTION
# Context

When running grist on docker, the only way to stop the node process is to kill (or wait for `docker stop`  to kill the container after 10 seconds).

We can see that the bash pid remains, which seems to be a bad practice

```
docker exec -it 74196865e076 ps faux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root          20  0.0  0.0   7640  2688 pts/0    Rs+  09:50   0:00 ps faux
root           1  0.0  0.0   2388  1408 ?        Ss   09:49   0:00 /bin/sh -c ./sandbox/run.sh
root           8  0.0  0.0   3736  2688 ?        S    09:49   0:00 bash ./sandbox/run.sh
root           9  9.0  0.5 1003572 194712 ?      Sl   09:49   0:01  \_ node _build/stubs/app/server/server.js
```

Instead we would like this situation:

```
docker exec -it f496a0a6fe273f59d288811deddb6a33f4105caf0f3ed43b485bb30d6afe92f1 ps faux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root          18  0.0  0.0   7640  2560 pts/0    Rs+  09:53   0:00 ps faux
root           1 15.7  0.6 1003316 196020 ?      Ssl  09:53   0:01 node _build/stubs/app/server/server.js
```

# Proposed solution

Here are two fixes:
1. In order to let nodejs gracefully shutdown, in `run.sh`, we run node using the `exec` command (this substitute the bash process with nodejs's one for pid `#1`)
2. We replace `process.kill()` with `process.exit()` which seems to stop the server without waiting (we are not 100% sure about this fix).

cc'ing @rouja @ohemelaar with whom I have pair-progged on this PR.