### PR TITLE
workflows: move experimental tag back to latest

### DIFF
--- a/.github/workflows/docker_latest.yml
+++ b/.github/workflows/docker_latest.yml
@@ -34,12 +34,12 @@ on:
         description: "Tag for the resulting images"
         type: string
         required: True
-        default: 'experimental'
+        default: 'latest'
 
 env:
   BRANCH: ${{ inputs.branch || 'latest_candidate' }}
   PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64/v8' }}
-  TAG: ${{ inputs.tag || 'experimental' }}
+  TAG: ${{ inputs.tag || 'latest' }}
   DOCKER_HUB_OWNER: ${{ vars.DOCKER_HUB_OWNER || github.repository_owner }}
 
 jobs:


### PR DESCRIPTION
Our builds seem to be fine now. It is time to release boldly and widely the new Docker images to the `latest` tag.