### PR TITLE
Fix #810

### DIFF
--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -1038,7 +1038,7 @@ export function buildUrlId(parts: UrlIdParts): string {
     // may be in a docId (leaving just the hyphen, which is permitted).  The limits
     // could be loosened, but without much benefit.
     const codedSnapshotId = encodeURIComponent(parts.snapshotId)
-      .replace(/[_.!~*'()]/g, ch => `_${ch.charCodeAt(0).toString(16).toUpperCase()}`)
+      .replace(/[_.!~*'()-]/g, ch => `_${ch.charCodeAt(0).toString(16).toUpperCase()}`)
       .replace(/%/g, '_');
     token = `${token}~v=${codedSnapshotId}`;
   }


### PR DESCRIPTION
# Context

When using MinIO as backend storage, the version IDs contain hyphens. Since https://github.com/gristlabs/grist-core/commit/bcb9740d89b0a59911a58eadea822b3ee7bef37d, hyphens are not considered when capturing the urlId.

Resolves #810 

# Proposed solution

I could not manage to keep only one route with the regexps, it seems like we cannot use groups (captured or not) inside `:urlId`…

So I created an alternative route that explicitly handles versions. To be honest I am far from being proud of this work, any help to improve that is highly welcome.

Also this would probably need to add some tests to ensure we would not have any regressions in the future.

# Alternative solution?

[tegs suggests in this comment](https://github.com/gristlabs/grist-core/issues/810#issuecomment-1902526138) as a workaround to open snapshots with adding `/doc`, which would redirect to this path: https://github.com/gristlabs/grist-core/blob/d8048c3998f6d5c7fbf784317e5aefb63e9408dc/app/server/lib/AppEndpoint.ts#L219

I wonder whether it is intented that the hyphens are not excluded in this path. If not, we may just change the client codebase so this is this path which would handle fetching the document version.