### PR TITLE
Fix DateEditor test (newly moved to grist-core) by adding a sinon.js symlink to static/

### DIFF
--- a/static/sinon.js
+++ b/static/sinon.js
@@ -1,0 +1,1 @@
+../node_modules/sinon/pkg/sinon.js


### PR DESCRIPTION
## Context

DateEditor test was recently moved into `grist-core`, but relies on loading sinon.js from the browser, which wasn't available.

## Proposed solution

Added static/sinon.js symlink, similar to the already existing static/mocha.js & co.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

`DateEditor` test now passes locally.