### PR TITLE
Remove `Origin` header in internal `fetchDoc`

### DIFF
--- a/app/server/lib/requestUtils.ts
+++ b/app/server/lib/requestUtils.ts
@@ -103,6 +103,12 @@ export function allowHost(req: IncomingMessage, allowedHost: string|URL) {
   const proto = getEndUserProtocol(req);
   const actualUrl = new URL(getOriginUrl(req));
   const allowedUrl = (typeof allowedHost === 'string') ? new URL(`${proto}://${allowedHost}`) : allowedHost;
+  log.rawDebug('allowHost: ', {
+    req: (new URL(req.url!, `http://${req.headers.host}`).href),
+    origin: req.headers.origin,
+    actualUrl: actualUrl.hostname,
+    allowedUrl: allowedUrl.hostname,
+  });
   if ((req as RequestWithOrg).isCustomHost) {
     // For a request to a custom domain, the full hostname must match.
     return actualUrl.hostname === allowedUrl.hostname;

--- a/app/server/lib/uploads.ts
+++ b/app/server/lib/uploads.ts
@@ -409,6 +409,12 @@ export async function fetchDoc(server: GristServer, docId: string, req: Request,
   // Prepare headers that preserve credentials of current user.
   const headers = getTransitiveHeaders(req);
 
+  // Passing the Origin header would serve no purpose here, as we are
+  // constructing an internal request to fetch from our own doc worker
+  // URL. Indeed, it may interfere, as it could incur a CORS check in
+  // `trustOrigin`, which we do not need.
+  delete headers.Origin;
+
   // Find the doc worker responsible for the document we wish to copy.
   // The backend needs to be well configured for this to work.
   const homeUrl = server.getHomeUrl(req);


### PR DESCRIPTION
Commit messages:

* uploads: do not use Origin header in `fetchDoc`

The `Origin` header is produced by `getTransitiveHeaders` but we don't
need it here, as this is only for an internal request where no
cross-origin attacks are possible

* requestUtils: add some logging to allowHost

I found it useful during my work to figure out what was going on in
this function and why some requests were being denied.

