### PR TITLE
Removes spacing from admin page auth translation key

### DIFF
--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -236,8 +236,8 @@ Please log in as an administrator.`)),
 
   private _buildAuthenticationNotice(owner: IDisposableOwner) {
     return t('Grist allows different types of authentication to be configured, including SAML and OIDC. \
-    We recommend enabling one of these if Grist is accessible over the network or being made available \
-    to multiple people.');
+We recommend enabling one of these if Grist is accessible over the network or being made available \
+to multiple people.');
   }
 
   private _buildUpdates(owner: MultiHolder) {


### PR DESCRIPTION
Updates the authentication message on the admin page, removing newlines and tabs. 

This cleans up the formatting of the resulting translation key (in `en.client.json`). 

Context: https://github.com/gristlabs/grist-core/pull/987#discussion_r1603799796