### PR TITLE
/status does not return a 500 HTTP code if docWorkerRegistered fails

### DIFF
--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -474,7 +474,12 @@ export class FlexServer implements GristServer {
         // be checked with the 'redis' parameter (the user may want to avoid
         // removing workers when connection is unstable).
         if (this._docWorkerMap.getRedisClient()?.connected) {
-          checks.set('docWorkerRegistered', asyncCheck(this._docWorkerMap.isWorkerRegistered(this.worker)));
+          checks.set('docWorkerRegistered', asyncCheck(
+            this._docWorkerMap.isWorkerRegistered(this.worker).then(isRegistered => {
+              if (!isRegistered) { throw new Error('doc worker not registered'); }
+              return isRegistered;
+            })
+          ));
         }
       }
       if (isParameterOn(req.query.ready)) {


### PR DESCRIPTION
Follow-up of #856 

I thought that the checks in the `/status` endpoints had to return a boolean in order to make it return an error (HTTP return code = 500), but after reading carefully found that it has to return a rejected Promise:

https://github.com/gristlabs/grist-core/blob/e28e1616ac7f9cbae0b9c6327fc4f21c5ee769d6/app/server/lib/FlexServer.ts#L455-L460

So when `DocWorkerMap#isWorkerRegistered()` returns `false`, I rather return a rejected promise.