### PR TITLE
config: make I/O operations synchronous

### DIFF
--- a/app/server/lib/config.ts
+++ b/app/server/lib/config.ts
@@ -2,9 +2,9 @@ import * as fse from "fs-extra";
 
 // Export dependencies for stubbing in tests.
 export const Deps = {
-  readFile: fse.readFile,
+  readFile: fse.readFileSync,
   writeFile: fse.writeFile,
-  pathExists: fse.pathExists,
+  pathExists: fse.pathExistsSync,
 };
 
 /**

--- a/app/server/lib/config.ts
+++ b/app/server/lib/config.ts
@@ -56,15 +56,15 @@ export class FileConfig<FileContents> {
    * @param validator - Validates the contents are in the correct format, and converts to the correct type.
    *  Should throw an error or return null if not valid.
    */
-  public static async create<CreateConfigFileContents>(
+  public static create<CreateConfigFileContents>(
     configPath: string,
     validator: FileContentsValidator<CreateConfigFileContents>
-  ): Promise<FileConfig<CreateConfigFileContents>> {
+  ): FileConfig<CreateConfigFileContents> {
     // Start with empty object, as it can be upgraded to a full config.
     let rawFileContents: any = {};
 
-    if (await Deps.pathExists(configPath)) {
-      rawFileContents = JSON.parse(await Deps.readFile(configPath, 'utf8'));
+    if (Deps.pathExists(configPath)) {
+      rawFileContents = JSON.parse(Deps.readFile(configPath, 'utf8'));
     }
 
     let fileContents = null;
@@ -97,7 +97,7 @@ export class FileConfig<FileContents> {
     await this.persistToDisk();
   }
 
-  public async persistToDisk(): Promise<void> {
+  public async persistToDisk() {
     await Deps.writeFile(this._filePath, JSON.stringify(this._rawConfig, null, 2));
   }
 }

--- a/app/server/lib/configCore.ts
+++ b/app/server/lib/configCore.ts
@@ -15,8 +15,8 @@ export interface IGristCoreConfig {
   edition: IWritableConfigValue<Edition>;
 }
 
-export async function loadGristCoreConfigFile(configPath?: string): Promise<IGristCoreConfig> {
-  const fileConfig = configPath ? await FileConfig.create(configPath, convertToCoreFileContents) : undefined;
+export function loadGristCoreConfigFile(configPath?: string): IGristCoreConfig {
+  const fileConfig = configPath ? FileConfig.create(configPath, convertToCoreFileContents) : undefined;
   return loadGristCoreConfig(fileConfig);
 }
 

--- a/app/server/mergedServerMain.ts
+++ b/app/server/mergedServerMain.ts
@@ -71,7 +71,7 @@ export async function main(port: number, serverTypes: ServerType[],
   const includeStatic = serverTypes.includes("static");
   const includeApp = serverTypes.includes("app");
 
-  options.settings ??= await getGlobalConfig();
+  options.settings ??= getGlobalConfig();
 
   const server = new FlexServer(port, `server(${serverTypes.join(",")})`, options);
 

--- a/stubs/app/server/lib/globalConfig.ts
+++ b/stubs/app/server/lib/globalConfig.ts
@@ -9,10 +9,10 @@ let cachedGlobalConfig: IGristCoreConfig | undefined = undefined;
 /**
  * Retrieves the cached grist config, or loads it from the default global path.
  */
-export async function getGlobalConfig(): Promise<IGristCoreConfig> {
+export function getGlobalConfig(): IGristCoreConfig {
   if (!cachedGlobalConfig) {
     log.info(`Loading config file from ${globalConfigPath}`);
-    cachedGlobalConfig = await loadGristCoreConfigFile(globalConfigPath);
+    cachedGlobalConfig = loadGristCoreConfigFile(globalConfigPath);
   }
 
   return cachedGlobalConfig;

--- a/test/server/lib/config.ts
+++ b/test/server/lib/config.ts
@@ -18,7 +18,7 @@ describe('FileConfig', () => {
   const useFakeConfigFile = (contents: string) => {
     const fakeFile = { contents };
     sinon.replace(Deps, 'pathExists', sinon.fake.resolves(true));
-    sinon.replace(Deps, 'readFile', sinon.fake((path, encoding: string) => Promise.resolve(fakeFile.contents)) as any);
+    sinon.replace(Deps, 'readFile', sinon.fake((path, encoding: string) => fakeFile.contents) as any);
     sinon.replace(Deps, 'writeFile', sinon.fake((path, newContents) => {
       fakeFile.contents = newContents;
       return Promise.resolve();
@@ -31,17 +31,17 @@ describe('FileConfig', () => {
     sinon.restore();
   });
 
-  it('throws an error from create if the validator does not return a value', async () => {
+  it('throws an error from create if the validator does not return a value', () => {
     useFakeConfigFile(testFileContentsJSON);
     const validator = () => null;
-    await assert.isRejected(FileConfig.create<TestFileContents>("anypath.json", validator));
+    assert.throws(() => FileConfig.create<TestFileContents>("anypath.json", validator));
   });
 
   it('persists changes when values are assigned', async () => {
     const fakeFile = useFakeConfigFile(testFileContentsJSON);
     // Don't validate - this is guaranteed to be valid above.
     const validator = (input: any) => input as TestFileContents;
-    const fileConfig = await FileConfig.create("anypath.json", validator);
+    const fileConfig = FileConfig.create("anypath.json", validator);
     await fileConfig.set("myNum", 999);
 
     assert.equal(fileConfig.get("myNum"), 999);
@@ -58,7 +58,7 @@ describe('FileConfig', () => {
     const fakeFile = useFakeConfigFile(JSON.stringify(configWithExtraProperties));
     // It's entirely possible the validator can damage the extra properties, but that's not in scope for this test.
     const validator = (input: any) => input as TestFileContents;
-    const fileConfig = await FileConfig.create("anypath.json", validator);
+    const fileConfig = FileConfig.create("anypath.json", validator);
     // Triggering a write to the file
     await fileConfig.set("myNum", 999);
     await fileConfig.set("myStr", "Something");
@@ -94,7 +94,7 @@ describe('createConfigValue', () => {
     assert.equal(accessors.get(), 2);
   });
 
-  it('initialises with the persistent value if available', async () => {
+  it('initialises with the persistent value if available', () => {
     const accessors = makeInMemoryAccessors(22);
     const configValue = createConfigValue(1, accessors);
     assert.equal(configValue.get(), 22);

--- a/test/server/lib/configCore.ts
+++ b/test/server/lib/configCore.ts
@@ -15,12 +15,12 @@ describe('loadGristCoreConfig', () => {
   });
 
   it('will function correctly when no config file is present', async () => {
-    sinon.replace(Deps, 'pathExists', sinon.fake.resolves(false));
-    sinon.replace(Deps, 'readFile', sinon.fake.resolves(""));
+    sinon.replace(Deps, 'pathExists', sinon.fake.returns(false));
+    sinon.replace(Deps, 'readFile', sinon.fake.returns("" as any));
     const writeFileFake = sinon.fake.resolves(undefined);
     sinon.replace(Deps, 'writeFile', writeFileFake);
 
-    const config = await loadGristCoreConfigFile("doesntmatter.json");
+    const config = loadGristCoreConfigFile("doesntmatter.json");
     assert.exists(config.edition.get());
 
     await config.edition.set("enterprise");

--- a/test/server/lib/configCoreFileFormats.ts
+++ b/test/server/lib/configCoreFileFormats.ts
@@ -2,7 +2,7 @@ import { assert } from 'chai';
 import { convertToCoreFileContents, IGristCoreConfigFileLatest } from "app/server/lib/configCoreFileFormats";
 
 describe('convertToCoreFileContents', () => {
-  it('fails with a malformed config', async () => {
+  it('fails with a malformed config', () => {
     const badConfig = {
       version: "This is a random version number that will never exist",
     };


### PR DESCRIPTION
Original commit messages:

* a27eb98b419d  config: replace fse functions with sync variants

  I need to be able to read the config at module load time, which makes
  async difficult if not impossible.

  This will make all config operations synchronous, which is fine. The
  file is tiny and seldom read or written to.

* 3268077330c1  config: remove IReadableConfigValue type

  This type is only used to define the IWritableConfigValue type, and
  since we are now doing synchronous read and writes, there's no point
  in separating get from set.

* bfa045b13f90  config: remove all async/await around config functions

  Now that I/O is synchronous, there's no need to have any more
  async/await in regards to the config functions.
