### PR TITLE
tweak Dockerfile so image is buildable with podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN \
 # Fetch gvisor-based sandbox. Note, to enable it to run within default
 # unprivileged docker, layers of protection that require privilege have
 # been stripped away, see https://github.com/google/gvisor/issues/4371
-FROM gristlabs/gvisor-unprivileged:buster as sandbox
+FROM docker.io/gristlabs/gvisor-unprivileged:buster as sandbox
 
 ################################################################################
 ## Run-time stage


### PR DESCRIPTION
This adds a docker.io registry name, the lack of which will otherwise cause image building to fail if podman is used rather than docker. Common images like node are automatically aliased and don't need the registry name. Based on a problem reported in discord.

https://discord.com/channels/1176642613022044301/1214877650108026881