### PR TITLE
Tiny: Clarify usefulness of GRIST_ALLOWED_HOSTS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ APP_STATIC_URL | url prefix for static resources
 APP_STATIC_INCLUDE_CUSTOM_CSS | set to "true" to include custom.css (from APP_STATIC_URL) in static pages
 APP_UNTRUSTED_URL   | URL at which to serve/expect plugin content.
 GRIST_ADAPT_DOMAIN  | set to "true" to support multiple base domains (careful, host header should be trustworthy)
-GRIST_ALLOWED_HOSTS | comma-separated list of permitted domains origin for requests (e.g. my.site,another.com)
+GRIST_ALLOWED_HOSTS | comma-separated list of permitted domains origin for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) requests (e.g. my.site,another.com) with authentication
 GRIST_APP_ROOT      | directory containing Grist sandbox and assets (specifically the sandbox and static subdirectories).
 GRIST_BACKUP_DELAY_SECS | wait this long after a doc change before making a backup
 GRIST_BOOT_KEY | if set, offer diagnostics at /boot/GRIST_BOOT_KEY


### PR DESCRIPTION
# Context

It was not clear to us what is the usefulness of `GRIST_ALLOWED_HOSTS` env var.

Especially we were wondering what kind of request this was meant to filter.

# Proposed solution

By looking at the code, it seems like this env var is used indirectly by several pieces of code, but they seem to relate to CORS requests (typically made by browsers) that require authentication.

~~(BTW, do you know whether it is required for plugins to access the content of the tables?)~~ Edit: that seems to be handled via grain-RPC