### PR TITLE
Fixing Grist's API console

### DIFF
--- a/app/client/apiconsole.ts
+++ b/app/client/apiconsole.ts
@@ -117,7 +117,11 @@ function setParamValue(resolvedParam: any, value: ParamValue) {
     // For every endpoint in the spec...
     for (const [pathKey, path] of spec.get("paths").entries()) {
       for (const [method, operation] of path.entries()) {
-
+        // Skip the $ref for now, it is only used in `scim` endpoints witch don't share
+        // parameters with other endpoints.
+        if (method === '$ref') {
+          continue;
+        }
         const parameters = operation.get("parameters");
         if (!parameters) { continue; }
         for (const param of parameters.values()) {
@@ -327,7 +331,7 @@ createAppPage((appModel) => {
     swaggerUI = buildSwaggerUI({
       filter: true,
       plugins: [gristPlugin.bind(null, appModel)],
-      url: 'https://raw.githubusercontent.com/gristlabs/grist-help/master/api/grist.yml',
+      url: 'http://127.0.0.1:8080/api/grist.yml',
       domNode: rootNode,
       showMutatedRequest: false,
       requestInterceptor,

--- a/app/client/apiconsole.ts
+++ b/app/client/apiconsole.ts
@@ -331,7 +331,7 @@ createAppPage((appModel) => {
     swaggerUI = buildSwaggerUI({
       filter: true,
       plugins: [gristPlugin.bind(null, appModel)],
-      url: 'http://127.0.0.1:8080/api/grist.yml',
+      url: 'https://raw.githubusercontent.com/gristlabs/grist-help/master/api/grist.yml',
       domNode: rootNode,
       showMutatedRequest: false,
       requestInterceptor,

--- a/app/client/apiconsole.ts
+++ b/app/client/apiconsole.ts
@@ -117,7 +117,7 @@ function setParamValue(resolvedParam: any, value: ParamValue) {
     // For every endpoint in the spec...
     for (const [pathKey, path] of spec.get("paths").entries()) {
       for (const [method, operation] of path.entries()) {
-        // Skip the $ref for now, it is only used in `scim` endpoints witch don't share
+        // Skip the $ref for now, it is only used in `scim` endpoints which don't share
         // parameters with other endpoints.
         if (method === '$ref') {
           continue;


### PR DESCRIPTION
## Context

Fixing Grist's API console JavaScript error caused by recent addition of new `scim` endpoint documentation.

## Proposed solution

Fix is simple, script that copies shared parameters across multiple endpoints just ignores external endpoints. Currently Grist doesn't share any parameters with `scim` endpoints so this solution is good enough.

## Related issues

Additionally there is a fix to `scim` endpoints, that externalize endpoint parameters. It is not needed now (as no parameters are shared), but might be needed in future.
 
https://github.com/gristlabs/grist-help/pull/467

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

manually only

## Screenshots / Screencasts

![image](https://github.com/user-attachments/assets/8ee173f8-3b44-43d9-9ffc-c187c9663407)

