### PR TITLE
Add a FLATTEN_RECORD_LIST formula

### DIFF
--- a/sandbox/grist/functions/lookup.py
+++ b/sandbox/grist/functions/lookup.py
@@ -36,7 +36,7 @@ def FLATTEN_RECORDS_LIST(list_of_records, dedup=False):
     el_type = {el.__class__.__name__ for el in flatten_list}
     if list(el_type)[0] != 'Record':
         return FLATTEN_RECORDS_LIST(flatten_list, dedup)
-    return set(flatten_list) if dedup else flatten_list
+    return list(set(flatten_list)) if dedup else flatten_list
 
 @unimplemented
 def GETPIVOTDATA(value_name, any_pivot_table_cell, original_column_1, pivot_item_1=None, *args):

--- a/sandbox/grist/functions/lookup.py
+++ b/sandbox/grist/functions/lookup.py
@@ -26,6 +26,16 @@ def COLUMNS(range):
   """Returns the number of columns in a specified array or range."""
   raise NotImplementedError()
 
+def FLATTEN_RECORDS_LIST(list_of_tables, dedup=False):
+    """Returns a flat list of records"""
+    # TODO add support for more than level 2 nesting
+    # Maybe by recursing while list_or_table is a list of list
+    # Maybe it's a good idea to put a max level of dive
+    if type(list_of_tables) is not list:
+        raise TypeError("Unexpected Argument, waiting of a list of tables")
+    flatten_record_list = [ el for val in list_of_tables for el in val]
+    return set(flatten_record_list) if dedup else flatten_record_list
+
 @unimplemented
 def GETPIVOTDATA(value_name, any_pivot_table_cell, original_column_1, pivot_item_1=None, *args):
   """Extracts an aggregated value from a pivot table that corresponds to the specified row and column headings."""

--- a/sandbox/grist/functions/lookup.py
+++ b/sandbox/grist/functions/lookup.py
@@ -26,15 +26,17 @@ def COLUMNS(range):
   """Returns the number of columns in a specified array or range."""
   raise NotImplementedError()
 
-def FLATTEN_RECORDS_LIST(list_of_tables, dedup=False):
+def FLATTEN_RECORDS_LIST(list_of_records, dedup=False):
     """Returns a flat list of records"""
-    # TODO add support for more than level 2 nesting
-    # Maybe by recursing while list_or_table is a list of list
-    # Maybe it's a good idea to put a max level of dive
-    if type(list_of_tables) is not list:
-        raise TypeError("Unexpected Argument, waiting of a list of tables")
-    flatten_record_list = [ el for val in list_of_tables for el in val]
-    return set(flatten_record_list) if dedup else flatten_record_list
+    if type(list_of_records) is not list:
+        raise TypeError("Unexpected Argument, waiting of a list of Records")
+    if len(list_of_records) == 0:
+        return list_of_records
+    flatten_list = [el for val in list_of_records for el in val]
+    el_type = {el.__class__.__name__ for el in flatten_list}
+    if list(el_type)[0] != 'Record':
+        return FLATTEN_RECORDS_LIST(flatten_list, dedup)
+    return set(flatten_list) if dedup else flatten_list
 
 @unimplemented
 def GETPIVOTDATA(value_name, any_pivot_table_cell, original_column_1, pivot_item_1=None, *args):


### PR DESCRIPTION
## Context

Formulas `Carts.lookupRecords(customer=$id).Cart` returns a "list of lists/RecordSet" ([Foods[[1, 2, 3]], Foods[[1]]]) which is not handled properly by Grist when trying to type it as a Reference List.

A fix is to return a flattened list using a list comprehension [el for val in Carts.lookupRecords(customer=$id).Cart for el in val]

## Proposed solution

Add a `FLATTEN_RECORD_LIST(RecordSet, dedup=False)` formula that returns a much more manageable list of `Records`

## Related issues

Fixes #1130

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [x] 🙋 no, because I need help

I'm not sure of the best way to test this. Creating a .grist file that verify the formula returns the good result in nbrowser tests or python tests inside the docstring, but how create a proper RecordSet to do unit tests ?

Thanks for your help.