### PR TITLE
use debian bookworm in docker container

### DIFF
--- a/.github/workflows/docker_latest.yml
+++ b/.github/workflows/docker_latest.yml
@@ -127,9 +127,36 @@ jobs:
       - name: Install Google Chrome for Testing
         run: ./test/test_env.sh node_modules/selenium-webdriver/bin/linux/selenium-manager
 
-      - name: Run tests
+      - name: Run tests with default settings
         if: ${{ !inputs.disable_tests }}
-        run: TEST_IMAGE=${{ env.DOCKER_HUB_OWNER }}/${{ matrix.image.name }}:${{ env.TAG }} VERBOSE=1 DEBUG=1 MOCHA_WEBDRIVER_HEADLESS=1 yarn run test:docker
+        run: |
+          export TEST_IMAGE=${{ env.DOCKER_HUB_OWNER }}/${{ matrix.image.name }}:${{ env.TAG }}
+          export VERBOSE=1
+          export DEBUG=1
+          export MOCHA_WEBDRIVER_HEADLESS=1
+          yarn run test:docker
+
+      - name: Run some tests with gvisor and python2
+        if: ${{ !inputs.disable_tests }}
+        run: |
+          export TEST_IMAGE=${{ env.DOCKER_HUB_OWNER }}/${{ matrix.image.name }}:${{ env.TAG }}
+          export VERBOSE=1
+          export DEBUG=1
+          export MOCHA_WEBDRIVER_HEADLESS=1
+          export GREP_TESTS='should support basic editing'
+          export TEST_DOCKER_OPTIONS='-e GRIST_SANDBOX_FLAVOR=gvisor -e PYTHON_VERSION_ON_CREATION=2'
+          yarn run test:docker
+
+      - name: Run some tests with gvisor and python3
+        if: ${{ !inputs.disable_tests }}
+        run: |
+          export TEST_IMAGE=${{ env.DOCKER_HUB_OWNER }}/${{ matrix.image.name }}:${{ env.TAG }}
+          export VERBOSE=1
+          export DEBUG=1
+          export MOCHA_WEBDRIVER_HEADLESS=1
+          export GREP_TESTS='should support basic editing'
+          export TEST_DOCKER_OPTIONS='-e GRIST_SANDBOX_FLAVOR=gvisor -e PYTHON_VERSION_ON_CREATION=3'
+          yarn run test:docker
 
       - name: Re-enable the ext/ directory
         if: ${{ !inputs.disable_tests }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -166,6 +166,12 @@ WORKDIR /grist
 # settings, you can get sandboxing as follows:
 #   docker run --env GRIST_SANDBOX_FLAVOR=gvisor -p 8484:8484 -it <image>
 #
+# "NODE_OPTIONS=--no-deprecation" is set because there is a punycode
+# deprecation nag that is relevant to developers but not to users.
+# TODO: upgrade package.json to avoid using all package versions
+# using the punycode functionality that may be removed in future
+# versions of node.
+#
 ENV \
   PYTHON_VERSION_ON_CREATION=3 \
   GRIST_ORG_IN_PATH=true \
@@ -177,6 +183,7 @@ ENV \
   GRIST_SESSION_COOKIE=grist_core \
   GVISOR_FLAGS="-unprivileged -ignore-cgroups" \
   GRIST_SANDBOX_FLAVOR=unsandboxed \
+  NODE_OPTIONS="--no-deprecation" \
   TYPEORM_DATABASE=/persist/home.sqlite3
 
 EXPOSE 8484

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,13 @@ RUN \
 # the workarounds needed to keep it are getting silly.
 # It doesn't exist in recent Debian, so we need to reach back
 # to buster.
+# Many Python2 imports require the ffi foreign-function interface
+# library binary, of course present on modern debian but with
+# a different ABI (currently version 8, versus version 6 for this
+# version of Python2). We move it from an achitecture-specific location
+# to a standard location so we can pick it up and copy it across later.
+# This will no longer be necessary when support for Python2 is dropped.
+# The Grist data engine code will not work without it.
 FROM debian:buster-slim AS collector-py2
 ADD sandbox/requirements.txt requirements.txt
 RUN \

--- a/sandbox/gvisor/run.py
+++ b/sandbox/gvisor/run.py
@@ -132,7 +132,7 @@ if memory_limit:
   ]
 
 # Helper for preparing a mount.
-def preserve(*locations, short_failure=False):
+def preserve(*locations, short_failure=False, skip_symlink=False):
   for location in locations:
     # Check the requested directory is visible on the host, and that there hasn't been a
     # muddle.  For Grist, this could happen if a parent directory of a temporary import
@@ -142,6 +142,12 @@ def preserve(*locations, short_failure=False):
         raise Exception('cannot find: ' + location)
       raise Exception('cannot find: ' + location + ' ' +
                       '(if tmp path, make sure TMPDIR when running grist and GRIST_TMP line up)')
+    if os.path.islink(location) and skip_symlink:
+      # Do not attempt to include symlink directories, they are not supported
+      # and will cause obscure failures. In Grist's docker image, they show
+      # up only via pairs like /lib64 and /usr/lib64, where we actually only
+      # need whichever is "real".
+      return
     mounts.append({
       "destination": location,
       "source": location,
@@ -162,7 +168,7 @@ if include_bash or start:
 
 preserve("/usr/local/lib")
 if os.path.exists('/lib64'):
-  preserve("/lib64")
+  preserve("/lib64", skip_symlink=True)
 if os.path.exists('/usr/lib64'):
   preserve("/usr/lib64")
 preserve("/usr/lib")

--- a/test/test_under_docker.sh
+++ b/test/test_under_docker.sh
@@ -37,6 +37,7 @@ if [[ "${DEBUG:-}" == 1 ]]; then
   GRIST_LOG_HTTP_BODY="true"
 fi
 
+set -x
 docker run --name $DOCKER_CONTAINER --rm \
   --env VERBOSE=${DEBUG:-} \
   -p $PORT:$PORT --env PORT=$PORT \
@@ -47,7 +48,9 @@ docker run --name $DOCKER_CONTAINER --rm \
   --env GRIST_LOG_HTTP_BODY=${GRIST_LOG_HTTP_BODY:-false} \
   --env TEST_SUPPORT_API_KEY=api_key_for_support \
   --env GRIST_TEMPLATE_ORG=templates \
+  ${TEST_DOCKER_OPTIONS:-} \
   ${TEST_IMAGE:-gristlabs/grist} &
+set +x
 
 DOCKER_PID="$!"
 


### PR DESCRIPTION
This returns to an upgrade first attempted in:
  https://github.com/gristlabs/grist-core/pull/1255
That upgrade ran into sandbox trouble, which eventually proved to be a small change in the layout of directories in bookworm relative to buster (`/lib64` became a symlink).

## Context

The base image used for Grist was getting quite old, along with the node version used.

## Proposed solution

This applies the upgrade and simply skips exposing `/lib64` in the sandbox if it is a symlink. If it is a symlink, then sandboxes will not survive being snapshotted and restored.

## Related issues

 * https://github.com/gristlabs/grist-core/pull/1255
 * https://github.com/gristlabs/grist-core/pull/1260
 * https://github.com/gristlabs/grist-core/pull/1300

## Has this been tested?

Tested manually, and  with PYTHON_VERSION_ON_CREATION=2 and 3 following https://github.com/gristlabs/grist-core/pull/1300
