### PR TITLE
workflows: disable the daily build on forks

### DIFF
--- a/.github/workflows/docker_latest.yml
+++ b/.github/workflows/docker_latest.yml
@@ -46,6 +46,7 @@ jobs:
   push_to_registry:
     name: Push latest Docker image to Docker Hub
     runs-on: ubuntu-latest
+    if: ${{ vars.RUN_DAILY_BUILD }}
     strategy:
       matrix:
         python-version: [3.11]


### PR DESCRIPTION
We'll now need to define this repo variable on our clone in order to make this run.

## Context

Closes  #1168 

## Proposed solution

This workflow is now disabled unless you create a repository variable. We'll need to add this one to our own repo.

![image](https://github.com/user-attachments/assets/43c54617-df63-4b60-abc6-1f7e8869c3d9)

## Related issues

#1168

## Has this been tested?

Yes, I tested it on my own fork. The workflow was skipped until I defined the variable.

- [x] 👍 yes, I tested on my own fork
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

![image](https://github.com/user-attachments/assets/9a3e4d3d-2b90-4beb-96cd-d9363b7335cf)
