### PR TITLE
Remove assertion from HomeIntro test

### DIFF
--- a/test/nbrowser/HomeIntro.ts
+++ b/test/nbrowser/HomeIntro.ts
@@ -98,7 +98,6 @@ describe('HomeIntro', function() {
 
     assert.isTrue(await driver.find('.test-intro-cards').isDisplayed());
     assert.isTrue(await driver.find('.test-intro-video-tour').isDisplayed());
-    assert.isTrue(await driver.find('.test-intro-tutorial').isDisplayed());
     assert.isTrue(await driver.find('.test-intro-create-doc').isDisplayed());
     assert.isTrue(await driver.find('.test-intro-import-doc').isDisplayed());
     assert.isTrue(await driver.find('.test-intro-templates').isDisplayed());


### PR DESCRIPTION
## Context

A HomeIntro test was asserting the presence of a tutorial card, but in Docker tests, tutorials are not configured, so the assertion always failed.

## Proposed solution

A different test (DocTutorial) already tests tutorial cards, so the assertion can be removed.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
