### PR TITLE
workflows: explicitly add a dummy ext/ directory

### DIFF
--- a/.github/workflows/docker_latest.yml
+++ b/.github/workflows/docker_latest.yml
@@ -70,6 +70,10 @@ jobs:
         with:
           ref: ${{ env.BRANCH }}
 
+      - name: Add a dummy ext/ directory
+        run:
+          mkdir ext && touch ext/dummy
+
       - name: Check out the ext/ directory
         if: matrix.image.name != 'grist-oss'
         run: buildtools/checkout-ext-directory.sh ${{ matrix.image.repo }}

--- a/ext/README.md
+++ b/ext/README.md
@@ -1,5 +1,0 @@
-`ext` is a directory that allows derivatives of Grist core to be created, without modifying any of the base files.
-
-Files placed in here should be new files, or replacing files in the `stubs` directory.
-
-When compiling, Typescript resolves files in `ext` before files in `stubs`, using the `ext` file instead (if it exists).


### PR DESCRIPTION
Having it checked in to git caused problems with Grist Desktop and Grist Static because their build processes expected to have nothing there, as well as interfering with checking out Grist Core as a submodule.

So we do this instead.