### PR TITLE
Fixes an import error when using S3/Minio with no redis

### DIFF
--- a/app/gen-server/lib/DocWorkerMap.ts
+++ b/app/gen-server/lib/DocWorkerMap.ts
@@ -580,8 +580,10 @@ let dummyDocWorkerMap: DummyDocWorkerMap|null = null;
 
 export function getDocWorkerMap(): IDocWorkerMap {
   if (process.env.REDIS_URL) {
+    log.info("Creating Redis-based DocWorker");
     return new DocWorkerMap();
   } else {
+    log.info("Creating local/dummy DocWorker");
     dummyDocWorkerMap = dummyDocWorkerMap || new DummyDocWorkerMap();
     return dummyDocWorkerMap;
   }

--- a/app/server/lib/DocManager.ts
+++ b/app/server/lib/DocManager.ts
@@ -638,6 +638,7 @@ export class DocManager extends EventEmitter {
         throw new Error('Grist docs must be uploaded individually');
       }
       const first = uploadInfo.files[0].origName;
+      log.debug(`DocManager._doImportDoc: Received doc with name ${first}`);
       const ext = extname(first);
       const basename = path.basename(first, ext).trim() || "Untitled upload";
       let id: string;
@@ -662,6 +663,7 @@ export class DocManager extends EventEmitter {
       }
       await options.register?.(id, basename);
       if (ext === '.grist') {
+        log.debug(`DocManager._doImportDoc: Importing .grist doc`);
         // If the import is a grist file, copy it to the docs directory.
         // TODO: We should be skeptical of the upload file to close a possible
         // security vulnerability. See https://phab.getgrist.com/T457.

--- a/app/server/lib/HostedMetadataManager.ts
+++ b/app/server/lib/HostedMetadataManager.ts
@@ -1,5 +1,7 @@
-import {DocumentMetadata, HomeDBManager} from 'app/gen-server/lib/homedb/HomeDBManager';
+import {DocumentMetadata} from 'app/gen-server/lib/homedb/HomeDBManager';
 import log from 'app/server/lib/log';
+
+export type SetDocsMetadataFunc = (metadata: { [p: string]: DocumentMetadata }) => Promise<any>;
 
 /**
  * HostedMetadataManager handles pushing document metadata changes to the Home database when
@@ -29,7 +31,7 @@ export class HostedMetadataManager {
    * Create an instance of HostedMetadataManager.
    * The minPushDelay is the default delay in seconds between metadata pushes to the database.
    */
-  constructor(private _dbManager: HomeDBManager, minPushDelay: number = 60) {
+  constructor(private _setDocsMetadata: SetDocsMetadataFunc, minPushDelay: number = 60) {
     this._minPushDelayMs = minPushDelay * 1000;
   }
 
@@ -68,7 +70,7 @@ export class HostedMetadataManager {
   }
 
   public setDocsMetadata(docUpdateMap: {[docId: string]: DocumentMetadata}): Promise<any> {
-    return this._dbManager.setDocsMetadata(docUpdateMap);
+    return this._setDocsMetadata(docUpdateMap);
   }
 
   /**

--- a/app/server/lib/HostedMetadataManager.ts
+++ b/app/server/lib/HostedMetadataManager.ts
@@ -1,7 +1,8 @@
 import {DocumentMetadata} from 'app/gen-server/lib/homedb/HomeDBManager';
 import log from 'app/server/lib/log';
 
-export type SetDocsMetadataFunc = (metadata: { [p: string]: DocumentMetadata }) => Promise<any>;
+// Callback that persists the updated metadata to storage for each document.
+export type SaveDocsMetadataFunc = (metadata: { [docId: string]: DocumentMetadata }) => Promise<any>;
 
 /**
  * HostedMetadataManager handles pushing document metadata changes to the Home database when
@@ -31,7 +32,7 @@ export class HostedMetadataManager {
    * Create an instance of HostedMetadataManager.
    * The minPushDelay is the default delay in seconds between metadata pushes to the database.
    */
-  constructor(private _setDocsMetadata: SetDocsMetadataFunc, minPushDelay: number = 60) {
+  constructor(private _saveDocsMetadata: SaveDocsMetadataFunc, minPushDelay: number = 60) {
     this._minPushDelayMs = minPushDelay * 1000;
   }
 
@@ -70,7 +71,7 @@ export class HostedMetadataManager {
   }
 
   public setDocsMetadata(docUpdateMap: {[docId: string]: DocumentMetadata}): Promise<any> {
-    return this._setDocsMetadata(docUpdateMap);
+    return this._saveDocsMetadata(docUpdateMap);
   }
 
   /**

--- a/app/server/lib/HostedStorageManager.ts
+++ b/app/server/lib/HostedStorageManager.ts
@@ -18,7 +18,7 @@ import {
   ExternalStorageCreator, ExternalStorageSettings,
   Unchanged
 } from 'app/server/lib/ExternalStorage';
-import {HostedMetadataManager, SetDocsMetadataFunc} from 'app/server/lib/HostedMetadataManager';
+import {HostedMetadataManager, SaveDocsMetadataFunc} from 'app/server/lib/HostedMetadataManager';
 import {EmptySnapshotProgress, IDocStorageManager, SnapshotProgress} from 'app/server/lib/IDocStorageManager';
 import {LogMethods} from "app/server/lib/LogMethods";
 import {fromCallback} from 'app/server/lib/serverUtils';
@@ -53,7 +53,9 @@ function checkValidDocId(docId: string): void {
 }
 
 export interface HostedStorageCallbacks {
-  setDocsMetadata: SetDocsMetadataFunc,
+  // Saves the given metadata for the specified documents.
+  setDocsMetadata: SaveDocsMetadataFunc,
+  // Retrieves account features enabled for the given document.
   getDocFeatures: (docId: string) => Promise<Features | undefined>
 }
 

--- a/app/server/lib/HostedStorageManager.ts
+++ b/app/server/lib/HostedStorageManager.ts
@@ -644,7 +644,7 @@ export class HostedStorageManager implements IDocStorageManager {
 
       const existsLocally = await fse.pathExists(this.getPath(docName));
       if (existsLocally) {
-        if (!docStatus.docMD5 || docStatus.docMD5 === DELETED_TOKEN) {
+        if (!docStatus.docMD5 || docStatus.docMD5 === DELETED_TOKEN || docStatus.docMD5 === 'unknown') {
           // New doc appears to already exist, but may not exist in S3.
           // Let's check.
           const head = await this._ext.head(docName);

--- a/test/server/lib/HostedStorageManager.ts
+++ b/test/server/lib/HostedStorageManager.ts
@@ -7,6 +7,7 @@ import {ActiveDoc} from 'app/server/lib/ActiveDoc';
 import {create} from 'app/server/lib/create';
 import {DocManager} from 'app/server/lib/DocManager';
 import {makeExceptionalDocSession} from 'app/server/lib/DocSession';
+import {IDocWorkerMap} from 'app/server/lib/DocWorkerMap';
 import {
   DELETED_TOKEN,
   ExternalStorage, ExternalStorageCreator,
@@ -33,7 +34,6 @@ import {createTmpDir, getGlobalPluginManager} from 'test/server/docTools';
 import {EnvironmentSnapshot, setTmpLogLevel, useFixtureDoc} from 'test/server/testUtils';
 import {waitForIt} from 'test/server/wait';
 import uuidv4 from "uuid/v4";
-import {IDocWorkerMap} from "app/server/lib/DocWorkerMap";
 
 bluebird.promisifyAll(RedisClient.prototype);
 
@@ -978,8 +978,9 @@ describe('HostedStorageManager', function() {
       // Disable Redis
       delete process.env.REDIS_URL;
 
-      const creator = create?.getStorageOptions?.('minio')?.create;
-      if (!creator) {
+      const storage = create?.getStorageOptions?.('minio');
+      const creator = storage?.create;
+      if (!creator || !storage?.check()) {
         return this.skip();
       }
       externalStorageCreate = creator;


### PR DESCRIPTION
## Context

Error is caused due to these steps:
- File is uploaded to Home server and attempts to import
- Import ends up in `claimDocument` in `HostedStorageManager`
- Tries to read doc metadata from DocWorkerMap, gets 'unknown' as md5 hash
- Thinks local doc is out of date and erases it.
- Downloads a non-existent file from S3, so import fails as it has no data.

## Proposed solution

This fixes it by checking for DummyDocWorker's special 'unknown' MD5, forcing an S3 check.

## Related issues

https://community.getgrist.com/t/no-metadata-for-imported-grist-document/6029/32

## Has this been tested?

Yes locally, but we don't have a CI/CD setup for S3 with no redis currently.
