### PR TITLE
make a /boot/GRIST_BOOT_KEY page for diagnosing configuration problems

### DIFF
--- a/app/client/boot.ts
+++ b/app/client/boot.ts
@@ -1,0 +1,227 @@
+import { AppModel } from 'app/client/models/AppModel';
+import { createAppPage } from 'app/client/ui/createAppPage';
+import { pagePanels } from 'app/client/ui/PagePanels';
+import { BootProbeInfo, BootProbeResult } from 'app/common/BootProbe';
+import { removeTrailingSlash } from 'app/common/gutil';
+import { getGristConfig } from 'app/common/urlUtils';
+import { Disposable, dom, Observable, styled, UseCBOwner } from 'grainjs';
+
+const cssBody = styled('div', `
+  padding: 20px;
+  overflow: auto;
+  max-width: 500px;
+`);
+
+const cssHeader = styled('div', `
+  padding: 20px;
+`);
+
+/**
+ * A "boot" page for inspecting the state of the Grist installation.
+ * The page should ideally be visible even if a lot is wrong with the,
+ * installation, so avoid introducing dependenceis on middleware, or
+ * authentication, or anything else that could break. TODO: there are some
+ * configuration problems that currently result in Grist not running
+ * at all, ideally they would result in Grist running in a limited
+ * mode that is enough to bring up the boot page.
+ *
+ * TODO: deferring using any internationalization machinery so as not
+ * to have to worry about its failure modes yet, but should be
+ * straightforward really.
+ */
+export class Boot extends Disposable {
+  public probes: Observable<BootProbeInfo[]>;
+  public results: Map<string, Observable<BootProbeResult>>;
+  public requests: Map<string, BootProbe>;
+
+  constructor(_appModel: AppModel) {
+    super();
+    // Setting title in constructor seems to be how we are doing this?
+    document.title = 'Booting Grist';
+    this.probes = Observable.create(this, []);
+    this.results = new Map();
+    this.requests = new Map();
+  }
+
+  public buildDom() {
+    const config = getGristConfig();
+
+    const errMessage = config.errMessage;
+
+    if (!errMessage) {
+      // Probe tool URLs are relative to current URL. Don't trust configuration.
+      const url = new URL(removeTrailingSlash(document.location.href));
+      url.pathname = url.pathname + '/probe';
+
+      fetch(url.href).then(async resp => {
+        const _probes = await resp.json();
+        this.probes.set(_probes.probes);
+      });
+    }
+
+    const rootNode = dom('div',
+      dom.domComputed(
+        use => {
+          return pagePanels({
+            leftPanel: {
+              panelWidth: Observable.create(this, 240),
+              panelOpen: Observable.create(this, false),
+              hideOpener: true,
+              header: null,
+              content: null,
+            },
+            headerMain: cssHeader(dom('h1', 'Grist Boot')),
+            contentMain: this.buildBody(use, {errMessage}),
+          });
+          // return main;
+        }
+      ),
+      );
+    return rootNode;
+  }
+
+  public buildBody(use: UseCBOwner, options: {errMessage?: string}) {
+    const p = use(this.probes);
+    const main = options.errMessage ? this.buildError() : [
+      ...p.map(p0 => {
+        const {id} = p0;
+        let ob = this.results.get(id);
+        if (!ob) {
+          ob = Observable.create(this, {});
+          this.results.set(id, ob);
+        }
+        let ob2 = this.requests.get(id);
+        if (!ob2) {
+          ob2 = new BootProbe(id, this);
+          this.requests.set(id, ob2);
+        }
+        ob2.start();
+        const result = use(ob);
+        const deets = probeDetails[id];
+        return this.buildResult(p0, result, deets);
+      }),
+    ];
+    return cssBody(main);
+  }
+
+  public buildError() {
+    return dom(
+      'div',
+      'A diagnostics page is available at:',
+      dom('blockquote', '/boot/GRIST_BOOT_KEY'),
+      'GRIST_BOOT_KEY is an environment variable ',
+      ' set before Grist starts. It should only',
+      ' contain characters that are valid in a URL.',
+      ' It should be a secret, since no authentication is needed',
+      ' To visit the diagnostics page.',
+    );
+  }
+
+  public buildResult(info: BootProbeInfo, result: BootProbeResult,
+                     details: ProbeDetails|undefined) {
+    const out: (HTMLElement|string|null)[] = [];
+    out.push(dom('h2', info.name));
+    if (details) {
+      out.push(dom('p', '> ', details.info));
+    }
+    if (result.verdict) {
+      out.push(dom('pre', result.verdict));
+    }
+    if (result.success !== undefined) {
+      out.push(result.success ? '✅' : '❌');
+    }
+    if (result.done === true) {
+      out.push(dom('p', 'no fault detected'));
+    }
+    if (result.details) {
+      for (const [key, val] of Object.entries(result.details)) {
+        out.push(dom(
+          'div',
+          key,
+          dom('input', dom.prop('value', JSON.stringify(val)))));
+      }
+    }
+    return out;
+  }
+}
+
+/**
+ * Represents a single diagnostic.
+ */
+export class BootProbe {
+  constructor(public id: string, public boot: Boot) {
+    const url = new URL(removeTrailingSlash(document.location.href));
+    url.pathname = url.pathname + '/probe/' + id;
+    fetch(url.href).then(async resp => {
+      const _probes: BootProbeResult = await resp.json();
+      const ob = boot.results.get(id);
+      if (ob) {
+        ob.set(_probes);
+      }
+    }).catch(e => console.error(e));
+  }
+
+  public start() {
+    let ob = this.boot.results.get(this.id);
+    if (!ob) {
+      ob = Observable.create(this.boot, {});
+      this.boot.results.set(this.id, ob);
+    }
+  }
+}
+
+/**
+ * Create a stripped down page to show boot information.
+ * Make sure the API isn't used since it may well be broken.
+ */
+createAppPage(appModel => {
+  return dom.create(Boot, appModel);
+}, {
+  useApi: false,
+});
+
+/**
+ * Basic information about diagnostics is kept on the server,
+ * but it can be useful to show extra details and tips in the
+ * client.
+ */
+interface ProbeDetails {
+  info: string;
+}
+
+const probeDetails: Record<string, ProbeDetails> = {
+  'boot-page': {
+    info: `
+This boot page should not be too easy to access. Either turn
+it off when configuration is ok (by unsetting GRIST_BOOT_KEY)
+or make GRIST_BOOT_KEY long and cryptographically secure.
+`,
+  },
+
+  'health-check': {
+    info: `
+Grist has a small built-in health check often used when running
+it as a container.
+`,
+  },
+
+  'host-header': {
+    info: `
+Requests arriving to Grist should have an accurate Host
+header. This is essential when GRIST_SERVE_SAME_ORIGIN
+is set.
+`,
+  },
+
+  'system-user': {
+    info: `
+It is good practice not to run Grist as the root user.
+`,
+  },
+
+  'reachable': {
+    info: `
+The main page of Grist should be available.
+`
+  },
+}

--- a/app/client/boot.ts
+++ b/app/client/boot.ts
@@ -56,7 +56,7 @@ export class Boot extends Disposable {
       fetch(url.href).then(async resp => {
         const _probes = await resp.json();
         this.probes.set(_probes.probes);
-      });
+      }).catch(e => console.error(e));
     }
 
     const rootNode = dom('div',
@@ -224,4 +224,4 @@ It is good practice not to run Grist as the root user.
 The main page of Grist should be available.
 `
   },
-}
+};

--- a/app/client/boot.ts
+++ b/app/client/boot.ts
@@ -9,11 +9,14 @@ import { Disposable, dom, Observable, styled, UseCBOwner } from 'grainjs';
 const cssBody = styled('div', `
   padding: 20px;
   overflow: auto;
-  max-width: 500px;
 `);
 
 const cssHeader = styled('div', `
   padding: 20px;
+`);
+
+const cssResult = styled('div', `
+  max-width: 500px;
 `);
 
 /**
@@ -98,7 +101,8 @@ export class Boot extends Disposable {
         ob2.start();
         const result = use(ob);
         const deets = probeDetails[id];
-        return this.buildResult(p0, result, deets);
+        return cssResult(
+          this.buildResult(p0, result, deets));
       }),
     ];
     return cssBody(main);
@@ -107,13 +111,17 @@ export class Boot extends Disposable {
   public buildError() {
     return dom(
       'div',
-      'A diagnostics page is available at:',
-      dom('blockquote', '/boot/GRIST_BOOT_KEY'),
-      'GRIST_BOOT_KEY is an environment variable ',
-      ' set before Grist starts. It should only',
-      ' contain characters that are valid in a URL.',
-      ' It should be a secret, since no authentication is needed',
-      ' To visit the diagnostics page.',
+      dom('p',
+          'A diagnostics page can be made available at:',
+          dom('blockquote', '/boot/GRIST_BOOT_KEY'),
+          'GRIST_BOOT_KEY is an environment variable ',
+          ' set before Grist starts. It should only',
+          ' contain characters that are valid in a URL.',
+          ' It should be a secret, since no authentication is needed',
+          ' To visit the diagnostics page.'),
+      dom('p',
+          'You are seeing this page because either the key is not set,',
+          ' or it is not in the URL.'),
     );
   }
 

--- a/app/client/boot.ts
+++ b/app/client/boot.ts
@@ -96,7 +96,7 @@ export class Boot extends Disposable {
    */
   public buildBody(use: UseCBOwner, options: {errMessage?: string}) {
     if (options.errMessage) {
-      return cssBody(this.buildError());
+      return cssBody(cssResult(this.buildError()));
     }
     return cssBody([
       ...use(this.probes).map(probe => {
@@ -134,7 +134,7 @@ export class Boot extends Disposable {
           ' set before Grist starts. It should only',
           ' contain characters that are valid in a URL.',
           ' It should be a secret, since no authentication is needed',
-          ' To visit the diagnostics page.'),
+          ' to visit the diagnostics page.'),
       dom('p',
           'You are seeing this page because either the key is not set,',
           ' or it is not in the URL.'),

--- a/app/client/models/AppModel.ts
+++ b/app/client/models/AppModel.ts
@@ -177,7 +177,7 @@ export class TopAppModelImpl extends Disposable implements TopAppModel {
     this.productFlavor = getFlavor(window.gristConfig && window.gristConfig.org);
     this._gristConfig = window.gristConfig;
     this._widgets = new AsyncCreate<ICustomWidget[]>(async () => {
-      const widgets = this.options.useApi ? (await this.api.getWidgets()) : [];
+      const widgets = this.options.useApi === false ? [] : await this.api.getWidgets();
       this.customWidgets.set(widgets);
       return widgets;
     });
@@ -187,7 +187,7 @@ export class TopAppModelImpl extends Disposable implements TopAppModel {
     this.autoDispose(subscribe(this.currentSubdomain, (use) => this.initialize()));
     this.plugins = this._gristConfig?.plugins || [];
 
-    if (this.options.useApi) {
+    if (this.options.useApi !== false) {
       this.fetchUsersAndOrgs().catch(reportError);
     }
   }
@@ -247,7 +247,7 @@ export class TopAppModelImpl extends Disposable implements TopAppModel {
   private async _doInitialize() {
     this.appObs.set(null);
     if (this.options.useApi === false) {
-      AppModelImpl.create(this.appObs, this, null, null, {error: 'zing', status: 500});
+      AppModelImpl.create(this.appObs, this, null, null, {error: 'no-api', status: 500});
       return;
     }
     try {

--- a/app/client/ui/createAppPage.ts
+++ b/app/client/ui/createAppPage.ts
@@ -1,6 +1,6 @@
 import {get as getBrowserGlobals} from 'app/client/lib/browserGlobals';
 import {setupLocale} from 'app/client/lib/localization';
-import {AppModel, TopAppModelImpl} from 'app/client/models/AppModel';
+import {AppModel, TopAppModelImpl, TopAppModelOptions} from 'app/client/models/AppModel';
 import {reportError, setUpErrorHandling} from 'app/client/models/errors';
 import {buildSnackbarDom} from 'app/client/ui/NotifyUI';
 import {addViewportTag} from 'app/client/ui/viewport';
@@ -14,10 +14,12 @@ const G = getBrowserGlobals('document', 'window');
  * Sets up the application model, error handling, and global styles, and replaces
  * the DOM body with the result of calling `buildAppPage`.
  */
-export function createAppPage(buildAppPage: (appModel: AppModel) => DomContents) {
+export function createAppPage(
+  buildAppPage: (appModel: AppModel) => DomContents,
+  modelOptions: TopAppModelOptions = {}) {
   setUpErrorHandling();
 
-  const topAppModel = TopAppModelImpl.create(null, {});
+  const topAppModel = TopAppModelImpl.create(null, {}, undefined, modelOptions);
 
   addViewportTag();
   attachCssRootVars(topAppModel.productFlavor);

--- a/app/common/BootProbe.ts
+++ b/app/common/BootProbe.ts
@@ -1,0 +1,22 @@
+
+export type BootProbeIds =
+    'boot-page' |
+    'health-check' |
+    'reachable' |
+    'host-header' |
+    'system-user'
+;
+
+export interface BootProbeResult {
+  verdict?: string;
+  success?: boolean;
+  done?: boolean;
+  severity?: 'fault' | 'warning' | 'hmm';
+  details?: Record<string, any>;
+}
+
+export interface BootProbeInfo {
+  id: BootProbeIds;
+  name: string;
+}
+

--- a/app/server/lib/BootProbes.ts
+++ b/app/server/lib/BootProbes.ts
@@ -172,4 +172,4 @@ const _hostHeaderProbe: Probe = {
       done: true,
     };
   },
-}
+};

--- a/app/server/lib/BootProbes.ts
+++ b/app/server/lib/BootProbes.ts
@@ -1,0 +1,175 @@
+import { BootProbeIds, BootProbeResult } from 'app/common/BootProbe';
+import { removeTrailingSlash } from 'app/common/gutil';
+import { GristServer } from 'app/server/lib/GristServer';
+import * as express from 'express';
+import fetch from 'node-fetch';
+
+/**
+ * Self-diagnostics useful when installing Grist.
+ */
+export class BootProbes {
+  public probes = new Array<Probe>();
+
+  public constructor(public app: express.Application,
+                     public server: GristServer,
+                     public base: string) {
+  }
+
+  public addProbes() {
+
+    this.probes.push(_homeUrlReachableProbe);
+    this.probes.push(_statusCheckProbe);
+    this.probes.push(_userProbe);
+    this.probes.push(_bootProbe);
+    this.probes.push(_hostHeaderProbe);
+
+    this.app.use(`${this.base}/probe$`, async (_, res) => {
+      res.json({
+        'probes': this.probes.map(probe => {
+          return { id: probe.id, name: probe.name };
+        }),
+      });
+    });
+  }
+
+  // NEED TO UPDATE WITH AUTH
+  public addEndpoints() {
+    for (const probe of this.probes) {
+      this.app.use(`${this.base}/probe/${probe.id}$`, async (req, res) => {
+        const result = await probe.apply(this.server, req);
+        res.json(result);
+      });
+    }
+  }
+}
+
+export interface Probe {
+  id: BootProbeIds;
+  name: string;
+  description?: string;
+  apply: (server: GristServer, req: express.Request) => Promise<BootProbeResult>;
+}
+
+const _homeUrlReachableProbe: Probe = {
+  id: 'reachable',
+  name: 'Grist is reachable',
+  apply: async (server, req) => {
+    const url = server.getHomeUrl(req);
+    try {
+      const resp = await fetch(url);
+      if (resp.status !== 200) {
+        return {
+          success: false,
+          severity: 'fault',
+          details: {
+            error: await resp.text(),
+            status: resp.status,
+          }
+        };
+      }
+      return {
+        success: true,
+      };
+    } catch (e) {
+      return {
+        success: false,
+        details: {
+          error: String(e),
+        },
+        severity: 'fault',
+      };
+    }
+  }
+};
+
+const _statusCheckProbe: Probe = {
+  id: 'health-check',
+  name: 'Built-in Health check',
+  apply: async (server, req) => {
+    const baseUrl = server.getHomeUrl(req);
+    const url = new URL(baseUrl);
+    url.pathname = removeTrailingSlash(url.pathname) + '/status';
+    try {
+      const resp = await fetch(url);
+      if (resp.status !== 200) {
+        throw new Error(`Failed with status ${resp.status}`);
+      }
+      const txt = await resp.text();
+      if (!txt.includes('is alive')) {
+        throw new Error(`Failed, page has unexpected content`);
+      }
+      return {
+        success: true,
+      };
+    } catch (e) {
+      return {
+        success: false,
+        error: String(e),
+        severity: 'fault',
+      };
+    }
+  },
+};
+
+const _userProbe: Probe = {
+  id: 'system-user',
+  name: 'System user is sane',
+  apply: async () => {
+    if (process.getuid && process.getuid() === 0) {
+      return {
+        success: false,
+        verdict: 'User appears to be root (UID 0)',
+        severity: 'warning',
+      };
+    } else {
+      return {
+        success: true,
+      };
+    }
+  },
+};
+
+const _bootProbe: Probe = {
+  id: 'boot-page',
+  name: 'Boot page exposure',
+  apply: async (server) => {
+    if (!server.hasBoot) {
+      return { success: true };
+    }
+    const maybeSecureEnough = String(process.env.GRIST_BOOT_KEY).length > 10;
+    return {
+      success: maybeSecureEnough,
+      severity: 'hmm',
+    };
+  },
+};
+
+/**
+ * Based on:
+ * https://github.com/gristlabs/grist-core/issues/228#issuecomment-1803304438
+ *
+ * When GRIST_SERVE_SAME_ORIGIN is set, requests arriving to Grist need
+ * to have an accurate Host header.
+ */
+const _hostHeaderProbe: Probe = {
+  id: 'host-header',
+  name: 'Host header is sane',
+  apply: async (server, req) => {
+    const host = req.header('host');
+    const url = new URL(server.getHomeUrl(req));
+    if (url.hostname === 'localhost') {
+      return {
+        done: true,
+      };
+    }
+    if (String(url.hostname).toLowerCase() !== String(host).toLowerCase()) {
+      return {
+        success: false,
+        severity: 'hmm',
+      };
+    }
+    return {
+      done: true,
+    };
+  },
+}

--- a/app/server/lib/BootProbes.ts
+++ b/app/server/lib/BootProbes.ts
@@ -75,14 +75,7 @@ const _homeUrlReachableProbe: Probe = {
     try {
       const resp = await fetch(url);
       if (resp.status !== 200) {
-        return {
-          success: false,
-          severity: 'fault',
-          details: {
-            error: await resp.text(),
-            status: resp.status,
-          }
-        };
+        throw new ApiError(await resp.text(), resp.status);
       }
       return {
         success: true,

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -483,6 +483,32 @@ export class FlexServer implements GristServer {
     });
   }
 
+  /**
+   *
+   * Adds a /boot/$GRIST_BOOT_KEY page that shows diagnostics.
+   * Accepts any /boot/... URL in order to let the front end
+   * give some guidance if the user is stumbling around trying
+   * to find the boot page, but won't actually provide diagnostics
+   * unless GRIST_BOOT_KEY is set in the environment, and is present
+   * in the URL.
+   *
+   * We take some steps to make the boot page available even when
+   * things are going wrong, and should take more in future.
+   *
+   * When rendering the page a hardcoded 'boot' tag is used, which
+   * is used to ensure that static assets are served locally and
+   * we aren't relying on APP_STATIC_URL being set correctly.
+   *
+   * We use a boot key so that it is more acceptable to have this
+   * boot page living outside of the authentication system, which
+   * could be broken.
+   *
+   * TODO: there are some configuration problems that currently
+   * result in Grist not running at all. ideally they would result in
+   * Grist running in a limited mode that is enough to bring up the boot
+   * page.
+   *
+   */
   public addBootPage() {
     if (this._check('boot')) { return; }
     const bootKey = appSettings.section('boot').flag('key').readString({
@@ -501,9 +527,6 @@ export class FlexServer implements GristServer {
     });
     this._probes.addProbes();
     this._probes.addEndpoints();
-    //this.app.get(base, async (req, res) => {
-    //this._sendAppPage(req, res, {path: 'error.html', status: 200, config: {errPage: 'access-denied'}});
-  //});
   }
 
   public hasBoot(): boolean {

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -488,15 +488,14 @@ export class FlexServer implements GristServer {
     const bootKey = appSettings.section('boot').flag('key').readString({
       envVar: 'GRIST_BOOT_KEY'
     });
-    if (!bootKey) { return; }
     const base = `/boot/${bootKey}`;
     this._probes = new BootProbes(this.app, this, base);
     this.app.get('/boot(/:bootKey/?)?$', async (req, res) => {
-      const goodKey = req.params.bootKey === bootKey;
+      const goodKey = bootKey && req.params.bootKey === bootKey;
       return this._sendAppPage(req, res, {
         path: 'boot.html', status: 200, config: goodKey ? {
         } : {
-          errMessage: 'wo wo',
+          errMessage: 'not-the-key',
         }, tag: 'boot',
       });
     });

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -516,7 +516,9 @@ export class FlexServer implements GristServer {
     });
     const base = `/boot/${bootKey}`;
     this._probes = new BootProbes(this.app, this, base);
-    this.app.get('/boot(/:bootKey/?)?$', async (req, res) => {
+    // Respond to /boot, /boot/, /boot/KEY, /boot/KEY/ to give
+    // a helpful message even if user gets KEY wrong or omits it.
+    this.app.get('/boot(/(:bootKey/?)?)?$', async (req, res) => {
       const goodKey = bootKey && req.params.bootKey === bootKey;
       return this._sendAppPage(req, res, {
         path: 'boot.html', status: 200, config: goodKey ? {
@@ -525,7 +527,6 @@ export class FlexServer implements GristServer {
         }, tag: 'boot',
       });
     });
-    this._probes.addProbes();
     this._probes.addEndpoints();
   }
 

--- a/app/server/lib/GristServer.ts
+++ b/app/server/lib/GristServer.ts
@@ -60,6 +60,7 @@ export interface GristServer {
   getPlugins(): LocalPlugin[];
   servesPlugins(): boolean;
   getBundledWidgets(): ICustomWidget[];
+  hasBoot(): boolean;
 }
 
 export interface GristLoginSystem {
@@ -147,6 +148,7 @@ export function createDummyGristServer(): GristServer {
     servesPlugins() { return false; },
     getPlugins() { return []; },
     getBundledWidgets() { return []; },
+    hasBoot() { return false; },
   };
 }
 

--- a/app/server/lib/sendAppPage.ts
+++ b/app/server/lib/sendAppPage.ts
@@ -139,8 +139,11 @@ export function makeSendAppPage(opts: {
     const needTagManager = (options.googleTagManager === 'anon' && isAnonymousUser(req)) ||
       options.googleTagManager === true;
     const tagManagerSnippet = needTagManager ? getTagManagerSnippet(process.env.GOOGLE_TAG_MANAGER_ID) : '';
-    const staticOrigin = process.env.APP_STATIC_URL || "";
-    const staticBaseUrl = `${staticOrigin}/v/${options.tag || tag}/`;
+    const staticTag = options.tag || tag;
+    // If boot tag is used, serve assets locally, otherwise respect
+    // APP_STATIC_URL.
+    const staticOrigin = staticTag === 'boot' ? '' : (process.env.APP_STATIC_URL || '');
+    const staticBaseUrl = `${staticOrigin}/v/${staticTag}/`;
     const customHeadHtmlSnippet = server.create.getExtraHeadHtml?.() ?? "";
     const warning = testLogin ? "<div class=\"dev_warning\">Authentication is not enforced</div>" : "";
     // Preload all languages that will be used or are requested by client.

--- a/app/server/mergedServerMain.ts
+++ b/app/server/mergedServerMain.ts
@@ -104,6 +104,7 @@ export async function main(port: number, serverTypes: ServerType[],
   }
 
   server.addHealthCheck();
+  server.addBootPage();
   server.denyRequestsIfNotReady();
 
   if (includeHome || includeStatic || includeApp) {

--- a/app/server/mergedServerMain.ts
+++ b/app/server/mergedServerMain.ts
@@ -104,7 +104,9 @@ export async function main(port: number, serverTypes: ServerType[],
   }
 
   server.addHealthCheck();
-  server.addBootPage();
+  if (includeHome || includeApp) {
+    server.addBootPage();
+  }
   server.denyRequestsIfNotReady();
 
   if (includeHome || includeStatic || includeApp) {

--- a/buildtools/webpack.config.js
+++ b/buildtools/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
     main: "app/client/app",
     errorPages: "app/client/errorMain",
     apiconsole: "app/client/apiconsole",
+    boot: "app/client/boot",
     billing: "app/client/billingMain",
     form: "app/client/formMain",
     // Include client test harness if it is present (it won't be in

--- a/static/boot.html
+++ b/static/boot.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf8">
+  <!-- INSERT BASE -->
+  <link rel="icon" type="image/x-icon" href="icons/favicon.png" />
+  <link rel="stylesheet" href="icons/icons.css">
+  <!-- INSERT LOCALE -->
+  <!-- INSERT CONFIG -->
+  <title>Loading...<!-- INSERT TITLE SUFFIX --></title>
+</head>
+<body>
+  <script crossorigin="anonymous" src="boot.bundle.js"></script>
+</body>
+</html>

--- a/test/nbrowser/Boot.ts
+++ b/test/nbrowser/Boot.ts
@@ -1,0 +1,52 @@
+import {assert, driver} from 'mocha-webdriver';
+import * as gu from 'test/nbrowser/gristUtils';
+import {server, setupTestSuite} from 'test/nbrowser/testUtils';
+import * as testUtils from 'test/server/testUtils';
+
+describe('Boot', function() {
+  this.timeout(30000);
+  setupTestSuite();
+
+  let oldEnv: testUtils.EnvironmentSnapshot;
+
+  afterEach(() => gu.checkForErrors());
+
+  async function hasPrompt() {
+    assert.include(
+      await driver.findContentWait('p', /diagnostics page/, 2000).getText(),
+      'A diagnostics page can be made available');
+  }
+
+  it('gives prompt about how to enable boot page', async function() {
+    await driver.get(`${server.getHost()}/boot`);
+    await hasPrompt();
+  });
+
+  describe('with a GRIST_BOOT_KEY', function() {
+    before(async function() {
+      oldEnv = new testUtils.EnvironmentSnapshot();
+      process.env.GRIST_BOOT_KEY = 'lala';
+      await server.restart();
+    });
+
+    after(async function() {
+      oldEnv.restore();
+      await server.restart();
+    });
+
+    it('gives prompt when key is missing', async function() {
+      await driver.get(`${server.getHost()}/boot`);
+      await hasPrompt();
+    });
+
+    it('gives prompt when key is wrong', async function() {
+      await driver.get(`${server.getHost()}/boot/bilbo`);
+      await hasPrompt();
+    });
+
+    it('gives page when key is right', async function() {
+      await driver.get(`${server.getHost()}/boot/lala`);
+      await driver.findContentWait('h2', /Grist is reachable/, 2000);
+    });
+  });
+});


### PR DESCRIPTION
This is a start at a page for diagnosing problems while setting up Grist. Starting to add some diagnostics based on feedback in github issues. We should make Grist installation easier! But when there is a problem it should be easier to diagnose than it is now, and this may help.