### PR TITLE
Hiding collapsed section in print preview

### DIFF
--- a/app/client/components/LayoutTray.ts
+++ b/app/client/components/LayoutTray.ts
@@ -1198,6 +1198,11 @@ const cssCollapsedTray = styled('div.collapsed_layout', `
     outline: 2px dashed #7B8CEA;
     background: rgba(123, 140, 234, 0.1);
   }
+  @media print {
+    & {
+      display: none;
+    }
+  }
 `
 );
 


### PR DESCRIPTION
## Context

When printing a widget that is on a page with collapsed widgets, print preview includes the collapsed widgets. 

## Proposed solution

Collapsed section is now hidden when printing.


## Has this been tested?

manual tests only

## Screenshots / Screencasts

![image](https://github.com/user-attachments/assets/dfcb530a-c21c-4a5d-936f-62d93dfa4438)
