### PR TITLE
Add Copy With Headers to grid cell popup.

### DIFF
--- a/app/client/components/Clipboard.js
+++ b/app/client/components/Clipboard.js
@@ -107,6 +107,7 @@ Base.setBaseFor(Clipboard);
 
 Clipboard.commands = {
   contextMenuCopy: function() { this._doContextMenuCopy(); },
+  contextMenuCopyWithHeaders: function() { this._doContextMenuCopyWithHeaders(); },
   contextMenuCut: function() { this._doContextMenuCut(); },
   contextMenuPaste: function() { this._doContextMenuPaste(); },
 };
@@ -120,13 +121,19 @@ Clipboard.prototype._onCopy = function(elem, event) {
 
   let pasteObj = commands.allCommands.copy.run();
 
-  this._setCBdata(pasteObj, event.originalEvent.clipboardData);
+  this._setCBdata(pasteObj, event.originalEvent.clipboardData, false);
 };
 
 Clipboard.prototype._doContextMenuCopy = function() {
   let pasteObj = commands.allCommands.copy.run();
 
-  this._copyToClipboard(pasteObj, 'copy');
+  this._copyToClipboard(pasteObj, 'copy', false);
+};
+
+Clipboard.prototype._doContextMenuCopyWithHeaders = function() {
+  let pasteObj = commands.allCommands.copy.run();
+
+  this._copyToClipboard(pasteObj, 'copy', true);
 };
 
 Clipboard.prototype._onCut = function(elem, event) {
@@ -143,24 +150,24 @@ Clipboard.prototype._doContextMenuCut = function() {
   this._copyToClipboard(pasteObj, 'cut');
 };
 
-Clipboard.prototype._setCBdata = function(pasteObj, clipboardData) {
+Clipboard.prototype._setCBdata = function(pasteObj, clipboardData, includeColHeaders) {
   if (!pasteObj) { return; }
 
-  const plainText = tableUtil.makePasteText(pasteObj.data, pasteObj.selection);
+  const plainText = tableUtil.makePasteText(pasteObj.data, pasteObj.selection, includeColHeaders);
   clipboardData.setData('text/plain', plainText);
-  const htmlText = tableUtil.makePasteHtml(pasteObj.data, pasteObj.selection);
+  const htmlText = tableUtil.makePasteHtml(pasteObj.data, pasteObj.selection, includeColHeaders);
   clipboardData.setData('text/html', htmlText);
 
   this._setCutCallback(pasteObj, plainText);
 };
 
-Clipboard.prototype._copyToClipboard = async function(pasteObj, action) {
+Clipboard.prototype._copyToClipboard = async function(pasteObj, action, includeColHeaders) {
   if (!pasteObj) { return; }
 
-  const plainText = tableUtil.makePasteText(pasteObj.data, pasteObj.selection);
+  const plainText = tableUtil.makePasteText(pasteObj.data, pasteObj.selection, includeColHeaders);
   let data;
   if (typeof ClipboardItem === 'function') {
-    const htmlText = tableUtil.makePasteHtml(pasteObj.data, pasteObj.selection);
+    const htmlText = tableUtil.makePasteHtml(pasteObj.data, pasteObj.selection, includeColHeaders);
     // eslint-disable-next-line no-undef
     data = new ClipboardItem({
       // eslint-disable-next-line no-undef

--- a/app/client/components/Clipboard.js
+++ b/app/client/components/Clipboard.js
@@ -121,7 +121,7 @@ Clipboard.prototype._onCopy = function(elem, event) {
 
   let pasteObj = commands.allCommands.copy.run();
 
-  this._setCBdata(pasteObj, event.originalEvent.clipboardData, false);
+  this._setCBdata(pasteObj, event.originalEvent.clipboardData);
 };
 
 Clipboard.prototype._doContextMenuCopy = function() {
@@ -150,12 +150,12 @@ Clipboard.prototype._doContextMenuCut = function() {
   this._copyToClipboard(pasteObj, 'cut');
 };
 
-Clipboard.prototype._setCBdata = function(pasteObj, clipboardData, includeColHeaders) {
+Clipboard.prototype._setCBdata = function(pasteObj, clipboardData) {
   if (!pasteObj) { return; }
 
-  const plainText = tableUtil.makePasteText(pasteObj.data, pasteObj.selection, includeColHeaders);
+  const plainText = tableUtil.makePasteText(pasteObj.data, pasteObj.selection, false);
   clipboardData.setData('text/plain', plainText);
-  const htmlText = tableUtil.makePasteHtml(pasteObj.data, pasteObj.selection, includeColHeaders);
+  const htmlText = tableUtil.makePasteHtml(pasteObj.data, pasteObj.selection, false);
   clipboardData.setData('text/html', htmlText);
 
   this._setCutCallback(pasteObj, plainText);

--- a/app/client/components/commandList.ts
+++ b/app/client/components/commandList.ts
@@ -473,7 +473,7 @@ export const groups: CommendGroupDef[] = [{
       bindKeys: false,
     }, {
       name: 'contextMenuCopyWithHeaders',
-      keys: ['Mod+Shift+C'],
+      keys: [],
       desc: 'Copy current selection to clipboard including headers',
     }, {
       name: 'contextMenuCut',

--- a/app/client/components/commandList.ts
+++ b/app/client/components/commandList.ts
@@ -63,6 +63,7 @@ export type CommandName =
   | 'cut'
   | 'paste'
   | 'contextMenuCopy'
+  | 'contextMenuCopyWithHeaders'
   | 'contextMenuCut'
   | 'contextMenuPaste'
   | 'fillSelectionDown'
@@ -470,6 +471,10 @@ export const groups: CommendGroupDef[] = [{
       keys: ['Mod+C'],
       desc: 'Copy current selection to clipboard',
       bindKeys: false,
+    }, {
+      name: 'contextMenuCopyWithHeaders',
+      keys: ['Mod+Shift+C'],
+      desc: 'Copy current selection to clipboard including headers',
     }, {
       name: 'contextMenuCut',
       keys: ['Mod+X'],

--- a/app/client/lib/tableUtil.ts
+++ b/app/client/lib/tableUtil.ts
@@ -33,7 +33,7 @@ export function fieldInsertPositions(viewFields: KoArray<ViewFieldRec>, index: n
 export function makePasteText(tableData: TableData, selection: CopySelection, includeColHeaders: boolean) {
   // tsvEncode expects data as a 2-d array with each a array representing a row
   // i.e. [["1-1", "1-2", "1-3"],["2-1", "2-2", "2-3"]]
-  let result = [];
+  const result = [];
   if (includeColHeaders) {
     result.push(selection.fields.map(f => f.label()));
   }

--- a/app/client/lib/tableUtil.ts
+++ b/app/client/lib/tableUtil.ts
@@ -30,12 +30,22 @@ export function fieldInsertPositions(viewFields: KoArray<ViewFieldRec>, index: n
  * @param {CopySelection} selection - a CopySelection instance
  * @return {String}
  **/
-export function makePasteText(tableData: TableData, selection: CopySelection) {
+export function makePasteText(tableData: TableData, selection: CopySelection, includeColHeaders: boolean) {
   // tsvEncode expects data as a 2-d array with each a array representing a row
   // i.e. [["1-1", "1-2", "1-3"],["2-1", "2-2", "2-3"]]
-  const values = selection.rowIds.map(rowId =>
-    selection.columns.map(col => col.fmtGetter(rowId)));
-  return tsvEncode(values);
+  let result;
+  if (includeColHeaders) {
+    result = [
+      selection.columns.map(col => col.colId),
+      ...selection.rowIds.map(rowId =>
+        selection.columns.map(col => col.fmtGetter(rowId))
+      )
+    ];
+  } else {
+    result = selection.rowIds.map(rowId =>
+      selection.columns.map(col => col.fmtGetter(rowId)));
+  }
+  return tsvEncode(result);
 }
 
 /**

--- a/app/client/lib/tableUtil.ts
+++ b/app/client/lib/tableUtil.ts
@@ -33,18 +33,12 @@ export function fieldInsertPositions(viewFields: KoArray<ViewFieldRec>, index: n
 export function makePasteText(tableData: TableData, selection: CopySelection, includeColHeaders: boolean) {
   // tsvEncode expects data as a 2-d array with each a array representing a row
   // i.e. [["1-1", "1-2", "1-3"],["2-1", "2-2", "2-3"]]
-  let result;
+  let result = [];
   if (includeColHeaders) {
-    result = [
-      selection.fields.map(f => f.label()),
-      ...selection.rowIds.map(rowId =>
-        selection.columns.map(col => col.fmtGetter(rowId))
-      )
-    ];
-  } else {
-    result = selection.rowIds.map(rowId =>
-      selection.columns.map(col => col.fmtGetter(rowId)));
+    result.push(selection.fields.map(f => f.label()));
   }
+  result.push(...selection.rowIds.map(rowId =>
+    selection.columns.map(col => col.fmtGetter(rowId))));
   return tsvEncode(result);
 }
 

--- a/app/client/lib/tableUtil.ts
+++ b/app/client/lib/tableUtil.ts
@@ -36,7 +36,7 @@ export function makePasteText(tableData: TableData, selection: CopySelection, in
   let result;
   if (includeColHeaders) {
     result = [
-      selection.columns.map(col => col.colId),
+      selection.fields.map(f => f.label()),
       ...selection.rowIds.map(rowId =>
         selection.columns.map(col => col.fmtGetter(rowId))
       )
@@ -80,7 +80,7 @@ export function makePasteHtml(tableData: TableData, selection: CopySelection, in
     )),
     // Include column headers if requested.
     (includeColHeaders ?
-      dom('tr', selection.colIds.map(colId => dom('th', colId))) :
+      dom('tr', selection.fields.map(field => dom('th', field.label()))) :
       null
     ),
     // Fill with table cells.

--- a/app/client/ui/CellContextMenu.ts
+++ b/app/client/ui/CellContextMenu.ts
@@ -38,6 +38,7 @@ export function CellContextMenu(cellOptions: ICellContextMenu, colOptions: IMult
   result.push(
     menuItemCmd(allCommands.contextMenuCut, t('Cut'), disableForReadonlyColumn),
     menuItemCmd(allCommands.contextMenuCopy, t('Copy')),
+    menuItemCmd(allCommands.contextMenuCopyWithHeaders, t('Copy with headers')),
     menuItemCmd(allCommands.contextMenuPaste, t('Paste'), disableForReadonlyColumn),
     menuDivider(),
     colOptions.isFormula ?

--- a/test/nbrowser/CopyPaste.ts
+++ b/test/nbrowser/CopyPaste.ts
@@ -637,7 +637,7 @@ async function copyAndCheck(
   }
 }
 
-function createDummyTextArea() {
+export function createDummyTextArea() {
   const textarea = document.createElement('textarea');
   textarea.style.position = "absolute";
   textarea.style.top = "0";
@@ -647,7 +647,7 @@ function createDummyTextArea() {
   window.document.body.appendChild(textarea);
 }
 
-function removeDummyTextArea() {
+export function removeDummyTextArea() {
   const textarea = document.getElementById('dummyText');
   if (textarea) {
     window.document.body.removeChild(textarea);

--- a/test/nbrowser/CopyWithHeaders.ts
+++ b/test/nbrowser/CopyWithHeaders.ts
@@ -26,17 +26,17 @@ describe("CopyWithHeaders", function() {
     await clipboard.lockAndPerform(async (cb) => {
         // Select all
         await gu.sendKeys(Key.chord(Key.CONTROL, 'a'));
-        // Copy with headers: control-shift-c
-        await gu.sendKeys(Key.chord(Key.CONTROL, Key.SHIFT, 'c'));
+        await gu.rightClick(gu.getCell({rowNum: 1, col: 'A'}));
+        await driver.findContent('.grist-floating-menu li', 'Copy with headers').click();
 
         await pasteAndCheck(cb, ["A", "B", "C", "D", "E"], 5);
     });
 
     await clipboard.lockAndPerform(async (cb) => {
         // Select a single cell.
-        await gu.getCell({col: 'D', rowNum: 2}).click();
-        // Copy with headers: control-shift-c
-        await gu.sendKeys(Key.chord(Key.CONTROL, Key.SHIFT, 'c'));
+        await gu.getCell({rowNum: 2, col: 'D'}).click();
+        await gu.rightClick(gu.getCell({rowNum: 2, col: 'D'}));
+        await driver.findContent('.grist-floating-menu li', 'Copy with headers').click();
 
         await pasteAndCheck(cb, ["D"], 2);
     });

--- a/test/nbrowser/CopyWithHeaders.ts
+++ b/test/nbrowser/CopyWithHeaders.ts
@@ -1,0 +1,59 @@
+/**
+ * Test for copying Grist data with headers.
+ */
+
+import {assert, driver, Key} from 'mocha-webdriver';
+import * as gu from 'test/nbrowser/gristUtils';
+import {setupTestSuite} from 'test/nbrowser/testUtils';
+import {createDummyTextArea, removeDummyTextArea} from 'test/nbrowser/CopyPaste';
+
+describe("CopyWithHeaders", function() {
+  this.timeout(90000);
+  const cleanup = setupTestSuite();
+  const clipboard = gu.getLockableClipboard();
+  afterEach(() => gu.checkForErrors());
+  gu.bigScreen();
+
+  after(async function() {
+    await driver.executeScript(removeDummyTextArea);
+  });
+
+  it('should copy headers', async function() {
+    const session = await gu.session().teamSite.login();
+    await session.tempDoc(cleanup, 'Hello.grist');
+    await driver.executeScript(createDummyTextArea);
+
+    await clipboard.lockAndPerform(async (cb) => {
+        // Select all
+        await gu.sendKeys(Key.chord(Key.CONTROL, 'a'));
+        // Copy with headers: control-shift-c
+        await gu.sendKeys(Key.chord(Key.CONTROL, Key.SHIFT, 'c'));
+
+        await pasteAndCheck(cb, ["A", "B", "C", "D", "E"], 5);
+    });
+
+    await clipboard.lockAndPerform(async (cb) => {
+        // Select a single cell.
+        await gu.getCell({col: 'D', rowNum: 2}).click();
+        // Copy with headers: control-shift-c
+        await gu.sendKeys(Key.chord(Key.CONTROL, Key.SHIFT, 'c'));
+
+        await pasteAndCheck(cb, ["D"], 2);
+    });
+  });
+});
+
+async function pasteAndCheck(cb: gu.IClipboard, headers: string[], rows: number) {
+  // Paste into the dummy textarea.
+  await driver.find('#dummyText').click();
+  await gu.waitAppFocus(false);
+  await cb.paste();
+
+  const textarea = await driver.find('#dummyText');
+  const text = await textarea.getAttribute('value');
+  const lines = text.split('\n');
+  const regex = new RegExp(`^${headers.join('\\s+')}$`);
+  assert.match(lines[0], regex);
+  assert.equal(lines.length, rows);
+  await textarea.clear();
+}


### PR DESCRIPTION
## Context

Add Copy With Headers to grid cell popup. This is what you want when you're going to paste into e.g. an email.

User story: I want to copy and paste from a grist table into email. The table contents don't make much sense without the headers, so I need them in the email as well.

## Proposed solution

Add new entry to the grid cell popup.

## Related issues

None

## Has this been tested?

I wrote a new test: CopyWithHeaders. This makes sure headers are copied when pasting plain text.

Tested by manually trying copy and paste into an editor and an email, and then again using the new variant to confirm the headers show up.

## Screenshots / Screencasts

![image](https://github.com/user-attachments/assets/4d4a97e0-03a1-4e29-979c-cdcad0d5b392)
