### PR TITLE
tweak admin test to also work under grist-core settings

### DIFF
--- a/test/nbrowser/AdminPanel.ts
+++ b/test/nbrowser/AdminPanel.ts
@@ -182,12 +182,14 @@ describe('AdminPanel', function() {
     await waitForAdminPanel();
     assert.equal(await driver.find('.test-admin-panel-item-sandboxing').isDisplayed(), true);
     await gu.waitToPass(
-      async () => assert.match(await driver.find('.test-admin-panel-item-value-sandboxing').getText(), /^unknown/),
+      // unknown for grist-saas, unconfigured for grist-core.
+      async () => assert.match(await driver.find('.test-admin-panel-item-value-sandboxing').getText(),
+                               /^((unknown)|(unconfigured))/),
       3000,
     );
     // It would be good to test other scenarios, but we are using
-    // a multi-server setup and the sandbox test isn't useful there
-    // yet.
+    // a multi-server setup on grist-saas and the sandbox test isn't
+    // useful there yet.
   });
 
   const upperCheckNow = () => driver.find('.test-admin-panel-updates-upper-check-now');


### PR DESCRIPTION
Generalize an already weak test to make it even weaker, since conditions are a little different between some repositories.