### PR TITLE
Small PR: Fix links in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Welcome to the contribution guide for Grist!
 
 You are eager to contribute to Grist? That's awesome! See below some contributions you can make:
-- [translate](/documentation/translate.md)
-- [write tutorials and user documentation](https://github.com/gristlabs/grist-help)
+- [translate](/documentation/translations.md)
+- [write tutorials and user documentation](https://github.com/gristlabs/grist-help?tab=readme-ov-file#grist-help-center)
 - [develop](/documentation/develop.md)
 - [report issues or suggest enhancement](https://github.com/gristlabs/grist-core/issues/new)
 


### PR DESCRIPTION
 - the link to the translation guide was wrong
 - grist-help: redirect to the README file through the anchor so visitors may understand better why they land to this separate project.

The second point is just a proposal that I may revert, I am not 100% sure what is the best