### PR TITLE
Spoffy/nativefs updates

### DIFF
--- a/app/server/lib/DocStorageManager.ts
+++ b/app/server/lib/DocStorageManager.ts
@@ -10,7 +10,6 @@ import {DocumentUsage} from 'app/common/DocUsage';
 import * as gutil from 'app/common/gutil';
 import {Comm} from 'app/server/lib/Comm';
 import * as docUtils from 'app/server/lib/docUtils';
-import {GristServer} from 'app/server/lib/GristServer';
 import {EmptySnapshotProgress, IDocStorageManager, SnapshotProgress} from 'app/server/lib/IDocStorageManager';
 import {IShell} from 'app/server/lib/IShell';
 import log from 'app/server/lib/log';
@@ -39,10 +38,10 @@ export class DocStorageManager implements IDocStorageManager {
    * The file watcher is created if the optComm argument is given.
    */
   constructor(private _docsRoot: string, private _samplesRoot?: string,
-              private _comm?: Comm, gristServer?: GristServer) {
+              private _comm?: Comm, shell?: IShell) {
     // If we have a way to communicate with clients, watch the docsRoot for changes.
     this._watcher = null;
-    this._shell = gristServer?.create.Shell?.() || {
+    this._shell = shell ?? {
       trashItem() { throw new Error('Unable to move document to trash'); },
       showItemInFolder() { throw new Error('Unable to show item in folder'); }
     };

--- a/app/server/lib/ExternalStorage.ts
+++ b/app/server/lib/ExternalStorage.ts
@@ -378,6 +378,15 @@ export interface ExternalStorageSettings {
 }
 
 /**
+ * Function returning the core ExternalStorage implementation,
+ * which may then be wrapped in additional layer(s) of ExternalStorage.
+ * See ICreate.ExternalStorage.
+ * Uses S3 by default in hosted Grist.
+*/
+export type ExternalStorageCreator =
+  (purpose: ExternalStorageSettings["purpose"], extraPrefix: string) => ExternalStorage | undefined;
+
+/**
  * The storage mapping we use for our SaaS. A reasonable default, but relies
  * on appropriate lifecycle rules being set up in the bucket.
  */

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1322,7 +1322,7 @@ export class FlexServer implements GristServer {
       this._storageManager = storageManager;
     } else {
       const samples = getAppPathTo(this.appRoot, 'public_samples');
-      const storageManager = new DocStorageManager(this.docsRoot, samples, this._comm, this);
+      const storageManager = new DocStorageManager(this.docsRoot, samples, this._comm, this.create.Shell?.());
       this._storageManager = storageManager;
     }
 

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -36,7 +36,6 @@ import {create} from 'app/server/lib/create';
 import {addDiscourseConnectEndpoints} from 'app/server/lib/DiscourseConnect';
 import {addDocApiRoutes} from 'app/server/lib/DocApi';
 import {DocManager} from 'app/server/lib/DocManager';
-import {DocStorageManager} from 'app/server/lib/DocStorageManager';
 import {DocWorker} from 'app/server/lib/DocWorker';
 import {DocWorkerInfo, IDocWorkerMap} from 'app/server/lib/DocWorkerMap';
 import {expressWrap, jsonErrorHandler, secureJsonErrorHandler} from 'app/server/lib/expressWrap';
@@ -45,7 +44,6 @@ import {addGoogleAuthEndpoint} from "app/server/lib/GoogleAuth";
 import {DocTemplate, GristLoginMiddleware, GristLoginSystem, GristServer,
   RequestWithGrist} from 'app/server/lib/GristServer';
 import {initGristSessions, SessionStore} from 'app/server/lib/gristSessions';
-import {HostedStorageManager} from 'app/server/lib/HostedStorageManager';
 import {IBilling} from 'app/server/lib/IBilling';
 import {IDocStorageManager} from 'app/server/lib/IDocStorageManager';
 import {EmptyNotifier, INotifier} from 'app/server/lib/INotifier';
@@ -1317,17 +1315,16 @@ export class FlexServer implements GristServer {
       const workers = this._docWorkerMap;
       const docWorkerId = await this._addSelfAsWorker(workers);
 
-      const storageManager = new HostedStorageManager(this.docsRoot, docWorkerId, this._disableExternalStorage, workers,
-                                                      this._dbManager, this.create.ExternalStorage);
+      const storageManager = this.create.createHostedDocStorageManager(
+        this.docsRoot, docWorkerId, this._disableExternalStorage, workers, this._dbManager, this.create.ExternalStorage
+      );
       this._storageManager = storageManager;
     } else {
       const samples = getAppPathTo(this.appRoot, 'public_samples');
-      const storageManager = new DocStorageManager(this.docsRoot, samples, this._comm, this.create.Shell?.());
+      const storageManager = this.create.createLocalDocStorageManager(
+        this.docsRoot, samples, this._comm, this.create.Shell?.()
+      );
       this._storageManager = storageManager;
-    }
-
-    if (this.create.decorateDocStorageManager) {
-      this.create.decorateDocStorageManager(this._storageManager);
     }
 
     const pluginManager = await this._addPluginManager();

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1318,7 +1318,7 @@ export class FlexServer implements GristServer {
       const docWorkerId = await this._addSelfAsWorker(workers);
 
       const storageManager = new HostedStorageManager(this.docsRoot, docWorkerId, this._disableExternalStorage, workers,
-                                                      this._dbManager, this.create);
+                                                      this._dbManager, this.create.ExternalStorage);
       this._storageManager = storageManager;
     } else {
       const samples = getAppPathTo(this.appRoot, 'public_samples');

--- a/app/server/lib/ICreate.ts
+++ b/app/server/lib/ICreate.ts
@@ -3,7 +3,7 @@ import {getCoreLoginSystem} from 'app/server/lib/coreLogins';
 import {getThemeBackgroundSnippet} from 'app/common/Themes';
 import {Document} from 'app/gen-server/entity/Document';
 import {HomeDBManager} from 'app/gen-server/lib/homedb/HomeDBManager';
-import {ExternalStorage} from 'app/server/lib/ExternalStorage';
+import {ExternalStorage, ExternalStorageCreator} from 'app/server/lib/ExternalStorage';
 import {createDummyTelemetry, GristLoginSystem, GristServer} from 'app/server/lib/GristServer';
 import {IBilling} from 'app/server/lib/IBilling';
 import {EmptyNotifier, INotifier} from 'app/server/lib/INotifier';
@@ -39,18 +39,17 @@ export const DEFAULT_SESSION_SECRET =
   'Phoo2ag1jaiz6Moo2Iese2xoaphahbai3oNg7diemohlah0ohtae9iengafieS2Hae7quungoCi9iaPh';
 
 export interface ICreate {
-
-  Billing(dbManager: HomeDBManager, gristConfig: GristServer): IBilling;
-  Notifier(dbManager: HomeDBManager, gristConfig: GristServer): INotifier;
-  Telemetry(dbManager: HomeDBManager, gristConfig: GristServer): ITelemetry;
-  Shell?(): IShell;  // relevant to electron version of Grist only.
-
   // Create a space to store files externally, for storing either:
   //  - documents. This store should be versioned, and can be eventually consistent.
   //  - meta. This store need not be versioned, and can be eventually consistent.
   // For test purposes an extra prefix may be supplied.  Stores with different prefixes
   // should not interfere with each other.
-  ExternalStorage(purpose: 'doc' | 'meta', testExtraPrefix: string): ExternalStorage | undefined;
+  ExternalStorage: ExternalStorageCreator;
+
+  Billing(dbManager: HomeDBManager, gristConfig: GristServer): IBilling;
+  Notifier(dbManager: HomeDBManager, gristConfig: GristServer): INotifier;
+  Telemetry(dbManager: HomeDBManager, gristConfig: GristServer): ITelemetry;
+  Shell?(): IShell;  // relevant to electron version of Grist only.
 
   NSandbox(options: ISandboxCreationOptions): ISandbox;
 

--- a/app/server/utils/pruneActionHistory.ts
+++ b/app/server/utils/pruneActionHistory.ts
@@ -1,9 +1,9 @@
 import * as gutil from 'app/common/gutil';
 import {ActionHistoryImpl} from 'app/server/lib/ActionHistoryImpl';
 import {DocStorage} from 'app/server/lib/DocStorage';
-import {DocStorageManager} from 'app/server/lib/DocStorageManager';
 import * as docUtils from 'app/server/lib/docUtils';
 import log from 'app/server/lib/log';
+import { create } from "app/server/lib/create";
 
 /**
  * A utility script for cleaning up the action log.
@@ -18,7 +18,7 @@ export async function pruneActionHistory(docPath: string, keepN: number) {
     throw new Error('Invalid document: Document should be a valid .grist file');
   }
 
-  const storageManager = new DocStorageManager(".", ".");
+  const storageManager = create.createLocalDocStorageManager(".", ".");
   const docStorage = new DocStorage(storageManager, docPath);
   const backupPath = gutil.removeSuffix(docPath, '.grist') + "-backup.grist";
 

--- a/test/server/docTools.ts
+++ b/test/server/docTools.ts
@@ -4,7 +4,6 @@ import {ActiveDoc} from 'app/server/lib/ActiveDoc';
 import {DummyAuthorizer} from 'app/server/lib/Authorizer';
 import {DocManager} from 'app/server/lib/DocManager';
 import {DocSession, makeExceptionalDocSession} from 'app/server/lib/DocSession';
-import {DocStorageManager} from 'app/server/lib/DocStorageManager';
 import {createDummyGristServer, GristServer} from 'app/server/lib/GristServer';
 import {IDocStorageManager} from 'app/server/lib/IDocStorageManager';
 import {getAppRoot} from 'app/server/lib/places';
@@ -17,6 +16,7 @@ import * as fse from 'fs-extra';
 import {tmpdir} from 'os';
 import * as path from 'path';
 import * as tmp from 'tmp';
+import { create } from "app/server/lib/create";
 
 tmp.setGracefulCleanup();
 
@@ -138,7 +138,7 @@ export async function createDocManager(
               server?: GristServer} = {}): Promise<DocManager> {
   // Set Grist home to a temporary directory, and wipe it out on exit.
   const tmpDir = options.tmpDir || await createTmpDir();
-  const docStorageManager = options.storageManager || new DocStorageManager(tmpDir);
+  const docStorageManager = options.storageManager || create.createLocalDocStorageManager(tmpDir);
   const pluginManager = options.pluginManager || await getGlobalPluginManager();
   const store = getDocWorkerMap();
   const internalPermitStore = store.getPermitStore('1');


### PR DESCRIPTION
## Context

The existing PR #1099 adds `decorateDocStorageManager` to ICreate, which replaces the method on an IDocStorageManager interface.

However, this isn't necessarily safe, as there's no guarantee what the implementation of IDocStorageManager is doing.

## Proposed solution

This replaces `decorateDocStorageManager` with new ICreate methods that allow the `DocStorageManager` implementation to overridden by other versions of Grist, allowing them to subclass or use a custom implementation.

## Related issues

#1099 

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

