### PR TITLE
Dockerfile: remove mention of docker-runner.mjs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,6 @@ ADD bower_components /grist/bower_components
 ADD sandbox /grist/sandbox
 ADD plugins /grist/plugins
 ADD static /grist/static
-ADD docker-runner.mjs /grist/docker-runner.mjs
 
 # Make optional pyodide sandbox available
 COPY --from=builder /grist/sandbox/pyodide /grist/sandbox/pyodide


### PR DESCRIPTION
When rewriting 1a64910be3c9a34641ae879437dd854a5df1fd9b, I accidentally left a stray reference to `docker-runner.mjs` in there. Since this file doesn't exist anymore, this prevents Docker builds from happening.