### PR TITLE
Makes docker images support non-root execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,10 @@ RUN \
   mv /grist/static-built/* /grist/static && \
   rmdir /grist/static-built
 
+# Add a user to allow de-escalating from root on startup
+RUN useradd -ms /bin/bash grist
+ENV GRIST_DOCKER_USER=grist\
+    GRIST_DOCKER_GROUP=grist
 WORKDIR /grist
 
 # Set some default environment variables to give a setup that works out of the box when
@@ -151,5 +155,5 @@ ENV \
 
 EXPOSE 8484
 
-ENTRYPOINT ["/usr/bin/tini", "-s", "--"]
+ENTRYPOINT ["./sandbox/docker_entrypoint.sh"]
 CMD ["./sandbox/run.sh"]

--- a/sandbox/docker_entrypoint.sh
+++ b/sandbox/docker_entrypoint.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Runs the command provided as arguments, but attempts to configure permissions first.
+
+important_dirs=("/grist" "/persist")
+current_user_id=$(id -u)
+
+# We want to avoid running Grist as root if possible.
+# Try to setup permissions and de-elevate to a normal user.
+if [[ $current_user_id == 0 ]]; then
+  target_user=${GRIST_DOCKER_USER:-grist}
+  target_group=${GRIST_DOCKER_GROUP:-grist}
+
+  for dir in "${important_dirs[@]}"; do
+    # Make sure the target user owns everything that Grist needs read/write access to.
+    find "$dir" ! -user $target_user -exec chown $target_user "{}" +
+  done
+
+  # Restart as the target user, replacing the current process (replacement is needed for security).
+  # Alternative tools are: setpriv, chroot, gosu.
+  exec setpriv --reuid "$target_user" --regid "$target_group" --init-groups /usr/bin/env bash "$BASH_SOURCE" "$@"
+fi
+
+# Validate that this user has access to the top level of each important directory.
+# There might be a benefit to testing an individual file in there,
+for dir in "${important_dirs[@]}"; do
+  if ! { test -r "$dir" && test -w "$dir" ;} ; then
+    echo "Invalid permissions, cannot read/write '$dir'. Aborting." >&2
+    exit 1
+  fi
+done
+
+exec /usr/bin/tini -s -- "$@"

--- a/sandbox/docker_entrypoint.sh
+++ b/sandbox/docker_entrypoint.sh
@@ -3,7 +3,9 @@ set -Eeuo pipefail
 
 # Runs the command provided as arguments, but attempts to configure permissions first.
 
-important_dirs=("/grist" "/persist")
+important_read_dirs=("/grist" "/persist")
+important_write_dirs=("/persist")
+important_dirs=( "${important_read_dirs[@]}" "${important_write_dirs[@]}" )
 current_user_id=$(id -u)
 
 # We want to avoid running Grist as root if possible.
@@ -14,7 +16,7 @@ if [[ $current_user_id == 0 ]]; then
 
   for dir in "${important_dirs[@]}"; do
     # Make sure the target user owns everything that Grist needs read/write access to.
-    find "$dir" ! -user $target_user -exec chown $target_user "{}" +
+    find "$dir" ! -user "$target_user" -exec chown "$target_user" "{}" +
   done
 
   # Restart as the target user, replacing the current process (replacement is needed for security).
@@ -24,9 +26,15 @@ fi
 
 # Validate that this user has access to the top level of each important directory.
 # There might be a benefit to testing an individual file in there,
-for dir in "${important_dirs[@]}"; do
+for dir in "${important_read_dirs[@]}"; do
+  if ! { test -r "$dir" ;} ; then
+    echo "Invalid permissions, cannot read '$dir'. Aborting." >&2
+    exit 1
+  fi
+done
+for dir in "${important_write_dirs[@]}"; do
   if ! { test -r "$dir" && test -w "$dir" ;} ; then
-    echo "Invalid permissions, cannot read/write '$dir'. Aborting." >&2
+    echo "Invalid permissions, cannot write '$dir'. Aborting." >&2
     exit 1
   fi
 done


### PR DESCRIPTION
De-escalates to a normal user when the docker image is run as root.

Allows GRIST_DOCKER_USER and GRIST_DOCKER_GROUP to be passed to override the default de-escalation behaviour.

Backwards compatible with previous root installations.

--------

This change adds a new docker_entrypoint.sh, which when run as root de-escalates to the provided user, defaulting to grist:grist. This is similar to the approach used by the official postgres docker image.

To achieve backwards compatibility, it changes ownership of any files in `/persist` and `/grist` to the user it's given at runtime. Since the docker container is typically run as root, this should always work.

If the container is run as a standard user from the very start:
* It's the admin's responsibility to ensure `/persist` is writable by that user.
* `/grist` remains owned by root and is read-only. 


it's the admin's responsibility to ensure the permissions on `/persist` 

