### PR TITLE
Adds GRIST_DOCKER_* vars to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,13 @@ TYPEORM_TYPE     | set to 'sqlite' or 'postgres'
 TYPEORM_USERNAME | username to connect as
 TYPEORM_EXTRA    | any other properties to pass to TypeORM in JSON format
 
+#### Docker-only variables:
+
+Variable | Purpose
+---------|--------
+GRIST_DOCKER_USER  | optional. When the container runs as the root user, this is the user the Grist services run as. Overrides the default.
+GRIST_DOCKER_GROUP | optional. When the container runs as the root user, this is the group the Grist services run as. Overrides the default.
+
 #### Testing:
 
 Variable | Purpose


### PR DESCRIPTION
Documents the GRIST_DOCKER_USER and GRIST_DOCKER_GROUP variables.

## Context

The GRIST_DOCKER_* variables were previously not documented anywhere, but issues around container permissions occasionally came up that needed to use them.

## Proposed solution

Added to README 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

