### PR TITLE
Fixes grist-oss experiemental accidentally including grist-ee code

### DIFF
--- a/.github/workflows/docker_latest.yml
+++ b/.github/workflows/docker_latest.yml
@@ -87,7 +87,7 @@ jobs:
           load: true
           tags: ${{ env.DOCKER_HUB_OWNER }}/${{ matrix.image.name }}:${{ env.TAG }}
           cache-from: type=gha
-          build-contexts: ${{ matrix.image.name != 'grist-oss' && 'ext=ext' || '' }}
+          build-contexts: ext=ext
 
       - name: Use Node.js ${{ matrix.node-version }} for testing
         if: ${{ !inputs.disable_tests }}
@@ -140,7 +140,7 @@ jobs:
           tags: ${{ env.DOCKER_HUB_OWNER }}/${{ matrix.image.name }}:${{ env.TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-contexts: ${{ matrix.image.name != 'grist-oss' && 'ext=ext' || '' }}
+          build-contexts: ext=ext
 
       - name: Push Enterprise to Docker Hub
         if: ${{ matrix.image.name == 'grist' }}

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ xunit.xml
 .clipboard.lock
 
 **/_build
+
+# ext directory can be overwritten
+ext/**

--- a/buildtools/checkout-ext-directory.sh
+++ b/buildtools/checkout-ext-directory.sh
@@ -14,5 +14,6 @@ pushd $repo
 git sparse-checkout set ext
 git checkout
 popd
+rm -rf ./ext
 mv $repo/ext .
 rm -rf $repo

--- a/ext/README.md
+++ b/ext/README.md
@@ -1,0 +1,5 @@
+`ext` is a directory that allows derivatives of Grist core to be created, without modifying any of the base files.
+
+Files placed in here should be new files, or replacing files in the `stubs` directory.
+
+When compiling, Typescript resolves files in `ext` before files in `stubs`, using the `ext` file instead (if it exists).


### PR DESCRIPTION
This fixes an issue where grist EE code was accidentally being included in the grist-oss docker build.

This appears to be an issue with docker caching build contexts (although this isn't 100% confirmed). 

The result is that when Grist-oss is built without the `ext` build context, it behaves as if it's using a previous version of the build context.

The fix is to explicitly provide an empty `ext` directory, so docker recognises that it's a new, empty value.