### PR TITLE
Add instructions for PERSIST_DIR to grist-local-testing README

### DIFF
--- a/docker-compose-examples/grist-local-testing/README.md
+++ b/docker-compose-examples/grist-local-testing/README.md
@@ -9,4 +9,12 @@ See https://support.getgrist.com/self-managed for more information.
 
 ## How to run this example
 
-This example can be run with `docker compose up`.
+Before running, create a directory where Grist will store its documents and settings:
+```sh
+mkdir ./persist
+```
+
+Then this example can be run with:
+```sh
+env PERSIST_DIR=./persist docker compose up
+```

--- a/docker-compose-examples/grist-local-testing/README.md
+++ b/docker-compose-examples/grist-local-testing/README.md
@@ -9,12 +9,11 @@ See https://support.getgrist.com/self-managed for more information.
 
 ## How to run this example
 
-Before running, create a directory where Grist will store its documents and settings:
+To run this example, change to the directory containing this example, and run:
 ```sh
-mkdir ./persist
+docker compose up
 ```
+Then you should be able to visit your local Grist instance at <http://localhost:8484>.
 
-Then this example can be run with:
-```sh
-env PERSIST_DIR=./persist docker compose up
-```
+This will start an instance that stores its documents and files in the `persist/` subdirectory.
+You can change this location using the `PERSIST_DIR` environment variable.

--- a/docker-compose-examples/grist-local-testing/docker-compose.yml
+++ b/docker-compose-examples/grist-local-testing/docker-compose.yml
@@ -3,6 +3,6 @@ services:
     image: gristlabs/grist:latest
     volumes:
       # Where to store persistent data, such as documents.
-      - ${PERSIST_DIR}/grist:/persist
+      - ${PERSIST_DIR:-./persist}/grist:/persist
     ports:
       - 8484:8484


### PR DESCRIPTION
## Context

grist-local-testing README has a how-to-use section, which didn't work.

## Proposed solution

Explain in README the extra step needed to make the minimal example work.

## Has this been tested?

I tested the new instruction. There are no code changes here.

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->