### PR TITLE
workflows: add a workflow to add issues to the self-hosted project

### DIFF
--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -1,0 +1,18 @@
+name: Add self-hosting issues to the self-hosting project
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.1
+        with:
+          project-url: https://github.com/orgs/gristlabs/projects/2
+          github-token: ${{ secrets.SELF_HOSTED_PROJECT }}
+          labeled: self-hosting


### PR DESCRIPTION
Based on instructions here:

https://github.com/actions/add-to-project

The idea is that anyone can tag an issue as self-hosting and if that's so, it'll show up in the corresponding kanban.