### PR TITLE
Tiny: Add README entry for GRIST_INCLUDE_CUSTOM_SCRIPT_URL variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ GRIST_HOST          | hostname to use when listening on a port.
 GRIST_HTTPS_PROXY   | if set, use this proxy for webhook payload delivery.
 GRIST_ID_PREFIX | for subdomains of form o-*, expect or produce o-${GRIST_ID_PREFIX}*.
 GRIST_IGNORE_SESSION | if set, Grist will not use a session for authentication.
+GRIST_INCLUDE_CUSTOM_SCRIPT_URL | if set, will load the referenced URL in a `<script>` tag on all app pages.
 GRIST_INST_DIR      | path to Grist instance configuration files, for Grist server.
 GRIST_LIST_PUBLIC_SITES | if set to true, sites shared with the public will be listed for anonymous users. Defaults to false.
 GRIST_MANAGED_WORKERS | if set, Grist can assume that if a url targeted at a doc worker returns a 404, that worker is gone


### PR DESCRIPTION
### Context

We were looking for a way to inject custom scripts to the app's html templates, and thought grist had no such feature yet.

Ref issue https://github.com/gristlabs/grist-core/issues/904

### Content

Turns out, the feature was implemented very recently (see [here](https://github.com/gristlabs/grist-core/blob/f3f320a1934c0d8f7dbb0aaf16ce8ebf54f398dd/app/server/lib/sendAppPage.ts#L130)) but was not yet documented.

We could mention the related env variable in the README for discoverability.