### PR TITLE
Jordigh/update stable docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,16 @@ on:
     types: [published]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag for the resulting images"
+        type: string
+        required: True
+        default: 'stable'
+
+env:
+  TAG: ${{ inputs.tag || 'stable' }}
+  DOCKER_HUB_OWNER: ${{ vars.DOCKER_HUB_OWNER || github.repository_owner }}
 
 jobs:
   push_to_registry:
@@ -47,7 +57,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            stable
+            ${{ env.TAG }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
+      - name: Add a dummy ext/ directory
+        run:
+          mkdir ext && touch ext/dummy
+
       - name: Check out the ext/ directory
         if: matrix.image.name != 'grist-oss'
         run: buildtools/checkout-ext-directory.sh ${{ matrix.image.repo }}
@@ -65,5 +69,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-contexts: ${{ matrix.image.name != 'grist-oss' && 'ext=ext' || '' }}
+          build-contexts: ext=ext
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,10 +29,6 @@ jobs:
             repo: "grist-core"
           - name: "grist"
             repo: "grist-ee"
-          # For now, we build it twice, with `grist-ee` being a
-          # backwards-compatible synoym for `grist`.
-          - name: "grist-ee"
-            repo: "grist-ee"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -81,3 +77,17 @@ jobs:
           cache-to: type=gha,mode=max
           build-contexts: ext=ext
 
+      - name: Push Enterprise to Docker Hub
+        if: ${{ matrix.image.name == 'grist' }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            BASE_IMAGE=${{ env.DOCKER_HUB_OWNER }}/${{ matrix.image.name}}
+            BASE_VERSION=${{ env.TAG }}
+          file: ext/Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: ${{ env.DOCKER_HUB_OWNER }}/grist-ee:${{ env.TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
I did it this way because the two builds aren't close enough to be a single one. It was easier to duplicate a little code than to create more abstractions.

My original commit messages follow:

* 6162de8d8d27
workflows: add a dummy ext to the stable build

See a437dfa28c7139bb436d8c1c88f674c9f16bb87a for details

* c4f06bee732e
workflows: use variable tags for the stable build

This will make it easier to do some testing while I make sure that
this build is correct.

* 059b2cd1ba17
workflows: don't build stable twice, just push it twice

This now matches the `docker_latest.yml` setup. No point building
grist-ee/grist twice.
