### PR TITLE
fix: stable OIDC logout URI when org in path

### DIFF
--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1286,7 +1286,7 @@ export class FlexServer implements GristServer {
     }
 
     this.app.get('/logout', ...this._logoutMiddleware(), expressWrap(async (req, resp) => {
-      const signedOutUrl = new URL(getOrgUrl(req) + 'signed-out');
+      const signedOutUrl = new URL(getOriginUrl(req) + 'signed-out');
       const redirectUrl = await this._getLogoutRedirectUrl(req, signedOutUrl);
       resp.redirect(redirectUrl);
     }));


### PR DESCRIPTION
## Context

Fixes #1235 

⚠️ @fflorent suggests that this might be a be a breaking change : https://github.com/gristlabs/grist-core/issues/1235#issuecomment-2393446811

However, this seems to be the case only in a very specific case where someone only uses very few team sites (few enough that they could list all possible logout uri with their OIDC providers) and has `ORG_IN_PATH` set to true (which is not the default).

## Proposed solution

Use `getOriginUrl` instead of `getOrgUrl` when building signedOutUrl` so that we get a stable `post_logout_redirect_uri` to register with the OIDC provider.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
