### PR TITLE
Remove the GRIST_ALLOWED_HOSTS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,6 @@ APP_STATIC_URL | url prefix for static resources
 APP_STATIC_INCLUDE_CUSTOM_CSS | set to "true" to include custom.css (from APP_STATIC_URL) in static pages
 APP_UNTRUSTED_URL   | URL at which to serve/expect plugin content.
 GRIST_ADAPT_DOMAIN  | set to "true" to support multiple base domains (careful, host header should be trustworthy)
-GRIST_ALLOWED_HOSTS | comma-separated list of permitted domains origin for requests (e.g. my.site,another.com)
 GRIST_APP_ROOT      | directory containing Grist sandbox and assets (specifically the sandbox and static subdirectories).
 GRIST_BACKUP_DELAY_SECS | wait this long after a doc change before making a backup
 GRIST_BOOT_KEY | if set, offer diagnostics at /boot/GRIST_BOOT_KEY

--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -18,7 +18,7 @@ import {makeId} from 'app/server/lib/idUtils';
 import log from 'app/server/lib/log';
 import {IPermitStore, Permit} from 'app/server/lib/Permit';
 import {AccessTokenInfo} from 'app/server/lib/AccessTokens';
-import {allowHost, getOriginUrl, isEnvironmentAllowedHost, optStringParam} from 'app/server/lib/requestUtils';
+import {allowHost, getOriginUrl, optStringParam} from 'app/server/lib/requestUtils';
 import * as cookie from 'cookie';
 import {NextFunction, Request, RequestHandler, Response} from 'express';
 import {IncomingMessage} from 'http';
@@ -271,7 +271,7 @@ export async function addRequestUser(
       // custom-domain owner could hijack such sessions.
       const allowedOrg = getAllowedOrgForSessionID(mreq.sessionID);
       if (allowedOrg) {
-        if (allowHost(req, allowedOrg.host) || isEnvironmentAllowedHost(allowedOrg.host)) {
+        if (allowHost(req, allowedOrg.host)) {
           customHostSession = ` custom-host-match ${allowedOrg.host}`;
         } else {
           // We need an exception for internal forwarding from home server to doc-workers. These use

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -4865,23 +4865,6 @@ function testDocApi() {
   });
 
   describe("Allowed Origin", () => {
-    it('should allow only example.com', async () => {
-      async function checkOrigin(origin: string, allowed: boolean) {
-        const resp = await axios.get(`${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1/data`,
-          {...chimpy, headers: {...chimpy.headers, "Origin": origin}}
-        );
-        assert.equal(resp.headers['access-control-allow-credentials'], allowed ? 'true' : undefined);
-        assert.equal(resp.status, allowed ? 200 : 403);
-      }
-
-      await checkOrigin("https://www.toto.com", false);
-      await checkOrigin("https://badexample.com", false);
-      await checkOrigin("https://bad.com/example.com/toto", false);
-      await checkOrigin("https://example.com/path", true);
-      await checkOrigin("https://example.com:3000/path", true);
-      await checkOrigin("https://good.example.com/toto", true);
-    });
-
     it("should respond with correct CORS headers", async function () {
       const wid = await getWorkspaceId(userApi, 'Private');
       const docId = await userApi.newDoc({name: 'CorsTestDoc'}, wid);

--- a/test/server/lib/helpers/TestServer.ts
+++ b/test/server/lib/helpers/TestServer.ts
@@ -49,7 +49,6 @@ export class TestServer {
       GRIST_PORT: '0',
       GRIST_DISABLE_S3: 'true',
       REDIS_URL: process.env.TEST_REDIS_URL,
-      GRIST_ALLOWED_HOSTS: `example.com,localhost`,
       GRIST_TRIGGER_WAIT_DELAY: '100',
       // this is calculated value, some tests expect 4 attempts and some will try 3 times
       GRIST_TRIGGER_MAX_ATTEMPTS: '4',


### PR DESCRIPTION
## Context

While reviewing @fflorent 's #895 and discussing with various people at ANCT we realized that the `GRIST_ALLOWED_HOSTS` environment variable was added in a PR submitted in 2022 by another developer working at the time with ANCT : #287.

It turns out that the use case that originally motivated the PR (#271) is now covered in two ways:
* since https://github.com/gristlabs/grist-core/commit/e590e65a3fe915ed95099c94c2e1852d56e4e33a, cross-origin requests that do not require authentication are allowed, so that public documents can be queried just fine from any external domain ;
* allowing authenticated requests from external domains currently requires, in addition to including the domain in `GRIST_ALLOWED_HOSTS`, making an API key available in a client, which is definitely something one wants to discourage as pointed out by @dsagal in https://github.com/gristlabs/grist-core/issues/271#issuecomment-1241288590. Indeed we saw this mistake occur in the very web app that motivated the addition of `GRIST_ALLOWED_HOSTS` (the exposed API key has since been revoked).

We are now confident that we do not need this variable and have removed it from our deployment. Given the specificity of the use case it enables, and the lack of adequate documentation as evidenced by #895, it seems doubtful that any other Grist deployment would currently be depending on it, although it is of course difficult to be certain.

We also estimate that keeping it available in Grist has multiple downsides:
* as mentioned above, pretty much the only scenario it enables is the unsafe one where an API key is accessible to a public Web client;
* it adds unnecessary complexity to an already difficult-to-follow process of origin validation (`GRIST_ALLOWED_HOSTS` played a significant part in my bafflement while trying to implement origin checking for #859);
* while I have no evidence for this, I suspect a confused Grist self-hoster may end up setting `GRIST_ALLOWED_HOSTS` to bypass an otherwise broken configuration of `APP_HOME_URL` and the other relevant variables (which are unfortunately numerous).

## Proposed solution

This PR mostly reverts commit 49b1749e98c873c564c2463eb8eb3189d434eaca. A few notes on what was kept:
* in `allowHost`, the logic introduced by #287 that allows a domain name that doesn't match the standard `<orgname>.<basedomain>.<tld>` pattern enforced by `parseSubdomain` to match itself was kept, although with simplified logic that does not involve `lodash`. This might not be necessary, since requests whose `Host` match their `Origin` are by definition not cross-origin, and would therefore not end up in `allowHost`, but was kept out of an abundance of caution.
* the `matchesBaseDomain` function seemeed like an unrelated but useful addition of #287 (notably making the checks against `ALLOWED_WEBHOOK_DOMAINS` more robust), so it was kept as well.