### PR TITLE
Document yarn test:gen-server

### DIFF
--- a/documentation/develop.md
+++ b/documentation/develop.md
@@ -118,7 +118,7 @@ You may run the tests using one of these commands:
  - `yarn test:nbrowser` to run the end-to-end tests
  - `yarn test:client` to run the tests for the client libraries
  - `yarn test:common` to run the tests for the common libraries shared between the client and the server
- - `yarn test:server` to run the backend tests
+ - `yarn test:server` and `yarn test:gen-server` to run the backend tests depending on where the feature you would like to test resides (respectively `app/server` or `app/gen-server`)
  - `yarn test:docker` to run some end-to-end tests under docker
  - `yarn test:python` to run the data engine tests
 


### PR DESCRIPTION
## Context

Documentation does not mention the existence of `yarn test:gen-server`.

## Proposed solution

Just mention it.

## Related issues

Following up #1336 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
