### PR TITLE
Tiny: Remove unused var GRIST_HOME_INCLUDE_STATIC

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,6 @@ GRIST_DOMAIN        | in hosted Grist, Grist is served from subdomains of this d
 GRIST_EXPERIMENTAL_PLUGINS | enables experimental plugins
 GRIST_ENABLE_REQUEST_FUNCTION | enables the REQUEST function. This function performs HTTP requests in a similar way to `requests.request`. This function presents a significant security risk, since it can let users call internal endpoints when Grist is available publicly. This function can also cause performance issues. Unset by default.
 GRIST_HIDE_UI_ELEMENTS | comma-separated list of UI features to disable. Allowed names of parts: `helpCenter,billing,templates,createSite,multiSite,multiAccounts,sendToDrive,tutorials`. If a part also exists in GRIST_UI_FEATURES, it will still be disabled.
-GRIST_HOME_INCLUDE_STATIC | if set, home server also serves static resources
 GRIST_HOST          | hostname to use when listening on a port.
 GRIST_HTTPS_PROXY   | if set, use this proxy for webhook payload delivery.
 GRIST_ID_PREFIX | for subdomains of form o-*, expect or produce o-${GRIST_ID_PREFIX}*.


### PR DESCRIPTION
The README document referenced a `GRIST_HOME_INCLUDE_STATIC` env variable, which seem to be used nowhere (unless I am wrong) and therefore to have no effect.

Also seem to be confusing with GRIST_SERVERS which can be set to `home,static`.