### PR TITLE
FIX: TYPEORM postgresql (...Emails) syntax bad handling in #1205

### DIFF
--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -502,6 +502,14 @@ export class HomeDBManager extends EventEmitter {
   }
 
   /**
+   * @see UsersManager.prototype.getExistingUsersByLogin
+   * Find users by emails.
+   */
+  public async getExistingUsersByLogin(emails: string[], manager?: EntityManager): Promise<User[]> {
+    return await this._usersManager.getExistingUsersByLogin(emails, manager);
+  }
+
+  /**
    * Returns true if the given domain string is available, and false if it is not available.
    * NOTE that the endpoint only checks if the domain string is taken in the database, it does
    * not check whether the string contains invalid characters.

--- a/app/gen-server/lib/homedb/UsersManager.ts
+++ b/app/gen-server/lib/homedb/UsersManager.ts
@@ -348,6 +348,9 @@ export class UsersManager {
     emails: string[],
     manager?: EntityManager
   ): Promise<User[]> {
+    if (emails.length === 0){
+      return [];
+    }
     return await this._buildExistingUsersByLoginRequest(emails, manager)
       .getMany();
   }

--- a/test/gen-server/lib/homedb/UsersManager.ts
+++ b/test/gen-server/lib/homedb/UsersManager.ts
@@ -10,7 +10,7 @@ import { User } from 'app/gen-server/entity/User';
 import { Workspace } from 'app/gen-server/entity/Workspace';
 import { HomeDBManager } from 'app/gen-server/lib/homedb/HomeDBManager';
 import { GetUserOptions, NonGuestGroup, Resource } from 'app/gen-server/lib/homedb/Interfaces';
-import { SUPPORT_EMAIL, UsersManager} from 'app/gen-server/lib/homedb/UsersManager';
+import { SUPPORT_EMAIL, UsersManager } from 'app/gen-server/lib/homedb/UsersManager';
 import { updateDb } from 'app/server/lib/dbUtils';
 import { EnvironmentSnapshot } from 'test/server/testUtils';
 import { createInitialDb, removeConnection, setUpDB } from 'test/gen-server/seed';

--- a/test/gen-server/lib/homedb/UsersManager.ts
+++ b/test/gen-server/lib/homedb/UsersManager.ts
@@ -10,7 +10,7 @@ import { User } from 'app/gen-server/entity/User';
 import { Workspace } from 'app/gen-server/entity/Workspace';
 import { HomeDBManager } from 'app/gen-server/lib/homedb/HomeDBManager';
 import { GetUserOptions, NonGuestGroup, Resource } from 'app/gen-server/lib/homedb/Interfaces';
-import { SUPPORT_EMAIL, UsersManager } from 'app/gen-server/lib/homedb/UsersManager';
+import { SUPPORT_EMAIL, UsersManager} from 'app/gen-server/lib/homedb/UsersManager';
 import { updateDb } from 'app/server/lib/dbUtils';
 import { EnvironmentSnapshot } from 'test/server/testUtils';
 import { createInitialDb, removeConnection, setUpDB } from 'test/gen-server/seed';
@@ -653,6 +653,40 @@ describe('UsersManager', function () {
         const retrievedUser = await db.getExistingUserByLogin(nonExistingEmail);
 
         assert.isUndefined(retrievedUser);
+      });
+    });
+
+    describe('getExistingUsersByLogin()', function () {
+      it('should return existing users', async function () {
+        const emails = [PREVIEWER_EMAIL, EVERYONE_EMAIL];
+        const retrievedUsers = await db.getExistingUsersByLogin(emails);
+        assertExists(retrievedUsers);
+
+        assert.equal(retrievedUsers[0].id, db.getPreviewerUserId());
+        assert.equal(retrievedUsers[0].name, 'Preview');
+        assert.equal(retrievedUsers[1].id, db.getEveryoneUserId());
+        assert.equal(retrievedUsers[1].name, 'Everyone');
+      });
+
+      it('should normalize the passed users email', async function () {
+        const emails = [PREVIEWER_EMAIL.toUpperCase(), EVERYONE_EMAIL.toUpperCase()];
+        const retrievedUsers = await db.getExistingUsersByLogin(emails);
+
+        assert.isNotEmpty(retrievedUsers);
+      });
+
+      it('should return an empty array when no user is found', async function () {
+        const nonExistingEmails = ['i-dont-exist@getgrist.com', 'me-neither@getgrist.com'];
+        const retrievedUsers = await db.getExistingUsersByLogin(nonExistingEmails);
+
+        assert.isEmpty(retrievedUsers);
+      });
+
+      it('should return an empty array when no emails/logins are given', async function () {
+        const nonExistingEmails: string[] = [];
+        const retrievedUsers = await db.getExistingUsersByLogin(nonExistingEmails);
+
+        assert.isEmpty(retrievedUsers);
       });
     });
 

--- a/test/gen-server/lib/homedb/UsersManager.ts
+++ b/test/gen-server/lib/homedb/UsersManager.ts
@@ -672,7 +672,7 @@ describe('UsersManager', function () {
         const emails = [PREVIEWER_EMAIL.toUpperCase(), EVERYONE_EMAIL.toUpperCase()];
         const retrievedUsers = await db.getExistingUsersByLogin(emails);
 
-        assert.isNotEmpty(retrievedUsers);
+        assert.lengthOf(retrievedUsers, 2);
       });
 
       it('should return an empty array when no user is found', async function () {
@@ -683,8 +683,8 @@ describe('UsersManager', function () {
       });
 
       it('should return an empty array when no emails/logins are given', async function () {
-        const nonExistingEmails: string[] = [];
-        const retrievedUsers = await db.getExistingUsersByLogin(nonExistingEmails);
+        const emptyEmailsList: string[] = [];
+        const retrievedUsers = await db.getExistingUsersByLogin(emptyEmailsList);
 
         assert.isEmpty(retrievedUsers);
       });


### PR DESCRIPTION
## Context

PR #1205 introduced a regression with postgreSQL.
The present PR addresses it.

## Proposed solution

As a workaround of TYPEORM postgresql (...Emails) syntax handling. The code now returns an empty Array if there is no emails given to get existing users.

## Related issues

#1005 

## Has this been tested?

yes locally with a psql database.

