### PR TITLE
include pyodide in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,12 @@ COPY stubs /grist/stubs
 COPY buildtools /grist/buildtools
 RUN yarn run build:prod
 
+# Prepare material for optional pyodide sandbox
+COPY sandbox/pyodide /grist/sandbox/pyodide
+COPY sandbox/requirements3.txt /grist/sandbox/requirements3.txt
+RUN \
+  cd /grist/sandbox/pyodide && make setup
+
 ################################################################################
 ## Python collection stage
 ################################################################################
@@ -107,6 +113,9 @@ ADD bower_components /grist/bower_components
 ADD sandbox /grist/sandbox
 ADD plugins /grist/plugins
 ADD static /grist/static
+
+# Make optional pyodide sandbox available
+COPY --from=builder /grist/sandbox/pyodide /grist/sandbox/pyodide
 
 # Finalize static directory
 RUN \


### PR DESCRIPTION
Grist has for some time supported a sandbox based on pyodide. It is a bit slower to start than the gvisor-based sandbox, but can run in situations where it can't. Until now it hasn't been easy to use when running Grist as a container, since the support files weren't included. This change rectifies that omission.

Nothing changes by default. But now if you start Grist as a container and set `GRIST_SANDBOX_FLAVOR=pyodide`, it should work rather than fail.