### PR TITLE
Bump Chrome for Testing version

### DIFF
--- a/test/nbrowser/testUtils.ts
+++ b/test/nbrowser/testUtils.ts
@@ -16,7 +16,7 @@
  * first-failure for debugging and quick reruns.
  */
 import log from 'app/server/lib/log';
-import {addToRepl, assert, driver, enableDebugCapture, ITimeouts,
+import {addToRepl, assert, Capability, driver, enableDebugCapture, ITimeouts,
   Key, setOptionsModifyFunc, useServer} from 'mocha-webdriver';
 import * as gu from 'test/nbrowser/gristUtils';
 import {server} from 'test/nbrowser/testServer';
@@ -43,6 +43,7 @@ setOptionsModifyFunc(({chromeOpts, firefoxOpts}) => {
   // eslint-disable-next-line max-len
   // https://github.com/shs96c/selenium/blob/ff82c4af6a493321d9eaec6ba8fa8589e4aa824d/javascript/node/selenium-webdriver/firefox.js#L415
   chromeOpts.set('webSocketUrl', true);
+  chromeOpts.set(Capability.UNHANDLED_PROMPT_BEHAVIOR, "ignore");
 
   chromeOpts.setUserPreferences({
     // Don't show popups to save passwords, which are shown when running against a deployment when

--- a/test/test_env.sh
+++ b/test/test_env.sh
@@ -3,9 +3,9 @@
 export GRIST_SESSION_COOKIE="grist_test_cookie"
 export LANGUAGE="en_US"
 export SE_BROWSER="chrome"
-export SE_BROWSER_VERSION="127"
+export SE_BROWSER_VERSION="130"
 export SE_DRIVER="chrome-driver"
-export SE_DRIVER_VERSION="127.0.6533.119"
+export SE_DRIVER_VERSION="130.0.6723.91"
 export TEST_CLEAN_DATABASE="true"
 export TEST_SUPPORT_API_KEY="api_key_for_support"
 


### PR DESCRIPTION
## Context

Browser CI tests began failing on Chrome 127 recently, presumably due to a bug in Selenium Manager. Chrome 130 does not appear to be affected.

## Proposed solution

Bump Chrome version to 130.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
