### PR TITLE
feat: forms inhibited when summary selected and vice versa

### DIFF
--- a/app/client/ui/PageWidgetPicker.ts
+++ b/app/client/ui/PageWidgetPicker.ts
@@ -95,12 +95,21 @@ export interface IOptions extends ISelectOptions {
   placement?: Popper.Placement;
 }
 
+export interface ICompatibleTypes {
+
+  // true if "New Page" is selected in Page Picker
+  isNewPage: Boolean | undefined;
+
+  // true if can be summarized
+  summarize: Boolean;
+}
+
 const testId = makeTestId('test-wselect-');
 
 // The picker disables some choices that do not make much sense. This function return the list of
 // compatible types given the tableId and whether user is creating a new page or not.
 function getCompatibleTypes(tableId: TableRef,
-                            {isNewPage, summarize}: {isNewPage: boolean|undefined, summarize: boolean}): IWidgetType[] {
+                            {isNewPage, summarize}: ICompatibleTypes): IWidgetType[] {
   let compatibleTypes: Array<IWidgetType> = [];
   if (tableId !== 'New Table') {
     compatibleTypes = ['record', 'single', 'detail', 'chart', 'custom', 'custom.calendar', 'form'];
@@ -116,15 +125,15 @@ function getCompatibleTypes(tableId: TableRef,
 
 // The Picker disables some choices that do not make much sense.
 // This function return a boolean telling if summary can be used with this type.
-function isSummaryCompatible(tableId: IWidgetType): boolean {
+function isSummaryCompatible(widgetType: IWidgetType): boolean {
   const incompatibleTypes: Array<IWidgetType> = ['form'];
-  return !incompatibleTypes.includes(tableId);
+  return !incompatibleTypes.includes(widgetType);
 }
 
 // Whether table and type make for a valid selection whether the user is creating a new page or not.
 function isValidSelection(table: TableRef,
                           type: IWidgetType,
-                          {isNewPage, summarize}: {isNewPage: boolean|undefined, summarize: boolean}) {
+                          {isNewPage, summarize}: ICompatibleTypes) {
   return table !== null && getCompatibleTypes(table, {isNewPage, summarize}).includes(type);
 }
 
@@ -459,9 +468,6 @@ export class PageWidgetSelect extends Disposable {
 
   private _selectType(type: IWidgetType) {
     this._value.type.set(type);
-    if (!isSummaryCompatible(type)) {
-      this._closeSummarizePanel();
-    }
   }
 
   private _selectTable(tid: TableRef) {

--- a/app/client/ui/PageWidgetPicker.ts
+++ b/app/client/ui/PageWidgetPicker.ts
@@ -374,7 +374,9 @@ export class PageWidgetSelect extends Disposable {
               ),
                 cssPivot(
                   cssBigIcon('Pivot'),
-                  cssEntry.cls('-selected', (use) => use(this._value.summarize) && use(this._value.table) === table.id()),
+                  cssEntry.cls('-selected', (use) => use(this._value.summarize) &&
+                                                     use(this._value.table) === table.id()
+                  ),
                   cssEntry.cls('-disabled', (use) => !isSummaryCompatible(use(this._value.type))),
                   dom.on('click', (ev, el) => this._selectPivot(table.id(), el as HTMLElement)),
                   testId('pivot'),

--- a/app/client/ui/PageWidgetPicker.ts
+++ b/app/client/ui/PageWidgetPicker.ts
@@ -99,7 +99,8 @@ const testId = makeTestId('test-wselect-');
 
 // The picker disables some choices that do not make much sense. This function return the list of
 // compatible types given the tableId and whether user is creating a new page or not.
-function getCompatibleTypes(tableId: TableRef, {isNewPage, summarize}: {isNewPage: boolean|undefined, summarize: boolean}): IWidgetType[] {
+function getCompatibleTypes(tableId: TableRef,
+                            {isNewPage, summarize}: {isNewPage: boolean|undefined, summarize: boolean}): IWidgetType[] {
   let compatibleTypes: Array<IWidgetType> = [];
   if (tableId !== 'New Table') {
     compatibleTypes = ['record', 'single', 'detail', 'chart', 'custom', 'custom.calendar', 'form'];
@@ -121,7 +122,9 @@ function isSummaryCompatible(tableId: IWidgetType): boolean{
 }
 
 // Whether table and type make for a valid selection whether the user is creating a new page or not.
-function isValidSelection(table: TableRef, type: IWidgetType, {isNewPage, summarize}: {isNewPage: boolean|undefined, summarize: boolean}) {
+function isValidSelection(table: TableRef,
+                          type: IWidgetType,
+                          {isNewPage, summarize}: {isNewPage: boolean|undefined, summarize: boolean}) {
   return table !== null && getCompatibleTypes(table, {isNewPage, summarize}).includes(type);
 }
 
@@ -222,7 +225,13 @@ export function buildPageWidgetPicker(
 
   // whether the current selection is valid
   function isValid() {
-    return isValidSelection(value.table.get(), value.type.get(), {isNewPage: options.isNewPage, summarize: value.summarize.get()});
+    return isValidSelection(
+      value.table.get(),
+      value.type.get(),
+      {
+        isNewPage: options.isNewPage,
+        summarize: value.summarize.get()
+      });
   }
 
   // Summarizing a table causes the 'Group By' panel to expand on the right. To prevent it from
@@ -424,7 +433,12 @@ export class PageWidgetSelect extends Disposable {
             // there are no changes.
             this._options.buttonLabel || t("Add to Page"),
             dom.prop('disabled', (use) => !isValidSelection(
-              use(this._value.table), use(this._value.type), { isNewPage: this._options.isNewPage, summarize: use(this._value.summarize)})
+              use(this._value.table),
+              use(this._value.type),
+              {
+                isNewPage: this._options.isNewPage,
+                summarize: use(this._value.summarize)
+              })
             ),
             dom.on('click', () => this._onSave().catch(reportError)),
             testId('addBtn'),

--- a/app/client/ui/PageWidgetPicker.ts
+++ b/app/client/ui/PageWidgetPicker.ts
@@ -111,12 +111,12 @@ function getCompatibleTypes(tableId: TableRef,
     // The type 'chart' makes little sense when creating a new table.
     compatibleTypes = ['record', 'single', 'detail', 'form'];
   }
-  return summarize ? compatibleTypes.filter((el)=> !['form'].includes(el)) : compatibleTypes;
+  return summarize ? compatibleTypes.filter((el) => isSummaryCompatible(el)) : compatibleTypes;
 }
 
 // The Picker disables some choices that do not make much sense.
 // This function return a boolean telling if summary can be used with this type.
-function isSummaryCompatible(tableId: IWidgetType): boolean{
+function isSummaryCompatible(tableId: IWidgetType): boolean {
   const incompatibleTypes: Array<IWidgetType> = ['form'];
   return !incompatibleTypes.includes(tableId);
 }

--- a/test/nbrowser/saveViewSection.ts
+++ b/test/nbrowser/saveViewSection.ts
@@ -160,7 +160,7 @@ describe("saveViewSection", function() {
     await assertActiveSectionColumns('Test', 'count');
   });
 
-  it("Should disable summary when form type is selected", async () => {
+  it("should disable summary when form type is selected", async () => {
     // select form type
     await driver.find('.test-dp-add-new').doClick();
     await driver.find('.test-dp-add-new-page').doClick();
@@ -171,10 +171,9 @@ describe("saveViewSection", function() {
 
     // close page widget picker
     await driver.sendKeys(Key.ESCAPE);
-    await gu.checkForErrors();
   });
 
-  it("Should disable form when summary is selected", async () => {
+  it("should disable form when summary is selected", async () => {
     // select table type then select summary for a Table
     await driver.find('.test-dp-add-new').doClick();
     await driver.find('.test-dp-add-new-page').doClick();
@@ -185,6 +184,5 @@ describe("saveViewSection", function() {
 
     // close page widget picker
     await driver.sendKeys(Key.ESCAPE);
-    await gu.checkForErrors();
   });
 });

--- a/test/nbrowser/saveViewSection.ts
+++ b/test/nbrowser/saveViewSection.ts
@@ -99,7 +99,6 @@ describe("saveViewSection", function() {
     await switchTypeAndAssert('Card');
     await switchTypeAndAssert('Table');
     await switchTypeAndAssert('Chart');
-
   });
 
   it("should work correctly when changing grouped by column", async () => {
@@ -159,5 +158,33 @@ describe("saveViewSection", function() {
 
     // Check all columns are visible.
     await assertActiveSectionColumns('Test', 'count');
+  });
+
+  it("Should disable summary when form type is selected", async () => {
+    // select form type
+    await driver.find('.test-dp-add-new').doClick();
+    await driver.find('.test-dp-add-new-page').doClick();
+    await driver.findContent('.test-wselect-type', gu.exactMatch("Form")).doClick();
+
+    // check that summary is disabled
+    assert.ok(await driver.find('.test-wselect-pivot[class*=-disabled]'));
+
+    // close page widget picker
+    await driver.sendKeys(Key.ESCAPE);
+    await gu.checkForErrors();
+  });
+
+  it("Should disable form when summary is selected", async () => {
+    // select table type then select summary for a Table
+    await driver.find('.test-dp-add-new').doClick();
+    await driver.find('.test-dp-add-new-page').doClick();
+    await driver.find('.test-wselect-pivot').doClick();
+
+    // check that form is disabled
+    assert.equal(await driver.find('.test-wselect-type[class*=-disabled]').getText(), "Form");
+
+    // close page widget picker
+    await driver.sendKeys(Key.ESCAPE);
+    await gu.checkForErrors();
   });
 });


### PR DESCRIPTION
fixes #967

Following behaviour proposed by @dsagal in the issue

>  It would make sense to me if in the "Add Widget" panel, "Sum" icon were disabled when Form widget is chosen, and if "Form" option were greyed out when "Sum" is selected.