### PR TITLE
allow seed rules to refer to columns

### DIFF
--- a/app/client/aclui/AccessRules.ts
+++ b/app/client/aclui/AccessRules.ts
@@ -1635,6 +1635,14 @@ class ObsRulePart extends Disposable {
         !isEqual(use(this._permissions), this._rulePart?.permissions ?? emptyPerms)
       );
     });
+    // The formula may be invalid from the beginning. Make sure we show errors in this
+    // case.
+    const text = this._aclFormula.get();
+    if (text) {
+      this._setAclFormula(text, true).catch(e => {
+        console.error(e);
+      });
+    }
   }
 
   public getRulePart(): RuleRec {
@@ -1790,8 +1798,8 @@ class ObsRulePart extends Disposable {
     return this.isBuiltIn() && this._ruleSet.getFirstBuiltIn() !== this;
   }
 
-  private async _setAclFormula(text: string) {
-    if (text === this._aclFormula.get()) { return; }
+  private async _setAclFormula(text: string, initial: boolean = false) {
+    if (text === this._aclFormula.get() && !initial) { return; }
     this._aclFormula.set(text);
     this._checkPending.set(true);
     this._formulaProperties.set({});
@@ -1809,6 +1817,9 @@ class ObsRulePart extends Disposable {
   private _warnInvalidColIds(colIds?: string[]) {
     if (!colIds || !colIds.length) { return false; }
     const allValid = new Set(this._ruleSet.getValidColIds());
+    // Don't check column validity if we don't have any.
+    // For example, the seed rule has no columns.
+    if (allValid.size === 0) { return false; }
     const invalid = colIds.filter(c => !allValid.has(c));
     if (invalid.length > 0) {
       return `Invalid columns: ${invalid.join(', ')}`;

--- a/test/nbrowser/AccessRules3.ts
+++ b/test/nbrowser/AccessRules3.ts
@@ -194,7 +194,8 @@ describe("AccessRules3", function() {
       await driver.findContentWait('.grist-floating-menu li', /FinancialsTable/, 3000).click();
       fin = findTable(/FinancialsTable/);
       assert.deepEqual(await getRules(fin),
-                       [{ formula: 'rec.Unreal == 1', perm: '-R-U-C-D', res: 'All', memo: 'memo1', error: 'Invalid columns: Unreal'},
+                       [{ formula: 'rec.Unreal == 1', perm: '-R-U-C-D', res: 'All', memo: 'memo1',
+                          error: 'Invalid columns: Unreal' },
                         { formula: 'user.Access in [OWNER]', perm: '+R+U+C+D', res: 'All' },
                         { formula: 'Everyone Else', perm: '', res: 'All' }]);
       assert.equal(await hasExtraAdd(fin), false);

--- a/test/nbrowser/aclTestUtils.ts
+++ b/test/nbrowser/aclTestUtils.ts
@@ -139,7 +139,8 @@ namespace gristUtils {
   export async function getRules(el: WebElement): Promise<Array<{
     formula: string, perm: string,
     res?: string,
-    memo?: string}>> {
+    memo?: string,
+    error?: string}>> {
     const ruleSets = await el.findAll('.test-rule-set');
     const results: Array<{formula: string, perm: string,
                           res?: string,
@@ -162,9 +163,12 @@ namespace gristUtils {
         }
         const hasMemo = await part.find('.test-rule-memo').isPresent();
         const memo = hasMemo ? await part.find('.test-rule-memo input').value() : undefined;
+        const hasError = await part.find('.test-rule-error').isPresent();
+        const error = hasError ? await part.find('.test-rule-error').getText() : undefined;
         results.push({formula, perm: permParts.join(''),
                       ...(memo ? {memo} : {}),
-                      ...(res ? {res} : {})
+                      ...(res ? {res} : {}),
+                      ...(error ? {error} : {}),
                      });
       }
     }


### PR DESCRIPTION
This makes a small change to the UI for entering seed rules, so that a seed rule that refers to a column may be added. This is a bit niche, but occasionally handy when all tables have some common structure.

## Context

This was motivated by a user's experience adding a seed rule related to UUIDs:
https://community.getgrist.com/t/linkkey-access-rule-for-all-tables/6707

## Proposed solution

We wait until a rule set is associated with some columns before checking column validity.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
