### PR TITLE
OIDC: allow configuring the request timeout

### DIFF
--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -47,7 +47,8 @@
  *        A JSON object with extra client metadata to pass to openid-client. Optional.
  *        Be aware that setting this object may override any other values passed to the openid client.
  *        More info: https://github.com/panva/node-openid-client/tree/main/docs#new-clientmetadata-jwks-options
- *
+ *    env GRIST_OIDC_HTTP_TIMEOUT
+ *        The timeout in milliseconds for HTTP requests to the IdP. Defaults to 3500.
  *
  * This version of OIDCConfig has been tested with Keycloak OIDC IdP following the instructions
  * at:
@@ -66,7 +67,7 @@
 import * as express from 'express';
 import { GristLoginSystem, GristServer } from './GristServer';
 import {
-  Client, ClientMetadata, Issuer, errors as OIDCError, TokenSet, UserinfoResponse
+  Client, ClientMetadata, custom, Issuer, errors as OIDCError, TokenSet, UserinfoResponse
 } from 'openid-client';
 import { Sessions } from './Sessions';
 import log from 'app/server/lib/log';
@@ -137,6 +138,12 @@ export class OIDCConfig {
       envVar: 'GRIST_OIDC_IDP_CLIENT_SECRET',
       censor: true,
     });
+    const httpTimeout = section.flag('httpTimeout').readInt({
+      envVar: 'GRIST_OIDC_HTTP_TIMEOUT',
+      // Default value matching that of node-openid-client
+      // See https://github.com/panva/node-openid-client/blob/main/docs/README.md#customizing-http-requests for more details.
+      defaultValue: 3500,
+    });
     this._namePropertyKey = section.flag('namePropertyKey').readString({
       envVar: 'GRIST_OIDC_SP_PROFILE_NAME_ATTR',
     });
@@ -175,6 +182,9 @@ export class OIDCConfig {
     this._redirectUrl = new URL(CALLBACK_URL, spHost).href;
     await this._initClient({ issuerUrl, clientId, clientSecret, extraMetadata });
 
+    custom.setHttpOptionsDefaults({
+      timeout: httpTimeout,
+    });
     if (this._client.issuer.metadata.end_session_endpoint === undefined &&
       !this._endSessionEndpoint && !this._skipEndSessionEndpoint) {
       throw new Error('The Identity provider does not propose end_session_endpoint. ' +


### PR DESCRIPTION
## Context

I take up this PR: #1072 (open by @atropos112)

In some case, the identity provider may take time before responding to requests sent by the OIDC client, leading to difficulties or even impossibility to start the server or to login.

For example, if the issuer discovery takes time, you may fail to start the server with this error:
```
RPError: outgoing request timed out after 3500ms
    at /home/florentpro/projects/grist-core/node_modules/openid-client/lib/helpers/request.js:137:13
    at async Issuer.discover (/home/florentpro/projects/grist-core/node_modules/openid-client/lib/issuer.js:171:22)
    at async OIDCConfig._initClient (/home/florentpro/projects/grist-core/_build/app/server/lib/OIDCConfig.js:246:24)
    at async OIDCConfig.initOIDC (/home/florentpro/projects/grist-core/_build/app/server/lib/OIDCConfig.js:155:9)
    at async OIDCConfig.build (/home/florentpro/projects/grist-core/_build/app/server/lib/OIDCConfig.js:104:9)
    at async Object.getMiddleware (/home/florentpro/projects/grist-core/_build/app/server/lib/OIDCConfig.js:330:28)
    at async FlexServer.addLoginMiddleware (/home/florentpro/projects/grist-core/_build/app/server/lib/FlexServer.js:1083:33)
    at async main (/home/florentpro/projects/grist-core/_build/app/server/mergedServerMain.js:86:5)
    at async main (/home/florentpro/projects/grist-core/_build/stubs/app/server/server.js:143:20)
```

## Proposed solution

Introduce the `GRIST_OIDC_SP_HTTP_TIMEOUT` env variable so the user may set a greater value than the default 3500ms, or even [set it to 0 to remove any timeout](https://nodejs.org/api/https.html#servertimeout).

## How to test it

I use this utility to add latency to the requests, so the openid-client requests may timeout: https://github.com/sitespeedio/throttle

Prerequisites:
 - Install throttle (introduced with a link above): `npm i -g @sitespeed.io/throttle`
 - Install `tc`. On Debian-family Linux distros, you must install iproute2 for that: `sudo apt install iproute2`.

STR:
 - Setup a Keycloak environment and use it
 - Configure Grist to use Keycloak as IdP: https://github.com/gristlabs/grist-help/blob/master/help/en/docs/install/oidc.md#example-keycloak 
 - Use throttle to add the latency. I run it this way: `throttle --localhost --up 9000 --down 9000 --rtt 5000` (the RTT is what matters here)
 - Then:
   - to reproduce the issue: `yarn start`, the server should fail to start with a timeout in the logs (see the `Context` section above)
   - or `GRIST_OIDC_SP_HTTP_TIMEOUT=30000 yarn start` to check that the problem is solved
 - Once you have finished testing, you may stop the latency: `throttle --localhost stop`

## Related issues

I also pave the way for #942

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
