### PR TITLE
Allow picking the same widget in custom widget gallery

### DIFF
--- a/app/client/ui/CustomWidgetGallery.ts
+++ b/app/client/ui/CustomWidgetGallery.ts
@@ -102,10 +102,10 @@ class CustomWidgetGallery extends Disposable {
       }
     });
 
-    this._saveDisabled = Computed.create(
-      this,
-      (use) => !use(this._selectedWidgetId)
-    );
+    this._saveDisabled = Computed.create(this, (use) => {
+      const selectedWidgetId = use(this._selectedWidgetId);
+      return selectedWidgetId === null;
+    });
 
     this._initializeWidgets().catch(reportError);
 

--- a/app/client/ui/CustomWidgetGallery.ts
+++ b/app/client/ui/CustomWidgetGallery.ts
@@ -102,21 +102,10 @@ class CustomWidgetGallery extends Disposable {
       }
     });
 
-    this._saveDisabled = Computed.create(this, use => {
-      const selectedWidgetId = use(this._selectedWidgetId);
-      if (!selectedWidgetId) { return true; }
-      if (!this._section) { return false; }
-
-      const savedWidgetId = use(this._savedWidgetId);
-      if (selectedWidgetId === CUSTOM_URL_WIDGET_ID) {
-        return (
-          use(this._savedWidgetId) === CUSTOM_URL_WIDGET_ID &&
-          use(this._customUrl) === use(this._section.customDef.url)
-        );
-      } else {
-        return selectedWidgetId === savedWidgetId;
-      }
-    });
+    this._saveDisabled = Computed.create(
+      this,
+      (use) => !use(this._selectedWidgetId)
+    );
 
     this._initializeWidgets().catch(reportError);
 

--- a/test/nbrowser/CustomWidgets.ts
+++ b/test/nbrowser/CustomWidgets.ts
@@ -674,6 +674,13 @@ describe('CustomWidgets', function () {
         (done: any) => (window as any).gristApp?.topAppModel.testReloadWidgets().then(done).catch(done) || done()
       );
     });
+
+    it("allows picking the same widget", async () => {
+      await gu.setCustomWidget(/W1/);
+      assert.equal(await gu.getCustomWidgetName(), "W1");
+      await gu.setCustomWidget(/W1/);
+      assert.equal(await gu.getCustomWidgetName(), "W1");
+    });
   });
 
   describe('gristApiSupport', async ()=>{


### PR DESCRIPTION
## Context

When changing a widget to a custom widget, the gallery is automatically shown, prompting you to select a custom widget. This happens even when the widget type is unchanged (e.g. changing just the select by or group by columns). But since
the primary button in the gallery is disabled if the selected widget is the same as the current widget, you can't confirm
that you'd like to use the same widget; all you can do is dismiss the gallery by closing it, which isn't always obvious.

## Proposed solution

You should be able to select any widget from the gallery, even if it's the same widget that's currently in use.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
