### PR TITLE
Adds an accessible home directory for docker user in container

### DIFF
--- a/sandbox/docker_entrypoint.sh
+++ b/sandbox/docker_entrypoint.sh
@@ -17,7 +17,7 @@ if [[ $current_user_id == 0 ]]; then
   find $write_dir ! -user "$target_user" -exec chown "$target_user" "{}" +
 
   # Make a home directory for the target user, in case anything needs to access it.
-  export HOME="/tmp/users/${target_user}"
+  export HOME="/grist_user_homes/${target_user}"
   mkdir -p "$HOME"
   chown -R "$target_user":"$target_group" "$HOME"
 

--- a/sandbox/docker_entrypoint.sh
+++ b/sandbox/docker_entrypoint.sh
@@ -16,11 +16,19 @@ if [[ $current_user_id == 0 ]]; then
   # Make sure the target user owns everything that Grist needs write access to.
   find $write_dir ! -user "$target_user" -exec chown "$target_user" "{}" +
 
+  # Make a home directory for the target user, in case anything needs to access it.
+  export HOME="/tmp/users/${target_user}"
+  mkdir -p "$HOME"
+  chown -R "$target_user":"$target_group" "$HOME"
+
   # Restart as the target user, replacing the current process (replacement is needed for security).
   # Alternative tools to setpriv are: chroot, gosu.
   # Need to use `exec` to close the parent shell, to avoid vulnerabilities: https://github.com/tianon/gosu/issues/37
   exec setpriv --reuid "$target_user" --regid "$target_group" --init-groups /usr/bin/env bash "$0" "$@"
 fi
+
+# Printing the user helps with setting volume permissions.
+echo "Running Grist as user $(id -u) with primary group $(id -g)"
 
 # Validate that this user has access to the top level of each important directory.
 # There might be a benefit to testing individual files, but this is simpler as the dir may start empty.


### PR DESCRIPTION
This should fix any issues where the container de-escalates to a non-root user, then tries to access the root user's home directory (/root). For example, if yarn were to run.

This should fix #1108.