### PR TITLE
Typeorm: Use DataSource instead of Connection

### DIFF
--- a/app/gen-server/ApiServer.ts
+++ b/app/gen-server/ApiServer.ts
@@ -429,7 +429,7 @@ export class ApiServer {
         throw new ApiError('Name expected in the body', 400);
       }
       const name = req.body.name;
-      await this._dbManager.updateUserName(userId, name);
+      await this._dbManager.updateUser(userId, { name });
       res.sendStatus(200);
     }));
 

--- a/app/gen-server/ApiServer.ts
+++ b/app/gen-server/ApiServer.ts
@@ -76,7 +76,7 @@ export function addOrg(
     billing?: BillingOptions,
   }
 ): Promise<number> {
-  return dbManager.connection.transaction(async manager => {
+  return dbManager.dataSource.transaction(async manager => {
     const user = await manager.findOne(User, {where: {id: userId}});
     if (!user) { return handleDeletedUser(); }
     const query = await dbManager.addOrg(user, props, {
@@ -505,7 +505,7 @@ export class ApiServer {
     this._app.post('/api/profile/apikey', expressWrap(async (req, res) => {
       const userId = getAuthorizedUserId(req);
       const force = req.body ? req.body.force : false;
-      const manager = this._dbManager.connection.manager;
+      const manager = this._dbManager.dataSource.manager;
       let user = await manager.findOne(User, {where: {id: userId}});
       if (!user) { return handleDeletedUser(); }
       if (!user.apiKey || force) {
@@ -520,7 +520,7 @@ export class ApiServer {
     // Delete apiKey
     this._app.delete('/api/profile/apikey', expressWrap(async (req, res) => {
       const userId = getAuthorizedUserId(req);
-      await this._dbManager.connection.transaction(async manager => {
+      await this._dbManager.dataSource.transaction(async manager => {
         const user = await manager.findOne(User, {where: {id: userId}});
         if (!user) { return handleDeletedUser(); }
         user.apiKey = null;

--- a/app/gen-server/lib/Activations.ts
+++ b/app/gen-server/lib/Activations.ts
@@ -15,7 +15,7 @@ export class Activations {
   // It will be created with an empty key column, which will get
   // filled in once an activation key is presented.
   public current(): Promise<Activation> {
-    return this._db.connection.manager.transaction(async manager => {
+    return this._db.dataSource.manager.transaction(async manager => {
       let activation = await manager.findOne(Activation, {where: {}});
       if (!activation) {
         activation = manager.create(Activation);

--- a/app/gen-server/lib/Doom.ts
+++ b/app/gen-server/lib/Doom.ts
@@ -152,7 +152,7 @@ export class Doom {
       }
     }
     const candidate = sortBy(owners, ['email'])[0];
-    await scrubUserFromOrg(orgId, userId, candidate.id, this._dbManager.connection.manager);
+    await scrubUserFromOrg(orgId, userId, candidate.id, this._dbManager.dataSource.manager);
   }
 
   // List the sites a user has access to.

--- a/app/gen-server/lib/Usage.ts
+++ b/app/gen-server/lib/Usage.ts
@@ -43,7 +43,7 @@ export class Usage {
 
   private async _apply(): Promise<void> {
     try {
-      const manager = this._dbManager.connection.manager;
+      const manager = this._dbManager.dataSource.manager;
       // raw count of users
       const userCount = await manager.count(User);
       // users who have logged in at least once

--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -461,10 +461,6 @@ export class HomeDBManager extends EventEmitter {
     }
   }
 
-  public async updateUserName(userId: number, name: string) {
-    return this._usersManager.updateUserName(userId, name);
-  }
-
   public async updateUserOptions(userId: number, props: Partial<UserOptions>) {
     return this._usersManager.updateUserOptions(userId, props);
   }
@@ -473,14 +469,14 @@ export class HomeDBManager extends EventEmitter {
    * @see UsersManager.prototype.getUserByLoginWithRetry
    */
   public async getUserByLoginWithRetry(email: string, options: GetUserOptions = {}): Promise<User|undefined> {
-    return this._usersManager.getUserByLoginWithRetry(email, options);
+    return await this._usersManager.getUserByLoginWithRetry(email, options) ?? undefined;
   }
 
   /**
    * @see UsersManager.prototype.getUserByLogin
    */
   public async getUserByLogin(email: string, options: GetUserOptions = {}): Promise<User|undefined> {
-    return this._usersManager.getUserByLogin(email, options);
+    return await this._usersManager.getUserByLogin(email, options) ?? undefined;
   }
 
   /**

--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -476,14 +476,14 @@ export class HomeDBManager extends EventEmitter {
    * @see UsersManager.prototype.getUserByLoginWithRetry
    */
   public async getUserByLoginWithRetry(email: string, options: GetUserOptions = {}): Promise<User> {
-    return await this._usersManager.getUserByLoginWithRetry(email, options);
+    return this._usersManager.getUserByLoginWithRetry(email, options);
   }
 
   /**
    * @see UsersManager.prototype.getUserByLogin
    */
   public async getUserByLogin(email: string, options: GetUserOptions = {}): Promise<User> {
-    return await this._usersManager.getUserByLogin(email, options);
+    return this._usersManager.getUserByLogin(email, options);
   }
 
   /**

--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -475,8 +475,8 @@ export class HomeDBManager extends EventEmitter {
   /**
    * @see UsersManager.prototype.getUserByLoginWithRetry
    */
-  public async getUserByLoginWithRetry(email: string, options: GetUserOptions = {}): Promise<User|undefined> {
-    return await this._usersManager.getUserByLoginWithRetry(email, options) ?? undefined;
+  public async getUserByLoginWithRetry(email: string, options: GetUserOptions = {}): Promise<User> {
+    return await this._usersManager.getUserByLoginWithRetry(email, options);
   }
 
   /**

--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -70,6 +70,7 @@ import {
   Brackets,
   Connection,
   DatabaseType,
+  DataSourceOptions,
   EntityManager,
   ObjectLiteral,
   SelectQueryBuilder,
@@ -353,8 +354,8 @@ export class HomeDBManager extends EventEmitter {
     this._connection = await getOrCreateConnection();
   }
 
-  public async createNewConnection(name?: string): Promise<void> {
-    this._connection = await createNewConnection(name);
+  public async createNewConnection(overrideConf?: Partial<DataSourceOptions>): Promise<void> {
+    this._connection = await createNewConnection(overrideConf);
   }
 
   // make sure special users and workspaces are available

--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -482,8 +482,8 @@ export class HomeDBManager extends EventEmitter {
   /**
    * @see UsersManager.prototype.getUserByLogin
    */
-  public async getUserByLogin(email: string, options: GetUserOptions = {}): Promise<User|undefined> {
-    return await this._usersManager.getUserByLogin(email, options) ?? undefined;
+  public async getUserByLogin(email: string, options: GetUserOptions = {}): Promise<User> {
+    return await this._usersManager.getUserByLogin(email, options);
   }
 
   /**

--- a/app/gen-server/lib/homedb/Interfaces.ts
+++ b/app/gen-server/lib/homedb/Interfaces.ts
@@ -34,7 +34,7 @@ export type NonGuestGroup = Group & { name: roles.NonGuestRole };
 
 export type Resource = Organization|Workspace|Document;
 
-export type RunInTransaction = (
+export type RunInTransaction = <T>(
   transaction: EntityManager|undefined,
-  op: ((manager: EntityManager) => Promise<any>)
-) => Promise<any>;
+  op: ((manager: EntityManager) => Promise<T>)
+) => Promise<T>;

--- a/app/gen-server/lib/homedb/UsersManager.ts
+++ b/app/gen-server/lib/homedb/UsersManager.ts
@@ -97,8 +97,10 @@ export class UsersManager {
   public async testClearUserPrefs(emails: string[]) {
     return await this._connection.transaction(async manager => {
       for (const email of emails) {
-        const user = await this.getUserByLogin(email, {manager});
-        await manager.delete(Pref, {userId: user.id});
+        const user = await this.getExistingUserByLogin(email, manager);
+        if (user) {
+          await manager.delete(Pref, {userId: user.id});
+        }
       }
     });
   }

--- a/app/gen-server/lib/homedb/UsersManager.ts
+++ b/app/gen-server/lib/homedb/UsersManager.ts
@@ -219,9 +219,6 @@ export class UsersManager {
           profile,
           manager
         });
-        if (!newUser) {
-          throw new ApiError("Unable to create user", 500);
-        }
         // No need to survey this user.
         newUser.isFirstTimeUser = false;
         await newUser.save();
@@ -313,7 +310,7 @@ export class UsersManager {
   // for an email key conflict failure. This is in case our transaction conflicts with a peer
   // doing the same thing. This is quite likely if the first page visited by a previously
   // unseen user fires off multiple api calls.
-  public async getUserByLoginWithRetry(email: string, options: GetUserOptions = {}): Promise<User|null> {
+  public async getUserByLoginWithRetry(email: string, options: GetUserOptions = {}): Promise<User> {
     try {
       return this.getUserByLogin(email, options);
     } catch (e) {
@@ -736,7 +733,7 @@ export class UsersManager {
       // user if a bunch of servers start simultaneously and the user doesn't exist
       // yet.
       const user = await this.getUserByLoginWithRetry(profile.email, {profile});
-      if (user) { id = this._specialUserIds[profile.email] = user.id; }
+      id = this._specialUserIds[profile.email] = user.id;
     }
     if (!id) { throw new Error(`Could not find or create user ${profile.email}`); }
     return id;

--- a/app/gen-server/lib/homedb/UsersManager.ts
+++ b/app/gen-server/lib/homedb/UsersManager.ts
@@ -114,7 +114,7 @@ export class UsersManager {
    */
   public getAnonymousUserId(): number {
     const id = this._specialUserIds[ANONYMOUS_USER_EMAIL];
-    if (!id) { throw new Error("Anonymous user not available"); }
+    if (!id) { throw new Error("'Anonymous' user not available"); }
     return id;
   }
 
@@ -123,7 +123,7 @@ export class UsersManager {
    */
   public getPreviewerUserId(): number {
     const id = this._specialUserIds[PREVIEWER_EMAIL];
-    if (!id) { throw new Error("Previewer user not available"); }
+    if (!id) { throw new Error("'Previewer' user not available"); }
     return id;
   }
 
@@ -132,7 +132,7 @@ export class UsersManager {
    */
   public getEveryoneUserId(): number {
     const id = this._specialUserIds[EVERYONE_EMAIL];
-    if (!id) { throw new Error("'everyone' user not available"); }
+    if (!id) { throw new Error("'Everyone' user not available"); }
     return id;
   }
 
@@ -141,7 +141,7 @@ export class UsersManager {
    */
   public getSupportUserId(): number {
     const id = this._specialUserIds[SUPPORT_EMAIL];
-    if (!id) { throw new Error("'support' user not available"); }
+    if (!id) { throw new Error("'Support' user not available"); }
     return id;
   }
 

--- a/app/gen-server/lib/homedb/UsersManager.ts
+++ b/app/gen-server/lib/homedb/UsersManager.ts
@@ -321,7 +321,7 @@ export class UsersManager {
         // This is a postgres-specific error message. This problem cannot arise in sqlite,
         // because we have to serialize sqlite transactions in any case to get around a typeorm
         // limitation.
-        return this.getUserByLogin(email, options);
+        return await this.getUserByLogin(email, options);
       }
       throw e;
     }
@@ -355,7 +355,7 @@ export class UsersManager {
   public async getUserByLogin(email: string, options: GetUserOptions = {}) {
     const {manager: transaction, profile, userOptions} = options;
     const normalizedEmail = normalizeEmail(email);
-    return this._runInTransaction(transaction, async manager => {
+    return await this._runInTransaction(transaction, async manager => {
       let needUpdate = false;
       const userQuery = manager.createQueryBuilder()
         .select('user')

--- a/app/gen-server/lib/homedb/UsersManager.ts
+++ b/app/gen-server/lib/homedb/UsersManager.ts
@@ -433,7 +433,6 @@ export class UsersManager {
         const startOfDay = timestamp - (timestamp % 86400 /*24h*/); // start of a day in seconds since epoc
         return startOfDay;
       };
-      console.log("user.lastConnectionAt = ", user.lastConnectionAt);
       if (!user.lastConnectionAt || getTimestampStartOfDay(user.lastConnectionAt) !== getTimestampStartOfDay(nowish)) {
         user.lastConnectionAt = nowish;
         needUpdate = true;

--- a/app/gen-server/lib/homedb/UsersManager.ts
+++ b/app/gen-server/lib/homedb/UsersManager.ts
@@ -82,7 +82,7 @@ export class UsersManager {
   private _specialUserIds: {[name: string]: number} = {}; // id for anonymous user, previewer, etc
 
   private get _connection () {
-    return this._homeDb.connection;
+    return this._homeDb.dataSource;
   }
 
   public constructor(

--- a/app/gen-server/lib/homedb/UsersManager.ts
+++ b/app/gen-server/lib/homedb/UsersManager.ts
@@ -98,9 +98,7 @@ export class UsersManager {
     return await this._connection.transaction(async manager => {
       for (const email of emails) {
         const user = await this.getUserByLogin(email, {manager});
-        if (user) {
-          await manager.delete(Pref, {userId: user.id});
-        }
+        await manager.delete(Pref, {userId: user.id});
       }
     });
   }
@@ -467,7 +465,7 @@ export class UsersManager {
         // In principle this could be optimized, but this is simpler to maintain.
         user = await userQuery.getOne();
       }
-      return user;
+      return user!;
     });
   }
 

--- a/app/gen-server/lib/homedb/UsersManager.ts
+++ b/app/gen-server/lib/homedb/UsersManager.ts
@@ -312,7 +312,7 @@ export class UsersManager {
   // unseen user fires off multiple api calls.
   public async getUserByLoginWithRetry(email: string, options: GetUserOptions = {}): Promise<User> {
     try {
-      return this.getUserByLogin(email, options);
+      return await this.getUserByLogin(email, options);
     } catch (e) {
       if (e.name === 'QueryFailedError' && e.detail &&
           e.detail.match(/Key \(email\)=[^ ]+ already exists/)) {

--- a/app/server/companion.ts
+++ b/app/server/companion.ts
@@ -3,7 +3,7 @@ import { version } from 'app/common/version';
 import { synchronizeProducts } from 'app/gen-server/entity/Product';
 import { HomeDBManager } from 'app/gen-server/lib/homedb/HomeDBManager';
 import { applyPatch } from 'app/gen-server/lib/TypeORMPatches';
-import { getMigrations, getOrCreateConnection, getTypeORMSettings,
+import { createNewConnection, getMigrations, getTypeORMSettings,
          undoLastMigration, updateDb } from 'app/server/lib/dbUtils';
 import { getDatabaseUrl } from 'app/server/lib/serverUtils';
 import { getTelemetryPrefs } from 'app/server/lib/Telemetry';
@@ -194,7 +194,7 @@ export function addDbCommand(program: commander.Command,
       if (!process.env.TYPEORM_LOGGING) {
         process.env.TYPEORM_LOGGING = 'true';
       }
-      const connection = reuseConnection || await getOrCreateConnection();
+      const connection = reuseConnection || await createNewConnection();
       const exitCode = await op(connection);
       if (exitCode !== 0) {
         program.error('db command failed', {exitCode});

--- a/app/server/companion.ts
+++ b/app/server/companion.ts
@@ -3,7 +3,7 @@ import { version } from 'app/common/version';
 import { synchronizeProducts } from 'app/gen-server/entity/Product';
 import { HomeDBManager } from 'app/gen-server/lib/homedb/HomeDBManager';
 import { applyPatch } from 'app/gen-server/lib/TypeORMPatches';
-import { createNewConnection, getMigrations, getTypeORMSettings,
+import { getMigrations, getOrCreateConnection, getTypeORMSettings,
          undoLastMigration, updateDb } from 'app/server/lib/dbUtils';
 import { getDatabaseUrl } from 'app/server/lib/serverUtils';
 import { getTelemetryPrefs } from 'app/server/lib/Telemetry';
@@ -190,7 +190,7 @@ export function addDbCommand(program: commander.Command,
       if (!process.env.TYPEORM_LOGGING) {
         process.env.TYPEORM_LOGGING = 'true';
       }
-      const connection = reuseConnection || await createNewConnection();
+      const connection = reuseConnection || await getOrCreateConnection();
       const exitCode = await op(connection);
       if (exitCode !== 0) {
         program.error('db command failed', {exitCode});

--- a/app/server/companion.ts
+++ b/app/server/companion.ts
@@ -166,10 +166,6 @@ export function addSiteCommand(program: commander.Command,
       const profile = {email, name: email};
       const db = await getHomeDBManager();
       const user = await db.getUserByLogin(email, {profile});
-      if (!user) {
-        // This should not happen.
-        throw new Error('failed to create user');
-      }
       db.unwrapQueryResult(await db.addOrg(user, {
         name: domain,
         domain,

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -1123,7 +1123,7 @@ export class DocWorkerApi {
         if (req.body.resetTutorialMetadata) {
           const scope = getDocScope(req);
           const tutorialTrunkId = options.sourceDocId;
-          await this._dbManager.connection.transaction(async (manager) => {
+          await this._dbManager.dataSource.transaction(async (manager) => {
             // Fetch the tutorial trunk so we can replace the tutorial fork's name.
             const tutorialTrunk = await this._dbManager.getDoc({...scope, urlId: tutorialTrunkId}, manager);
             await this._dbManager.updateDocument(

--- a/app/server/lib/TestLogin.ts
+++ b/app/server/lib/TestLogin.ts
@@ -25,10 +25,8 @@ export async function getTestLoginSystem(): Promise<GristLoginSystem> {
           if (process.env.TEST_SUPPORT_API_KEY) {
             const dbManager = gristServer.getHomeDBManager();
             const user = await dbManager.getUserByLogin(SUPPORT_EMAIL);
-            if (user) {
-              user.apiKey = process.env.TEST_SUPPORT_API_KEY;
-              await user.save();
-            }
+            user.apiKey = process.env.TEST_SUPPORT_API_KEY;
+            await user.save();
           }
           return "test-login";
         },

--- a/app/server/lib/dbUtils.ts
+++ b/app/server/lib/dbUtils.ts
@@ -45,7 +45,7 @@ export async function updateDb(connection?: Connection) {
   await synchronizeProducts(connection, true);
 }
 
-function getConnectionName() {
+export function getConnectionName() {
   return process.env.TYPEORM_NAME || 'default';
 }
 

--- a/app/server/lib/extractOrg.ts
+++ b/app/server/lib/extractOrg.ts
@@ -103,7 +103,7 @@ export class Hosts {
     } else {
       // Otherwise check for a custom host.
       const org = await mapGetOrSet(this._host2org, hostname, async () => {
-        const o = await this._dbManager.connection.manager.findOne(Organization, {where: {host: hostname}});
+        const o = await this._dbManager.dataSource.manager.findOne(Organization, {where: {host: hostname}});
         return o && o.domain || undefined;
       });
       if (!org) { throw new ApiError(`Domain not recognized: ${hostname}`, 404); }
@@ -154,7 +154,7 @@ export class Hosts {
     if (org && this._getHostType(req.headers.host!) === 'native' && !this._dbManager.isMergedOrg(org)) {
       // Check if the org has a preferred host.
       const orgHost = await mapGetOrSet(this._org2host, org, async () => {
-        const o = await this._dbManager.connection.manager.findOne(Organization, {where: {domain: org}});
+        const o = await this._dbManager.dataSource.manager.findOne(Organization, {where: {domain: org}});
         return o && o.host || undefined;
       });
       if (orgHost && orgHost !== req.hostname) {

--- a/stubs/app/server/server.ts
+++ b/stubs/app/server/server.ts
@@ -59,7 +59,7 @@ async function setupDb() {
     await updateDb();
   }
   const db = new HomeDBManager();
-  await db.connect();
+  await db.initializeDataSource();
   await db.initializeSpecialIds({skipWorkspaces: true});
 
   // If a team/organization is specified, make sure it exists.

--- a/stubs/app/server/server.ts
+++ b/stubs/app/server/server.ts
@@ -80,10 +80,6 @@ async function setupDb() {
       }
       const profile = {email, name: email};
       const user = await db.getUserByLogin(email, {profile});
-      if (!user) {
-        // This should not happen.
-        throw new Error('failed to create GRIST_DEFAULT_EMAIL user');
-      }
       db.unwrapQueryResult(await db.addOrg(user, {
         name: org,
         domain: org,

--- a/test/gen-server/ApiServer.ts
+++ b/test/gen-server/ApiServer.ts
@@ -49,9 +49,9 @@ describe('ApiServer', function() {
     homeUrl = await server.start(['home', 'docs']);
     dbManager = server.dbManager;
 
-    chimpyRef = await dbManager.getUserByLogin(chimpyEmail).then((user) => user!.ref);
-    kiwiRef = await dbManager.getUserByLogin(kiwiEmail).then((user) => user!.ref);
-    charonRef = await dbManager.getUserByLogin(charonEmail).then((user) => user!.ref);
+    chimpyRef = await dbManager.getUserByLogin(chimpyEmail).then((user) => user.ref);
+    kiwiRef = await dbManager.getUserByLogin(kiwiEmail).then((user) => user.ref);
+    charonRef = await dbManager.getUserByLogin(charonEmail).then((user) => user.ref);
 
     // Listen to user count updates and add them to an array.
     dbManager.on('userChange', ({org, countBefore, countAfter}: UserChange) => {
@@ -2070,8 +2070,7 @@ describe('ApiServer', function() {
     // create a new user
     const profile = {email: 'meep@getgrist.com', name: 'Meep'};
     const user = await dbManager.getUserByLogin('meep@getgrist.com', {profile});
-    assert(user);
-    const userId = user!.id;
+    const userId = user.id;
     // set up an api key
     await dbManager.connection.query("update users set api_key = 'api_key_for_meep' where id = $1", [userId]);
 
@@ -2111,11 +2110,10 @@ describe('ApiServer', function() {
     const userBlank = await dbManager.getUserByLogin('blank@getgrist.com',
                                                      {profile: {email: 'blank@getgrist.com',
                                                       name: ''}});
-    assert(userBlank);
-    await dbManager.connection.query("update users set api_key = 'api_key_for_blank' where id = $1", [userBlank!.id]);
+    await dbManager.connection.query("update users set api_key = 'api_key_for_blank' where id = $1", [userBlank.id]);
 
     // check that user can delete themselves
-    resp = await axios.delete(`${homeUrl}/api/users/${userBlank!.id}`,
+    resp = await axios.delete(`${homeUrl}/api/users/${userBlank.id}`,
                               {data: {name: ""}, ...configForUser("blank")});
     assert.equal(resp.status, 200);
 

--- a/test/gen-server/ApiServer.ts
+++ b/test/gen-server/ApiServer.ts
@@ -929,7 +929,7 @@ describe('ApiServer', function() {
     assert.isNotNull(org.updatedAt);
 
     // Upgrade this org to a fancier plan, and check that vanity domain starts working
-    const db = dbManager.connection.manager;
+    const db = dbManager.dataSource.manager;
     const dbOrg = await db.findOne(Organization,
                                    {where: {name: 'Magic'},
                                     relations: ['billingAccount', 'billingAccount.product']});
@@ -2072,7 +2072,7 @@ describe('ApiServer', function() {
     const user = await dbManager.getUserByLogin('meep@getgrist.com', {profile});
     const userId = user.id;
     // set up an api key
-    await dbManager.connection.query("update users set api_key = 'api_key_for_meep' where id = $1", [userId]);
+    await dbManager.dataSource.query("update users set api_key = 'api_key_for_meep' where id = $1", [userId]);
 
     // make sure we have at least one extra user, a login, an org, a group_user entry,
     // a billing account, a billing account manager.
@@ -2110,7 +2110,7 @@ describe('ApiServer', function() {
     const userBlank = await dbManager.getUserByLogin('blank@getgrist.com',
                                                      {profile: {email: 'blank@getgrist.com',
                                                       name: ''}});
-    await dbManager.connection.query("update users set api_key = 'api_key_for_blank' where id = $1", [userBlank.id]);
+    await dbManager.dataSource.query("update users set api_key = 'api_key_for_blank' where id = $1", [userBlank.id]);
 
     // check that user can delete themselves
     resp = await axios.delete(`${homeUrl}/api/users/${userBlank.id}`,
@@ -2151,7 +2151,7 @@ describe('ApiServer', function() {
       const prevAccount = await dbManager.getBillingAccount(
         {userId: dbManager.getPreviewerUserId()},
         'best-friends-squad', false);
-      await dbManager.connection.query(
+      await dbManager.dataSource.query(
         'update billing_accounts set product_id = (select id from products where name = $1) where id = $2',
         [TEAM_FREE_PLAN, prevAccount.id]
       );
@@ -2339,7 +2339,7 @@ describe('ApiServer', function() {
 // in postgres.
 async function getNextId(dbManager: HomeDBManager, table: 'orgs'|'workspaces') {
   // Check current top org id.
-  const row = await dbManager.connection.query(`select max(id) as id from ${table}`);
+  const row = await dbManager.dataSource.query(`select max(id) as id from ${table}`);
   const id = row[0]['id'];
   return id + 1;
 }

--- a/test/gen-server/ApiServerAccess.ts
+++ b/test/gen-server/ApiServerAccess.ts
@@ -61,9 +61,9 @@ describe('ApiServerAccess', function() {
       }
     );
     dbManager = server.dbManager;
-    chimpyRef = await dbManager.getUserByLogin(chimpyEmail).then((user) => user!.ref);
-    kiwiRef = await dbManager.getUserByLogin(kiwiEmail).then((user) => user!.ref);
-    charonRef = await dbManager.getUserByLogin(charonEmail).then((user) => user!.ref);
+    chimpyRef = await dbManager.getUserByLogin(chimpyEmail).then((user) => user.ref);
+    kiwiRef = await dbManager.getUserByLogin(kiwiEmail).then((user) => user.ref);
+    charonRef = await dbManager.getUserByLogin(charonEmail).then((user) => user.ref);
     // Listen to user count updates and add them to an array.
     dbManager.on('userChange', ({org, countBefore, countAfter}: UserChange) => {
       if (countBefore === countAfter) { return; }

--- a/test/gen-server/ApiServerAccess.ts
+++ b/test/gen-server/ApiServerAccess.ts
@@ -1411,7 +1411,7 @@ describe('ApiServerAccess', function() {
 
     before(async function() {
       // Set NASA to be specifically on a team plan, with team plan restrictions.
-      const db = dbManager.connection.manager;
+      const db = dbManager.dataSource.manager;
       nasaOrg = (await db.findOne(Organization, {where: {domain: 'nasa'},
                                                  relations: ['billingAccount',
                                                              'billingAccount.product']}))!;
@@ -1600,12 +1600,12 @@ describe('ApiServerAccess', function() {
     describe('force flag is not needed if apiKey is not set', function() {
       before(function() {
         // turn off api key access for chimpy
-        return dbManager.connection.query(`update users set api_key = null where name = 'Chimpy'`);
+        return dbManager.dataSource.query(`update users set api_key = null where name = 'Chimpy'`);
       });
 
       after(function() {
         // bring back api key access for chimpy
-        return dbManager.connection.query(`update users set api_key = 'api_key_for_chimpy' where name = 'Chimpy'`);
+        return dbManager.dataSource.query(`update users set api_key = 'api_key_for_chimpy' where name = 'Chimpy'`);
       });
 
       it('force flag is not needed', async function() {

--- a/test/gen-server/ApiServerBenchmark.ts
+++ b/test/gen-server/ApiServerBenchmark.ts
@@ -6,7 +6,7 @@ import {assert} from 'chai';
 
 import {FlexServer} from 'app/server/lib/FlexServer';
 
-import {createBenchmarkServer, removeConnection, setUpDB} from 'test/gen-server/seed';
+import {createBenchmarkServer, setUpDB} from 'test/gen-server/seed';
 
 let home: FlexServer;
 let homeUrl: string;
@@ -31,7 +31,7 @@ describe('ApiServerBenchmark', function() {
   after(async function() {
     if (home) {
       await home.stopListening();
-      await removeConnection();
+      await home.getHomeDBManager().destroyDataSource();
     }
   });
 

--- a/test/gen-server/ApiServerBugs.ts
+++ b/test/gen-server/ApiServerBugs.ts
@@ -32,7 +32,7 @@ describe('ApiServerBugs', function() {
     server = new TestServer(this);
     homeUrl = await server.start();
     dbManager = server.dbManager;
-    userRef = (email) => server.dbManager.getUserByLogin(email).then((user) => user!.ref);
+    userRef = (email) => server.dbManager.getUserByLogin(email).then((user) => user.ref);
   });
 
   after(async function() {

--- a/test/gen-server/AuthCaching.ts
+++ b/test/gen-server/AuthCaching.ts
@@ -10,7 +10,7 @@ import {tmpdir} from 'os';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import {TestSession} from 'test/gen-server/apiUtils';
-import {createInitialDb, removeConnection, setUpDB} from 'test/gen-server/seed';
+import {createInitialDb, setUpDB} from 'test/gen-server/seed';
 import {configForUser, getGristConfig} from 'test/gen-server/testUtils';
 import {openClient} from 'test/server/gristClient';
 import * as testUtils from 'test/server/testUtils';
@@ -80,7 +80,6 @@ describe('AuthCaching', function() {
     await testUtils.captureLog('warn', async () => {
       await docsServer.close();
       await homeServer.close();
-      await removeConnection();
     });
   });
 

--- a/test/gen-server/lib/DocApiForwarder.ts
+++ b/test/gen-server/lib/DocApiForwarder.ts
@@ -11,7 +11,7 @@ import morganLogger from 'morgan';
 import { AddressInfo } from 'net';
 import sinon = require("sinon");
 
-import { createInitialDb, removeConnection, setUpDB } from "test/gen-server/seed";
+import { createInitialDb, setUpDB } from "test/gen-server/seed";
 import { configForUser } from 'test/gen-server/testUtils';
 
 import { DocApiForwarder } from "app/gen-server/lib/DocApiForwarder";
@@ -59,8 +59,8 @@ describe('DocApiForwarder', function() {
   before(async function() {
     setUpDB(this);
     dbManager = new HomeDBManager();
-    await dbManager.connect();
-    await createInitialDb(dbManager.connection);
+    await dbManager.initializeDataSource();
+    await createInitialDb(dbManager.dataSource);
     await dbManager.initializeSpecialIds();
 
     // create cheap doc worker
@@ -95,7 +95,6 @@ describe('DocApiForwarder', function() {
   });
 
   after(async function() {
-    await removeConnection();
     homeServer.close();
     docWorker.close();
     dbManager.flushDocAuthCache();    // To avoid hanging up exit from tests.

--- a/test/gen-server/lib/DocWorkerMap.ts
+++ b/test/gen-server/lib/DocWorkerMap.ts
@@ -8,7 +8,7 @@ import {assert, expect} from 'chai';
 import {countBy, values} from 'lodash';
 import {createClient, RedisClient} from 'redis';
 import {TestSession} from 'test/gen-server/apiUtils';
-import {createInitialDb, removeConnection, setUpDB} from 'test/gen-server/seed';
+import {createInitialDb, setUpDB} from 'test/gen-server/seed';
 import sinon from 'sinon';
 import * as testUtils from 'test/server/testUtils';
 
@@ -413,7 +413,6 @@ describe('DocWorkerMap', function() {
     after(async function() {
       if (servers) {
         await Promise.all(Object.values(servers).map(server => server.close()));
-        await removeConnection();
         delete process.env.REDIS_URL;
         delete process.env.GRIST_DOC_WORKER_ID;
         delete process.env.GRIST_WORKER_GROUP;

--- a/test/gen-server/lib/HomeDBManager.ts
+++ b/test/gen-server/lib/HomeDBManager.ts
@@ -315,13 +315,13 @@ describe('HomeDBManager', function() {
   it('will fail on parameter collision', async function() {
     // Check collision in a simple query.
     // Note: it is query construction that fails, not query execution.
-    assert.throws(() => home.connection.createQueryBuilder().from('orgs', 'orgs')
+    assert.throws(() => home.dataSource.createQueryBuilder().from('orgs', 'orgs')
                   .where('id = :id', {id: 1}).andWhere('id = :id', {id: 2}),
                   /parameter collision/);
 
     // Check collision between subqueries.
     assert.throws(
-      () => home.connection.createQueryBuilder().from('orgs', 'orgs')
+      () => home.dataSource.createQueryBuilder().from('orgs', 'orgs')
         .select(q => q.subQuery().from('orgs', 'orgs').where('x IN :x', {x: ['five']}))
         .addSelect(q => q.subQuery().from('orgs', 'orgs').where('x IN :x', {x: ['six']})),
         /parameter collision/);

--- a/test/gen-server/lib/Housekeeper.ts
+++ b/test/gen-server/lib/Housekeeper.ts
@@ -35,12 +35,12 @@ describe('Housekeeper', function() {
   });
 
   async function getDoc(docId: string) {
-    const manager = home.dbManager.connection.manager;
+    const manager = home.dbManager.dataSource.manager;
     return manager.findOneOrFail(Document, {where: {id: docId}});
   }
 
   async function getWorkspace(wsId: number) {
-    const manager = home.dbManager.connection.manager;
+    const manager = home.dbManager.dataSource.manager;
     return manager.findOneOrFail(Workspace, {where: {id: wsId}});
   }
 

--- a/test/gen-server/lib/emails.ts
+++ b/test/gen-server/lib/emails.ts
@@ -19,7 +19,7 @@ describe('emails', function() {
   beforeEach(async function() {
     this.timeout(5000);
     server = new TestServer(this);
-    ref = (email: string) => server.dbManager.getUserByLogin(email).then((user) => user!.ref);
+    ref = (email: string) => server.dbManager.getUserByLogin(email).then((user) => user.ref);
     serverUrl = await server.start();
   });
 

--- a/test/gen-server/lib/homedb/UsersManager.ts
+++ b/test/gen-server/lib/homedb/UsersManager.ts
@@ -26,6 +26,7 @@ import winston from 'winston';
 import fs from 'fs/promises';
 import { tmpdir } from 'os';
 import path from 'path';
+import { dereferenceConnection } from 'test/gen-server/seed';
 
 const username = process.env.USER || "nobody";
 const tmpDirPrefix = path.join(tmpdir(), `grist_test_${username}_userendpoint_`);
@@ -276,6 +277,7 @@ describe('UsersManager', function () {
         // TODO: Check whether using DataSource would help and avoid this hack.
         await db.connection.destroy();
         await db.createNewConnection();
+        dereferenceConnection(dbName);
       }
     }
 

--- a/test/gen-server/lib/homedb/UsersManager.ts
+++ b/test/gen-server/lib/homedb/UsersManager.ts
@@ -1,0 +1,370 @@
+import { User } from 'app/gen-server/entity/User';
+import { AclRuleOrg } from 'app/gen-server/entity/AclRule';
+import { Group } from 'app/gen-server/entity/Group';
+import { Organization } from 'app/gen-server/entity/Organization';
+import { SUPPORT_EMAIL, UsersManager } from 'app/gen-server/lib/homedb/UsersManager';
+import { NonGuestGroup, Resource } from 'app/gen-server/lib/homedb/Interfaces';
+import { tmpdir } from 'os';
+import path from 'path';
+import { prepareDatabase } from 'test/server/lib/helpers/PrepareDatabase';
+import { prepareFilesystemDirectoryForTests } from 'test/server/lib/helpers/PrepareFilesystemDirectoryForTests';
+import { EnvironmentSnapshot } from 'test/server/testUtils';
+import { getDatabase } from 'test/testUtils';
+import { Workspace } from 'app/gen-server/entity/Workspace';
+import { Document } from 'app/gen-server/entity/Document';
+import { HomeDBManager } from 'app/gen-server/lib/homedb/HomeDBManager';
+import Sinon, { SinonSandbox } from 'sinon';
+import { assert } from 'chai';
+import { addSeedData } from 'test/gen-server/seed';
+import { FullUser } from 'app/common/LoginSessionAPI';
+import { ANONYMOUS_USER_EMAIL } from 'app/common/UserAPI';
+import { Login } from 'app/gen-server/entity/Login';
+import { Pref } from 'app/gen-server/entity/Pref';
+
+const username = process.env.USER || "nobody";
+const tmpDir = path.join(tmpdir(), `grist_test_${username}_userendpoint`);
+
+describe('UsersManager', function () {
+  this.timeout(30000);
+  let env: EnvironmentSnapshot;
+  let db: HomeDBManager;
+
+  before(async function () {
+    env = new EnvironmentSnapshot();
+    await prepareFilesystemDirectoryForTests(tmpDir);
+    await prepareDatabase(tmpDir);
+    db = await getDatabase();
+    await addSeedData(db.connection);
+  });
+
+  after(async function () {
+    env.restore();
+  });
+
+  function* makeIdxIterator() {
+    for (let i = 0; i < 500; i++) {
+      yield i;
+    }
+  }
+
+  function makeUsers(nbUsers: number, idxIt = makeIdxIterator()) {
+    return Array(nbUsers).fill(null).map(() => {
+      const user = new User();
+      const index = idxIt.next();
+      if (index.done) {
+        throw new Error('Excessive number of users created');
+      }
+      user.id = index.value;
+      user.name = `User ${index.value}`;
+      return user;
+    });
+  }
+
+  function makeUsersList(usersListLength: number) {
+    const nbUsersByGroups = 5; // arbitrary value
+    const idxIt = makeIdxIterator();
+    return Array(usersListLength).fill(null).map(_ => makeUsers(nbUsersByGroups, idxIt));
+  }
+
+  describe('getResourceUsers', function () {
+    function populateResourceWithMembers(res: Resource, members: User[], groupName?: string) {
+      const aclRule = new AclRuleOrg();
+      const group = new Group();
+      if (groupName) {
+        group.name = groupName;
+      }
+      group.memberUsers = members;
+      aclRule.group = group;
+      res.aclRules = [
+        aclRule
+      ];
+    }
+
+    it('should return all users from a single organization ACL', function () {
+      const resource = new Organization();
+      const users = makeUsers(5);
+      populateResourceWithMembers(resource, users);
+      const result = UsersManager.getResourceUsers(resource);
+      assert.deepEqual(result, users);
+    });
+
+    it('should return all users from all resources ACL', function () {
+      const resources: Resource[] = [new Organization(), new Workspace(), new Document()];
+      const usersList = makeUsersList(3);
+      for (const [idx, resource] of resources.entries()) {
+        populateResourceWithMembers(resource, usersList[idx]);
+      }
+      const result = UsersManager.getResourceUsers(resources);
+      assert.deepEqual(result, usersList.flat());
+    });
+
+    it('should return users matching group names from all resources ACL', function () {
+      const resources: Resource[] = [new Organization(), new Workspace(), new Document()];
+      const usersList = makeUsersList(3);
+      const allGroupNames = ['Grp1', 'Grp2', 'Grp3'];
+      const filteredGroupNames = allGroupNames.slice(1);
+      for (const [idx, resource] of resources.entries()) {
+        populateResourceWithMembers(resource, usersList[idx], allGroupNames[idx]);
+      }
+      const result = UsersManager.getResourceUsers(resources, filteredGroupNames);
+      assert.deepEqual(result, usersList.slice(1).flat(), 'should discard the users from the first resource');
+    });
+  });
+
+  describe('getUsersWithRole', function () {
+    function makeGroups(groupDefinition: {[k in NonGuestGroup['name']]?: User[] | undefined}){
+      return (Object.entries(groupDefinition) as [NonGuestGroup['name'], User[] | undefined][])
+        .map(([groupName, users], index) => {
+          const group = new Group() as NonGuestGroup;
+          group.id = index;
+          group.name = groupName;
+          if (users) {
+            group.memberUsers = users;
+          }
+          return group;
+        });
+    }
+
+    it('should retrieve no users if passed groups do not contain any', function () {
+      const groups = makeGroups({
+        'members': undefined
+      });
+      assert.deepEqual(UsersManager.getUsersWithRole(groups), new Map([['members', undefined]] as any));
+    });
+
+    it('should retrieve users of passed groups', function () {
+      const idxIt = makeIdxIterator();
+      const groupsUsersMap = {
+        'editors': makeUsers(3, idxIt),
+        'owners': makeUsers(4, idxIt),
+        'members': makeUsers(5, idxIt),
+        'viewers': []
+      };
+      const groups = makeGroups(groupsUsersMap);
+      assert.deepEqual(UsersManager.getUsersWithRole(groups), new Map(Object.entries(groupsUsersMap)));
+    });
+
+    it('should exclude users of given IDs', function () {
+      const groupUsersMap = {
+        'editors': makeUsers(5),
+      };
+      const excludedUsersId = [1, 2, 3, 4];
+      const expectedUsers = [groupUsersMap.editors[0]];
+      const groups = makeGroups(groupUsersMap);
+
+      assert.deepEqual(
+        UsersManager.getUsersWithRole(groups, excludedUsersId),
+        new Map([
+          ['editors', expectedUsers]
+        ])
+      );
+    });
+  });
+
+  describe('Special User Ids', function () {
+    const ANONYMOUS_USER_ID = 6;
+    const PREVIEWER_USER_ID = 7;
+    const EVERYONE_USER_ID = 8;
+    const SUPPORT_USER_ID = 5;
+    it('getAnonymousUserId() should retrieve anonymous user id', function () {
+      assert.strictEqual(db.getAnonymousUserId(), ANONYMOUS_USER_ID);
+    });
+
+    it('getPreviewerUserId() should retrieve previewer user id', function () {
+      assert.strictEqual(db.getPreviewerUserId(), PREVIEWER_USER_ID);
+    });
+
+    it("getEveryoneUserId() should retrieve 'everyone' user id", function () {
+      assert.strictEqual(db.getEveryoneUserId(), EVERYONE_USER_ID);
+    });
+
+    it("getSupportUserId() should retrieve 'support' user id", function () {
+      assert.strictEqual(db.getSupportUserId(), SUPPORT_USER_ID);
+    });
+
+    describe('Without special id initialization', function () {
+      let sandbox: SinonSandbox;
+      before(function () {
+        sandbox = Sinon.createSandbox();
+      });
+      after(function () {
+        sandbox.restore();
+      });
+
+      async function createDatabaseWithoutSpecialIds() {
+        const stub = sandbox.stub(HomeDBManager.prototype, 'initializeSpecialIds').resolves(undefined);
+        const localDb = await getDatabase('without-special-ids');
+        stub.restore();
+        return localDb;
+      }
+
+      it('should throw an error', async function () {
+        const localDb = await createDatabaseWithoutSpecialIds();
+        assert.throws(() => localDb.getAnonymousUserId(), "Anonymous user not available");
+        assert.throws(() => localDb.getPreviewerUserId(), "Previewer user not available");
+        assert.throws(() => localDb.getEveryoneUserId(), "'everyone' user not available");
+        assert.throws(() => localDb.getSupportUserId(), "'support' user not available");
+      });
+    });
+  });
+
+  describe('getUserByKey', function () {
+    it('should return the user given their API Key', async function () {
+      const user = await db.getUserByKey('api_key_for_chimpy');
+      assert.strictEqual(user?.name, 'Chimpy', 'should retrieve Chimpy by their API key');
+      assert.strictEqual(user?.logins?.[0].email, 'chimpy@getgrist.com');
+    });
+
+    it('should return undefined if no user matches the API key', async function () {
+      const user = await db.getUserByKey('non-existing API key');
+      assert.strictEqual(user, undefined);
+    });
+  });
+
+  describe('getUser', async function () {
+
+    const userWithPrefsEmail = 'userwithprefs@getgrist.com';
+    async function getOrCreateUserWithPrefs() {
+      const user = await db.getUserByLogin(userWithPrefsEmail);
+      if (!user) {
+        throw new Error('getOrCreateUserWithPrefs: User not created!');
+      }
+      return user;
+    }
+
+    it('should retrieve a user by their ID', async function () {
+      const user = await db.getUser(db.getSupportUserId());
+      assert.ok(user, 'Should have returned a user');
+      assert.strictEqual(user!.name, 'Support');
+      assert.strictEqual(user!.loginEmail, SUPPORT_EMAIL);
+      assert.ok(!user!.prefs, "should not have retrieved user's prefs");
+    });
+
+    it('should retrieve a user along with their prefs with `includePrefs` set to true', async function () {
+      const expectedUser = await getOrCreateUserWithPrefs();
+      const user = await db.getUser(expectedUser.id, {includePrefs: true});
+      assert.ok(user, "Should have retrieved the user");
+      assert.ok(user!.loginEmail);
+      assert.strictEqual(user!.loginEmail, expectedUser.loginEmail);
+      assert.ok(Array.isArray(user!.prefs), "should not have retrieved user's prefs");
+      assert.deepEqual(user!.prefs, [{
+        userId: expectedUser.id,
+        orgId: expectedUser.personalOrg.id,
+        prefs: { showGristTour: true } as any
+      }]);
+    });
+  });
+
+  describe('getFullUser()', function () {
+    it('should return the support user', async function () {
+      const supportId = db.getSupportUserId();
+      const user = await db.getFullUser(supportId);
+      const expectedResult: FullUser = {
+        isSupport: true,
+        email: SUPPORT_EMAIL,
+        id: supportId,
+        name: 'Support'
+      };
+      assert.deepInclude(user, expectedResult);
+      assert.ok(!user.anonymous, 'anonymous property should be falsy');
+    });
+
+    it('should return the anonymous user', async function () {
+      const anonId = db.getAnonymousUserId();
+      const user = await db.getFullUser(anonId);
+      const expectedResult: FullUser = {
+        anonymous: true,
+        email: ANONYMOUS_USER_EMAIL,
+        id: anonId,
+        name: 'Anonymous',
+      };
+      assert.deepInclude(user, expectedResult);
+      assert.ok(!user.isSupport, 'support property should be falsy');
+    });
+
+    it('should throw when user is not found', async function () {
+      await assert.isRejected(db.getFullUser(1337), "unable to find user");
+    });
+  });
+
+  describe('makeFullUser()', function () {
+    const someUserDisplayEmail = 'SomeUser@getgrist.com';
+    const normalizedSomeUserEmail = 'someuser@getgrist.com';
+    const someUserLocale = 'en-US';
+    const SOME_USER_ID = 42;
+    const prefWithOrg: Pref = {
+      prefs: {placeholder: 'pref-with-org'},
+      orgId: 43,
+      user: new User(),
+      userId: SOME_USER_ID,
+    };
+    const prefWithoutOrg: Pref = {
+      prefs: {placeholder: 'pref-without-org'},
+      orgId: null,
+      user: new User(),
+      userId: SOME_USER_ID
+    }
+
+
+    function makeSomeUser() {
+      return User.create({
+        id: SOME_USER_ID,
+        ref: 'some ref',
+        name: 'some user',
+        picture: 'https://grist.com/mypic',
+        options: {
+          locale: someUserLocale
+        },
+        logins: [
+          Login.create({
+            userId: SOME_USER_ID,
+            email: normalizedSomeUserEmail,
+            displayEmail: someUserDisplayEmail,
+          }),
+        ],
+        prefs: [
+          prefWithOrg,
+          prefWithoutOrg
+        ]
+      });
+    }
+
+    it('creates a FullUser from a User entity', function () {
+      const input = makeSomeUser();
+      const fullUser = db.makeFullUser(input);
+      assert.deepEqual(fullUser, {
+        id: SOME_USER_ID,
+        email: someUserDisplayEmail,
+        loginEmail: normalizedSomeUserEmail,
+        name: input.name,
+        picture: input.picture,
+        ref: input.ref,
+        locale: someUserLocale,
+        prefs: prefWithoutOrg.prefs
+      });
+    });
+
+    it('sets `anonymous` property to true for anon@getgrist.com', function () {
+      const anon = db.getAnonymousUser();
+      const fullUser = db.makeFullUser(anon);
+      assert.isTrue(fullUser.anonymous, "`anonymous` property should be set to true");
+      assert.ok(!fullUser.isSupport, "`isSupport` should be falsy");
+    });
+
+    it('sets `isSupport` property to true for support account', async function () {
+      const support = await db.getUser(db.getSupportUserId());
+      const fullUser = db.makeFullUser(support!);
+      assert.isTrue(fullUser.isSupport, "`isSupport` property should be set to true");
+      assert.ok(!fullUser.anonymous, "`anonymouse` should be falsy");
+    });
+
+    it('should throw when no displayEmail exist for this user', function () {
+      const input = makeSomeUser();
+      input.logins[0].displayEmail = '';
+      assert.throws(() => db.makeFullUser(input), "unable to find mandatory user email");
+      input.logins = [];
+      assert.throws(() => db.makeFullUser(input), "unable to find mandatory user email");
+    });
+  });
+
+});

--- a/test/gen-server/lib/homedb/UsersManager.ts
+++ b/test/gen-server/lib/homedb/UsersManager.ts
@@ -28,149 +28,89 @@ const username = process.env.USER || "nobody";
 const tmpDir = path.join(tmpdir(), `grist_test_${username}_userendpoint`);
 
 describe('UsersManager', function () {
-  const NON_EXISTING_USER_ID = 10001337;
   this.timeout(30000);
-  let env: EnvironmentSnapshot;
-  let db: HomeDBManager;
-  let sandbox: SinonSandbox;
-  const uniqueLocalPart = new Set<string>();
 
-  function getTmpDatabase(typeormDb: string) {
-    return getDatabase(path.join(tmpDir, typeormDb));
-  }
-
-  /**
-   * Works around lacks of type narrowing after asserting the value is defined.
-   * This is fixed in latest version of @types/chai
-   * FIXME: once using @types/chai > 4.3.17, remove this function
-   */
-  function assertExists<T>(value?: T, message?: string): asserts value is T {
-    assert.exists(value, message);
-  }
-
-  function ensureUnique(localPart: string) {
-    if (uniqueLocalPart.has(localPart)) {
-      throw new Error('passed localPart is already used elsewhere');
-    }
-    uniqueLocalPart.add(localPart);
-    return localPart;
-  }
-
-  function createUniqueUser(uniqueEmailLocalPart: string) {
-    ensureUnique(uniqueEmailLocalPart);
-    return getOrCreateUser(uniqueEmailLocalPart);
-  }
-
-  async function getOrCreateUser(localPart: string, options?: GetUserOptions) {
-    return db.getUserByLogin(makeEmail(localPart), options);
-  }
-
-  function makeEmail(localPart: string) {
-    return localPart + '@getgrist.com';
-  }
-
-  async function getPersonalOrg(user: User) {
-    return db.getOrg({userId: user.id}, user.personalOrg.id);
-  }
-
-  function disableLogging<T extends keyof winston.LoggerInstance>(method: T) {
-    return sandbox.stub(log, method);
-  }
-
-  before(async function () {
-    env = new EnvironmentSnapshot();
-    await prepareFilesystemDirectoryForTests(tmpDir);
-    await prepareDatabase(tmpDir);
-    db = await getDatabase();
-  });
-
-  after(async function () {
-    env.restore();
-  });
-
-  beforeEach(function () {
-    sandbox = Sinon.createSandbox();
-  });
-
-  afterEach(function () {
-    sandbox.restore();
-  });
-
-
-  function* makeIdxIterator() {
-    for (let i = 0; i < 500; i++) {
-      yield i;
-    }
-  }
-
-  function makeUsers(nbUsers: number, idxIt = makeIdxIterator()) {
-    return Array(nbUsers).fill(null).map(() => {
-      const user = new User();
-      const index = idxIt.next();
-      if (index.done) {
-        throw new Error('Excessive number of users created');
+  describe('static method', function () {
+    function* makeIdxIterator() {
+      for (let i = 0; i < 500; i++) {
+        yield i;
       }
-      user.id = index.value;
-      user.name = `User ${index.value}`;
-      return user;
-    });
-  }
-
-  function makeUsersList(usersListLength: number) {
-    const nbUsersByGroups = 5; // arbitrary value
-    const idxIt = makeIdxIterator();
-    return Array(usersListLength).fill(null).map(_ => makeUsers(nbUsersByGroups, idxIt));
-  }
-
-  describe('getResourceUsers()', function () {
-    function populateResourceWithMembers(res: Resource, members: User[], groupName?: string) {
-      const aclRule = new AclRuleOrg();
-      const group = new Group();
-      if (groupName) {
-        group.name = groupName;
-      }
-      group.memberUsers = members;
-      aclRule.group = group;
-      res.aclRules = [
-        aclRule
-      ];
     }
 
-    it('should return all users from a single organization ACL', function () {
-      const resource = new Organization();
-      const users = makeUsers(5);
-      populateResourceWithMembers(resource, users);
-      const result = UsersManager.getResourceUsers(resource);
-      assert.deepEqual(result, users);
-    });
+    function makeUsers(nbUsers: number, idxIt = makeIdxIterator()) {
+      return Array(nbUsers).fill(null).map(() => {
+        const user = new User();
+        const index = idxIt.next();
+        if (index.done) {
+          throw new Error('Excessive number of users created');
+        }
+        user.id = index.value;
+        user.name = `User ${index.value}`;
+        return user;
+      });
+    }
 
-    it('should return all users from all resources ACL', function () {
-      const resources: Resource[] = [new Organization(), new Workspace(), new Document()];
-      const usersList = makeUsersList(3);
-      for (const [idx, resource] of resources.entries()) {
-        populateResourceWithMembers(resource, usersList[idx]);
+    function makeUsersList(usersListLength: number, nbUsersByGroups: number) {
+      const idxIt = makeIdxIterator();
+      return Array(usersListLength).fill(null).map(_ => makeUsers(nbUsersByGroups, idxIt));
+    }
+
+    describe('getResourceUsers()', function () {
+      function populateResourceWithMembers(res: Resource, members: User[], groupName?: string) {
+        const aclRule = new AclRuleOrg();
+        const group = new Group();
+        if (groupName) {
+          group.name = groupName;
+        }
+        group.memberUsers = members;
+        aclRule.group = group;
+        res.aclRules = [
+          aclRule
+        ];
       }
-      const result = UsersManager.getResourceUsers(resources);
-      assert.deepEqual(result, usersList.flat());
+
+      it('should return all users from a single organization ACL', function () {
+        const resource = new Organization();
+        const users = makeUsers(5);
+        populateResourceWithMembers(resource, users);
+
+        const result = UsersManager.getResourceUsers(resource);
+
+        assert.deepEqual(result, users);
+      });
+
+      it('should return all users from all resources ACL', function () {
+        const resources: Resource[] = [new Organization(), new Workspace(), new Document()];
+        const usersList = makeUsersList(3, 5);
+        for (const [idx, resource] of resources.entries()) {
+          populateResourceWithMembers(resource, usersList[idx]);
+        }
+
+        const result = UsersManager.getResourceUsers(resources);
+
+        assert.deepEqual(result, usersList.flat());
+      });
+
+      it('should return users matching group names from all resources ACL', function () {
+        const resources: Resource[] = [new Organization(), new Workspace(), new Document()];
+        const usersList = makeUsersList(3, 5);
+        const allGroupNames = ['Grp1', 'Grp2', 'Grp3'];
+        const filteredGroupNames = [ 'Grp2', 'Grp3' ];
+        for (const [idx, resource] of resources.entries()) {
+          populateResourceWithMembers(resource, usersList[idx], allGroupNames[idx]);
+        }
+
+        const result = UsersManager.getResourceUsers(resources, filteredGroupNames);
+
+        assert.deepEqual(result, usersList.slice(1).flat(), 'should discard the users from the first resource');
+      });
     });
 
-    it('should return users matching group names from all resources ACL', function () {
-      const resources: Resource[] = [new Organization(), new Workspace(), new Document()];
-      const usersList = makeUsersList(3);
-      const allGroupNames = ['Grp1', 'Grp2', 'Grp3'];
-      const filteredGroupNames = allGroupNames.slice(1);
-      for (const [idx, resource] of resources.entries()) {
-        populateResourceWithMembers(resource, usersList[idx], allGroupNames[idx]);
-      }
-      const result = UsersManager.getResourceUsers(resources, filteredGroupNames);
-      assert.deepEqual(result, usersList.slice(1).flat(), 'should discard the users from the first resource');
-    });
-  });
+    describe('getUsersWithRole()', function () {
+      function makeGroups(groupDefinition: {[k in NonGuestGroup['name']]?: User[] | undefined}){
+        const entries = Object.entries(groupDefinition) as [NonGuestGroup['name'], User[] | undefined][];
 
-  describe('getUsersWithRole()', function () {
-    function makeGroups(groupDefinition: {[k in NonGuestGroup['name']]?: User[] | undefined}){
-      return (Object.entries(groupDefinition) as [NonGuestGroup['name'], User[] | undefined][])
-        .map(([groupName, users], index) => {
+        return entries.map(([groupName, users], index) => {
           const group = new Group() as NonGuestGroup;
           group.id = index;
           group.name = groupName;
@@ -179,761 +119,855 @@ describe('UsersManager', function () {
           }
           return group;
         });
-    }
-
-    it('should retrieve no users if passed groups do not contain any', function () {
-      const groups = makeGroups({
-        'members': undefined
-      });
-      assert.deepEqual(UsersManager.getUsersWithRole(groups), new Map([['members', undefined]] as any));
-    });
-
-    it('should retrieve users of passed groups', function () {
-      const idxIt = makeIdxIterator();
-      const groupsUsersMap = {
-        'editors': makeUsers(3, idxIt),
-        'owners': makeUsers(4, idxIt),
-        'members': makeUsers(5, idxIt),
-        'viewers': []
-      };
-      const groups = makeGroups(groupsUsersMap);
-      assert.deepEqual(UsersManager.getUsersWithRole(groups), new Map(Object.entries(groupsUsersMap)));
-    });
-
-    it('should exclude users of given IDs', function () {
-      const groupUsersMap = {
-        'editors': makeUsers(5),
-      };
-      const excludedUsersId = [1, 2, 3, 4];
-      const expectedUsers = [groupUsersMap.editors[0]];
-      const groups = makeGroups(groupUsersMap);
-
-      assert.deepEqual(
-        UsersManager.getUsersWithRole(groups, excludedUsersId),
-        new Map([
-          ['editors', expectedUsers]
-        ])
-      );
-    });
-  });
-
-  describe('Special User Ids', function () {
-    const ANONYMOUS_USER_ID = 6;
-    const PREVIEWER_USER_ID = 7;
-    const EVERYONE_USER_ID = 8;
-    const SUPPORT_USER_ID = 5;
-    it('getAnonymousUserId() should retrieve anonymous user id', function () {
-      assert.strictEqual(db.getAnonymousUserId(), ANONYMOUS_USER_ID);
-    });
-
-    it('getPreviewerUserId() should retrieve previewer user id', function () {
-      assert.strictEqual(db.getPreviewerUserId(), PREVIEWER_USER_ID);
-    });
-
-    it("getEveryoneUserId() should retrieve 'everyone' user id", function () {
-      assert.strictEqual(db.getEveryoneUserId(), EVERYONE_USER_ID);
-    });
-
-    it("getSupportUserId() should retrieve 'support' user id", function () {
-      assert.strictEqual(db.getSupportUserId(), SUPPORT_USER_ID);
-    });
-
-    describe('Without special id initialization', function () {
-      async function createDatabaseWithoutSpecialIds() {
-        const stub = sandbox.stub(HomeDBManager.prototype, 'initializeSpecialIds').resolves(undefined);
-        const localDb = await getTmpDatabase('without-special-ids.db');
-        stub.restore();
-        return localDb;
       }
 
-      it('should throw an error', async function () {
-        const localDb = await createDatabaseWithoutSpecialIds();
-        assert.throws(() => localDb.getAnonymousUserId(), "Anonymous user not available");
-        assert.throws(() => localDb.getPreviewerUserId(), "Previewer user not available");
-        assert.throws(() => localDb.getEveryoneUserId(), "'everyone' user not available");
-        assert.throws(() => localDb.getSupportUserId(), "'support' user not available");
+      it('should retrieve no users if passed groups do not contain any', function () {
+        const groups = makeGroups({
+          'members': undefined
+        });
+
+        const result = UsersManager.getUsersWithRole(groups);
+
+        assert.deepEqual(result, new Map([['members', undefined]] as any));
+      });
+
+      it('should retrieve users of passed groups', function () {
+        const idxIt = makeIdxIterator();
+        const groupsUsersMap = {
+          'editors': makeUsers(3, idxIt),
+          'owners': makeUsers(4, idxIt),
+          'members': makeUsers(5, idxIt),
+          'viewers': []
+        };
+        const groups = makeGroups(groupsUsersMap);
+
+        const result = UsersManager.getUsersWithRole(groups);
+
+        assert.deepEqual(result, new Map(Object.entries(groupsUsersMap)));
+      });
+
+      it('should exclude users of given IDs', function () {
+        const groupUsersMap = {
+          'editors': makeUsers(5),
+        };
+        const excludedUsersId = [1, 2, 3, 4];
+        const expectedUsers = [groupUsersMap.editors[0]];
+        const groups = makeGroups(groupUsersMap);
+
+        const result = UsersManager.getUsersWithRole(groups, excludedUsersId);
+
+        assert.deepEqual( result, new Map([ ['editors', expectedUsers] ]));
       });
     });
   });
 
-  describe('getUserByKey()', function () {
-    it('should return the user given their API Key', async function () {
-      const user = await db.getUserByKey('api_key_for_chimpy');
-      assert.strictEqual(user?.name, 'Chimpy', 'should retrieve Chimpy by their API key');
-      assert.strictEqual(user?.logins?.[0].email, 'chimpy@getgrist.com');
-    });
-
-    it('should return undefined if no user matches the API key', async function () {
-      const user = await db.getUserByKey('non-existing API key');
-      assert.strictEqual(user, undefined);
-    });
-  });
-
-  describe('getUser()', async function () {
-
-    const userWithPrefsEmail = 'userwithprefs@getgrist.com';
-    async function getOrCreateUserWithPrefs() {
-      const user = await db.getUserByLogin(userWithPrefsEmail);
-      if (!user) {
-        throw new Error('getOrCreateUserWithPrefs: User not created!');
-      }
-      return user;
-    }
-
-    it('should retrieve a user by their ID', async function () {
-      const user = await db.getUser(db.getSupportUserId());
-      assertExists(user, 'Should have returned a user');
-      assert.strictEqual(user.name, 'Support');
-      assert.strictEqual(user.loginEmail, SUPPORT_EMAIL);
-      assertExists(!user.prefs, "should not have retrieved user's prefs");
-    });
-
-    it('should retrieve a user along with their prefs with `includePrefs` set to true', async function () {
-      const expectedUser = await getOrCreateUserWithPrefs();
-      const user = await db.getUser(expectedUser.id, {includePrefs: true});
-      assertExists(user, "Should have retrieved the user");
-      assertExists(user.loginEmail);
-      assert.strictEqual(user.loginEmail, expectedUser.loginEmail);
-      assertExists(Array.isArray(user.prefs), "should not have retrieved user's prefs");
-      assert.deepEqual(user.prefs, [{
-        userId: expectedUser.id,
-        orgId: expectedUser.personalOrg.id,
-        prefs: { showGristTour: true } as any
-      }]);
-    });
-  });
-
-  describe('getFullUser()', function () {
-    it('should return the support user', async function () {
-      const supportId = db.getSupportUserId();
-      const user = await db.getFullUser(supportId);
-      const expectedResult: FullUser = {
-        isSupport: true,
-        email: SUPPORT_EMAIL,
-        id: supportId,
-        name: 'Support'
-      };
-      assert.deepInclude(user, expectedResult);
-      assert.ok(!user.anonymous, 'anonymous property should be falsy');
-    });
-
-    it('should return the anonymous user', async function () {
-      const anonId = db.getAnonymousUserId();
-      const user = await db.getFullUser(anonId);
-      const expectedResult: FullUser = {
-        anonymous: true,
-        email: ANONYMOUS_USER_EMAIL,
-        id: anonId,
-        name: 'Anonymous',
-      };
-      assert.deepInclude(user, expectedResult);
-      assert.ok(!user.isSupport, 'support property should be falsy');
-    });
-
-    it('should throw when user is not found', async function () {
-      await assert.isRejected(db.getFullUser(NON_EXISTING_USER_ID), "unable to find user");
-    });
-  });
-
-  describe('makeFullUser()', function () {
-    const someUserDisplayEmail = 'SomeUser@getgrist.com';
-    const normalizedSomeUserEmail = 'someuser@getgrist.com';
-    const someUserLocale = 'en-US';
-    const SOME_USER_ID = 42;
-    const prefWithOrg: Pref = {
-      prefs: {placeholder: 'pref-with-org'},
-      orgId: 43,
-      user: new User(),
-      userId: SOME_USER_ID,
-    };
-    const prefWithoutOrg: Pref = {
-      prefs: {placeholder: 'pref-without-org'},
-      orgId: null,
-      user: new User(),
-      userId: SOME_USER_ID
-    };
-
-
-    function makeSomeUser() {
-      return User.create({
-        id: SOME_USER_ID,
-        ref: 'some ref',
-        name: 'some user',
-        picture: 'https://grist.com/mypic',
-        options: {
-          locale: someUserLocale
-        },
-        logins: [
-          Login.create({
-            userId: SOME_USER_ID,
-            email: normalizedSomeUserEmail,
-            displayEmail: someUserDisplayEmail,
-          }),
-        ],
-        prefs: [
-          prefWithOrg,
-          prefWithoutOrg
-        ]
-      });
-    }
-
-    it('creates a FullUser from a User entity', function () {
-      const input = makeSomeUser();
-      const fullUser = db.makeFullUser(input);
-      assert.deepEqual(fullUser, {
-        id: SOME_USER_ID,
-        email: someUserDisplayEmail,
-        loginEmail: normalizedSomeUserEmail,
-        name: input.name,
-        picture: input.picture,
-        ref: input.ref,
-        locale: someUserLocale,
-        prefs: prefWithoutOrg.prefs
-      });
-    });
-
-    it('sets `anonymous` property to true for anon@getgrist.com', function () {
-      const anon = db.getAnonymousUser();
-      const fullUser = db.makeFullUser(anon);
-      assert.isTrue(fullUser.anonymous, "`anonymous` property should be set to true");
-      assert.ok(!fullUser.isSupport, "`isSupport` should be falsy");
-    });
-
-    it('sets `isSupport` property to true for support account', async function () {
-      const support = await db.getUser(db.getSupportUserId());
-      const fullUser = db.makeFullUser(support!);
-      assert.isTrue(fullUser.isSupport, "`isSupport` property should be set to true");
-      assert.ok(!fullUser.anonymous, "`anonymouse` should be falsy");
-    });
-
-    it('should throw when no displayEmail exist for this user', function () {
-      const input = makeSomeUser();
-      input.logins[0].displayEmail = '';
-      assert.throws(() => db.makeFullUser(input), "unable to find mandatory user email");
-      input.logins = [];
-      assert.throws(() => db.makeFullUser(input), "unable to find mandatory user email");
-    });
-  });
-
-  describe('ensureExternalUser()', function () {
-    let managerSaveSpy: SinonSpy;
-    let userSaveSpy: SinonSpy;
-
-    beforeEach(function () {
-      managerSaveSpy = sandbox.spy(EntityManager.prototype, 'save');
-      userSaveSpy = sandbox.spy(User.prototype, 'save');
-
-    });
+  describe('class method', function () {
+    const NON_EXISTING_USER_ID = 10001337;
+    let env: EnvironmentSnapshot;
+    let db: HomeDBManager;
+    let sandbox: SinonSandbox;
+    const uniqueLocalPart = new Set<string>();
 
     /**
-     * Make a user profile.
-     * @param localPart A unique local part of the email (also used for the other fields).
-     */
-    function makeProfile(localPart: string): UserProfile {
-      ensureUnique(localPart);
-      return {
-        email: makeEmail(localPart),
-        name: `NewUser ${localPart}`,
-        connectId: `ConnectId-${localPart}`,
-        picture: `https://mypic.com/${localPart}.png`
-      };
+    * Works around lacks of type narrowing after asserting the value is defined.
+    * This is fixed in latest versions of @types/chai
+    *
+    * FIXME: once upgrading @types/chai to 4.3.17 or higher, remove this function which would not be usefull anymore
+    */
+    function assertExists<T>(value?: T, message?: string): asserts value is T {
+      assert.exists(value, message);
     }
 
-    async function checkUserInfo(profile: UserProfile) {
-      const user = await db.getExistingUserByLogin(profile.email);
-      assertExists(user, "the new user should be in database");
-      assert.deepInclude(user, {
-        isFirstTimeUser: false,
-        name: profile.name,
-        picture: profile.picture
-      });
-      assert.exists(user.logins?.[0]);
-      assert.deepInclude(user.logins[0], {
-        email: profile.email.toLowerCase(),
-        displayEmail: profile.email
-      });
+    function ensureUnique(localPart: string) {
+      if (uniqueLocalPart.has(localPart)) {
+        throw new Error('passed localPart is already used elsewhere');
+      }
+      uniqueLocalPart.add(localPart);
+      return localPart;
     }
 
-    it('should not do anything if the user already exists and is up to date', async function () {
-      await db.ensureExternalUser({
-        name: 'Chimpy',
-        email: 'chimpy@getgrist.com',
-      });
-      assert.isFalse(userSaveSpy.called, 'user.save() should not have been called');
-      assert.isFalse(managerSaveSpy.called, 'manager.save() should not have been called');
-    });
-
-    it('should save an unknown user', async function () {
-      const profile = makeProfile('ensureExternalUser-saves-an-unknown-user');
-      await db.ensureExternalUser(profile);
-      assert.isTrue(userSaveSpy.called, 'user.save() should have been called');
-      assert.isTrue(managerSaveSpy.called, 'manager.save() should have been called');
-
-      await checkUserInfo(profile);
-    });
-
-    it('should update a user if they already exist in database', async function () {
-      const oldProfile = makeProfile('ensureexternaluser-updates-an-existing-user_old');
-      await db.ensureExternalUser(oldProfile);
-
-      let oldUser = await db.getExistingUserByLogin(oldProfile.email);
-      assertExists(oldUser);
-
-      const newProfile = {
-        ...makeProfile('ensureexternaluser-updates-an-existing-user_new'),
-        connectId: oldProfile.connectId,
-      };
-
-      await db.ensureExternalUser(newProfile);
-      oldUser = await db.getExistingUserByLogin(oldProfile.email);
-      assert.notExists(oldUser, 'we should not retrieve the user given their old email address');
-
-      await checkUserInfo(newProfile);
-    });
-
-    it('should normalize email address', async function() {
-      const profile = makeProfile('ENSUREEXTERNALUSER-NORMALIZES-email-address');
-      await db.ensureExternalUser(profile);
-      await checkUserInfo(profile);
-    });
-  });
-
-  describe('updateUser()', function () {
-    let emitSpy: SinonSpy;
-
-    before(function () {
-      emitSpy = Sinon.spy();
-      db.on('firstLogin', emitSpy);
-    });
-
-    after(function () {
-      db.off('firstLogin', emitSpy);
-    });
-
-    afterEach(function () {
-      emitSpy.resetHistory();
-    });
-
-    function checkNoEventEmitted() {
-      assert.equal(emitSpy.callCount, 0, 'No event should have been emitted');
+    function createUniqueUser(uniqueEmailLocalPart: string) {
+      ensureUnique(uniqueEmailLocalPart);
+      return getOrCreateUser(uniqueEmailLocalPart);
     }
 
-    it('should reject when user is not found', async function () {
-      disableLogging('debug');
-      const promise = db.updateUser(NON_EXISTING_USER_ID, {name: 'foobar'});
-      await assert.isRejected(promise, 'unable to find user');
-    });
-
-    it('should update a user name', async function () {
-      const emailLocalPart = 'updateUser-should-update-user-name';
-      const createdUser = await createUniqueUser(emailLocalPart);
-      assert.equal(createdUser.name, '');
-      const userName = 'user name';
-      await db.updateUser(createdUser.id, {name: userName});
-      checkNoEventEmitted();
-      const updatedUser = await getOrCreateUser(emailLocalPart);
-      assert.equal(updatedUser.name, userName);
-    });
-
-    it('should not emit any event when isFirstTimeUser value has not changed', async function () {
-      const localPart = 'updateuser-should-not-emit-when-isfirsttimeuser-not-changed';
-      const createdUser = await createUniqueUser(localPart);
-      assert.equal(createdUser.isFirstTimeUser, true);
-
-      await db.updateUser(createdUser.id, {isFirstTimeUser: true});
-      checkNoEventEmitted();
-    });
-
-    it('should emit "firstLogin" event when isFirstTimeUser value has been toggled to false', async function () {
-      const localPart = 'updateuser-emits-firstlogin';
-      const userName = 'user name';
-      const newUser = await createUniqueUser(localPart);
-      assert.equal(newUser.isFirstTimeUser, true);
-
-      await db.updateUser(newUser.id, {isFirstTimeUser: false, name: userName});
-      assert.equal(emitSpy.callCount, 1, '"firstLogin" event should have been emitted');
-
-      const fullUserFromEvent = emitSpy.firstCall.args[0];
-      assertExists(fullUserFromEvent, 'a FullUser object should be passed with the "firstLogin" event');
-      assert.equal(fullUserFromEvent.name, userName);
-      assert.equal(fullUserFromEvent.email, makeEmail(localPart));
-
-      const updatedUser = await getOrCreateUser(localPart);
-      assert.equal(updatedUser.isFirstTimeUser, false);
-    });
-  });
-
-  describe('updateUserOptions()', function () {
-    it('should reject when user is not found', async function () {
-      disableLogging('debug');
-      const promise = db.updateUserOptions(NON_EXISTING_USER_ID, {});
-      await assert.isRejected(promise, 'unable to find user');
-    });
-
-    it('should update user options', async function () {
-      const localPart = 'updateuseroptions-updates-user-options';
-      const createdUser = await createUniqueUser(localPart);
-
-      assert.notExists(createdUser.options);
-
-      const options: UserOptions = {locale: 'fr', authSubject: 'subject', isConsultant: true, allowGoogleLogin: true};
-      await db.updateUserOptions(createdUser.id, options);
-
-      const updatedUser = await getOrCreateUser(localPart);
-      assertExists(updatedUser);
-      assertExists(updatedUser.options);
-      assert.deepEqual(updatedUser.options, options);
-    });
-  });
-
-  describe('getExistingUserByLogin()', function () {
-    it('should return an existing user', async function () {
-      const localPart = 'getexistinguserbylogin-returns-existing-user';
-      const createdUser = await createUniqueUser(localPart);
-
-      const retrievedUser = await db.getExistingUserByLogin(createdUser.loginEmail!);
-      assertExists(retrievedUser);
-
-      assert.equal(retrievedUser.id, createdUser.id);
-      assert.equal(retrievedUser.name, createdUser.name);
-    });
-
-    it('should normalize the passed user email', async function () {
-      const localPart = 'getexistinguserbylogin-normalizes-user-email';
-      const newUser = await createUniqueUser(localPart);
-
-      const retrievedUser = await db.getExistingUserByLogin(newUser.loginEmail!.toUpperCase());
-      assertExists(retrievedUser);
-    });
-
-    it('should return undefined when the user is not found', async function () {
-      const nonExistingEmail = 'i-dont-exist@getgrist.com';
-      const retrievedUser = await db.getExistingUserByLogin(nonExistingEmail);
-      assert.isUndefined(retrievedUser);
-    });
-  });
-
-  describe('getUserByLogin()', function () {
-    it('should create a user when none exist with the corresponding email', async function () {
-      const localPart = ensureUnique('getuserbylogin-creates-user-when-not-already-exists');
-      const email = makeEmail(localPart);
-      sandbox.useFakeTimers(42_000);
-      assert.notExists(await db.getExistingUserByLogin(email));
-
-      const user = await db.getUserByLogin(makeEmail(localPart.toUpperCase()));
-
-      assert.isTrue(user.isFirstTimeUser, 'should be marked as first time user');
-      assert.equal(user.loginEmail, email);
-      assert.equal(user.logins[0].displayEmail, makeEmail(localPart.toUpperCase()));
-      assert.equal(user.name, '');
-      // FIXME: why is user.lastConnectionAt actually a string and not a Date?
-      // FIXME: why is user.lastConnectionAt updated here and ont firstLoginAt?
-      assert.equal(String(user.lastConnectionAt), '1970-01-01 00:00:42.000');
-    });
-
-    it('should create a personnal organization for the new user', async function () {
-      const localPart = ensureUnique('getuserbylogin-creates-personnal-org');
-
-      const user = await db.getUserByLogin(makeEmail(localPart));
-
-      const org = await getPersonalOrg(user);
-      assertExists(org.data, 'should have retrieved personnal org data');
-      assert.equal(org.data.name, 'Personal');
-    });
-
-    it('should not create organizations for non-login emails', async function () {
-      const user = await db.getUserByLogin(EVERYONE_EMAIL);
-      assert.notOk(user.personalOrg);
-    });
-
-    it('should not update user information when no profile is passed', async function () {
-      const localPart = ensureUnique('getuserbylogin-does-not-update-without-profile');
-      const userFirstCall = await db.getUserByLogin(makeEmail(localPart));
-      const userSecondCall = await db.getUserByLogin(makeEmail(localPart));
-      assert.deepEqual(userFirstCall, userSecondCall);
-    });
-
-    // FIXME: why using Sinon.useFakeTimers() makes user.lastConnectionAt a string instead of a Date
-    it.skip('should update lastConnectionAt only for different days', async function () {
-      const fakeTimer = sandbox.useFakeTimers(0);
-      const localPart = ensureUnique('getuserbylogin-updates-last_connection_at-for-different-days');
-      let user = await db.getUserByLogin(makeEmail(localPart));
-      const epochDateTime = '1970-01-01 00:00:00.000';
-      assert.equal(String(user.lastConnectionAt), epochDateTime);
-
-      await fakeTimer.tickAsync(42_000);
-      user = await db.getUserByLogin(makeEmail(localPart));
-      assert.equal(String(user.lastConnectionAt), epochDateTime);
-
-      await fakeTimer.tickAsync('1d');
-      user = await db.getUserByLogin(makeEmail(localPart));
-      assert.match(String(user.lastConnectionAt), /^1970-01-02/);
-    });
-
-    describe('when passing information to update (using `profile`)', function () {
-      const makeProfile = (newEmail: string): UserProfile => ({
-        name: 'my user name',
-        email: newEmail,
-        picture: 'https://mypic.com/foo.png',
-        connectId: 'new-connect-id',
-      });
-
-      it('should populate the firstTimeLogin and deduce the name from the email', async function () {
-        sandbox.useFakeTimers(42_000);
-        const localPart = ensureUnique('getuserbylogin-with-profile-populates-first_time_login-and-name');
-        const user = await db.getUserByLogin(makeEmail(localPart), {profile: {name: '', email: makeEmail(localPart)}});
-        assert.equal(user.name, localPart);
-        // FIXME: why using Sinon.useFakeTimers() makes user.firstLoginAt a string instead of a Date
-        assert.equal(String(user.firstLoginAt), '1970-01-01 00:00:42.000');
-      });
-
-      it('should populate user with any passed information', async function () {
-        const localPart = ensureUnique('getuserbylogin-with-profile-populates-user-with-passed-info_OLD');
-        await db.getUserByLogin(makeEmail(localPart));
-
-        const profile = makeProfile(makeEmail('getuserbylogin-with-profile-populates-user-with-passed-info_NEW'));
-        const userOptions: UserOptions = {authSubject: 'my-auth-subject'};
-
-        const updatedUser = await db.getUserByLogin(makeEmail(localPart), { profile, userOptions });
-        assert.deepInclude(updatedUser, {
-          name: profile.name,
-          connectId: profile.connectId,
-          picture: profile.picture,
-        });
-        assert.deepInclude(updatedUser.logins[0], {
-          displayEmail: profile.email,
-        });
-        assert.deepInclude(updatedUser.options, {
-          authSubject: userOptions.authSubject,
-        });
-      });
-    });
-  });
-
-  describe('getUserByLoginWithRetry()', async function () {
-    async function ensureGetUserByLoginWithRetryWorks(localPart: string) {
-      const email = makeEmail(localPart);
-      const user = await db.getUserByLoginWithRetry(email);
-      assertExists(user);
-      assert.equal(user.loginEmail, email);
+    async function getOrCreateUser(localPart: string, options?: GetUserOptions) {
+      return db.getUserByLogin(makeEmail(localPart), options);
     }
 
-    function makeQueryFailedError() {
-      const error = new Error() as any;
-      error.name = 'QueryFailedError';
-      error.detail = 'Key (email)=whatever@getgrist.com already exists';
-      return error;
+    function makeEmail(localPart: string) {
+      return localPart + '@getgrist.com';
     }
 
-    it('should work just like getUserByLogin', async function () {
-      await ensureGetUserByLoginWithRetryWorks( ensureUnique('getuserbyloginwithretry-works-like-getuserbylogin'));
-    });
-
-    it('should make a second attempt on special error', async function () {
-      sandbox.stub(UsersManager.prototype, 'getUserByLogin')
-        .onFirstCall().throws(makeQueryFailedError())
-        .callThrough();
-      await ensureGetUserByLoginWithRetryWorks( 'getuserbyloginwithretry-makes-a-single-retry');
-    });
-
-    it('should reject after 2 attempts', async function () {
-      const secondError = makeQueryFailedError();
-      sandbox.stub(UsersManager.prototype, 'getUserByLogin')
-        .onFirstCall().throws(makeQueryFailedError())
-        .onSecondCall().throws(secondError)
-        .callThrough();
-
-      const email = makeEmail(ensureUnique('getuserbyloginwithretry-rejects-after-2-attempts'));
-      const promise = db.getUserByLoginWithRetry(email);
-      await assert.isRejected(promise);
-      await promise.catch(err => assert.equal(err, secondError));
-    });
-
-    it('should reject immediately if the error is not a QueryFailedError', async function () {
-      const errorMsg = 'my error';
-      sandbox.stub(UsersManager.prototype, 'getUserByLogin')
-        .rejects(new Error(errorMsg))
-        .callThrough();
-
-      const email = makeEmail(ensureUnique('getuserbyloginwithretry-rejects-immediately-when-not-queryfailederror'));
-      const promise = db.getUserByLoginWithRetry(email);
-      await assert.isRejected(promise, errorMsg);
-    });
-  });
-
-  describe('deleteUser()', function () {
-    function userHasPrefs(userId: number, manager: EntityManager) {
-      return manager.exists(Pref, { where: { userId: userId }});
+    async function getPersonalOrg(user: User) {
+      return db.getOrg({userId: user.id}, user.personalOrg.id);
     }
 
-    function userHasGroupUsers(userId: number, manager: EntityManager) {
-      return manager.exists('group_users', { where: {user_id: userId} });
-    }
-
-    it('should refuse to delete the account of someone else', async function () {
-      const localPart = ensureUnique('deleteuser-refuses-for-someone-else');
-      const userToDelete = await getOrCreateUser(localPart);
-
-      const promise = db.deleteUser({userId: 2}, userToDelete.id);
-      await assert.isRejected(promise, 'not permitted to delete this user');
-    });
-
-    it('should refuse to delete a non existing account', async function () {
-      disableLogging('debug');
-      const promise = db.deleteUser({userId: NON_EXISTING_USER_ID}, NON_EXISTING_USER_ID);
-      await assert.isRejected(promise, 'user not found');
-    });
-
-    it('should refuse to delete the account if the passed name is not matching', async function () {
-      disableLogging('debug');
-      const localPart = ensureUnique('deleteuser-refuses-if-name-not-matching');
-      const userToDelete = await getOrCreateUser(localPart, {
-        profile: {
-          name: 'someone to delete',
-          email: makeEmail(localPart),
-        }
-      });
-
-      const promise = db.deleteUser({userId: userToDelete.id}, userToDelete.id, 'wrong name');
-
-      await assert.isRejected(promise);
-      await promise.catch(e => assert.match(e.message, /user name did not match/));
-    });
-
-    it('should remove the user and cleanup their info and personal organization', async function () {
-      const localPart = ensureUnique('deleteuser-removes-user-and-cleanups-info');
-      const userToDelete = await getOrCreateUser(localPart, {
-        profile: {
-          name: 'someone to delete',
-          email: makeEmail(localPart),
-        }
-      });
-
-      assertExists(await getPersonalOrg(userToDelete));
-
-      await db.connection.transaction(async (manager) => {
-        assert.isTrue(await userHasGroupUsers(userToDelete.id, manager));
-        assert.isTrue(await userHasPrefs(userToDelete.id, manager));
-      });
-
-      await db.deleteUser({userId: userToDelete.id}, userToDelete.id);
-
-      assert.notExists(await db.getUser(userToDelete.id));
-      assert.deepEqual(await getPersonalOrg(userToDelete), { errMessage: 'organization not found', status: 404 });
-
-      await db.connection.transaction(async (manager) => {
-        assert.isFalse(await userHasGroupUsers(userToDelete.id, manager));
-        assert.isFalse(await userHasPrefs(userToDelete.id, manager));
-      });
-    });
-
-    it("should remove the user when passed name corresponds to the user's name", async function () {
-      const localPart = ensureUnique('deleteuser-removes-user-when-name-matches');
-      const userName = 'someone to delete';
-      const userToDelete = await getOrCreateUser(localPart, {
-        profile: {
-          name: userName,
-          email: makeEmail(localPart),
-        }
-      });
-      const promise = db.deleteUser({userId: userToDelete.id}, userToDelete.id, userName);
-      await assert.isFulfilled(promise);
-    });
-  });
-
-  describe('initializeSpecialIds()', function () {
     async function withDataBase(dbName: string, cb: (db: HomeDBManager) => Promise<void>) {
-      // await prepareDatabase(tmpDir, dbName);
-      const database = path.join(tmpDir, dbName);
+      const database = path.join(tmpDir, dbName + '.db');
       const localDb = new HomeDBManager();
-      await localDb.createNewConnection({ name: 'special-id', database });
+      await localDb.createNewConnection({ name: dbName, database });
       await updateDb(localDb.connection);
       try {
         await cb(localDb);
       } finally {
         await localDb.connection.destroy();
+        // HACK: This is a weird case, we have established a different connection
+        // but the existing connection is also impacted.
+        // A found workaround consist in destroying and creating again the connection.
+        //
+        // TODO: Check whether using DataSource would help and avoid this hack.
+        await db.connection.destroy();
+        await db.createNewConnection();
       }
     }
 
-    after(async function () {
-      // HACK: This is a weird case, we have established a different connection
-      // but the existing connection is also impacted.
-      // A found workaround consist in destroying and creating again the connection.
-      //
-      // TODO: Check whether using DataSource would help and avoid this hack.
-      await db.connection.destroy();
-      await db.createNewConnection();
+    function disableLoggingLevel<T extends keyof winston.LoggerInstance>(method: T) {
+      return sandbox.stub(log, method);
+    }
+
+    before(async function () {
+      env = new EnvironmentSnapshot();
+      await prepareFilesystemDirectoryForTests(tmpDir);
+      await prepareDatabase(tmpDir);
+      db = await getDatabase();
     });
 
-    it('should initialize special ids', async function () {
-      return withDataBase('test-special-ids.db', async (localDb) => {
-        const specialAccounts = [
-          {name: "Support", email: SUPPORT_EMAIL},
-          {name: "Anonymous", email: ANONYMOUS_USER_EMAIL},
-          {name: "Preview", email: PREVIEWER_EMAIL},
-          {name: "Everyone", email: EVERYONE_EMAIL}
-        ];
-        for (const {email} of specialAccounts) {
-          assert.notExists(await localDb.getExistingUserByLogin(email));
-        }
-        await localDb.initializeSpecialIds();
-        for (const {name, email} of specialAccounts) {
-          const res = await localDb.getExistingUserByLogin(email);
-          assertExists(res);
-          assert.equal(res.name, name);
-        }
+    after(async function () {
+      env.restore();
+    });
+
+    beforeEach(function () {
+      sandbox = Sinon.createSandbox();
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    describe('Special User Ids', function () {
+      const ANONYMOUS_USER_ID = 6;
+      const PREVIEWER_USER_ID = 7;
+      const EVERYONE_USER_ID = 8;
+      const SUPPORT_USER_ID = 5;
+      it('getAnonymousUserId() should retrieve anonymous user id', function () {
+        assert.strictEqual(db.getAnonymousUserId(), ANONYMOUS_USER_ID);
+      });
+
+      it('getPreviewerUserId() should retrieve previewer user id', function () {
+        assert.strictEqual(db.getPreviewerUserId(), PREVIEWER_USER_ID);
+      });
+
+      it("getEveryoneUserId() should retrieve 'everyone' user id", function () {
+        assert.strictEqual(db.getEveryoneUserId(), EVERYONE_USER_ID);
+      });
+
+      it("getSupportUserId() should retrieve 'support' user id", function () {
+        assert.strictEqual(db.getSupportUserId(), SUPPORT_USER_ID);
+      });
+
+      describe('Without special id initialization', function () {
+        it('should throw an error', async function () {
+          await withDataBase('without-special-ids', async function (localDb) {
+            assert.throws(() => localDb.getAnonymousUserId(), "Anonymous user not available");
+            assert.throws(() => localDb.getPreviewerUserId(), "Previewer user not available");
+            assert.throws(() => localDb.getEveryoneUserId(), "'everyone' user not available");
+            assert.throws(() => localDb.getSupportUserId(), "'support' user not available");
+          });
+        });
       });
     });
-  });
 
-  describe('completeProfiles()', function () {
-    it('should return an empty array if no profiles are provided', async function () {
-      const res = await db.completeProfiles([]);
-      assert.deepEqual(res, []);
+    describe('getUserByKey()', function () {
+      it('should return the user given their API Key', async function () {
+        const user = await db.getUserByKey('api_key_for_chimpy');
+
+        assert.strictEqual(user?.name, 'Chimpy', 'should retrieve Chimpy by their API key');
+        assert.strictEqual(user?.logins?.[0].email, 'chimpy@getgrist.com');
+      });
+
+      it('should return undefined if no user matches the API key', async function () {
+        const user = await db.getUserByKey('non-existing API key');
+
+        assert.strictEqual(user, undefined);
+      });
     });
 
-    it("should complete a single user profile with looking by normalized address", async function () {
-      const localPart = ensureUnique('completeprofiles-with-single-profile');
-      const email = makeEmail(localPart);
-      const profile = {
-        name: 'complete-profile-email-normalized-user',
-        email: makeEmail(localPart),
-        picture: 'https://mypic.com/me.png',
+    describe('getUser()', async function () {
+      it('should retrieve a user by their ID', async function () {
+        const user = await db.getUser(db.getSupportUserId());
+        assertExists(user, 'Should have returned a user');
+        assert.strictEqual(user.name, 'Support');
+        assert.strictEqual(user.loginEmail, SUPPORT_EMAIL);
+        assertExists(!user.prefs, "should not have retrieved user's prefs");
+      });
+
+      it('should retrieve a user along with their prefs with `includePrefs` set to true', async function () {
+        const expectedUser = await createUniqueUser('getuser-userwithprefs');
+        const user = await db.getUser(expectedUser.id, {includePrefs: true});
+        assertExists(user, "Should have retrieved the user");
+        assertExists(user.loginEmail);
+        assert.strictEqual(user.loginEmail, expectedUser.loginEmail);
+        assertExists(Array.isArray(user.prefs), "should not have retrieved user's prefs");
+        assert.deepEqual(user.prefs, [{
+          userId: expectedUser.id,
+          orgId: expectedUser.personalOrg.id,
+          prefs: { showGristTour: true } as any
+        }]);
+      });
+    });
+
+    describe('getFullUser()', function () {
+      it('should return the support user', async function () {
+        const supportId = db.getSupportUserId();
+
+        const user = await db.getFullUser(supportId);
+
+        const expectedResult: FullUser = {
+          isSupport: true,
+          email: SUPPORT_EMAIL,
+          id: supportId,
+          name: 'Support'
+        };
+        assert.deepInclude(user, expectedResult);
+        assert.ok(!user.anonymous, 'anonymous property should be falsy');
+      });
+
+      it('should return the anonymous user', async function () {
+        const anonId = db.getAnonymousUserId();
+
+        const user = await db.getFullUser(anonId);
+
+        const expectedResult: FullUser = {
+          anonymous: true,
+          email: ANONYMOUS_USER_EMAIL,
+          id: anonId,
+          name: 'Anonymous',
+        };
+        assert.deepInclude(user, expectedResult);
+        assert.ok(!user.isSupport, 'support property should be falsy');
+      });
+
+      it('should throw when user is not found', async function () {
+        await assert.isRejected(db.getFullUser(NON_EXISTING_USER_ID), "unable to find user");
+      });
+    });
+
+    describe('makeFullUser()', function () {
+      const someUserDisplayEmail = 'SomeUser@getgrist.com';
+      const normalizedSomeUserEmail = 'someuser@getgrist.com';
+      const someUserLocale = 'en-US';
+      const SOME_USER_ID = 42;
+      const prefWithOrg: Pref = {
+        prefs: {placeholder: 'pref-with-org'},
+        orgId: 43,
+        user: new User(),
+        userId: SOME_USER_ID,
       };
-      const someLocale = 'fr-FR';
-      const userCreated = await getOrCreateUser(localPart, { profile });
-      await db.updateUserOptions(userCreated.id, {locale: someLocale});
+      const prefWithoutOrg: Pref = {
+        prefs: {placeholder: 'pref-without-org'},
+        orgId: null,
+        user: new User(),
+        userId: SOME_USER_ID
+      };
 
-      const res = await db.completeProfiles([{name: 'whatever', email: email.toUpperCase()}]);
 
-      assert.deepEqual(res, [{
-        ...profile,
-        id: userCreated.id,
-        locale: someLocale,
-        anonymous: false
-      }]);
-    });
-
-    it('should complete several user profiles', async function () {
-      const localPartPrefix = ensureUnique('completeprofiles-with-several-profiles');
-      const seq = Array(10).fill(null).map((_, i) => i+1);
-      const localParts = seq.map(i => `${localPartPrefix}_${i}`);
-      const usersCreated = await Promise.all(
-        localParts.map(localPart => getOrCreateUser(localPart))
-      );
-
-      const res = await db.completeProfiles(
-        localParts.map(
-          localPart => ({name: 'whatever', email: makeEmail(localPart)})
-        )
-      );
-      assert.lengthOf(res, localParts.length);
-      for (const [index, localPart] of localParts.entries()) {
-        assert.deepInclude(res[index], {
-          id: usersCreated[index].id,
-          email: makeEmail(localPart),
+      function makeSomeUser() {
+        return User.create({
+          id: SOME_USER_ID,
+          ref: 'some ref',
+          name: 'some user',
+          picture: 'https://grist.com/mypic',
+          options: {
+            locale: someUserLocale
+          },
+          logins: [
+            Login.create({
+              userId: SOME_USER_ID,
+              email: normalizedSomeUserEmail,
+              displayEmail: someUserDisplayEmail,
+            }),
+          ],
+          prefs: [
+            prefWithOrg,
+            prefWithoutOrg
+          ]
         });
       }
+
+      it('creates a FullUser from a User entity', function () {
+        const input = makeSomeUser();
+
+        const fullUser = db.makeFullUser(input);
+
+        assert.deepEqual(fullUser, {
+          id: SOME_USER_ID,
+          email: someUserDisplayEmail,
+          loginEmail: normalizedSomeUserEmail,
+          name: input.name,
+          picture: input.picture,
+          ref: input.ref,
+          locale: someUserLocale,
+          prefs: prefWithoutOrg.prefs
+        });
+      });
+
+      it('sets `anonymous` property to true for anon@getgrist.com', function () {
+        const anon = db.getAnonymousUser();
+
+        const fullUser = db.makeFullUser(anon);
+
+        assert.isTrue(fullUser.anonymous, "`anonymous` property should be set to true");
+        assert.ok(!fullUser.isSupport, "`isSupport` should be falsy");
+      });
+
+      it('sets `isSupport` property to true for support account', async function () {
+        const support = await db.getUser(db.getSupportUserId());
+
+        const fullUser = db.makeFullUser(support!);
+
+        assert.isTrue(fullUser.isSupport, "`isSupport` property should be set to true");
+        assert.ok(!fullUser.anonymous, "`anonymouse` should be falsy");
+      });
+
+      it('should throw when no displayEmail exist for this user', function () {
+        const input = makeSomeUser();
+        input.logins[0].displayEmail = '';
+
+        assert.throws(() => db.makeFullUser(input), "unable to find mandatory user email");
+
+        input.logins = [];
+        assert.throws(() => db.makeFullUser(input), "unable to find mandatory user email");
+      });
+    });
+
+    describe('ensureExternalUser()', function () {
+      let managerSaveSpy: SinonSpy;
+      let userSaveSpy: SinonSpy;
+
+      beforeEach(function () {
+        managerSaveSpy = sandbox.spy(EntityManager.prototype, 'save');
+        userSaveSpy = sandbox.spy(User.prototype, 'save');
+      });
+
+      /**
+      * Make a user profile.
+      * @param localPart A unique local part of the email (also used for the other fields).
+      */
+      function makeProfile(localPart: string): UserProfile {
+        ensureUnique(localPart);
+        return {
+          email: makeEmail(localPart),
+          name: `NewUser ${localPart}`,
+          connectId: `ConnectId-${localPart}`,
+          picture: `https://mypic.com/${localPart}.png`
+        };
+      }
+
+      async function checkUserInfo(profile: UserProfile) {
+        const user = await db.getExistingUserByLogin(profile.email);
+        assertExists(user, "the new user should be in database");
+        assert.deepInclude(user, {
+          isFirstTimeUser: false,
+          name: profile.name,
+          picture: profile.picture
+        });
+        assert.exists(user.logins?.[0]);
+        assert.deepInclude(user.logins[0], {
+          email: profile.email.toLowerCase(),
+          displayEmail: profile.email
+        });
+        return user;
+      }
+
+      it('should not do anything if the user already exists and is up to date', async function () {
+        await db.ensureExternalUser({
+          name: 'Chimpy',
+          email: 'chimpy@getgrist.com',
+        });
+
+        assert.isFalse(userSaveSpy.called, 'user.save() should not have been called');
+        assert.isFalse(managerSaveSpy.called, 'manager.save() should not have been called');
+      });
+
+      it('should save an unknown user', async function () {
+        const profile = makeProfile('ensureExternalUser-saves-an-unknown-user');
+        await db.ensureExternalUser(profile);
+        assert.isTrue(userSaveSpy.called, 'user.save() should have been called');
+        assert.isTrue(managerSaveSpy.called, 'manager.save() should have been called');
+
+        await checkUserInfo(profile);
+      });
+
+      it('should update a user if they already exist in database', async function () {
+        const oldProfile = makeProfile('ensureexternaluser-updates-an-existing-user_old');
+
+        await db.ensureExternalUser(oldProfile);
+
+        let oldUser = await db.getExistingUserByLogin(oldProfile.email);
+        assertExists(oldUser);
+
+        const newProfile = {
+          ...makeProfile('ensureexternaluser-updates-an-existing-user_new'),
+          connectId: oldProfile.connectId,
+        };
+
+        await db.ensureExternalUser(newProfile);
+
+        oldUser = await db.getExistingUserByLogin(oldProfile.email);
+        assert.notExists(oldUser, 'we should not retrieve the user given their old email address');
+
+        await checkUserInfo(newProfile);
+      });
+
+      it('should normalize email address', async function() {
+        const profile = makeProfile('ENSUREEXTERNALUSER-NORMALIZES-email-address');
+
+        await db.ensureExternalUser(profile);
+
+        const user = await checkUserInfo(profile);
+        assert.equal(user.logins[0].email, profile.email.toLowerCase(), 'the email should be lowercase');
+        assert.equal(user.logins[0].displayEmail, profile.email, 'the display email should keep the original case');
+      });
+    });
+
+    describe('updateUser()', function () {
+      let emitSpy: SinonSpy;
+
+      before(function () {
+        emitSpy = Sinon.spy();
+        db.on('firstLogin', emitSpy);
+      });
+
+      after(function () {
+        db.off('firstLogin', emitSpy);
+      });
+
+      afterEach(function () {
+        emitSpy.resetHistory();
+      });
+
+      function checkNoEventEmitted() {
+        assert.equal(emitSpy.callCount, 0, 'No event should have been emitted');
+      }
+
+      it('should reject when user is not found', async function () {
+        disableLoggingLevel('debug');
+
+        const promise = db.updateUser(NON_EXISTING_USER_ID, {name: 'foobar'});
+
+        await assert.isRejected(promise, 'unable to find user');
+        checkNoEventEmitted();
+      });
+
+      it('should update a user name', async function () {
+        const emailLocalPart = 'updateUser-should-update-user-name';
+        const createdUser = await createUniqueUser(emailLocalPart);
+        assert.equal(createdUser.name, '');
+        const userName = 'user name';
+
+        await db.updateUser(createdUser.id, {name: userName});
+
+        checkNoEventEmitted();
+        const updatedUser = await getOrCreateUser(emailLocalPart);
+        assert.equal(updatedUser.name, userName);
+      });
+
+      it('should not emit any event when isFirstTimeUser value has not changed', async function () {
+        const localPart = 'updateuser-should-not-emit-when-isfirsttimeuser-not-changed';
+        const createdUser = await createUniqueUser(localPart);
+        assert.equal(createdUser.isFirstTimeUser, true);
+
+        await db.updateUser(createdUser.id, {isFirstTimeUser: true});
+
+        checkNoEventEmitted();
+      });
+
+      it('should emit "firstLogin" event when isFirstTimeUser value has been toggled to false', async function () {
+        const localPart = 'updateuser-emits-firstlogin';
+        const userName = 'user name';
+        const newUser = await createUniqueUser(localPart);
+        assert.equal(newUser.isFirstTimeUser, true);
+
+        await db.updateUser(newUser.id, {isFirstTimeUser: false, name: userName});
+        assert.equal(emitSpy.callCount, 1, '"firstLogin" event should have been emitted');
+
+        const fullUserFromEvent = emitSpy.firstCall.args[0];
+        assertExists(fullUserFromEvent, 'a FullUser object should be passed with the "firstLogin" event');
+        assert.equal(fullUserFromEvent.name, userName);
+        assert.equal(fullUserFromEvent.email, makeEmail(localPart));
+
+        const updatedUser = await getOrCreateUser(localPart);
+        assert.equal(updatedUser.isFirstTimeUser, false, 'the user is not considered as being first time user anymore');
+      });
+    });
+
+    describe('updateUserOptions()', function () {
+      it('should reject when user is not found', async function () {
+        disableLoggingLevel('debug');
+
+        const promise = db.updateUserOptions(NON_EXISTING_USER_ID, {});
+
+        await assert.isRejected(promise, 'unable to find user');
+      });
+
+      it('should update user options', async function () {
+        const localPart = 'updateuseroptions-updates-user-options';
+        const createdUser = await createUniqueUser(localPart);
+
+        assert.notExists(createdUser.options);
+
+        const options: UserOptions = {locale: 'fr', authSubject: 'subject', isConsultant: true, allowGoogleLogin: true};
+        await db.updateUserOptions(createdUser.id, options);
+
+        const updatedUser = await getOrCreateUser(localPart);
+        assertExists(updatedUser);
+        assertExists(updatedUser.options);
+        assert.deepEqual(updatedUser.options, options);
+      });
+    });
+
+    describe('getExistingUserByLogin()', function () {
+      it('should return an existing user', async function () {
+        const localPart = 'getexistinguserbylogin-returns-existing-user';
+        const createdUser = await createUniqueUser(localPart);
+
+        const retrievedUser = await db.getExistingUserByLogin(createdUser.loginEmail!);
+        assertExists(retrievedUser);
+
+        assert.equal(retrievedUser.id, createdUser.id);
+        assert.equal(retrievedUser.name, createdUser.name);
+      });
+
+      it('should normalize the passed user email', async function () {
+        const localPart = 'getexistinguserbylogin-normalizes-user-email';
+        const newUser = await createUniqueUser(localPart);
+
+        const retrievedUser = await db.getExistingUserByLogin(newUser.loginEmail!.toUpperCase());
+
+        assertExists(retrievedUser);
+      });
+
+      it('should return undefined when the user is not found', async function () {
+        const nonExistingEmail = 'i-dont-exist@getgrist.com';
+
+        const retrievedUser = await db.getExistingUserByLogin(nonExistingEmail);
+
+        assert.isUndefined(retrievedUser);
+      });
+    });
+
+    describe('getUserByLogin()', function () {
+      it('should create a user when none exist with the corresponding email', async function () {
+        const localPart = ensureUnique('getuserbylogin-creates-user-when-not-already-exists');
+        const email = makeEmail(localPart);
+        sandbox.useFakeTimers(42_000);
+        assert.notExists(await db.getExistingUserByLogin(email));
+
+        const user = await db.getUserByLogin(makeEmail(localPart.toUpperCase()));
+
+        assert.isTrue(user.isFirstTimeUser, 'should be marked as first time user');
+        assert.equal(user.loginEmail, email);
+        assert.equal(user.logins[0].displayEmail, makeEmail(localPart.toUpperCase()));
+        assert.equal(user.name, '');
+        // FIXME: why is user.lastConnectionAt actually a string and not a Date?
+        // FIXME: is it consistent that user.lastConnectionAt updated here and not firstLoginAt?
+        assert.equal(String(user.lastConnectionAt), '1970-01-01 00:00:42.000');
+      });
+
+      it('should create a personnal organization for the new user', async function () {
+        const localPart = ensureUnique('getuserbylogin-creates-personnal-org');
+
+        const user = await db.getUserByLogin(makeEmail(localPart));
+
+        const org = await getPersonalOrg(user);
+        assertExists(org.data, 'should have retrieved personnal org data');
+        assert.equal(org.data.name, 'Personal');
+      });
+
+      it('should not create organizations for non-login emails', async function () {
+        const user = await db.getUserByLogin(EVERYONE_EMAIL);
+        assert.notExists(user.personalOrg);
+      });
+
+      it('should not update user information when no profile is passed', async function () {
+        const localPart = ensureUnique('getuserbylogin-does-not-update-without-profile');
+
+        const userFirstCall = await db.getUserByLogin(makeEmail(localPart));
+        const userSecondCall = await db.getUserByLogin(makeEmail(localPart));
+
+        assert.deepEqual(userFirstCall, userSecondCall);
+      });
+
+      // FIXME: why using Sinon.useFakeTimers() makes user.lastConnectionAt a string instead of a Date
+      it.skip('should update lastConnectionAt only for different days', async function () {
+        const fakeTimer = sandbox.useFakeTimers(0);
+        const localPart = ensureUnique('getuserbylogin-updates-last_connection_at-for-different-days');
+        let user = await db.getUserByLogin(makeEmail(localPart));
+        const epochDateTime = '1970-01-01 00:00:00.000';
+        assert.equal(String(user.lastConnectionAt), epochDateTime);
+
+        await fakeTimer.tickAsync(42_000);
+        user = await db.getUserByLogin(makeEmail(localPart));
+        assert.equal(String(user.lastConnectionAt), epochDateTime);
+
+        await fakeTimer.tickAsync('1d');
+        user = await db.getUserByLogin(makeEmail(localPart));
+        assert.match(String(user.lastConnectionAt), /^1970-01-02/);
+      });
+
+      describe('when passing information to update (using `profile`)', function () {
+        const makeProfile = (newEmail: string): UserProfile => ({
+          name: 'my user name',
+          email: newEmail,
+          picture: 'https://mypic.com/foo.png',
+          connectId: 'new-connect-id',
+        });
+
+        it('should populate the firstTimeLogin and deduce the name from the email', async function () {
+          sandbox.useFakeTimers(42_000);
+          const localPart = ensureUnique('getuserbylogin-with-profile-populates-first_time_login-and-name');
+          const user = await db.getUserByLogin(makeEmail(localPart), {
+            profile: {name: '', email: makeEmail(localPart)}
+          });
+          assert.equal(user.name, localPart);
+          // FIXME: why using Sinon.useFakeTimers() makes user.firstLoginAt a string instead of a Date
+          assert.equal(String(user.firstLoginAt), '1970-01-01 00:00:42.000');
+        });
+
+        it('should populate user with any passed information', async function () {
+          const localPart = ensureUnique('getuserbylogin-with-profile-populates-user-with-passed-info_OLD');
+          await db.getUserByLogin(makeEmail(localPart));
+
+          const profile = makeProfile(makeEmail('getuserbylogin-with-profile-populates-user-with-passed-info_NEW'));
+          const userOptions: UserOptions = {authSubject: 'my-auth-subject'};
+
+          const updatedUser = await db.getUserByLogin(makeEmail(localPart), { profile, userOptions });
+          assert.deepInclude(updatedUser, {
+            name: profile.name,
+            connectId: profile.connectId,
+            picture: profile.picture,
+          });
+          assert.deepInclude(updatedUser.logins[0], {
+            displayEmail: profile.email,
+          });
+          assert.deepInclude(updatedUser.options, {
+            authSubject: userOptions.authSubject,
+          });
+        });
+      });
+    });
+
+    describe('getUserByLoginWithRetry()', async function () {
+      async function ensureGetUserByLoginWithRetryWorks(localPart: string) {
+        const email = makeEmail(localPart);
+        const user = await db.getUserByLoginWithRetry(email);
+        assertExists(user);
+        assert.equal(user.loginEmail, email);
+      }
+
+      function makeQueryFailedError() {
+        const error = new Error() as any;
+        error.name = 'QueryFailedError';
+        error.detail = 'Key (email)=whatever@getgrist.com already exists';
+        return error;
+      }
+
+      it('should work just like getUserByLogin', async function () {
+        await ensureGetUserByLoginWithRetryWorks( ensureUnique('getuserbyloginwithretry-works-like-getuserbylogin'));
+      });
+
+      it('should make a second attempt on special error', async function () {
+        sandbox.stub(UsersManager.prototype, 'getUserByLogin')
+          .onFirstCall().throws(makeQueryFailedError())
+          .callThrough();
+        await ensureGetUserByLoginWithRetryWorks( 'getuserbyloginwithretry-makes-a-single-retry');
+      });
+
+      it('should reject after 2 attempts', async function () {
+        const secondError = makeQueryFailedError();
+        sandbox.stub(UsersManager.prototype, 'getUserByLogin')
+          .onFirstCall().throws(makeQueryFailedError())
+          .onSecondCall().throws(secondError)
+          .callThrough();
+
+        const email = makeEmail(ensureUnique('getuserbyloginwithretry-rejects-after-2-attempts'));
+        const promise = db.getUserByLoginWithRetry(email);
+        await assert.isRejected(promise);
+        await promise.catch(err => assert.equal(err, secondError));
+      });
+
+      it('should reject immediately if the error is not a QueryFailedError', async function () {
+        const errorMsg = 'my error';
+        sandbox.stub(UsersManager.prototype, 'getUserByLogin')
+          .rejects(new Error(errorMsg))
+          .callThrough();
+
+        const email = makeEmail(ensureUnique('getuserbyloginwithretry-rejects-immediately-when-not-queryfailederror'));
+        const promise = db.getUserByLoginWithRetry(email);
+        await assert.isRejected(promise, errorMsg);
+      });
+    });
+
+    describe('deleteUser()', function () {
+      function userHasPrefs(userId: number, manager: EntityManager) {
+        return manager.exists(Pref, { where: { userId: userId }});
+      }
+
+      function userHasGroupUsers(userId: number, manager: EntityManager) {
+        return manager.exists('group_users', { where: {user_id: userId} });
+      }
+
+      it('should refuse to delete the account of someone else', async function () {
+        const localPart = ensureUnique('deleteuser-refuses-for-someone-else');
+        const userToDelete = await getOrCreateUser(localPart);
+
+        const promise = db.deleteUser({userId: 2}, userToDelete.id);
+
+        await assert.isRejected(promise, 'not permitted to delete this user');
+      });
+
+      it('should refuse to delete a non existing account', async function () {
+        disableLoggingLevel('debug');
+
+        const promise = db.deleteUser({userId: NON_EXISTING_USER_ID}, NON_EXISTING_USER_ID);
+
+        await assert.isRejected(promise, 'user not found');
+      });
+
+      it('should refuse to delete the account if the passed name is not matching', async function () {
+        disableLoggingLevel('debug');
+        const localPart = ensureUnique('deleteuser-refuses-if-name-not-matching');
+        const userToDelete = await getOrCreateUser(localPart, {
+          profile: {
+            name: 'someone to delete',
+            email: makeEmail(localPart),
+          }
+        });
+
+        const promise = db.deleteUser({userId: userToDelete.id}, userToDelete.id, 'wrong name');
+
+        await assert.isRejected(promise);
+        await promise.catch(e => assert.match(e.message, /user name did not match/));
+      });
+
+      it('should remove the user and cleanup their info and personal organization', async function () {
+        const localPart = ensureUnique('deleteuser-removes-user-and-cleanups-info');
+        const userToDelete = await getOrCreateUser(localPart, {
+          profile: {
+            name: 'someone to delete',
+            email: makeEmail(localPart),
+          }
+        });
+
+        assertExists(await getPersonalOrg(userToDelete));
+
+        await db.connection.transaction(async (manager) => {
+          assert.isTrue(await userHasGroupUsers(userToDelete.id, manager));
+          assert.isTrue(await userHasPrefs(userToDelete.id, manager));
+        });
+
+        await db.deleteUser({userId: userToDelete.id}, userToDelete.id);
+
+        assert.notExists(await db.getUser(userToDelete.id));
+        assert.deepEqual(await getPersonalOrg(userToDelete), { errMessage: 'organization not found', status: 404 });
+
+        await db.connection.transaction(async (manager) => {
+          assert.isFalse(await userHasGroupUsers(userToDelete.id, manager));
+          assert.isFalse(await userHasPrefs(userToDelete.id, manager));
+        });
+      });
+
+      it("should remove the user when passed name corresponds to the user's name", async function () {
+        const localPart = ensureUnique('deleteuser-removes-user-when-name-matches');
+        const userName = 'someone to delete';
+        const userToDelete = await getOrCreateUser(localPart, {
+          profile: {
+            name: userName,
+            email: makeEmail(localPart),
+          }
+        });
+
+        const promise = db.deleteUser({userId: userToDelete.id}, userToDelete.id, userName);
+
+        await assert.isFulfilled(promise);
+      });
+    });
+
+    describe('initializeSpecialIds()', function () {
+      it('should initialize special ids', async function () {
+        return withDataBase('test-special-ids', async (localDb) => {
+          const specialAccounts = [
+            {name: "Support", email: SUPPORT_EMAIL},
+            {name: "Anonymous", email: ANONYMOUS_USER_EMAIL},
+            {name: "Preview", email: PREVIEWER_EMAIL},
+            {name: "Everyone", email: EVERYONE_EMAIL}
+          ];
+          for (const {email} of specialAccounts) {
+            assert.notExists(await localDb.getExistingUserByLogin(email));
+          }
+
+          await localDb.initializeSpecialIds();
+
+          for (const {name, email} of specialAccounts) {
+            const res = await localDb.getExistingUserByLogin(email);
+            assertExists(res);
+            assert.equal(res.name, name);
+          }
+        });
+      });
+    });
+
+    describe('completeProfiles()', function () {
+      it('should return an empty array if no profiles are provided', async function () {
+        const res = await db.completeProfiles([]);
+        assert.deepEqual(res, []);
+      });
+
+      it("should complete a single user profile with looking by normalized address", async function () {
+        const localPart = ensureUnique('completeprofiles-with-single-profile');
+        const email = makeEmail(localPart);
+        const emailUpperCase = email.toUpperCase();
+        const profile = {
+          name: 'completeprofiles-with-single-profile-username',
+          email: makeEmail(localPart),
+          picture: 'https://mypic.com/me.png',
+        };
+        const someLocale = 'fr-FR';
+        const userCreated = await getOrCreateUser(localPart, { profile });
+        await db.updateUserOptions(userCreated.id, {locale: someLocale});
+
+        const res = await db.completeProfiles([{name: 'whatever', email: emailUpperCase}]);
+
+        assert.deepEqual(res, [{
+          ...profile,
+          id: userCreated.id,
+          locale: someLocale,
+          anonymous: false
+        }]);
+      });
+
+      it('should complete several user profiles', async function () {
+        const localPartPrefix = ensureUnique('completeprofiles-with-several-profiles');
+        const seq = Array(10).fill(null).map((_, i) => i+1);
+        const localParts = seq.map(i => `${localPartPrefix}_${i}`);
+        const usersCreated = await Promise.all(
+          localParts.map(localPart => getOrCreateUser(localPart))
+        );
+
+        const res = await db.completeProfiles(
+          localParts.map(
+            localPart => ({name: 'whatever', email: makeEmail(localPart)})
+          )
+        );
+        assert.lengthOf(res, localParts.length);
+        for (const [index, localPart] of localParts.entries()) {
+          assert.deepInclude(res[index], {
+            id: usersCreated[index].id,
+            email: makeEmail(localPart),
+          });
+        }
+      });
     });
   });
 });

--- a/test/gen-server/lib/homedb/UsersManager.ts
+++ b/test/gen-server/lib/homedb/UsersManager.ts
@@ -800,7 +800,7 @@ describe('UsersManager', function () {
       it('should reject immediately if the error is not a QueryFailedError', async function () {
         const errorMsg = 'my error';
         sandbox.stub(UsersManager.prototype, 'getUserByLogin')
-          .rejects(new Error(errorMsg))
+          .onFirstCall().rejects(new Error(errorMsg))
           .callThrough();
 
         const email = makeEmail(ensureUnique('getuserbyloginwithretry-rejects-immediately-when-not-queryfailederror'));

--- a/test/gen-server/lib/homedb/UsersManager.ts
+++ b/test/gen-server/lib/homedb/UsersManager.ts
@@ -299,13 +299,16 @@ describe('UsersManager', function () {
 
 
     before(async function () {
+      if (process.env.TYPEORM_TYPE === "postgres") {
+        this.skip();
+      }
       env = new EnvironmentSnapshot();
       await prepareDatabase(tmpDir);
       db = await getDatabase();
     });
 
     after(async function () {
-      env.restore();
+      env?.restore();
     });
 
     beforeEach(function () {

--- a/test/gen-server/lib/homedb/UsersManager.ts
+++ b/test/gen-server/lib/homedb/UsersManager.ts
@@ -1,29 +1,31 @@
-import { User } from 'app/gen-server/entity/User';
+import { isAffirmative } from 'app/common/gutil';
+import { FullUser, UserProfile } from 'app/common/LoginSessionAPI';
+import { ANONYMOUS_USER_EMAIL, EVERYONE_EMAIL, PREVIEWER_EMAIL, UserOptions } from 'app/common/UserAPI';
 import { AclRuleOrg } from 'app/gen-server/entity/AclRule';
+import { Document } from 'app/gen-server/entity/Document';
 import { Group } from 'app/gen-server/entity/Group';
+import { Login } from 'app/gen-server/entity/Login';
 import { Organization } from 'app/gen-server/entity/Organization';
-import { SUPPORT_EMAIL, UsersManager } from 'app/gen-server/lib/homedb/UsersManager';
+import { Pref } from 'app/gen-server/entity/Pref';
+import { User } from 'app/gen-server/entity/User';
+import { Workspace } from 'app/gen-server/entity/Workspace';
+import { HomeDBManager } from 'app/gen-server/lib/homedb/HomeDBManager';
 import { GetUserOptions, NonGuestGroup, Resource } from 'app/gen-server/lib/homedb/Interfaces';
-import { tmpdir } from 'os';
-import fs from 'node:fs/promises';
-import path from 'path';
+import { SUPPORT_EMAIL, UsersManager } from 'app/gen-server/lib/homedb/UsersManager';
+import { updateDb } from 'app/server/lib/dbUtils';
 import { prepareDatabase } from 'test/server/lib/helpers/PrepareDatabase';
 import { EnvironmentSnapshot } from 'test/server/testUtils';
 import { getDatabase } from 'test/testUtils';
-import { Workspace } from 'app/gen-server/entity/Workspace';
-import { Document } from 'app/gen-server/entity/Document';
-import { HomeDBManager } from 'app/gen-server/lib/homedb/HomeDBManager';
-import Sinon, { SinonSandbox, SinonSpy } from 'sinon';
-import { assert } from 'chai';
-import { FullUser, UserProfile } from 'app/common/LoginSessionAPI';
-import { ANONYMOUS_USER_EMAIL, EVERYONE_EMAIL, PREVIEWER_EMAIL, UserOptions } from 'app/common/UserAPI';
-import { Login } from 'app/gen-server/entity/Login';
-import { Pref } from 'app/gen-server/entity/Pref';
-import { EntityManager } from 'typeorm';
+
 import log from 'app/server/lib/log';
+import { assert } from 'chai';
+import Sinon, { SinonSandbox, SinonSpy } from 'sinon';
+import { EntityManager } from 'typeorm';
 import winston from 'winston';
-import { updateDb } from 'app/server/lib/dbUtils';
-import { isAffirmative } from 'app/common/gutil';
+
+import fs from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
 
 const username = process.env.USER || "nobody";
 const tmpDirPrefix = path.join(tmpdir(), `grist_test_${username}_userendpoint_`);

--- a/test/gen-server/lib/homedb/UsersManager.ts
+++ b/test/gen-server/lib/homedb/UsersManager.ts
@@ -34,7 +34,7 @@ describe('UsersManager', function () {
     /**
      * Create a simple iterator of integer starting from 0 which is incremented every time we call next()
      */
-    function* makeIdxIterator() {
+    function* makeUserIdIterator() {
       for (let i = 0; i < 500; i++) {
         yield i;
       }
@@ -48,7 +48,7 @@ describe('UsersManager', function () {
      *        Pass your own iterator if you want to call this methods several times and keep the id unique.
      *        If omitted, create its own iterator that starts from 0.
      */
-    function makeUsers(nbUsers: number, userIdIterator = makeIdxIterator()): User[] {
+    function makeUsers(nbUsers: number, userIdIterator = makeUserIdIterator()): User[] {
       return Array(nbUsers).fill(null).map(() => {
         const user = new User();
         const itItem = userIdIterator.next();
@@ -71,7 +71,7 @@ describe('UsersManager', function () {
       resources: Resource[], nbUsersByResource: number, makeResourceGrpName?: (idx: number) => string
     ): Map<Resource, User[]> {
       const membersByResource = new Map<Resource, User[]>();
-      const idxIterator = makeIdxIterator();
+      const idxIterator = makeUserIdIterator();
       for (const [idx, resource] of resources.entries()) {
         const aclRule = new AclRuleOrg();
         const group = new Group();
@@ -173,7 +173,7 @@ describe('UsersManager', function () {
       });
 
       it('should retrieve users of passed groups', function () {
-        const idxIt = makeIdxIterator();
+        const idxIt = makeUserIdIterator();
         const groupsUsersMap = {
           'editors': makeUsers(3, idxIt),
           'owners': makeUsers(4, idxIt),

--- a/test/gen-server/lib/limits.ts
+++ b/test/gen-server/lib/limits.ts
@@ -41,7 +41,7 @@ describe('limits', function() {
     const samHome = await createUser(dbManager, 'sam');
     // Overwrite default product
     const billingId = samHome.billingAccount.id;
-    await dbManager.connection.createQueryBuilder()
+    await dbManager.dataSource.createQueryBuilder()
       .update(BillingAccount)
       .set({product})
       .where('id = :billingId', {billingId})
@@ -309,7 +309,7 @@ describe('limits', function() {
 
     // Try smuggling in a doc that breaks the rules
     // Tweak NASA's product to allow 4 shares per doc.
-    const db = dbManager.connection.manager;
+    const db = dbManager.dataSource.manager;
     const nasaOrg = await db.findOne(Organization, {where: {domain: 'nasa'},
                                                     relations: ['billingAccount',
                                                                 'billingAccount.product']});

--- a/test/gen-server/lib/mergedOrgs.ts
+++ b/test/gen-server/lib/mergedOrgs.ts
@@ -4,7 +4,7 @@ import {FlexServer} from 'app/server/lib/FlexServer';
 import {main as mergedServerMain} from 'app/server/mergedServerMain';
 import axios from 'axios';
 import {assert} from 'chai';
-import {createInitialDb, removeConnection, setUpDB} from 'test/gen-server/seed';
+import {createInitialDb, setUpDB} from 'test/gen-server/seed';
 import {configForUser, createUser, setPlan} from 'test/gen-server/testUtils';
 import * as testUtils from 'test/server/testUtils';
 
@@ -28,7 +28,6 @@ describe('mergedOrgs', function() {
 
   after(async function() {
     await home.close();
-    await removeConnection();
   });
 
   it('can list all shared workspaces from personal orgs', async function() {

--- a/test/gen-server/lib/previewer.ts
+++ b/test/gen-server/lib/previewer.ts
@@ -34,7 +34,7 @@ describe('previewer', function() {
     dbManager = home.dbManager;
     homeUrl = home.serverUrl;
     // for these tests, give the previewer an api key.
-    await dbManager.connection.query(`update users set api_key = 'api_key_for_thumbnail' where name = 'Preview'`);
+    await dbManager.dataSource.query(`update users set api_key = 'api_key_for_thumbnail' where name = 'Preview'`);
   });
 
   after(async function() {

--- a/test/gen-server/lib/removedAt.ts
+++ b/test/gen-server/lib/removedAt.ts
@@ -258,7 +258,7 @@ describe('removedAt', function() {
           'test3@getgrist.com': 'editors',
         }
       });
-      const userRef = (email: string) => home.dbManager.getUserByLogin(email).then((user) => user!.ref);
+      const userRef = (email: string) => home.dbManager.getUserByLogin(email).then((user) => user.ref);
       const idTest1 = (await home.dbManager.getUserByLogin("test1@getgrist.com"))!.id;
       const idTest2 = (await home.dbManager.getUserByLogin("test2@getgrist.com"))!.id;
       const idTest3 = (await home.dbManager.getUserByLogin("test3@getgrist.com"))!.id;

--- a/test/gen-server/lib/scrubUserFromOrg.ts
+++ b/test/gen-server/lib/scrubUserFromOrg.ts
@@ -27,7 +27,7 @@ describe('scrubUserFromOrg', function() {
 
   // count how many rows there are in the group_users table, for sanity checks.
   async function countGroupUsers() {
-    return await server.dbManager.connection.manager.count('group_users');
+    return await server.dbManager.dataSource.manager.count('group_users');
   }
 
   // get the home api, making sure the user's api key is set.

--- a/test/gen-server/lib/urlIds.ts
+++ b/test/gen-server/lib/urlIds.ts
@@ -80,7 +80,7 @@ describe('urlIds', function() {
     });
 
     it(`cannot use an existing docId as a urlId in ${org}`, async function() {
-      const doc = await home.dbManager.connection.manager.findOneOrFail(Document, {where: {}});
+      const doc = await home.dbManager.dataSource.manager.findOneOrFail(Document, {where: {}});
       const prevDocId = doc.id;
       try {
         // Change doc id to ensure it has characters permitted for a urlId.

--- a/test/gen-server/testUtils.ts
+++ b/test/gen-server/testUtils.ts
@@ -58,10 +58,10 @@ export async function createUser(dbManager: HomeDBManager, name: string): Promis
  */
 export async function setPlan(dbManager: HomeDBManager, org: {billingAccount?: {id: number}},
                               productName: string) {
-  const product = await dbManager.connection.manager.findOne(Product, {where: {name: productName}});
+  const product = await dbManager.dataSource.manager.findOne(Product, {where: {name: productName}});
   if (!product) { throw new Error(`cannot find product ${productName}`); }
   if (!org.billingAccount) { throw new Error('must join billingAccount'); }
-  await dbManager.connection.createQueryBuilder()
+  await dbManager.dataSource.createQueryBuilder()
     .update(BillingAccount)
     .set({product})
     .where('id = :bid', {bid: org.billingAccount.id})
@@ -92,7 +92,7 @@ export async function waitForAllNotifications(notifier: INotifier, maxWait: numb
 
 // count the number of rows in a table
 export async function getRowCount(dbManager: HomeDBManager, tableName: string): Promise<number> {
-  const result = await dbManager.connection.query(`select count(*) as ct from ${tableName}`);
+  const result = await dbManager.dataSource.query(`select count(*) as ct from ${tableName}`);
   return parseInt(result[0].ct, 10);
 }
 

--- a/test/gen-server/testUtils.ts
+++ b/test/gen-server/testUtils.ts
@@ -46,7 +46,6 @@ export async function createUser(dbManager: HomeDBManager, name: string): Promis
   const username = name.toLowerCase();
   const email = `${username}@getgrist.com`;
   const user = await dbManager.getUserByLogin(email, {profile: {email, name}});
-  if (!user) { throw new Error('failed to create user'); }
   user.apiKey = `api_key_for_${username}`;
   await user.save();
   const userHome = (await dbManager.getOrg({userId: user.id}, null)).data;

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -768,7 +768,7 @@ export async function enterGridRows(cell: ICellSelect, rowsOfValues: string[][])
 export async function setApiKey(username: string, apiKey?: string) {
   apiKey = apiKey || `api_key_for_${username.toLowerCase()}`;
   const dbManager = await server.getDatabase();
-  await dbManager.connection.query(`update users set api_key = $1 where name = $2`,
+  await dbManager.dataSource.query(`update users set api_key = $1 where name = $2`,
                                    [apiKey, username]);
   if (!await dbManager.getUserByKey(apiKey)) {
     throw new Error(`setApiKey failed: user ${username} may not yet be in the database`);
@@ -780,7 +780,7 @@ export async function setApiKey(username: string, apiKey?: string) {
  */
 export async function updateOrgPlan(orgName: string, productName: string = 'team') {
   const dbManager = await server.getDatabase();
-  const db = dbManager.connection.manager;
+  const db = dbManager.dataSource.manager;
   const dbOrg = await db.findOne(Organization, {where: {name: orgName},
     relations: ['billingAccount', 'billingAccount.product']});
   if (!dbOrg) { throw new Error(`cannot find org ${orgName}`); }

--- a/test/nbrowser/homeUtil.ts
+++ b/test/nbrowser/homeUtil.ts
@@ -420,7 +420,7 @@ export class HomeUtil {
     if (this.server.isExternalServer()) { throw new Error('not supported'); }
     const dbManager = await this.server.getDatabase();
     const user = await dbManager.getUserByLogin(email);
-    if (user) { await dbManager.deleteUser({userId: user.id}, user.id, user.name); }
+    await dbManager.deleteUser({userId: user.id}, user.id, user.name);
   }
 
   // Set whether this is the user's first time logging in.  Requires access to the database.
@@ -428,10 +428,8 @@ export class HomeUtil {
     if (this.server.isExternalServer()) { throw new Error('not supported'); }
     const dbManager = await this.server.getDatabase();
     const user = await dbManager.getUserByLogin(email);
-    if (user) {
-      user.isFirstTimeUser = isFirstLogin;
-      await user.save();
-    }
+    user.isFirstTimeUser = isFirstLogin;
+    await user.save();
   }
 
   private async _initShowGristTour(email: string, showGristTour: boolean) {
@@ -463,7 +461,6 @@ export class HomeUtil {
 
     const dbManager = await this.server.getDatabase();
     const user = await dbManager.getUserByLogin(email);
-    if (!user) { return; }
 
     if (user.personalOrg) {
       const org = await dbManager.getOrg({userId: user.id}, user.personalOrg.id);

--- a/test/nbrowser/testServer.ts
+++ b/test/nbrowser/testServer.ts
@@ -24,7 +24,6 @@ import {driver, IMochaServer, WebDriver} from 'mocha-webdriver';
 import fetch from 'node-fetch';
 import {tmpdir} from 'os';
 import * as path from 'path';
-import {removeConnection} from 'test/gen-server/seed';
 import {HomeUtil} from 'test/nbrowser/homeUtil';
 import {getDatabase} from 'test/testUtils';
 
@@ -273,8 +272,8 @@ export class TestServerMerged extends EventEmitter implements IMochaServer {
   }
 
   public async closeDatabase() {
+    await this._dbManager?.destroyDataSource();
     this._dbManager = undefined;
-    await removeConnection();
   }
 
   public get driver() {

--- a/test/server/fixSiteProducts.ts
+++ b/test/server/fixSiteProducts.ts
@@ -39,7 +39,7 @@ describe('fixSiteProducts', function() {
   it('fixes sites that where created with a wrong product', async function() {
     const db = server.dbManager;
     const user = await db.getUserByLogin(email, {profile}) as any;
-    const getOrg = (id: number) => db.connection.manager.findOne(
+    const getOrg = (id: number) => db.dataSource.manager.findOne(
       Organization,
       {where: {id}, relations: ['billingAccount', 'billingAccount.product']});
 
@@ -132,7 +132,7 @@ describe('fixSiteProducts', function() {
       product: 'teamFree',
     }));
 
-    const getOrg = (id: number) => db.connection.manager.findOne(Organization,
+    const getOrg = (id: number) => db.dataSource.manager.findOne(Organization,
       {where: {id}, relations: ['billingAccount', 'billingAccount.product']});
     const productOrg = (id: number) => getOrg(id)?.then(org => org?.billingAccount?.product?.name);
     assert.equal(await productOrg(orgId), 'teamFree');

--- a/test/server/fixSiteProducts.ts
+++ b/test/server/fixSiteProducts.ts
@@ -122,7 +122,7 @@ describe('fixSiteProducts', function() {
     assert.equal(getDefaultProductNames().teamInitial, 'stub');
 
     const db = server.dbManager;
-    const user = await db.getUserByLogin(email, {profile}) as any;
+    const user = await db.getUserByLogin(email, {profile});
     const orgId = db.unwrapQueryResult(await db.addOrg(user, {
       name: 'sanity-check-org',
       domain: 'sanity-check-org',

--- a/test/server/lib/Authorizer.ts
+++ b/test/server/lib/Authorizer.ts
@@ -5,7 +5,7 @@ import {FlexServer} from 'app/server/lib/FlexServer';
 import axios from 'axios';
 import {assert} from 'chai';
 import {toPairs} from 'lodash';
-import {createInitialDb, removeConnection, setUpDB} from 'test/gen-server/seed';
+import {createInitialDb, setUpDB} from 'test/gen-server/seed';
 import {configForUser, getGristConfig} from 'test/gen-server/testUtils';
 import {createDocTools} from 'test/server/docTools';
 import {openClient} from 'test/server/gristClient';
@@ -90,7 +90,6 @@ describe('Authorizer', function() {
   after(async function() {
     const messages = await testUtils.captureLog('warn', async () => {
       await server.close();
-      await removeConnection();
     });
     assert.lengthOf(messages, 0);
     oldEnv.restore();

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -2949,7 +2949,7 @@ function testDocApi() {
     assert.equal(resp.status, 200);
 
     const db = await getDatabase();
-    const shares = await db.connection.query('select * from shares');
+    const shares = await db.dataSource.query('select * from shares');
     const {key} = shares[0];
 
     resp = await axios.get(`${serverUrl}/api/docs/${docId}/tables/Table1/records`, chimpy);

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -3279,7 +3279,7 @@ describe('GranularAccess', function() {
     cliOwner.flush();
     let perm: PermissionDataWithExtraUsers = (await cliOwner.send("getUsersForViewAs", 0)).data;
     const getId = (name: string) => home.dbManager.testGetId(name) as Promise<number>;
-    const getRef = (email: string) => home.dbManager.getUserByLogin(email).then(user => user!.ref);
+    const getRef = (email: string) => home.dbManager.getUserByLogin(email).then(user => user.ref);
     assert.deepEqual(perm.users, [
       { id: await getId('Chimpy'), email: 'chimpy@getgrist.com', name: 'Chimpy',
         ref: await getRef('chimpy@getgrist.com'),

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -95,7 +95,7 @@ describe('GranularAccess', function() {
   }
 
   async function getShareKeyForUrl(linkId: string) {
-    const shares = await home.dbManager.connection.query(
+    const shares = await home.dbManager.dataSource.query(
       'select * from shares where link_id = ?', [linkId]);
     const key = shares[0].key;
     if (!key) {
@@ -3729,7 +3729,7 @@ describe('GranularAccess', function() {
       ]);
 
       // Check it reached the home db.
-      let shares = await home.dbManager.connection.query('select * from shares');
+      let shares = await home.dbManager.dataSource.query('select * from shares');
       assert.lengthOf(shares, 1);
       assert.equal(shares[0].link_id, 'x');
       assert.deepEqual(JSON.parse(shares[0].options),
@@ -3804,7 +3804,7 @@ describe('GranularAccess', function() {
           options: '{"publish": true, "test": true}'
         }],
       ]);
-      shares = await home.dbManager.connection.query('select * from shares');
+      shares = await home.dbManager.dataSource.query('select * from shares');
       assert.lengthOf(shares, 1);
       assert.deepEqual(JSON.parse(shares[0].options),
                        {publish: true, test: true});
@@ -3822,7 +3822,7 @@ describe('GranularAccess', function() {
       await owner.applyUserActions(docId, [
         ['RemoveRecord', '_grist_Shares', 1]
       ]);
-      shares = await home.dbManager.connection.query('select * from shares');
+      shares = await home.dbManager.dataSource.query('select * from shares');
       assert.lengthOf(shares, 0);
     });
 
@@ -4053,7 +4053,7 @@ describe('GranularAccess', function() {
       await hamShare.addRows('Customer', { Name: ['Foo'] });
       await assert.isRejected(hamShare.addRows('Actor', { Name: ['Foo'] }));
       await removeShares(docId, owner);
-      const shares = await home.dbManager.connection.query('select * from shares');
+      const shares = await home.dbManager.dataSource.query('select * from shares');
       assert.lengthOf(shares, 0);
     });
 
@@ -4069,7 +4069,7 @@ describe('GranularAccess', function() {
       ]);
 
       // Check it reached the home db.
-      let shares = await home.dbManager.connection.query('select * from shares');
+      let shares = await home.dbManager.dataSource.query('select * from shares');
       assert.lengthOf(shares, 1);
       assert.equal(shares[0].link_id, 'x2');
 
@@ -4078,7 +4078,7 @@ describe('GranularAccess', function() {
       });
       // Do anything with the new document.
       await owner.getDocAPI(copyDocId).getRows('Table1');
-      shares = await home.dbManager.connection.query('select * from shares');
+      shares = await home.dbManager.dataSource.query('select * from shares');
       assert.lengthOf(shares, 2);
       assert.equal(shares[0].link_id, 'x2');
       assert.equal(shares[1].link_id, 'x2');

--- a/test/server/lib/helpers/PrepareDatabase.ts
+++ b/test/server/lib/helpers/PrepareDatabase.ts
@@ -2,13 +2,13 @@ import path from "path";
 import * as testUtils from "test/server/testUtils";
 import {execFileSync} from "child_process";
 
-export async function prepareDatabase(tempDirectory: string) {
+export async function prepareDatabase(tempDirectory: string, filename: string = 'landing.db') {
   // Let's create a sqlite db that we can share with servers that run in other processes, hence
   // not an in-memory db. Running seed.ts directly might not take in account the most recent value
   // for TYPEORM_DATABASE, because ormconfig.js may already have been loaded with a different
   // configuration (in-memory for instance). Spawning a process is one way to make sure that the
   // latest value prevail.
-  process.env.TYPEORM_DATABASE = path.join(tempDirectory, 'landing.db');
+  process.env.TYPEORM_DATABASE = path.join(tempDirectory, filename);
   const seed = await testUtils.getBuildFile('test/gen-server/seed.js');
   execFileSync('node', [seed, 'init'], {
     env: process.env,

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -6,7 +6,7 @@ export async function getDatabase(typeormDb?: string): Promise<HomeDBManager> {
     process.env.TYPEORM_DATABASE = typeormDb;
   }
   const db = new HomeDBManager();
-  await db.connect();
+  await db.initializeDataSource();
   await db.initializeSpecialIds();
   if (origTypeormDB) {
     process.env.TYPEORM_DATABASE = origTypeormDB;


### PR DESCRIPTION
WIP! This PR is open to see whether it passes the tests

## Context

Since version 0.3.0, Typeorm functions, methods and classes related to Connections have been deprecated in favor of the use of DataSources.

## Proposed solution

Huge refactoration to use DataSource, and remove use of ConnectionManager.

## Related issues

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
