### PR TITLE
fix: #992 do not localize numbers in csv

### DIFF
--- a/app/common/ValueFormatter.ts
+++ b/app/common/ValueFormatter.ts
@@ -122,7 +122,7 @@ export class NumericFormatter extends BaseFormatter {
   }
 
   public _formatPlain(value: number): string {
-    return this._numFormat.format(value);
+    return String(value)
   }
 
   public _formatParens(value: number): string {


### PR DESCRIPTION
Fix #992

Numbers should not be localized.
French float numbers representation was "1,234" in csv now its 1.234.

It makes it simpler for many other softwares to guess correctly data type when importing csv generated by grist.