### PR TITLE
Add an endpoint to restart Grist with a new config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,7 @@ ADD bower_components /grist/bower_components
 ADD sandbox /grist/sandbox
 ADD plugins /grist/plugins
 ADD static /grist/static
+ADD docker-runner.mjs /grist/docker-runner.mjs
 
 # Make optional pyodide sandbox available
 COPY --from=builder /grist/sandbox/pyodide /grist/sandbox/pyodide
@@ -152,4 +153,4 @@ ENV \
 EXPOSE 8484
 
 ENTRYPOINT ["/usr/bin/tini", "-s", "--"]
-CMD ["./sandbox/run.sh"]
+CMD ["node", "./sandbox/supervisor.mjs"]

--- a/sandbox/supervisor.mjs
+++ b/sandbox/supervisor.mjs
@@ -1,0 +1,35 @@
+import {spawn} from 'child_process';
+
+let grist;
+
+function startGrist(newConfig={}) {
+  saveNewConfig(newConfig);
+  // H/T https://stackoverflow.com/a/36995148/11352427
+  grist = spawn('./sandbox/run.sh', {
+    stdio: ['inherit', 'inherit', 'inherit', 'ipc']
+  });
+  grist.on('message', function(data) {
+    if (data.action === 'restart') {
+      console.log('Restarting Grist with new environment');
+
+      // Note that we only set this event handler here, after we have
+      // a new environment to reload with. Small chance of a race here
+      // in case something else sends a SIGINT before we do it
+      // ourselves further below.
+      grist.on('exit', () => {
+        grist = startGrist(data.newConfig);
+      });
+
+      grist.kill('SIGINT');
+    }
+  });
+  return grist;
+}
+
+// Stub function
+function saveNewConfig(newConfig) {
+  // TODO: something here to actually persist the new config before
+  // restarting Grist.
+}
+
+startGrist();


### PR DESCRIPTION
This adds a very simple wrapper process for Docker that will control the main Grist process. Its purpose is to restart the main process upon demand so that the configuration can be changed. This is intended to be used for the UI as a way to give users a way to update their configuration without having to mess with Docker in the backend.