### PR TITLE
Update CONTRIBUTING.md to link to issue templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,5 +4,5 @@ You are eager to contribute to Grist? That's awesome! See below some contributio
 - [translate](/documentation/translations.md)
 - [write tutorials and user documentation](https://github.com/gristlabs/grist-help?tab=readme-ov-file#grist-help-center)
 - [develop](/documentation/develop.md)
-- [report issues or suggest enhancement](https://github.com/gristlabs/grist-core/issues/new)
+- [report issues or suggest enhancement](https://github.com/gristlabs/grist-core/issues/new/choose)
 


### PR DESCRIPTION
Point to the new issue-creation page, now that we have templates for new issues.

## Context

The file CONTRIBUTING.md points users to the page to create new issues, but uses a URL for a blank issue rather than one that lists the available templates.

## Proposed solution

Point to the URL that offers a choice of available issue templates.

## Related issues

Templates are new: #1135 .

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

