### PR TITLE
switch default LLM from a model that is going away

### DIFF
--- a/app/server/lib/Assistance.ts
+++ b/app/server/lib/Assistance.ts
@@ -148,8 +148,8 @@ class RetryableError extends Error {
  * An optional ASSISTANT_MAX_TOKENS can be specified.
  */
 export class OpenAIAssistant implements Assistant {
-  public static DEFAULT_MODEL = "gpt-3.5-turbo-0613";
-  public static DEFAULT_LONGER_CONTEXT_MODEL = "gpt-3.5-turbo-16k-0613";
+  public static DEFAULT_MODEL = "gpt-4o-2024-08-06";
+  public static DEFAULT_LONGER_CONTEXT_MODEL = "";
 
   private _apiKey?: string;
   private _model?: string;


### PR DESCRIPTION
## Context

If an api key is provided, Grist can use an LLM as an assistant for writing formulas. The LLM can be self-hosted or an external service. The default external service is OpenAI, but the default model currently specified is going away.

https://platform.openai.com/docs/deprecations/2023-11-06-chat-model-updates

## Proposed solution

This commit freshens the default model used, if this feature is enabled, since the existing one is going away. Benchmarking suggests the results are generally better, though not dramatically so.

The feature of falling back on a longer context model is no longer as important, but is retained since it could be useful for self-hosters.

## Related issues

https://github.com/gristlabs/grist-core/pull/345

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I <s>added</s> updated tests in the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

There are existing benchmarking scripts in https://github.com/gristlabs/grist-core/tree/main/test/formula-dataset which I ran on this model. The Grist Labs SaaS is also already using this model.
