### PR TITLE
CI: actually split `:server-x-of-y:` tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,7 @@ jobs:
           export TEST_SPLITS=$(echo $TESTS | sed "s/.*:server-\([^:]*\).*/\1/")
           MOCHA_WEBDRIVER_HEADLESS=1 yarn run test:server
         env:
+          TESTS: ${{ matrix.tests }}
           GRIST_DOCS_MINIO_ACCESS_KEY: administrator
           GRIST_DOCS_MINIO_SECRET_KEY: administrator
           TEST_REDIS_URL: "redis://localhost/11"


### PR DESCRIPTION
## Problem

The `CI` workflow on this repository runs the entire suite of `server` tests twice, instead of splitting it in two parallel runs as intended. See for example how https://github.com/gristlabs/grist-core/actions/runs/7960496537/job/21729617312 and https://github.com/gristlabs/grist-core/actions/runs/7960496537/job/21729617571 run the same list of tests.

## Cause

The `split-tests.js` script does not do anything because the `TEST_SPLITS` variable is empty, in turn because the `TESTS` variable is not being initialized from the `matrix.tests` value.

## Proposed solution

Set `TESTS` from `matrix.tests`.

## Expected result

The logs for `build_and_test (3.9, 18.x, :server-X-of-2:)` jobs should include a `Split tests groups; will run group X of 2` line at the start of the `Run main tests without minio and redis` step. They should also take about half as long each.