### PR TITLE
(docs) overview.md: explain tableId in data actions

### DIFF
--- a/documentation/overview.md
+++ b/documentation/overview.md
@@ -88,7 +88,7 @@ export type RemoveTable = ['RemoveTable', string];
 export type RenameTable = ['RenameTable', string, string];
 ```
 
-Data actions take a numeric `rowId` (or a list of them, for “bulk” actions) and a set of values:
+Data actions take a string `tableId` and a numeric `rowId` (or a list of them, for “bulk” actions) and a set of values:
 
 ```
 export interface ColValues { [colId: string]: CellValue; }


### PR DESCRIPTION
The docs give examples of Doc Actions like this
```
export type AddRecord = ['AddRecord', string, number, ColValues];
```

It defines what the `number` is but not what the `string` is. This PR documents the string.