### PR TITLE
support $id in dropdown condition

### DIFF
--- a/app/client/components/DropdownConditionConfig.ts
+++ b/app/client/components/DropdownConditionConfig.ts
@@ -51,7 +51,7 @@ export class DropdownConditionConfig extends Disposable {
 
     const {recColIds = [], choiceColIds = []} = properties;
     const columns = use(this._columns);
-    const validRecColIds = new Set(columns.map((({colId}) => use(colId))));
+    const validRecColIds = new Set(['id', ...columns.map((({colId}) => use(colId)))]);
     const invalidRecColIds = recColIds.filter(colId => !validRecColIds.has(colId));
     if (invalidRecColIds.length > 0) {
       return t('Invalid columns: {{colIds}}', {colIds: invalidRecColIds.join(', ')});

--- a/test/nbrowser/DropdownConditionEditor.ts
+++ b/test/nbrowser/DropdownConditionEditor.ts
@@ -157,11 +157,11 @@ describe('DropdownConditionEditor', function () {
           'choice\n.Supervisor\n '
         ]);
       });
-      await gu.sendKeys('.Role == "Supervisor" and $Role != "Supervisor"', Key.ENTER);
+      await gu.sendKeys('.Role == "Supervisor" and $Role != "Supervisor" and $id != 2', Key.ENTER);
       await gu.waitForServer();
       assert.equal(
         await driver.find('.test-field-dropdown-condition .ace_line').getAttribute('textContent'),
-        'choice.Role == "Supervisor" and $Role != "Supervisor"\n'
+        'choice.Role == "Supervisor" and $Role != "Supervisor" and $id != 2\n'
       );
 
       // Check that autocomplete values are filtered.
@@ -171,6 +171,23 @@ describe('DropdownConditionEditor', function () {
         'Marie Ziyad',
       ]);
       await gu.sendKeys(Key.ESCAPE);
+
+      // Should be no options on row 2 because of $id != 2 part of condition.
+      await gu.getCell(2, 2).click();
+      await gu.sendKeys(Key.ENTER);
+      assert.deepEqual(await driver.findAll('.test-autocomplete li', (el) => el.getText()), [
+      ]);
+      await gu.sendKeys(Key.ESCAPE);
+
+      // Row 3 should be like row 1.
+      await gu.getCell(2, 3).click();
+      await gu.sendKeys(Key.ENTER);
+      assert.deepEqual(await driver.findAll('.test-autocomplete li', (el) => el.getText()), [
+        'Pavan Madilyn',
+        'Marie Ziyad',
+      ]);
+      await gu.sendKeys(Key.ESCAPE);
+
       await gu.getCell(2, 4).click();
       await gu.sendKeys(Key.ENTER);
       assert.isEmpty(await driver.findAll('.test-autocomplete li', (el) => el.getText()));
@@ -187,7 +204,7 @@ describe('DropdownConditionEditor', function () {
       await gu.setType('Reference List', {apply: true});
       assert.equal(
         await driver.find('.test-field-dropdown-condition .ace_line').getAttribute('textContent'),
-        'choice.Role == "Supervisor" and $Role != "Supervisor"\n'
+        'choice.Role == "Supervisor" and $Role != "Supervisor" and $id != 2\n'
       );
       await gu.getCell(2, 4).click();
       await gu.sendKeys(Key.ENTER);


### PR DESCRIPTION
This adds support for $id in dropdown conditions, using the same method used for supporting referencedColumn.id, and extends a test to exercise the variable. Without this, the dropdown editor gives an error if $id or rec.id is used, stating that the column is invalid.