### PR TITLE
Add user id middleware to form pages

### DIFF
--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1123,6 +1123,7 @@ export class FlexServer implements GristServer {
         welcomeNewUser
       ],
       formMiddleware: [
+        this._userIdMiddleware,
         forcedLoginMiddleware,
       ],
       forceLogin: this._redirectToLoginUnconditionally,


### PR DESCRIPTION
Fixes #966.

Tested locally with a default grist-omnibus instance.