### PR TITLE
mention boot page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,23 @@ You can find a lot more about configuring Grist, setting up authentication,
 and running it on a public server in our
 [Self-Managed Grist](https://support.getgrist.com/self-managed/) handbook.
 
+## Activating the boot page for diagnosing problems
+
+You can turn on a special "boot page" to inspect the status of your
+installation. Just visit `/boot` on your Grist server for instructions.
+Since it is useful for the boot page to be available even when authentication
+isn't set up, you can give it a special access key by setting `GRIST_BOOT_KEY`.
+
+```
+docker run -p 8484:8484 -e GRIST_BOOT_KEY=secret -it gristlabs/grist
+```
+
+The boot page should then be available at `/boot/<GRIST_BOOT_KEY>`. We are
+starting to collect probes for common problems there. If you hit a problem that
+isn't covered, it would be great if you could add a probe for it in
+[BootProbes](https://github.com/gristlabs/grist-core/blob/main/app/server/lib/BootProbes.ts).
+Or file an issue so someone else can add it, we're just getting start with this.
+
 ## Building from source
 
 To build Grist from source, follow these steps:
@@ -242,6 +259,7 @@ GRIST_ADAPT_DOMAIN  | set to "true" to support multiple base domains (careful, h
 GRIST_ALLOWED_HOSTS | comma-separated list of permitted domains origin for requests (e.g. my.site,another.com)
 GRIST_APP_ROOT      | directory containing Grist sandbox and assets (specifically the sandbox and static subdirectories).
 GRIST_BACKUP_DELAY_SECS | wait this long after a doc change before making a backup
+GRIST_BOOT_KEY | if set, offer diagnostics at /boot/GRIST_BOOT_KEY
 GRIST_DATA_DIR      | directory in which to store document caches.
 GRIST_DEFAULT_EMAIL | if set, login as this user if no other credentials presented
 GRIST_DEFAULT_PRODUCT  | if set, this controls enabled features and limits of new sites. See names of PRODUCTS in Product.ts.


### PR DESCRIPTION
This mentions how to enable the boot page diagnostics in the README. Ideally, something like the boot page would be available on initial installation without doing anything special, but that can come later.