### PR TITLE
Edit the errors and warnings mentioning OpenAI

### DIFF
--- a/app/server/lib/Assistance.ts
+++ b/app/server/lib/Assistance.ts
@@ -276,7 +276,7 @@ export class OpenAIAssistant implements Assistant {
     const errorCode = result.error?.code;
     const errorMessage = result.error?.message;
     if (errorCode === "context_length_exceeded" || result.choices?.[0].finish_reason === "length") {
-      log.warn("OpenAI context length exceeded: ", errorMessage);
+      log.warn("AI context length exceeded: ", errorMessage);
       if (messages.length <= 2) {
         throw new TokensExceededFirstMessageError();
       } else {
@@ -284,11 +284,11 @@ export class OpenAIAssistant implements Assistant {
       }
     }
     if (errorCode === "insufficient_quota") {
-      log.error("OpenAI billing quota exceeded!!!");
+      log.error("AI service provider billing quota exceeded!!!");
       throw new QuotaExceededError();
     }
     if (apiResponse.status !== 200) {
-      throw new Error(`OpenAI API returned status ${apiResponse.status}: ${resultText}`);
+      throw new Error(`AI service provider API returned status ${apiResponse.status}: ${resultText}`);
     }
     return result.choices[0].message.content;
   }

--- a/test/server/lib/Assistance.ts
+++ b/test/server/lib/Assistance.ts
@@ -184,7 +184,7 @@ describe('Assistance', function () {
       checkSendForCompletion(),
       "Sorry, the assistant is unavailable right now. " +
       "Try again in a few minutes. \n" +
-      '(Error: OpenAI API returned status 500: {"status":500})',
+      '(Error: AI service provider API returned status 500: {"status":500})',
     );
     assert.equal(fakeFetch.callCount, 3);
   });


### PR DESCRIPTION


## Context

In most cases, Grist uses the OpenAI assistant.
A French user was worried ANCT instance used GPT and therefore sent information to OpenAI. In fact, this instance uses a self-hosted Llama model, thus the message was confusing.

## Proposed solution

We instead mention an AI service provider for that sake.

## Related issues

It's a rather small change, I did not report an issue. If you feel like it is required, I can open one.

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

The error message (that this PR changes) the user got and confused him was the following:
![image](https://github.com/user-attachments/assets/e1919752-cea3-4dbc-8b96-533aa58ebcaa)


