### PR TITLE
Document our current security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+| Version  | Supported          |
+| -------  | ------------------ |
+| >= 1.3.2 | :white_check_mark: |
+| < 1.3.2  | upgrade required   |
+
+## Reporting a Vulnerability
+
+1. **Contact us** by sending an email to **[security@getgrist.com](mailto:security@getgrist.com)** with the following information:
+   - A description of the vulnerability.
+   - Steps to reproduce the issue.
+   - Any known impacts or suggested fixes.
+
+2. **Our response:**  
+   - We will acknowledge your report within **three working days**.
+   - We will collaborate with you to verify and address the issue.
+   - Once resolved, we’ll release a patch and notify users.


### PR DESCRIPTION
This adds the essentials of our current security policy:
 * Versions before 1.3.2 should upgrade.
 * Report problems via our standard security-related email address.