### PR TITLE
Assistant: ensure that ASSISTANT_API_KEY is a real synonym for OPEN_AI_KEY

### DIFF
--- a/app/server/lib/Assistance.ts
+++ b/app/server/lib/Assistance.ts
@@ -158,8 +158,7 @@ export class OpenAIAssistant implements Assistant {
   private _maxTokens = process.env.ASSISTANT_MAX_TOKENS ?
       parseInt(process.env.ASSISTANT_MAX_TOKENS, 10) : undefined;
 
-  public constructor() {
-    const apiKey = process.env.ASSISTANT_API_KEY || process.env.OPENAI_API_KEY;
+  public constructor(apiKey: string | undefined) {
     const endpoint = process.env.ASSISTANT_CHAT_COMPLETION_ENDPOINT;
     if (!apiKey && !endpoint) {
       throw new Error('Please set either OPENAI_API_KEY or ASSISTANT_CHAT_COMPLETION_ENDPOINT');
@@ -485,11 +484,13 @@ class EchoAssistant implements Assistant {
  * Instantiate an assistant, based on environment variables.
  */
 export function getAssistant() {
-  if (process.env.OPENAI_API_KEY === 'test') {
+  const apiKey = process.env.ASSISTANT_API_KEY || process.env.OPENAI_API_KEY;
+
+  if (apiKey === 'test') {
     return new EchoAssistant();
   }
-  if (process.env.OPENAI_API_KEY || process.env.ASSISTANT_CHAT_COMPLETION_ENDPOINT) {
-    return new OpenAIAssistant();
+  if (apiKey || process.env.ASSISTANT_CHAT_COMPLETION_ENDPOINT) {
+    return new OpenAIAssistant(apiKey);
   }
   throw new Error('Please set OPENAI_API_KEY or ASSISTANT_CHAT_COMPLETION_ENDPOINT');
 }

--- a/app/server/lib/sendAppPage.ts
+++ b/app/server/lib/sendAppPage.ts
@@ -89,7 +89,9 @@ export function makeGristConfig(options: MakeGristConfigOptions): GristLoadConfi
     supportedLngs: readLoadedLngs(req?.i18n),
     namespaces: readLoadedNamespaces(req?.i18n),
     featureComments: isAffirmative(process.env.COMMENTS),
-    featureFormulaAssistant: Boolean(process.env.OPENAI_API_KEY || process.env.ASSISTANT_CHAT_COMPLETION_ENDPOINT),
+    featureFormulaAssistant: Boolean(process.env.OPENAI_API_KEY ||
+      process.env.ASSISTANT_API_KEY  ||
+      process.env.ASSISTANT_CHAT_COMPLETION_ENDPOINT),
     assistantService: process.env.OPENAI_API_KEY ? 'OpenAI' : undefined,
     permittedCustomWidgets: getPermittedCustomWidgets(server),
     supportEmail: SUPPORT_EMAIL,


### PR DESCRIPTION
## Context

This was flagged as inconsistent in a community post.

https://community.getgrist.com/t/does-the-ai-formula-assist-also-works-with-the-desktop-mac-app/5677/6

## Proposed solution

Define the `apiKey` variable earlier in the call stack.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
