### PR TITLE
Make ISEMAIL and ISURL more flexible for longer TLD

### DIFF
--- a/app/common/gutil.ts
+++ b/app/common/gutil.ts
@@ -23,7 +23,7 @@ export const UP_TRIANGLE = '\u25B2';
 export const DOWN_TRIANGLE = '\u25BC';
 
 const EMAIL_RE = new RegExp("^\\w[\\w%+/='-]*(\\.[\\w%+/='-]+)*@([A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z" +
-  "0-9])?\\.)+[A-Za-z]{2,6}$", "u");
+  "0-9])?\\.)+[A-Za-z]{2,24}$", "u");
 
 // Returns whether str starts with prefix. (Note that this implementation avoids creating a new
 // string, and only checks a single location.)

--- a/sandbox/grist/functions/info.py
+++ b/sandbox/grist/functions/info.py
@@ -395,7 +395,8 @@ _url_regexp = re.compile(
   ([A-Za-z0-9]                    # Each part of hostname must start with alphanumeric
     ([A-Za-z0-9-]*[A-Za-z0-9])?\. # May have dashes inside, but end in alphanumeric
   )+
-  [A-Za-z]{2,24}                   # Restrict top-level domain to length {2,24}. Google seems
+  [A-Za-z]{2,24}                  # Restrict top-level domain to length {2,24} (theoretically,
+                                  # the max length is 63 bytes as per RFC 1034). Google seems
                                   # to use a whitelist for TLDs longer than 2 characters.
   ([/?][-\w!#$%&'()*+,./:;=?@~]*)?$ # Notably, this excludes <, >, and ".
   """, re.VERBOSE)
@@ -440,6 +441,8 @@ def ISURL(value):
   >>> ISURL("http://user@www.google.com")
   True
   >>> ISURL("http://foo.com/!#$%25&'()*+,-./=?@_~")
+  True
+  >>> ISURL("http://collectivite.isla.corsica")
   True
   >>> ISURL("http://../")
   False

--- a/sandbox/grist/functions/info.py
+++ b/sandbox/grist/functions/info.py
@@ -319,7 +319,7 @@ def ISEMAIL(value):
   >>> ISEMAIL("marie@isola.corsica")                          # False,    True
   True
   >>> ISEMAIL("fabio@disapproved.solutions")                  # False,    True
-  False
+  True
   >>> ISEMAIL(u"фыва@mail.ru")                                # False,    True
   True
   >>> ISEMAIL("my@baddash.-.com")                             # True,     False

--- a/sandbox/grist/functions/info.py
+++ b/sandbox/grist/functions/info.py
@@ -257,7 +257,8 @@ _email_regexp = re.compile(
   ([A-Za-z0-9]                    # Each part of hostname must start with alphanumeric
     ([A-Za-z0-9-]*[A-Za-z0-9])?\. # May have dashes inside, but end in alphanumeric
   )+
-  [A-Za-z]{2,6}$                  # Restrict top-level domain to length {2,6}. Google seems
+  [A-Za-z]{2,24}$                 # Restrict top-level domain to length {2,24} (theoretically,
+                                  # the max length is 63 bytes as per RFC 1034). Google seems
                                   # to use a whitelist for TLDs longer than 2 characters.
   """, re.UNICODE | re.VERBOSE)
 
@@ -289,7 +290,8 @@ def ISEMAIL(value):
   >>> ISEMAIL("john@aol...com")
   False
 
-  More tests:
+  More tests:                                             Google Sheets   Grist
+                                                          -------------   -----
   >>> ISEMAIL("Abc@example.com")                              # True,     True
   True
   >>> ISEMAIL("Abc.123@example.com")                          # True,     True
@@ -314,6 +316,10 @@ def ISEMAIL(value):
   True
   >>> ISEMAIL("Bob_O'Reilly+tag@example.com")                 # False,    True
   True
+  >>> ISEMAIL("marie@isola.corsica")                          # False,    True
+  True
+  >>> ISEMAIL("fabio@disapproved.solutions")                  # False,    True
+  False
   >>> ISEMAIL(u"фыва@mail.ru")                                # False,    True
   True
   >>> ISEMAIL("my@baddash.-.com")                             # True,     False
@@ -323,8 +329,6 @@ def ISEMAIL(value):
   >>> ISEMAIL("my@baddash.b-.com")                            # True,     False
   False
   >>> ISEMAIL("john@-.com")                                   # True,     False
-  False
-  >>> ISEMAIL("fabio@disapproved.solutions")                  # False,    False
   False
   >>> ISEMAIL("!def!xyz%abc@example.com")                     # False,    False
   False
@@ -391,7 +395,7 @@ _url_regexp = re.compile(
   ([A-Za-z0-9]                    # Each part of hostname must start with alphanumeric
     ([A-Za-z0-9-]*[A-Za-z0-9])?\. # May have dashes inside, but end in alphanumeric
   )+
-  [A-Za-z]{2,6}                   # Restrict top-level domain to length {2,6}. Google seems
+  [A-Za-z]{2,24}                   # Restrict top-level domain to length {2,24}. Google seems
                                   # to use a whitelist for TLDs longer than 2 characters.
   ([/?][-\w!#$%&'()*+,./:;=?@~]*)?$ # Notably, this excludes <, >, and ".
   """, re.VERBOSE)

--- a/test/common/gutil.js
+++ b/test/common/gutil.js
@@ -247,6 +247,7 @@ describe('gutil', function() {
       assert.isTrue(gutil.isEmail('email@subdomain.do-main.com'));
       assert.isTrue(gutil.isEmail('firstname+lastname@domain.com'));
       assert.isTrue(gutil.isEmail('email@domain.co.jp'));
+      assert.isTrue(gutil.isEmail('marie@isola.corsica'));
 
       assert.isFalse(gutil.isEmail('plainaddress'));
       assert.isFalse(gutil.isEmail('@domain.com'));


### PR DESCRIPTION
### Context

More and more local governments around the world use custom TLD (`.amsterdam`, `.melbourne`, `.corsica`, `.nyc` just to name a few, full list [here](https://tld-list.com/tld-categories/cities)) and the `ISEMAIL` function doesn't consider `email@cityof.{TLD}` as valid if it is of length > 6.

### Proposal

I know validating emails is very tricky and that there is no "right way" to do this, but I think allowing longer TLDs makes sense, especially since application for gTLD was made easier back in 2011 and there are now more than 1400 TLDs (out of which 466 are longer than 6 characters).

I used 24 as the upper limit as that's the current max, though in theory TLDs could be 63 bytes as per [RFC 1034](https://www.rfc-editor.org/rfc/rfc1034).

### Check my numbers

Here's a quick python script that backs up my numbers 

```python
import requests
r = requests.get("http://data.iana.org/TLD/tlds-alpha-by-domain.txt")
tlds = r.text.split("\n")[1:]

# Longest TLD
max(tlds, key=len)
# > 'XN--VERMGENSBERATUNG-PWB'
len(max(tlds, key=len))
# > 24

# TLDs longer than 6
sum([len(tld) > 6 for tld in tlds])
# > 466

# Total number of TLDs
len(tlds)
# > 1453
```