### PR TITLE
Dockerfile: don't mix up Docker and debian versions of python 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,16 +59,15 @@ RUN \
 # the workarounds needed to keep it are getting silly.
 # It doesn't exist in recent Debian, so we need to reach back
 # to buster.
-FROM python:2.7-slim-buster AS collector-py2
+FROM debian:buster-slim AS collector-py2
 ADD sandbox/requirements.txt requirements.txt
 RUN \
   apt update && \
   apt install -y --no-install-recommends python2 python-pip python-setuptools \
   build-essential libxml2-dev libxslt-dev python-dev zlib1g-dev && \
   pip2 install wheel && \
-  pip2 install -r requirements.txt && \
-  pip2 install six && \
-  find /usr/lib -iname "libffi.so.6*" -exec cp {} /usr/local/lib \;
+  pip2 install -r requirements.txt 
+
 
 ################################################################################
 ## Sandbox collection stage
@@ -108,10 +107,6 @@ COPY --from=builder /grist/static /grist/static-built
 COPY --from=collector-py2 /usr/bin/python2.7 /usr/bin/python2.7
 COPY --from=collector-py2 /usr/lib/python2.7 /usr/lib/python2.7
 COPY --from=collector-py2 /usr/local/lib/python2.7 /usr/local/lib/python2.7
-# Make a small python2 tweak so that material in /usr/local/lib is found.
-RUN \
-  mkdir /etc/python2.7 && \
-  echo "import sys\nsys.path.append('/usr/local/lib/python2.7/site-packages')" > /etc/python2.7/sitecustomize.py
 # Copy across an older libffi library binary needed by python2.
 # We moved it a bit sleazily to a predictable location to avoid awkward
 # architecture-dependent logic.


### PR DESCRIPTION
## Context

Fixing #1298.

## Proposed solution

When the Python 3 and Python 2 collecting images were separated, the `python:2.7-slim-buster` image started being used to download a Python 2.7 binary.

Unfortunately the `apt-get install python2` command that was necessary when the base image was `python:3.11-slim-buster` was left in, causing two installations of Python 2.7 to exist in the resulting `collector-py2` image.

This resulted in a somewhat broken `python2.7` in the final image, that required a new configuration script in `/etc/python2.7`. But that script wasn't exposed to the gvisor sandbox, causing Python 2 to fail.

By starting from the `debian:buster-slim` image and using only the Apt-installed `python2` as before, compatibility with the existing gvisor sandbox is maintained without any workaround.

## Related issues

#1298 

## Has this been tested?

I built an image locally and ran the command described in #1298:

```
$ GREP_TESTS='should support basic editing' \
   TEST_IMAGE='-e GRIST_SANDBOX_FLAVOR=gvisor -e PYTHON_VERSION_ON_CREATION=2 grist' \
   yarn test:docker
```

Obviously the current CI test suite does not have a case for Python 2 under gvisor, or the issue would have been caught earlier. I'm not sure how to add such a test or whether it's worth the effort.

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
