### PR TITLE
workflows: revert changes to `tsconfig-ext.json`

### DIFF
--- a/.github/workflows/docker_latest.yml
+++ b/.github/workflows/docker_latest.yml
@@ -82,13 +82,15 @@ jobs:
 
       - name: Build Node.js code
         run: |
-          pushd ext && \
-          { if [ -e package.json ] ; then yarn install --frozen-lockfile --modules-folder=../../node_modules; fi } && \
-          popd
+          rm -rf ext
           yarn run build:prod
 
       - name: Run tests
         run: TEST_IMAGE=${{ github.repository_owner }}/${{ matrix.image.name }}:experimental VERBOSE=1 DEBUG=1 MOCHA_WEBDRIVER_HEADLESS=1 yarn run test:docker
+
+      - name: Restore the ext/ directory
+        if: matrix.image.name != 'grist-oss'
+        run: buildtools/checkout-ext-directory.sh ${{ matrix.image.repo }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v1 

--- a/tsconfig-ext.json
+++ b/tsconfig-ext.json
@@ -3,9 +3,6 @@
   "files": [],
   "include": [],
   "references": [
-    { "path": "./app" },
-    { "path": "./stubs/app" },
-    { "path": "./test" },
     { "path": "./ext/app" }
   ],
 }


### PR DESCRIPTION
My original commit messages:

* d38788e428a2
workflows: Do not use `ext/` director to run tests

We need this directory for building the image, but not for running the
tests outside of it.

* 7ad3871cd102
tsconfig-ext: revert bc52f65b2648ff7987383537fc06c6a388d29ce2

While the intent was to run tests with it, we don't need it. Instead,
this caused problems because the stubs overrode the intended `ext`
directory and therefore disabled the ext features.