### PR TITLE
workflows: delete Docker image artifact during fly deploy

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -42,6 +42,11 @@ jobs:
             });
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/docker-image.zip', Buffer.from(download.data));
+            await github.rest.actions.deleteArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+            });
       - name: Extract artifacts
         id: extract_artifacts
         run: |


### PR DESCRIPTION
This is the relevant API endpoint:

https://octokit.github.io/rest.js/v21/#actions-delete-artifact

Turns out that these artifacts can accumulate and add up to a limit. We don't need the docker image after it's been downloaded and ready to deploy, so just delete it when we're done.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
