### PR TITLE
Moves core ICreate object and core GristLoginSystem to server/lib

### DIFF
--- a/app/server/lib/coreCreator.ts
+++ b/app/server/lib/coreCreator.ts
@@ -1,0 +1,22 @@
+import { checkMinIOBucket, checkMinIOExternalStorage,
+         configureMinIOExternalStorage } from 'app/server/lib/configureMinIOExternalStorage';
+import { makeSimpleCreator } from 'app/server/lib/ICreate';
+import { Telemetry } from 'app/server/lib/Telemetry';
+
+export const makeCoreCreator = () => makeSimpleCreator({
+  deploymentType: 'core',
+  // This can and should be overridden by GRIST_SESSION_SECRET
+  // (or generated randomly per install, like grist-omnibus does).
+  sessionSecret: 'Phoo2ag1jaiz6Moo2Iese2xoaphahbai3oNg7diemohlah0ohtae9iengafieS2Hae7quungoCi9iaPh',
+  storage: [
+    {
+      name: 'minio',
+      check: () => checkMinIOExternalStorage() !== undefined,
+      checkBackend: () => checkMinIOBucket(),
+      create: configureMinIOExternalStorage,
+    },
+  ],
+  telemetry: {
+    create: (dbManager, gristServer) => new Telemetry(dbManager, gristServer),
+  }
+});

--- a/app/server/lib/coreLogins.ts
+++ b/app/server/lib/coreLogins.ts
@@ -1,0 +1,12 @@
+import { getForwardAuthLoginSystem } from 'app/server/lib/ForwardAuthLogin';
+import { GristLoginSystem } from 'app/server/lib/GristServer';
+import { getMinimalLoginSystem } from 'app/server/lib/MinimalLogin';
+import { getOIDCLoginSystem } from 'app/server/lib/OIDCConfig';
+import { getSamlLoginSystem } from 'app/server/lib/SamlConfig';
+
+export async function getCoreLoginSystem(): Promise<GristLoginSystem> {
+  return await getSamlLoginSystem() ||
+    await getOIDCLoginSystem() ||
+    await getForwardAuthLoginSystem() ||
+    await getMinimalLoginSystem();
+}

--- a/stubs/app/server/lib/create.ts
+++ b/stubs/app/server/lib/create.ts
@@ -1,22 +1,13 @@
-import { checkMinIOBucket, checkMinIOExternalStorage,
-         configureMinIOExternalStorage } from 'app/server/lib/configureMinIOExternalStorage';
-import { makeSimpleCreator } from 'app/server/lib/ICreate';
-import { Telemetry } from 'app/server/lib/Telemetry';
+import {ICreate} from "app/server/lib/ICreate";
+import {makeCoreCreator} from "app/server/lib/coreCreator";
 
-export const create = makeSimpleCreator({
-  deploymentType: 'core',
-  // This can and should be overridden by GRIST_SESSION_SECRET
-  // (or generated randomly per install, like grist-omnibus does).
-  sessionSecret: 'Phoo2ag1jaiz6Moo2Iese2xoaphahbai3oNg7diemohlah0ohtae9iengafieS2Hae7quungoCi9iaPh',
-  storage: [
-    {
-      name: 'minio',
-      check: () => checkMinIOExternalStorage() !== undefined,
-      checkBackend: () => checkMinIOBucket(),
-      create: configureMinIOExternalStorage,
-    },
-  ],
-  telemetry: {
-    create: (dbManager, gristServer) => new Telemetry(dbManager, gristServer),
-  }
-});
+export const create: ICreate = makeCoreCreator();
+
+/**
+ * Fetch the ICreate object for grist-core.
+ * Placeholder to enable eventual refactoring away from a global singleton constant.
+ * Needs to exist in all repositories before core can be switched!
+ */
+export function getCreator(): ICreate {
+  return create;
+}

--- a/stubs/app/server/lib/logins.ts
+++ b/stubs/app/server/lib/logins.ts
@@ -1,12 +1,6 @@
-import { getForwardAuthLoginSystem } from 'app/server/lib/ForwardAuthLogin';
-import { GristLoginSystem } from 'app/server/lib/GristServer';
-import { getMinimalLoginSystem } from 'app/server/lib/MinimalLogin';
-import { getOIDCLoginSystem } from 'app/server/lib/OIDCConfig';
-import { getSamlLoginSystem } from 'app/server/lib/SamlConfig';
+import { getCoreLoginSystem } from "app/server/lib/coreLogins";
+import { GristLoginSystem } from "app/server/lib/GristServer";
 
 export async function getLoginSystem(): Promise<GristLoginSystem> {
-  return await getSamlLoginSystem() ||
-    await getOIDCLoginSystem() ||
-    await getForwardAuthLoginSystem() ||
-    await getMinimalLoginSystem();
+  return getCoreLoginSystem();
 }


### PR DESCRIPTION
Enables code in ext/ to be able to access it (e.g for proxying / interception).

Adds getCreate() to enable future refactoring of `const create` away from being a global singleton constant.