### PR TITLE
fix: add support for Azure OpenAI Services endpoints

### DIFF
--- a/app/server/lib/Assistance.ts
+++ b/app/server/lib/Assistance.ts
@@ -256,6 +256,7 @@ export class OpenAIAssistant implements Assistant {
         headers: {
           ...(this._apiKey ? {
             "Authorization": `Bearer ${this._apiKey}`,
+            "api-key": this._apiKey,
           } : undefined),
           "Content-Type": "application/json",
         },


### PR DESCRIPTION
## Context

adds support for Azure OpenAI Services endpoints.

## Proposed solution

add another header `api-key` that is required for azure openai services endpoints. 
OpenAI ignores the `api-key` header and Microsofts token auth ignores the Authorization header so this is a pragmatic solutionto just set both to same value. 
Bonus: support for EntraID auth also is working (which uses the Authorization Header)

## Related issues

fix #1282 


## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->