### PR TITLE
Issue 1219 poc service accounts

### DIFF
--- a/app/common/User.ts
+++ b/app/common/User.ts
@@ -10,6 +10,8 @@ export enum UserTypes {
   'service'
 }
 
+export type UserTypesStrings = keyof typeof UserTypes;
+
 /**
  * Information about a user, including any user attributes.
  */

--- a/app/common/User.ts
+++ b/app/common/User.ts
@@ -3,6 +3,14 @@ import {EmptyRecordView, RecordView} from 'app/common/RecordView';
 import {Role} from 'app/common/roles';
 
 /**
+ * User type to distinguish beetween Users and service accounts
+ */
+export enum UserTypes {
+  'login',
+  'service'
+}
+
+/**
  * Information about a user, including any user attributes.
  */
 export interface UserInfo {
@@ -19,6 +27,7 @@ export interface UserInfo {
    * via a share. Otherwise null.
    */
   ShareRef: number | null;
+  Type: UserTypes | null;
   [attributes: string]: unknown;
 }
 
@@ -37,6 +46,7 @@ export class User implements UserInfo {
   public SessionID: string | null = null;
   public UserRef: string | null = null;
   public ShareRef: number | null = null;
+  public Type: UserTypes | null = null;
   [attribute: string]: any;
 
   constructor(info: Record<string, unknown> = {}) {

--- a/app/gen-server/ApiServer.ts
+++ b/app/gen-server/ApiServer.ts
@@ -599,6 +599,35 @@ export class ApiServer {
       if (data) { this._logDeleteUserEvents(req, data); }
       return sendReply(req, res, result);
     }));
+
+    // POST /service-accounts/
+    // Creates a new service account attached to the user making the api call.
+    this._app.post('/api/service-accounts', expressWrap(async (req, res) => {
+      const userId = getAuthorizedUserId(req);
+      const serviceAccount: any = await this._dbManager.createServiceAccount(req.body);
+      return sendOkReply(req, res, {
+        key:serviceAccount.key,
+      });
+      throw new ApiError(`${userId} post Not implemented yet ;)`, 501);
+    }));
+
+    // GET /service-accounts/
+    // Reads all service accounts attached to the user making the api call.
+    this._app.get('/api/service-accounts', expressWrap(async (req, res) => {
+      throw new ApiError('get Not implemented yet ;)', 501);
+    }));
+
+    // GET /service-accounts/:said
+    // Reads one particular service account of the user making the api call.
+    this._app.get('/api/service-accounts/:said', expressWrap(async (req, res) => {
+      throw new ApiError('get by id Not implemented yet ;)', 501);
+    }));
+
+    // DELETE /service-accounts/:said
+    // Deletes one particular service account of the user making the api call.
+    this._app.delete('/api/service-accounts/:said', expressWrap(async (req, res) => {
+      throw new ApiError('delete by id Not implemented yet ;)', 501);
+    }));
   }
 
   private async _getFullUser(req: Request, options: {includePrefs?: boolean} = {}): Promise<FullUser> {

--- a/app/gen-server/entity/ServiceAccount.ts
+++ b/app/gen-server/entity/ServiceAccount.ts
@@ -7,11 +7,10 @@ export class ServiceAccount extends BaseEntity {
   @PrimaryGeneratedColumn()
   public id: number;
 
-
   @Column({type: String})
   public description: string;
 
-  @Column({type: Date, default: Date.now()})
+  @Column({type: Date, nullable: false})
   public endOfLife: string;
 
   @ManyToOne(type => User)

--- a/app/gen-server/entity/ServiceAccount.ts
+++ b/app/gen-server/entity/ServiceAccount.ts
@@ -1,0 +1,24 @@
+import {BaseEntity, Column, Entity, JoinTable, ManyToOne, PrimaryGeneratedColumn} from "typeorm";
+import { User } from './User';
+
+@Entity({name: 'service_accounts'})
+export class ServiceAccount extends BaseEntity {
+
+  @PrimaryGeneratedColumn()
+  public id: number;
+
+
+  @Column({type: String})
+  public description: string;
+
+  @Column({type: Date, default: Date.now()})
+  public endOfLife: string;
+
+  @ManyToOne(type => User)
+  @JoinTable({
+    name: 'service_account_user',
+    joinColumn: {name: 'service_account_id'},
+    inverseJoinColumn: {name: 'user_id'}
+  })
+  public service_account_owner: User;
+}

--- a/app/gen-server/entity/ServiceAccount.ts
+++ b/app/gen-server/entity/ServiceAccount.ts
@@ -1,5 +1,4 @@
-import {BaseEntity, Column, Entity, JoinTable, ManyToOne, PrimaryGeneratedColumn} from "typeorm";
-import { User } from './User';
+import {BaseEntity, Column, Entity, PrimaryGeneratedColumn} from "typeorm";
 
 @Entity({name: 'service_accounts'})
 export class ServiceAccount extends BaseEntity {
@@ -7,17 +6,15 @@ export class ServiceAccount extends BaseEntity {
   @PrimaryGeneratedColumn()
   public id: number;
 
+  @Column({type: Number})
+  public owner_id: number;
+
+  @Column({type: Number})
+  public service_user_id: number;
+
   @Column({type: String})
   public description: string;
 
   @Column({type: Date, nullable: false})
   public endOfLife: string;
-
-  @ManyToOne(type => User)
-  @JoinTable({
-    name: 'service_account_user',
-    joinColumn: {name: 'service_account_id'},
-    inverseJoinColumn: {name: 'user_id'}
-  })
-  public service_account_owner: User;
 }

--- a/app/gen-server/entity/User.ts
+++ b/app/gen-server/entity/User.ts
@@ -1,5 +1,5 @@
 import {UserOptions} from 'app/common/UserAPI';
-import {UserTypes} from 'app/common/User';
+import {UserTypesStrings} from 'app/common/User';
 import {nativeValues} from 'app/gen-server/lib/values';
 import {makeId} from 'app/server/lib/idUtils';
 import {BaseEntity, BeforeInsert, Column, Entity, JoinTable, ManyToMany, OneToMany, OneToOne,
@@ -74,7 +74,7 @@ export class User extends BaseEntity {
   public ref: string;
 
   @Column({name: 'type', type: String, default: 'login'})
-  public type: UserTypes | null;
+  public type: UserTypesStrings | null;
 
   @BeforeInsert()
   public async beforeInsert() {

--- a/app/gen-server/entity/User.ts
+++ b/app/gen-server/entity/User.ts
@@ -1,4 +1,5 @@
 import {UserOptions} from 'app/common/UserAPI';
+import {UserTypes} from 'app/common/User';
 import {nativeValues} from 'app/gen-server/lib/values';
 import {makeId} from 'app/server/lib/idUtils';
 import {BaseEntity, BeforeInsert, Column, Entity, JoinTable, ManyToMany, OneToMany, OneToOne,
@@ -63,6 +64,9 @@ export class User extends BaseEntity {
    */
   @Column({name: 'ref', type: String, nullable: false})
   public ref: string;
+
+  @Column({name: 'type', type: String, default: 'login'})
+  public type: UserTypes | null;
 
   @BeforeInsert()
   public async beforeInsert() {

--- a/app/gen-server/entity/User.ts
+++ b/app/gen-server/entity/User.ts
@@ -9,6 +9,7 @@ import {Group} from "./Group";
 import {Login} from "./Login";
 import {Organization} from "./Organization";
 import {Pref} from './Pref';
+import {ServiceAccount} from './ServiceAccount';
 
 @Entity({name: 'users'})
 export class User extends BaseEntity {
@@ -59,6 +60,13 @@ export class User extends BaseEntity {
   @Column({name: 'connect_id', type: String, nullable: true})
   public connectId: string | null;
 
+  @OneToMany(type => User, user => user.serviceAccounts)
+  @JoinTable({
+    name: 'service_account_user',
+    joinColumn: {name: 'user_id'},
+    inverseJoinColumn: {name: 'service_account_id'}
+  })
+  public serviceAccounts: ServiceAccount[];
   /**
    * Unique reference for this user. Primarily used as an ownership key in a cell metadata (comments).
    */

--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -89,6 +89,7 @@ import {
 } from "typeorm";
 import {v4 as uuidv4} from "uuid";
 import { GroupsManager } from './GroupsManager';
+import { ServiceAccountsManager } from './ServiceAccountsManager';
 
 // Support transactions in Sqlite in async code.  This is a monkey patch, affecting
 // the prototypes of various TypeORM classes.
@@ -254,6 +255,7 @@ export type BillingOptions = Partial<Pick<BillingAccount,
 export class HomeDBManager extends EventEmitter {
   private _usersManager = new UsersManager(this, this._runInTransaction.bind(this));
   private _groupsManager = new GroupsManager();
+  private _serviceAccountsManager = new ServiceAccountsManager(this);
   private _connection: DataSource;
   private _exampleWorkspaceId: number;
   private _exampleOrgId: number;
@@ -3065,6 +3067,18 @@ export class HomeDBManager extends EventEmitter {
       query = query.andWhere("configs.org_id IS NULL");
     }
     return query.getOne();
+  }
+
+  public async deleteAllServiceAccounts(){
+    return this._serviceAccountsManager.deleteAllServiceAccounts();
+  }
+
+  public async createServiceAccount(
+    ownerId: number,
+    description?: string,
+    endOfLife?: Date
+  ){
+  return this._serviceAccountsManager.createServiceAccount(ownerId, description, endOfLife);
   }
 
   private _installConfig(

--- a/app/gen-server/lib/homedb/ServiceAccountsManager.ts
+++ b/app/gen-server/lib/homedb/ServiceAccountsManager.ts
@@ -1,0 +1,55 @@
+import { HomeDBManager } from 'app/gen-server/lib/homedb/HomeDBManager';
+//import { UsersManager } from 'app/gen-server/lib/homedb/UsersManager';
+import { EntityManager } from 'typeorm';
+import { User } from 'app/gen-server/entity/User';
+import {v4 as uuidv4} from 'uuid';
+//import { ServiceAccount } from 'app/gen-server/entity/ServiceAccount';
+
+export class ServiceAccountsManager {
+
+  private get _connection () {
+    return this._homeDb.connection;
+  }
+
+  public constructor(
+    private readonly _homeDb: HomeDBManager,
+    //private _runInTransaction: RunInTransaction
+  ) {}
+
+  // This method is implemented for test purpose only
+  // Using it outside of tests context will lead to partial db
+  // destruction
+  public async deleteAllServiceAccounts(optManager?: EntityManager){
+    const manager = optManager || new EntityManager(this._connection);
+    const queryBuilder = manager.createQueryBuilder()
+      .delete()
+      .from(User, 'users')
+      .where('users.type ="service"');
+    return await queryBuilder.execute();
+  }
+
+  public async createServiceAccount(
+    ownerId: number,
+    description?: string,
+    endOfLife?: Date,
+  ){
+    await this._connection.transaction(async manager => {
+      //TODO create new service user in order to have its
+      //id to insert
+      const uuid = uuidv4();
+      const email = `${uuid}@serviceaccounts.local`;
+      const serviceUser = await this._homeDb.getUserByLogin(email);
+      // FIXME use manager.save(entité);
+      return await manager.createQueryBuilder()
+        .insert()
+        .into('service_accounts')
+        .values({
+          ownerId,
+          serviceUserId: serviceUser.id,
+          description,
+          endOfLife,
+        })
+        .execute();
+    });
+  }
+}

--- a/app/gen-server/lib/homedb/UsersManager.ts
+++ b/app/gen-server/lib/homedb/UsersManager.ts
@@ -27,6 +27,8 @@ import { Pref } from 'app/gen-server/entity/Pref';
 import flatten from 'lodash/flatten';
 import { EntityManager } from 'typeorm';
 
+import { UserTypesStrings } from 'app/common/User';
+
 // A special user allowed to add/remove the EVERYONE_EMAIL to/from a resource.
 export const SUPPORT_EMAIL = appSettings.section('access').flag('supportEmail').requireString({
   envVar: 'GRIST_SUPPORT_EMAIL',
@@ -371,7 +373,7 @@ export class UsersManager {
    * unset/outdated fields of an existing record.
    *
    */
-  public async getUserByLogin(email: string, options: GetUserOptions = {}) {
+  public async getUserByLogin(email: string, options: GetUserOptions = {}, type?: UserTypesStrings) {
     const {manager: transaction, profile, userOptions} = options;
     const normalizedEmail = normalizeEmail(email);
     return await this._runInTransaction(transaction, async manager => {
@@ -389,6 +391,8 @@ export class UsersManager {
         // Special users do not have first time user set so that they don't get redirected to the
         // welcome page.
         user.isFirstTimeUser = !NON_LOGIN_EMAILS.includes(normalizedEmail);
+        // redémarrer lundi ici TODO
+        user.type = typeof type === 'undefined' ? 'login' : type;
         login = new Login();
         login.email = normalizedEmail;
         login.user = user;

--- a/app/gen-server/migration/1730215435023-ServiceAccounts.ts
+++ b/app/gen-server/migration/1730215435023-ServiceAccounts.ts
@@ -23,8 +23,16 @@ export class ServiceAccounts1730215435023 implements MigrationInterface {
             isPrimary: true,
           },
           {
+            name: 'owner_id',
+            type: 'int',
+          },
+          {
+            name: 'service_user_id',
+            type: 'int',
+          },
+          {
             name: 'description',
-            type: 'varchar'
+            type: 'varchar',
           },
           {
             name: 'endOfLife',
@@ -34,44 +42,29 @@ export class ServiceAccounts1730215435023 implements MigrationInterface {
         ],
       })
     );
-    await queryRunner.createTable(
-      new Table({
-        name: 'service_account_user',
-        columns: [
-          {
-            name: 'service_account_id',
-            type: 'int',
-          },
-          {
-            name: 'user_id',
-            type: 'int'
-          },
-        ],
-      })
-    );
     await queryRunner.createForeignKey(
-      'service_account_user',
+      'service_accounts',
       new TableForeignKey({
-        columnNames: ['service_account_id'],
+        columnNames: ['service_user_id'],
         referencedColumnNames: ['id'],
-        referencedTableName: 'service_accounts',
+        referencedTableName: 'users',
         onDelete: 'CASCADE',
       })
     );
     await queryRunner.createForeignKey(
-      'service_account_user',
+      'service_accounts',
       new TableForeignKey({
-        columnNames: ['user_id'],
+        columnNames: ['owner_id'],
         referencedColumnNames: ['id'],
         referencedTableName: 'users',
         onDelete: 'CASCADE',
       })
     );
     await queryRunner.createIndex(
-      'service_account_user',
+      'service_accounts',
       new TableIndex({
-        name: 'service_account__user',
-        columnNames: ['service_account_id', 'user_id'],
+        name: 'service_account__owner',
+        columnNames: ['service_accounts_owner', 'user_id'],
       })
     );
   }
@@ -79,6 +72,5 @@ export class ServiceAccounts1730215435023 implements MigrationInterface {
   public async down(queryRunner: QueryRunner): Promise<any> {
     await queryRunner.dropColumn('users', 'type');
     await queryRunner.dropTable('service_accounts');
-    await queryRunner.dropTable('service_account_user');
   }
 }

--- a/app/gen-server/migration/1730215435023-ServiceAccounts.ts
+++ b/app/gen-server/migration/1730215435023-ServiceAccounts.ts
@@ -1,8 +1,12 @@
 import { MigrationInterface, QueryRunner, Table, TableColumn, TableForeignKey, TableIndex } from "typeorm";
+import * as sqlUtils from "app/gen-server/sqlUtils";
 
 export class ServiceAccounts1730215435023 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<any> {
+    const dbType = queryRunner.connection.driver.options.type;
+    const datetime = sqlUtils.datetime(dbType);
+
     await queryRunner.addColumn('users', new TableColumn({
       name: 'type',
       type: 'varchar',
@@ -24,8 +28,8 @@ export class ServiceAccounts1730215435023 implements MigrationInterface {
           },
           {
             name: 'endOfLife',
-            type: 'date',
-            default: 'now()',
+            type: datetime,
+            isNullable: false,
           },
         ],
       })

--- a/app/gen-server/migration/1730215435023-ServiceAccounts.ts
+++ b/app/gen-server/migration/1730215435023-ServiceAccounts.ts
@@ -1,0 +1,80 @@
+import { MigrationInterface, QueryRunner, Table, TableColumn, TableForeignKey, TableIndex } from "typeorm";
+
+export class ServiceAccounts1730215435023 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.addColumn('users', new TableColumn({
+      name: 'type',
+      type: 'varchar',
+      isNullable: false,
+      default: "'login'",
+    }));
+    await queryRunner.createTable(
+      new Table({
+        name: 'service_accounts',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+          },
+          {
+            name: 'description',
+            type: 'varchar'
+          },
+          {
+            name: 'endOfLife',
+            type: 'date',
+            default: 'now()',
+          },
+        ],
+      })
+    );
+    await queryRunner.createTable(
+      new Table({
+        name: 'service_account_user',
+        columns: [
+          {
+            name: 'service_account_id',
+            type: 'int',
+          },
+          {
+            name: 'user_id',
+            type: 'int'
+          },
+        ],
+      })
+    );
+    await queryRunner.createForeignKey(
+      'service_account_user',
+      new TableForeignKey({
+        columnNames: ['service_account_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'service_accounts',
+        onDelete: 'CASCADE',
+      })
+    );
+    await queryRunner.createForeignKey(
+      'service_account_user',
+      new TableForeignKey({
+        columnNames: ['user_id'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'users',
+        onDelete: 'CASCADE',
+      })
+    );
+    await queryRunner.createIndex(
+      'service_account_user',
+      new TableIndex({
+        name: 'service_account__user',
+        columnNames: ['service_account_id', 'user_id'],
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.dropColumn('users', 'type');
+    await queryRunner.dropTable('service_accounts');
+    await queryRunner.dropTable('service_account_user');
+  }
+}

--- a/test/gen-server/ApiServer.ts
+++ b/test/gen-server/ApiServer.ts
@@ -2378,9 +2378,7 @@ describe('ApiServer', function() {
 
     afterEach(async function() {
       oldEnv.restore();
-      // FIXME create the new method to delete services accounts
-      //const did = await dbManager.testGetId('Curiosity');
-      // await dbManager.deleteServices(did as string);
+      await dbManager.deleteAllServiceAccounts();
     });
 
     after(async function() {
@@ -2448,6 +2446,10 @@ describe('ApiServer', function() {
     // it('Endpoint UPDATE /api/service-accounts/{saId}/transfer-to/{userId}', async function() {
 
     // });
+
+    // it('MUSN'T connect as a login user, async function() {
+
+    //});
   });
 });
 

--- a/test/gen-server/ApiServer.ts
+++ b/test/gen-server/ApiServer.ts
@@ -2351,6 +2351,104 @@ describe('ApiServer', function() {
     // Assert that the response status is 404 because the templates org doesn't exist.
     assert.equal(resp.status, 404);
   });
+
+  describe('Service Accounts', function() {
+   let oldEnv: testUtils.EnvironmentSnapshot;
+
+    testUtils.setTmpLogLevel('error');
+
+    before(async function() {
+      oldEnv = new testUtils.EnvironmentSnapshot();
+      process.env.GRIST_TEMPLATE_ORG = 'templates';
+      server = new TestServer(this);
+      homeUrl = await server.start(['home', 'docs']);
+      dbManager = server.dbManager;
+
+      chimpyRef = await dbManager.getUserByLogin(chimpyEmail).then((user) => user.ref);
+      kiwiRef = await dbManager.getUserByLogin(kiwiEmail).then((user) => user.ref);
+      charonRef = await dbManager.getUserByLogin(charonEmail).then((user) => user.ref);
+
+      // Listen to user count updates and add them to an array.
+      dbManager.on('userChange', ({org, countBefore, countAfter}: UserChange) => {
+        if (countBefore === countAfter) { return; }
+        userCountUpdates[org.id] = userCountUpdates[org.id] || [];
+        userCountUpdates[org.id].push(countAfter);
+      });
+    });
+
+    afterEach(async function() {
+      oldEnv.restore();
+      // FIXME create the new method to delete services accounts
+      //const did = await dbManager.testGetId('Curiosity');
+      // await dbManager.deleteServices(did as string);
+    });
+
+    after(async function() {
+      await server.stop();
+    });
+
+    it('Endpoint POST /api/service-accounts is operational', async function() {
+
+    });
+
+    it('Endpoint POST /api/service-accounts returns 400 when missing parameter in request body', async function() {
+
+    });
+
+    it('Endpoint POST /api/service-accounts returns 400 on invalid endOfLife', async function() {
+
+    });
+
+    it('Endpoint GET /api/service-accounts is operational', async function() {
+
+    });
+
+    it("Endpoint GET /api/service-accounts returns 404 when user don't own any service account", async function() {
+
+    });
+
+    it('Endpoint GET /api/service-accounts/{saId} is operational', async function() {
+
+    });
+
+    it('Endpoint GET /api/service-accounts/{saId} returns 404 on non-existing {saId}', async function() {
+
+    });
+
+    it('Endpoint UPDATE /api/service-accounts/{saId} is operational', async function() {
+
+    });
+
+    it('Endpoint UPDATE /api/service-accounts/{saId} returns 404 on non-existing {saId}', async function() {
+
+    });
+
+    it('Endpoint UPDATE /api/service-accounts/{saId} returns 400 on empty label', async function() {
+
+    });
+
+    // What are we doing about empty description ?
+
+    it('Endpoint UPDATE /api/service-accounts/{saId} returns 400 on invalid endOfLife', async function() {
+
+    });
+
+    it('Endpoint UPDATE /api/service-accounts/{saId} returns 400 if trying to update owner', async function() {
+
+    });
+
+    it('Endpoint DELETE /api/service-accounts/{saId} is operational', async function() {
+
+    });
+
+    it('Endpoint DELETE /api/service-accounts/{saId} returns 404 on non-existing {saId}', async function() {
+
+    });
+
+    // it('Endpoint UPDATE /api/service-accounts/{saId}/transfer-to/{userId}', async function() {
+
+    // });
+  });
 });
 
 

--- a/test/gen-server/migrations.ts
+++ b/test/gen-server/migrations.ts
@@ -49,6 +49,7 @@ import {ActivationEnabled1722529827161
 import {Configs1727747249153 as Configs} from 'app/gen-server/migration/1727747249153-Configs';
 import {LoginsEmailsIndex1729754662550
         as LoginsEmailsIndex} from 'app/gen-server/migration/1729754662550-LoginsEmailIndex';
+import {ServiceAccounts1730215435023 as ServiceAccounts} from 'app/gen-server/migration/1730215435023-ServiceAccounts';
 
 const home: HomeDBManager = new HomeDBManager();
 
@@ -58,7 +59,7 @@ const migrations = [Initial, Login, PinDocs, UserPicture, DisplayEmail, DisplayE
                     ExternalBilling, DocOptions, Secret, UserOptions, GracePeriodStart,
                     DocumentUsage, Activations, UserConnectId, UserUUID, UserUniqueRefUUID,
                     Forks, ForkIndexes, ActivationPrefs, AssistantLimit, Shares, BillingFeatures,
-                    UserLastConnection, ActivationEnabled, Configs, LoginsEmailsIndex];
+                    UserLastConnection, ActivationEnabled, Configs, LoginsEmailsIndex, ServiceAccounts];
 
 // Assert that the "members" acl rule and group exist (or not).
 function assertMembersGroup(org: Organization, exists: boolean) {


### PR DESCRIPTION
**This is an evolving PR with draft status**
**Following lines MUST evolved across development**

## Context

This PR add an API as a first implementation of service accounts as defined in previous discussions. C.F. #579 #1115 

## Proposed solution

**In evolution**

Under the hood, Service account is a just a user account.
It can act exactly like a user account.
It has the same action as a user account.

It's differentiated by the following elements:

1. a type column in user table. `type=login|service` 

2. A table handling:
    + id
    + description,
    + endOfLive, 

* Label/key-name can stored in users.name

* technicalId can be the logins.email or the email_username (part before the \@)
    
 3. An associative table linking Service account to its owners and to its associated user/personna.

4. Service accounts are not allowed to connect through web.

## DB schema updates 

The two previous features have to be implemented in the table.

## API description

base endpoint : `/api/service-accounts`

### CREATE Service Account

`POST /api/service-account`
* Authorizations: ApiKey

##### Request Body schema: application/json

* label: \<String\>
* description: \<String\>
* endOfLife: \<String\>

`endOfLife` is a String that can be parsed as a date. Following the [date time string format specification](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date-time-string-format).
**To be discussed** Possibly a `-1` EndOf life will give never ending Service Account

##### Response

`200`

An object containing :
* Service account APIkey: \<String\>
* Service APIkey technical id: \<String\>

`400`
on invalid endOfLife

### UPDATE Service Account

`UPDATE /api/serviceaccount/{saId}`
* Authorizations: ApiKey

##### path Parameters
| parameter | type |
|-|-|
|saId `required` | **string** A string id (UUID)|

##### Request Body schema: application/json

* label: \<String\>
* description: \<String\>
* endOfLife: \<String\>
* ownerId: \<Number\>

** Verify if ownership transfer is still a thing **

##### Response

`200`

* Service account object as updated: \<Object\>

### READ Service Account

`GET /api/serviceaccount/{saId}`
* Authorizations: ApiKey

##### path Parameters
| parameter | type |
|-|-|
|saId `required` | **string** A string id (UUID)|

##### Response

`200`

* Service account object: \<Object\>

### DELETE Service Account 

`DELETE /api/serviceaccount/{saId}`
* Authorizations: ApiKey

##### path Parameters
| parameter | type |
|-|-|
|saId `required` | **string** A string id (UUID)|

##### Response

`200`

* A deletion confirmation message ? 

The `200` instead of `204` is chosen to be consistent with other DELETE routes in grist.

### READ Service Accounts by Owner/GroupOwner

`GET /api/servicesccounts`
* Authorizations: ApiKey

##### path Parameters
| parameter | type |
|-|-|
|UserId `required` | **number**|

##### Response

`200`

* List of service account objects: \<Object\>[]

## To be answered questions / decision to be made

* What is the form of emails given to the service accounts ?
    > For this first draft the opiniated option is
    > TechnicalId@instanceName.ext
    > It must be a domain that for sure is rejected for web login.
* What happened to documents owned by a Service Account on service account deletion ?
 > In an API point of view it's not handled. It the duty to the key owner to perform an UPDATE call with a new ownerId.
* Can service account create documents ?
 > Yes, if the linked persona as been added as editor on a workspace or org. 
* How implement a logic like **can't edit it's own Rights** (Only lowering it)
> Yes a every users. The only difference its that it can be deleted by another user.
* Can multiple users have access to the same key ?
> Let say no for the first implementation. The good news is that is inherits its owner rights.
    
A service account max right is its owner max right.

Can a service account be owner of another service account ?
> To be determined


## Related issues

fixes #1219


## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ x ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
