### PR TITLE
[TINY] Don't throttle /api/docs/{docId}/force-reload #1107

### DIFF
--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -972,11 +972,12 @@ export class DocWorkerApi {
 
     // Reload a document forcibly (in fact this closes the doc, it will be automatically
     // reopened on use).
-    this._app.post('/api/docs/:docId/force-reload', canEdit, throttled(async (req, res) => {
-      const activeDoc = await this._getActiveDoc(req);
+    this._app.post('/api/docs/:docId/force-reload', canEdit, async (req, res) => {
+      const mreq = req as RequestWithLogin;
+      const activeDoc = await this._getActiveDoc(mreq);
       await activeDoc.reloadDoc();
       res.json(null);
-    }));
+    });
 
     this._app.post('/api/docs/:docId/recover', canEdit, throttled(async (req, res) => {
       const recoveryModeRaw = req.body.recoveryMode;


### PR DESCRIPTION
## Context

As a document owner, when a document has too many requests, I want to force a document to be reopened. However, the /force-reload endpoint may raise a 429 (TOO_MANY_REQUESTS) error, because it uses the throttled middleware.

## Proposed solution

Don't throttle the force-reload, so pending request may be interrupted.

## Related issues

Fixes #1107

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help

I indeed feel like it is not worth making a test for that test, if that's also fine for you.