### PR TITLE
FIX slowness when adding user to workspace

### DIFF
--- a/app/gen-server/entity/Login.ts
+++ b/app/gen-server/entity/Login.ts
@@ -1,4 +1,4 @@
-import {BaseEntity, Column, Entity, JoinColumn, ManyToOne, PrimaryColumn} from "typeorm";
+import {BaseEntity, Column, Entity, Index, JoinColumn, ManyToOne, PrimaryColumn} from "typeorm";
 
 import {User} from "./User";
 
@@ -9,6 +9,7 @@ export class Login extends BaseEntity {
   public id: number;
 
   // This is the normalized email address we use for equality and indexing.
+  @Index()
   @Column({type: String})
   public email: string;
 

--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -2034,9 +2034,8 @@ export class HomeDBManager extends EventEmitter {
       const orgId = ws.org.id;
       let orgQuery = this._buildOrgWithACLRulesQuery(scope, orgId, options);
       orgQuery = this._addFeatures(orgQuery);
-      const orgQueryResult = await verifyEntity(orgQuery);
-      const org: Organization = orgQueryResult.data;
-
+      const orgQueryResult = await orgQuery.getRawAndEntities();
+      const org: Organization = orgQueryResult.entities[0];
       // Get all the non-guest groups on the org.
       const orgGroups = getNonGuestGroups(org);
       // Get all the non-guest groups to be updated by the delta.

--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -2016,30 +2016,29 @@ export class HomeDBManager extends EventEmitter {
     const result = await this._connection.transaction(async manager => {
       const analysis = await this._usersManager.verifyAndLookupDeltaEmails(userId, delta, false, manager);
       let {userIdDelta} = analysis;
-      let wsQuery = this._workspace(scope, wsId, {
+      const options = {
         manager,
         markPermissions: analysis.permissionThreshold,
-      })
-      // Join the workspace's ACL rules and groups/users so we can edit them.
-      .leftJoinAndSelect('workspaces.aclRules', 'acl_rules')
-      .leftJoinAndSelect('acl_rules.group', 'workspace_groups')
-      .leftJoinAndSelect('workspace_groups.memberUsers', 'workspace_users')
-      // Join the workspace's org and org member groups so we know what should be inherited.
-      .leftJoinAndSelect('workspaces.org', 'org')
-      .leftJoinAndSelect('org.aclRules', 'org_acl_rules')
-      .leftJoinAndSelect('org_acl_rules.group', 'org_groups')
-      .leftJoinAndSelect('org_groups.memberUsers', 'org_users');
-      wsQuery = this._addFeatures(wsQuery, 'org');
+      };
+      let wsQuery = this._buildWorkspaceWithACLRules(scope, wsId, options);
       wsQuery = this._withAccess(wsQuery, userId, 'workspaces');
-      const queryResult = await verifyEntity(wsQuery);
-      if (queryResult.status !== 200) {
+      const wsQueryResult = await verifyEntity(wsQuery);
+
+      if (wsQueryResult.status !== 200) {
         // If the query for the workspace failed, return the failure result.
-        return queryResult;
+        return wsQueryResult;
       }
-      this._failIfPowerfulAndChangingSelf(analysis, queryResult);
-      const ws: Workspace = queryResult.data;
+      this._failIfPowerfulAndChangingSelf(analysis, wsQueryResult);
+      const ws: Workspace = wsQueryResult.data;
+
+      const orgId = ws.org.id;
+      let orgQuery = this._buildOrgWithACLRulesQuery(scope, orgId, options);
+      orgQuery = this._addFeatures(orgQuery);
+      const orgQueryResult = await verifyEntity(orgQuery);
+      const org: Organization = orgQueryResult.data;
+
       // Get all the non-guest groups on the org.
-      const orgGroups = getNonGuestGroups(ws.org);
+      const orgGroups = getNonGuestGroups(org);
       // Get all the non-guest groups to be updated by the delta.
       const groups = getNonGuestGroups(ws);
       if ('maxInheritedRole' in delta) {
@@ -2062,7 +2061,7 @@ export class HomeDBManager extends EventEmitter {
         await this._updateUserPermissions(groups, userIdDelta, manager);
         this._checkUserChangeAllowed(userId, groups);
         const nonOrgMembersAfter = this._usersManager.getUserDifference(groups, orgGroups);
-        const features = ws.org.billingAccount.getFeatures();
+        const features = org.billingAccount.getFeatures();
         const limit = features.maxSharesPerWorkspace;
         if (limit !== undefined) {
           this._restrictShares(null, limit, removeRole(nonOrgMembersBefore),
@@ -2072,7 +2071,7 @@ export class HomeDBManager extends EventEmitter {
       await manager.save(groups);
       // If the users in workspace were changed, make a call to repair the guests in the org.
       if (userIdDelta) {
-        await this._repairOrgGuests(scope, ws.org.id, manager);
+        await this._repairOrgGuests(scope, orgId, manager);
         notifications.push(this._inviteNotification(userId, ws, userIdDelta, membersBefore));
       }
       return {
@@ -4652,9 +4651,8 @@ export class HomeDBManager extends EventEmitter {
     return { personal: true, public: !realAccess };
   }
 
-  private _getWorkspaceWithACLRules(scope: Scope, wsId: number, options: Partial<QueryOptions> = {}) {
-    const query = this._workspace(scope, wsId, {
-      markPermissions: Permissions.VIEW,
+  private _buildWorkspaceWithACLRules(scope: Scope, wsId: number, options: Partial<QueryOptions> = {}) {
+    return this._workspace(scope, wsId, {
       ...options
     })
     // Join the workspace's ACL rules (with 1st level groups/users listed).
@@ -4664,6 +4662,13 @@ export class HomeDBManager extends EventEmitter {
     .leftJoinAndSelect('workspace_groups.memberGroups', 'workspace_group_groups')
     .leftJoinAndSelect('workspace_group_users.logins', 'workspace_user_logins')
     .leftJoinAndSelect('workspaces.org', 'org');
+  }
+
+  private _getWorkspaceWithACLRules(scope: Scope, wsId: number, options: Partial<QueryOptions> = {}) {
+    const query = this._buildWorkspaceWithACLRules(scope, wsId, {
+      markPermissions: Permissions.VIEW,
+      ...options
+    });
     return verifyEntity(query);
   }
 

--- a/app/gen-server/lib/homedb/UsersManager.ts
+++ b/app/gen-server/lib/homedb/UsersManager.ts
@@ -638,7 +638,7 @@ export class UsersManager {
         emailUsers.set(user.loginEmail, user);
       }
       emails.forEach((email) => {
-        const userIdAffected = emailUsers.get(email)!.id;
+        const userIdAffected = emailUsers.get(normalizeEmail(email))!.id;
         // Org-level sharing with everyone would allow serious spamming - forbid it.
         if (emailMap[email] !== null &&                    // allow removing anything
             userId !== this.getSupportUserId() &&          // allow support user latitude

--- a/app/gen-server/migration/1727689195356-LoginsEmailIndex.ts
+++ b/app/gen-server/migration/1727689195356-LoginsEmailIndex.ts
@@ -1,0 +1,16 @@
+import {MigrationInterface, QueryRunner, TableIndex} from "typeorm";
+
+export class LoginsEmailsIndex1727689195356 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.createIndex("logins", new TableIndex({
+      name: "logins__email",
+      columnNames: ["email"]
+    }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.dropIndex("logins", "logins__email");
+  }
+}
+

--- a/app/gen-server/migration/1729754662550-LoginsEmailIndex.ts
+++ b/app/gen-server/migration/1729754662550-LoginsEmailIndex.ts
@@ -1,6 +1,6 @@
 import {MigrationInterface, QueryRunner, TableIndex} from "typeorm";
 
-export class LoginsEmailsIndex1727689195356 implements MigrationInterface {
+export class LoginsEmailsIndex1729754662550 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<any> {
     await queryRunner.createIndex("logins", new TableIndex({

--- a/test/gen-server/migrations.ts
+++ b/test/gen-server/migrations.ts
@@ -47,6 +47,8 @@ import {UserLastConnection1713186031023
 import {ActivationEnabled1722529827161
         as ActivationEnabled} from 'app/gen-server/migration/1722529827161-Activation-Enabled';
 import {Configs1727747249153 as Configs} from 'app/gen-server/migration/1727747249153-Configs';
+import {LoginsEmailsIndex1729754662550
+        as LoginsEmailsIndex} from 'app/gen-server/migration/1729754662550-LoginsEmailIndex';
 
 const home: HomeDBManager = new HomeDBManager();
 
@@ -56,7 +58,7 @@ const migrations = [Initial, Login, PinDocs, UserPicture, DisplayEmail, DisplayE
                     ExternalBilling, DocOptions, Secret, UserOptions, GracePeriodStart,
                     DocumentUsage, Activations, UserConnectId, UserUUID, UserUniqueRefUUID,
                     Forks, ForkIndexes, ActivationPrefs, AssistantLimit, Shares, BillingFeatures,
-                    UserLastConnection, ActivationEnabled, Configs];
+                    UserLastConnection, ActivationEnabled, Configs, LoginsEmailsIndex];
 
 // Assert that the "members" acl rule and group exist (or not).
 function assertMembersGroup(org: Organization, exists: boolean) {


### PR DESCRIPTION
## Context

On French administration we can experience instances not beeing able to add users to workspaces due to long queries, and never ending queries.

## Proposed solution

<https://github.com/gristlabs/grist-core/commit/e26673eff10e93f7383f09886affdd999a2ecde4>

To fix this issue we propose the same strategy than in #824.
Splitting the query in to simpler queries to gather informations about workspace and organization.

<https://github.com/gristlabs/grist-core/commit/bd43d12110c3ae33fa793b1d658e1a5c630a186a>
We also propose to remove the promisyfyAll around iteration of getUsers queries.
During local test, it seems to be the main culprit.
The ForEach iteration launches asynchonously many queries recycling the same transaction. Sometime the transaction never ended.

<https://github.com/gristlabs/grist-core/commit/3c6388cb165fe79dbff57454caf2014247bfb53e>
Cause the newly added function getExistingUsersByLogin uses a WHERE on logins.email a INDEX is added to allow fastest queries.

## Related issues

FIXES #1005 

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
