### PR TITLE
Add support for markdown links.

### DIFF
--- a/app/client/lib/textUtils.ts
+++ b/app/client/lib/textUtils.ts
@@ -72,6 +72,7 @@ export function findLinks(text: string):  Array<{value: string, link: string, is
     });
 
     lastIndex = offset + match.length;
+    return match;
   });
 
   // Add any remaining text after the last URL

--- a/app/client/lib/textUtils.ts
+++ b/app/client/lib/textUtils.ts
@@ -32,9 +32,8 @@ For 'Link (in http://www.uk?)'
 'url-regex' [ 'http://www.uk?)' ]
 */
 
-
-// Match http or https then domain name or capture markdown link text and URL separately 
-const urlRegex = /(?:\[(.*?)\]\()?https?:\/\/[A-Za-z\d][A-Za-z\d-.]*\.[A-Za-z]{2,}(?::\d+)?(?:\/[^\s\)]*)?(?:\))?/;
+// Match http or https then domain name and capture markdown link text and URL separately
+const urlRegex = /(?:\[(.*?)\]\()?https?:\/\/[A-Za-z\d][A-Za-z\d-.]*\.[A-Za-z]{2,}(?::\d+)?(?:\/[^\s)]*)?(?:\))?/;
 
 /**
  * Detects URLs in a text and returns list of tokens { value, link, isLink }
@@ -44,12 +43,12 @@ export function findLinks(text: string):  Array<{value: string, link: string, is
     return [{ value: text, link: text, isLink: false }];
   }
 
-  let tokens = [];
+  const tokens = [];
   let lastIndex = 0;
   text.replace(urlRegex, (match: string, markdownText: string, offset: number) => {
     // Add text before the URL
     if (offset > lastIndex) {
-      const currentValue = text.substring(lastIndex, offset)
+      const currentValue = text.substring(lastIndex, offset);
       tokens.push({ value: currentValue, link: currentValue, isLink: false });
     }
 
@@ -77,7 +76,7 @@ export function findLinks(text: string):  Array<{value: string, link: string, is
 
   // Add any remaining text after the last URL
   if (lastIndex < text.length) {
-    const currentValue = text.substring(lastIndex)
+    const currentValue = text.substring(lastIndex);
     tokens.push({ value: currentValue, link: currentValue, isLink: false });
   }
 

--- a/app/client/ui2018/links.ts
+++ b/app/client/ui2018/links.ts
@@ -58,11 +58,11 @@ export async function onClickHyperLink(ev: MouseEvent, url: CellValue) {
 export function makeLinks(text: string) {
   try {
     const domElements: DomArg[] = [];
-    for (const {value, isLink} of findLinks(text)) {
+    for (const {value, link, isLink} of findLinks(text)) {
       if (isLink) {
         // Wrap link with a span to provide hover on and to override wrapping.
         domElements.push(cssMaybeWrap(
-          gristLink(value,
+          gristLink(link,
             cssIconBackground(
               icon("FieldLink", testId('tb-link-icon')),
               dom.cls(cssHoverInText.className),


### PR DESCRIPTION
This PR introduces markdown link detection and rendering. To achieve this, the regex has been updated, and an additional property, link, has been added to the tokens. If it's a URL, the URL remains the same, with the actual text rendered. However, for markdown, we aim to have a named link where the text differs from the link.

**Screenshot examples:**

Here is the raw text content
![image](https://github.com/gristlabs/grist-core/assets/37806520/51bbdb9e-775f-4457-819e-7981b314c036)

Here is the rendered 
![image](https://github.com/gristlabs/grist-core/assets/37806520/f97c8a89-8b5f-4cea-8312-6a850a6ed9f8)

Special thanks to Darius for recognizing the need for named links.