### PR TITLE
Adding slow notification on document open method

### DIFF
--- a/app/client/models/DocPageModel.ts
+++ b/app/client/models/DocPageModel.ts
@@ -201,11 +201,11 @@ export class DocPageModelImpl extends Disposable implements DocPageModel {
         } else {
           FlowRunner.create(
             this._openerHolder,
-            (flow: AsyncFlow) => this._openDoc(flow, urlId, {
+            (flow: AsyncFlow) => this.appModel.notifier.slowNotification(this._openDoc(flow, urlId, {
               openMode: urlOpenMode,
               linkParameters,
               originalUrlId: state.doc,
-            }, state.params?.compare)
+            }, state.params?.compare))
           )
           .resultPromise.catch(err => this._onOpenError(err));
         }


### PR DESCRIPTION
## Context

Loading big document for the very first time can be slow and user sees blank screen without any
information of what is happening. The the longest time (without any visual progress) is spend on `openDoc`
method in `Comm.ts`. 

## Proposed solution

Reusing existing `Still working ...` dialog on the method that opens up a document.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

Manual only by opening cold big document on slow network.
