### PR TITLE
README: Rewrite boot page section to reflect new admin page

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,22 +117,24 @@ You can find a lot more about configuring Grist, setting up authentication,
 and running it on a public server in our
 [Self-Managed Grist](https://support.getgrist.com/self-managed/) handbook.
 
-## Activating the boot page for diagnosing problems
+## The administrator panel
 
-You can turn on a special "boot page" to inspect the status of your
-installation. Just visit `/boot` on your Grist server for instructions.
-Since it is useful for the boot page to be available even when authentication
-isn't set up, you can give it a special access key by setting `GRIST_BOOT_KEY`.
+You can turn on a special admininistrator panel to inspect the status
+of your installation. Just visit `/admin` on your Grist server for
+instructions. Since it is useful for the admin panel to be
+available even when authentication isn't set up, you can give it a
+special access key by setting `GRIST_BOOT_KEY`.
 
 ```
 docker run -p 8484:8484 -e GRIST_BOOT_KEY=secret -it gristlabs/grist
 ```
 
-The boot page should then be available at `/boot/<GRIST_BOOT_KEY>`. We are
-starting to collect probes for common problems there. If you hit a problem that
-isn't covered, it would be great if you could add a probe for it in
+The boot page should then be available at
+`/admin?boot-key=<GRIST_BOOT_KEY>`. We are collecting probes for
+common problems there. If you hit a problem that isn't covered, it
+would be great if you could add a probe for it in
 [BootProbes](https://github.com/gristlabs/grist-core/blob/main/app/server/lib/BootProbes.ts).
-Or file an issue so someone else can add it, we're just getting start with this.
+You may instead file an issue so someone else can add it.
 
 ## Building from source
 


### PR DESCRIPTION
We removed the boot page in 5dc4706dc7ff3e3fb1adb0ab81e4d8559a021b7c, but we forgot to update the README to reflect this.