### PR TITLE
Fixes flaky ViewLayoutCollapse test

### DIFF
--- a/test/nbrowser/ViewLayoutCollapse.ts
+++ b/test/nbrowser/ViewLayoutCollapse.ts
@@ -311,7 +311,9 @@ describe("ViewLayoutCollapse", function() {
 
     // Move back and drop.
     await gu.getSection(COMPANIES_CHART).getRect();
-    await move(getDragElement(COMPANIES_CHART));
+    await move(getDragElement(COMPANIES_CHART), {x : 50});
+    await driver.sleep(100);
+    await move(getDragElement(COMPANIES_CHART), {x : 100});
     await driver.sleep(100);
     await move(getDragElement(COMPANIES_CHART), {x : 200});
     await gu.waitToPass(async () => {


### PR DESCRIPTION
This fixes the flaky test in "ViewLayoutCollapse.ts": "fix: should not dispose the instance when drag is cancelled".

The 'mouseenter' event wasn't consistently triggering properly on the drop target (LayoutEditor.ts - line 342) when the mouse was moved onto it.

The change simulates a "drag" over the drop target, moving the mouse into multiple positions over it, seemingly fixing the problem.

This passed 500 runs in a row post-fix, and was failing consistently within 200 runs pre-fix.