### PR TITLE
make small tweaks in preparation for freshening grist-static

### DIFF
--- a/app/server/lib/DocStorage.ts
+++ b/app/server/lib/DocStorage.ts
@@ -468,7 +468,7 @@ export class DocStorage implements ISQLiteDB, OnDemandStorage {
    */
   private static _encodeValue(
     marshaller: marshal.Marshaller, gristType: string, sqlType: string, val: any
-  ): Uint8Array|string|number|boolean {
+  ): Uint8Array|string|number|boolean|null {
     const marshalled = () => {
       marshaller.marshal(val);
       return marshaller.dump();
@@ -490,6 +490,8 @@ export class DocStorage implements ISQLiteDB, OnDemandStorage {
     }
     // Leave nulls unchanged.
     if (val === null) { return val; }
+    // Return undefined as null.
+    if (val === undefined) { return null; }
     // At this point, we have a non-null primitive.  Check what is the Sqlite affinity
     // of the destination.  May be NUMERIC, INTEGER, TEXT, or BLOB.  We handle REAL
     // also even though it is not currently used.

--- a/app/server/lib/ExportDSV.ts
+++ b/app/server/lib/ExportDSV.ts
@@ -3,13 +3,12 @@ import {ActiveDoc} from 'app/server/lib/ActiveDoc';
 import {FilterColValues} from "app/common/ActiveDocAPI";
 import {DownloadOptions, ExportData, ExportHeader, exportSection, exportTable, Filter} from 'app/server/lib/Export';
 import log from 'app/server/lib/log';
-import * as bluebird from 'bluebird';
 import contentDisposition from 'content-disposition';
-import csv from 'csv';
+import {stringify} from 'csv';
 import * as express from 'express';
+import {promisify} from 'util';
 
-// promisify csv
-bluebird.promisifyAll(csv);
+const stringifyAsync = promisify(stringify);
 
 export interface DownloadDsvOptions extends DownloadOptions {
   delimiter: Delimiter;
@@ -137,7 +136,7 @@ function convertToDsv(data: ExportData, options: ConvertToDsvOptions) {
   rowIds.forEach(row => {
     csvMatrix.push(access.map((getter, c) => formatters[c].formatAny(getter(row))));
   });
-  return csv.stringifyAsync(csvMatrix, {delimiter});
+  return stringifyAsync(csvMatrix, {delimiter});
 }
 
 type DSVFileExtension = '.csv' | '.tsv' | '.dsv';

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "saml2-js": "4.0.2",
     "scimmy": "1.2.4",
     "scimmy-routers": "1.2.2",
-    "short-uuid": "3.1.1",
+    "short-uuid": "5.2.0",
     "slugify": "1.6.6",
     "swagger-ui-dist": "5.11.0",
     "tmp": "0.0.33",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7499,13 +7499,13 @@ shell-quote@^1.6.1:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
   integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
 
-short-uuid@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/short-uuid/-/short-uuid-3.1.1.tgz"
-  integrity sha512-7dI69xtJYpTIbg44R6JSgrbDtZFuZ9vAwwmnF/L0PinykbFrhQ7V8omKsQcVw1TP0nYJ7uQp1PN6/aVMkzQFGQ==
+short-uuid@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/short-uuid/-/short-uuid-5.2.0.tgz#49378f8c5335a603bc801c279ae521c5d22532dc"
+  integrity sha512-296/Nzi4DmANh93iYBwT4NoYRJuHnKEzefrkSagQbTH/A6NTaB68hSPDjm5IlbI5dx9FXdmtqPcj6N5H+CPm6w==
   dependencies:
     any-base "^1.1.0"
-    uuid "^3.3.2"
+    uuid "^9.0.1"
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -8446,17 +8446,12 @@ uuid@10.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
   integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
-uuid@^3.3.2:
-  version "3.4.0"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
 uuid@^8.0.0, uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-uuid@^9.0.0:
+uuid@^9.0.0, uuid@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==


### PR DESCRIPTION
This makes some small changes for the benefit of an update to grist-static, which has become quite stale.

 * When testing grist-static with latest grist-core, a problem showed up where `_encodeValue` is now sometimes called with `undefined` which is a problem for SQLite wrappers other than node-sqlite3. This change encodes it as null, which appears to be the intent.
 * Small non-obvious tweaks related to webpack and specific packages that do no harm in grist-core and remove a problem in grist-static.

You can preview where this will go at https://gristlabs.github.io/grist-static/next.html by clicking on the "investment research" image to get a popup. It will be somewhat slow because the document shown hasn't been upgraded to latest Grist so full data engine in pyodide/python needs to start and run migrations before rendering can begin.