### PR TITLE
Activations: add an enabled_at column

### DIFF
--- a/app/gen-server/entity/Activation.ts
+++ b/app/gen-server/entity/Activation.ts
@@ -22,6 +22,15 @@ export class Activation extends BaseEntity {
   @Column({name: 'updated_at', default: () => "CURRENT_TIMESTAMP"})
   public updatedAt: Date;
 
+  // When the enterprise activation was first enabled, so we know when
+  // to start counting the trial date.
+  //
+  // Activations are created at Grist installation to track other
+  // things such as prefs, but the user might not enable Enterprise
+  // until later.
+  @Column({name: 'enabled_at', type: nativeValues.dateTimeType, nullable: true})
+  public enabledAt: Date|null;
+
   public checkProperties(props: any): props is Partial<InstallProperties> {
     for (const key of Object.keys(props)) {
       if (!installPropertyKeys.includes(key)) {

--- a/app/gen-server/migration/1722529827161-Activation-Enabled.ts
+++ b/app/gen-server/migration/1722529827161-Activation-Enabled.ts
@@ -1,0 +1,18 @@
+import * as sqlUtils from "app/gen-server/sqlUtils";
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class ActivationEnabled1722529827161 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const dbType = queryRunner.connection.driver.options.type;
+    const datetime = sqlUtils.datetime(dbType);
+    await queryRunner.addColumn('activations', new TableColumn({
+      name: 'enabled_at',
+      type: datetime,
+      isNullable: true,
+    }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('activations', 'enabled_at');
+  }
+}

--- a/test/gen-server/migrations.ts
+++ b/test/gen-server/migrations.ts
@@ -44,6 +44,8 @@ import {Shares1701557445716 as Shares} from 'app/gen-server/migration/1701557445
 import {Billing1711557445716 as BillingFeatures} from 'app/gen-server/migration/1711557445716-Billing';
 import {UserLastConnection1713186031023
         as UserLastConnection} from 'app/gen-server/migration/1713186031023-UserLastConnection';
+import {ActivationEnabled1722529827161
+        as ActivationEnabled} from 'app/gen-server/migration/1722529827161-Activation-Enabled';
 
 const home: HomeDBManager = new HomeDBManager();
 
@@ -53,7 +55,7 @@ const migrations = [Initial, Login, PinDocs, UserPicture, DisplayEmail, DisplayE
                     ExternalBilling, DocOptions, Secret, UserOptions, GracePeriodStart,
                     DocumentUsage, Activations, UserConnectId, UserUUID, UserUniqueRefUUID,
                     Forks, ForkIndexes, ActivationPrefs, AssistantLimit, Shares, BillingFeatures,
-                    UserLastConnection];
+                    UserLastConnection, ActivationEnabled];
 
 // Assert that the "members" acl rule and group exist (or not).
 function assertMembersGroup(org: Organization, exists: boolean) {


### PR DESCRIPTION
For #1140, I considered trying to use the existing fields in a better way, but because we already use the activations table to store preferences, we need to keep all of the existing data and its usage as-is.

The enterprise code will use this new column to decide how long the trial period should be.