### PR TITLE
Fix: formula assistant translations

### DIFF
--- a/app/client/widgets/FormulaAssistant.ts
+++ b/app/client/widgets/FormulaAssistant.ts
@@ -35,7 +35,7 @@ import {Marked} from 'marked';
 import {markedHighlight} from 'marked-highlight';
 import {v4 as uuidv4} from 'uuid';
 
-const t = makeT('FormulaEditor');
+const t = makeT('FormulaAssistant');
 const testId = makeTestId('test-formula-editor-');
 
 const LOW_CREDITS_WARNING_BANNER_THRESHOLD = 10;


### PR DESCRIPTION
## Context

The AI Formula assistant prompt was not translated.

## Proposed solution

These strings are translated under the `FormulaAssistant.*` keys in weblate (https://hosted.weblate.org/translate/grist/client/fr/?q=FormulaAssistant&sort_by=-priority%2Cposition&offset=23 )

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
