### PR TITLE
worfklows: update upload-artifacts version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Save artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ runner.temp }}/test-logs  # only exists for webdriver tests


### PR DESCRIPTION
v3 of `upload-artifacts` will soon error out, so we need to migrate to v4.

I tested that it works by temporarily removing the `if: failed()` conditional and verifying that it uploaded artifacts.