### PR TITLE
lock down Ubuntu version for CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   push_to_registry:
     name: Push Docker images to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         image:

--- a/.github/workflows/docker_latest.yml
+++ b/.github/workflows/docker_latest.yml
@@ -45,7 +45,7 @@ env:
 jobs:
   push_to_registry:
     name: Push latest Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ vars.RUN_DAILY_BUILD }}
     strategy:
       matrix:
@@ -169,7 +169,7 @@ jobs:
 
   update_latest_branch:
     name: Update latest branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: push_to_registry
     steps:
       - name: Check out the repo

--- a/.github/workflows/fly-build.yml
+++ b/.github/workflows/fly-build.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Build when the 'preview' label is added, or when PR is updated with this label present.
     if: >
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/fly-cleanup.yml
+++ b/.github/workflows/fly-cleanup.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   clean:
     name: Clean stale deployed apps
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository_owner == 'gristlabs'
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy:
     name: Deploy app to fly.io
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: |
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/fly-destroy.yml
+++ b/.github/workflows/fly-destroy.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   destroy:
     name: Remove app from fly.io
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Remove the deployment when 'preview' label is removed, or the PR is closed.
     if: |
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       # it is helpful to know which sets of tests would have succeeded,
       # even when there is a failure.
@@ -167,7 +167,7 @@ jobs:
   candidate:
     needs: build_and_test
     if: ${{ success() && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Fetch new candidate branch
         uses: actions/checkout@v3

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   add-to-project:
     name: Add issue to project
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/add-to-project@v1.0.1
         with:

--- a/.github/workflows/translation_keys.yml
+++ b/.github/workflows/translation_keys.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build:
     if: github.repository_owner == 'gristlabs'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
CI tests have just started failing, perhaps as ubuntu-latest migrates to a new version. This locks down workflows to use the ubuntu version that ubuntu-latest pointed to until recently (22.04).
