### PR TITLE
Attempts to make DropdownConditionEditor tests less flaky

### DIFF
--- a/test/nbrowser/DropdownConditionEditor.ts
+++ b/test/nbrowser/DropdownConditionEditor.ts
@@ -30,7 +30,6 @@ describe('DropdownConditionEditor', function () {
           're\nc\n.Supervisor\n ',
         ]);
       });
-      await gu.sendKeysSlowly(['hoice not in $']);
       await gu.sendKeysSlowly(['hoice not in ']);
       // Attempts to reduce test flakiness by delaying input of $. Not guaranteed to do anything.
       await driver.sleep(100);

--- a/test/nbrowser/DropdownConditionEditor.ts
+++ b/test/nbrowser/DropdownConditionEditor.ts
@@ -31,7 +31,13 @@ describe('DropdownConditionEditor', function () {
         ]);
       });
       await gu.sendKeysSlowly(['hoice not in $']);
+      await gu.sendKeysSlowly(['hoice not in ']);
+      // Attempts to reduce test flakiness by delaying input of $. Not guaranteed to do anything.
+      await driver.sleep(100);
+      await gu.sendKeys('$');
       await gu.waitToPass(async () => {
+        // This test is sometimes flaky here. It will consistently return the wrong value, usually an array of
+        // empty strings. The running theory is it's an issue in Ace editor.
         const completions = await driver.findAll('.ace_autocomplete .ace_line', el => el.getText());
         assert.deepEqual(completions, [
           '$\nName\n ',


### PR DESCRIPTION
Attempts to fix "DropdownConditionEditor in choice columns creates dropdown conditions", and adds comments to inform future investigators.