### PR TITLE
admin: fix warning in websocket probe

### DIFF
--- a/app/server/lib/BootProbes.ts
+++ b/app/server/lib/BootProbes.ts
@@ -118,7 +118,7 @@ const _webSocketsProbe: Probe = {
         url,
       };
       ws.on('open', () => {
-        ws.send('Just nod if you can hear me.');
+        ws.send('{"msg": "Just nod if you can hear me."}');
         resolve({
           status: 'success',
           details,


### PR DESCRIPTION
This is a small thing, but when visiting the admin, the websocket test doesn't send valid JSON, which the receiving endpoint expects. This results in a harmless exception being thrown.

While this test should eventually be modified to be run from the frontend, for now let's just make a small fix and send valid JSON in order to avoid that JSON parsing exception.