### PR TITLE
bump Python version for tests, no longer supporting 3.9

### DIFF
--- a/.github/workflows/docker_latest.yml
+++ b/.github/workflows/docker_latest.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.11]
         node-version: [18.x]
         image:
           # We build two images, `grist-oss` and `grist`.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       # even when there is a failure.
       fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: [3.11]
         node-version: [18.x]
         tests:
           - ':lint:python:client:common:smoke:stubs:'
@@ -32,9 +32,6 @@ jobs:
           - tests: ':lint:python:client:common:smoke:'
             node-version: 18.x
             python-version: '3.10'
-          - tests: ':lint:python:client:common:smoke:'
-            node-version: 18.x
-            python-version: '3.11'
     steps:
       - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ Then, you can run the main test suite like so:
 yarn test
 ```
 
-Python tests may also be run locally. (Note: currently requires Python 3.9 - 3.11.)
+Python tests may also be run locally. (Note: currently requires Python 3.10 - 3.11.)
 
 ```
 yarn test:python


### PR DESCRIPTION
After changes for `PREVIOUS` and related functions, we now depend on new versions of the `bisect` function.