### PR TITLE
Adding en-GB locale to support Monday as a first day of week

### DIFF
--- a/static/locales/en_GB.client.json
+++ b/static/locales/en_GB.client.json
@@ -1,0 +1,5 @@
+{
+    "App": {
+        "Translators: please translate this only when your language is ready to be offered to users": "Translators: please translate this only when your language is ready to be offered to users"
+    }
+}


### PR DESCRIPTION
## Context

Adding a stub English file in order to support en-GB locale. File is only stub (so it will inherit all default values), but will change how calendar control is render, treating Monday as the first day of a week.

## Proposed solution

New stub file for en_GB locale.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here (manual tests)
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

![image](https://github.com/user-attachments/assets/0d752639-b84d-478b-a421-05d4117d46b8)
![image](https://github.com/user-attachments/assets/e165948a-21b7-4fc9-992c-979bf56af5ca)

