### PR TITLE
feat: More readable Document settings

### DIFF
--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -479,20 +479,17 @@ in the future as session IDs generated since v1.1.16 are inherently cryptographi
           throw new Error('Invalid state');
         })
       ),
-      expandedContent: cssColumns(
-        cssColumn(
-          cssColumn.cls('-left'),
+      expandedContent: dom('div',
+        cssExpandedContent(
           dom('div', t('Grist releases are at '), makeLinks(releaseURL)),
-          dom.maybe(lastCheckDate, ms => dom('div',
+        ),
+        dom.maybe(lastCheckDate, ms => cssExpandedContent(
+          dom('div',
             dom('span', t('Last checked {{time}}', {time: getTimeFromNow(ms)})),
             dom('span', ' '),
             // Format date in local format.
             cssGrayed(new Date(ms).toLocaleString()),
-          )),
-          dom('div', t('Auto-check when this page loads')),
-        ),
-        cssColumn(
-          cssColumn.cls('-right'),
+          ),
           // `Check now` button, only shown when auto checks are enabled and we are not in the
           // middle of checking. Otherwise the button is shown in the summary row, and there is
           // no need to duplicate it.
@@ -503,8 +500,11 @@ in the future as session IDs generated since v1.1.16 are inherently cryptographi
               dom.on('click', actions.checkForUpdates),
               dom.prop('disabled', use => use(state) === State.CHECKING),
             ),
-          ]),
-          toggle(enabledController, testId('admin-panel-updates-auto-check')),
+          ])
+        )),
+        cssExpandedContent(
+          dom('span', t('Auto-check when this page loads')),
+          dom( 'div', toggle(enabledController, testId('admin-panel-updates-auto-check'))),
         ),
       )
     });
@@ -720,34 +720,12 @@ export const cssValueLabel = styled('div', `
   border-radius: ${vars.controlBorderRadius};
 `);
 
-// A wrapper for the version details panel. Shows two columns.
-// First grows as needed, second shrinks as needed and is aligned to the bottom.
-const cssColumns = styled('div', `
+const cssExpandedContent = styled('div', `
   display: flex;
-  align-items: flex-end;
-  & > div:first-child {
-    flex-grow: 1;
-    flex-shrink: 0;
-  }
-  & > div:last-child {
-    flex-shrink: 1;
-  }
-`);
-
-const cssColumn = styled('div', `
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  flex-grow: 1;
-  flex-shrink: 1;
-  margin-block: 1px; /* otherwise toggle is squashed: TODO: -1px in toggle looks like a bug */
-  &-left {
-    align-items: flex-start;
-  }
-  &-right {
-    align-items: flex-end;
-    justify-content: flex-end;
-  }
+  justify-content: space-between;
+  margin-right: 8px;
+  margin-bottom: 1rem;
+  align-items: center;
 `);
 
 const cssValueButton = styled('div', `

--- a/app/client/ui/AdminPanelCss.ts
+++ b/app/client/ui/AdminPanelCss.ts
@@ -175,7 +175,7 @@ const cssItemValue = styled('div', `
   margin: -8px;
   padding: 16px;
   cursor: auto;
-  width: 200px;
+  max-width: 200px;
 
   .${cssItemShort.className}-disabled & {
     pointer-events: none;

--- a/app/client/ui/AdminPanelCss.ts
+++ b/app/client/ui/AdminPanelCss.ts
@@ -113,6 +113,8 @@ const cssItemShort = styled('div', `
   padding: 8px;
   margin: 0 -8px;
   border-radius: 4px;
+  justify-content: space-around;
+  flex-direction: row;
   &-expandable {
     cursor: pointer;
   }
@@ -154,7 +156,6 @@ const cssItemName = styled('div', `
   }
   @media ${mediaSmall} {
     & {
-      width: calc(100% - 28px);
       padding-left: 0;
     }
     &:first-child {
@@ -164,16 +165,17 @@ const cssItemName = styled('div', `
 `);
 
 const cssItemDescription = styled('div', `
-  max-width: 250px;
+  width: 250px;
   margin-right: auto;
   margin-bottom: -1px; /* aligns with the value */
 `);
 
 const cssItemValue = styled('div', `
   flex: none;
-  margin: -16px;
+  margin: -8px;
   padding: 16px;
   cursor: auto;
+  width: 200px;
 
   .${cssItemShort.className}-disabled & {
     pointer-events: none;

--- a/app/client/ui/AdminPanelCss.ts
+++ b/app/client/ui/AdminPanelCss.ts
@@ -73,7 +73,7 @@ export function AdminSectionItem(owner: IDisposableOwner, options: {
 
 const cssSection = styled('div', `
   padding: 24px;
-  max-width: 600px;
+  max-width: 750px;
   width: 100%;
   margin: 16px auto;
   border: 1px solid ${theme.widgetBorder};

--- a/app/client/ui/AdminPanelCss.ts
+++ b/app/client/ui/AdminPanelCss.ts
@@ -107,8 +107,8 @@ const cssItem = styled('div', `
 
 const cssItemShort = styled('div', `
   display: flex;
-  flex-wrap: wrap;
   row-gap: 4px;
+  flex-wrap: nowrap;
   align-items: center;
   padding: 8px;
   margin: 0 -8px;
@@ -133,7 +133,7 @@ const cssItemShort = styled('div', `
 `);
 
 const cssItemName = styled('div', `
-  width: 150px;
+  width: 230px;
   font-weight: bold;
   display: flex;
   align-items: center;
@@ -164,6 +164,7 @@ const cssItemName = styled('div', `
 `);
 
 const cssItemDescription = styled('div', `
+  max-width: 250px;
   margin-right: auto;
   margin-bottom: -1px; /* aligns with the value */
 `);

--- a/app/client/ui/DocumentSettings.ts
+++ b/app/client/ui/DocumentSettings.ts
@@ -81,7 +81,7 @@ export class DocSettingsPage extends Disposable {
     const isDocEditor = isOwnerOrEditor(docPageModel.currentDoc.get());
 
     return cssContainer(
-      dom.create(cssAdminSection, t('Document Settings'), [
+      dom.create(AdminSection, t('Document Settings'), [
         dom.create(AdminSectionItem, {
           id: 'timezone',
           name: t('Time Zone'),
@@ -121,7 +121,7 @@ export class DocSettingsPage extends Disposable {
         }),
       ]),
 
-      dom.create(cssAdminSection, t('Data Engine'), [
+      dom.create(AdminSection, t('Data Engine'), [
         dom.create(AdminSectionItem, {
           id: 'timings',
           name: t('Formula timer'),
@@ -169,7 +169,7 @@ export class DocSettingsPage extends Disposable {
         }) : null,
       ]),
 
-      dom.create(cssAdminSection, t('API'), [
+      dom.create(AdminSection, t('API'), [
         dom.create(AdminSectionItem, {
           id: 'documentId',
           name: t('Document ID'),
@@ -927,8 +927,4 @@ const cssLoadingSpinner = styled(loadingSpinner, `
       --loader-bg: #adadad;
     }
   }
-|`);
-
-const cssAdminSection = styled(AdminSection, `
-  max-width: 750px;
 `);

--- a/app/client/ui/DocumentSettings.ts
+++ b/app/client/ui/DocumentSettings.ts
@@ -81,7 +81,7 @@ export class DocSettingsPage extends Disposable {
     const isDocEditor = isOwnerOrEditor(docPageModel.currentDoc.get());
 
     return cssContainer(
-      dom.create(AdminSection, t('Document Settings'), [
+      dom.create(cssAdminSection, t('Document Settings'), [
         dom.create(AdminSectionItem, {
           id: 'timezone',
           name: t('Time Zone'),
@@ -121,7 +121,7 @@ export class DocSettingsPage extends Disposable {
         }),
       ]),
 
-      dom.create(AdminSection, t('Data Engine'), [
+      dom.create(cssAdminSection, t('Data Engine'), [
         dom.create(AdminSectionItem, {
           id: 'timings',
           name: t('Formula timer'),
@@ -169,7 +169,7 @@ export class DocSettingsPage extends Disposable {
         }) : null,
       ]),
 
-      dom.create(AdminSection, t('API'), [
+      dom.create(cssAdminSection, t('API'), [
         dom.create(AdminSectionItem, {
           id: 'documentId',
           name: t('Document ID'),
@@ -880,6 +880,7 @@ const cssDocTypeContainer = styled('div', `
     display: inline-block;
   }
 `);
+
 const cssFlex = styled('div', `
   display: flex;
   align-items: center;
@@ -908,4 +909,8 @@ const cssLoadingSpinner = styled(loadingSpinner, `
       --loader-bg: #adadad;
     }
   }
+|`);
+
+const cssAdminSection = styled(AdminSection, `
+  max-width: 750px;
 `);

--- a/app/client/ui/DocumentSettings.ts
+++ b/app/client/ui/DocumentSettings.ts
@@ -132,8 +132,8 @@ export class DocSettingsPage extends Disposable {
           ),
           value: dom.domComputed(isTimingOn, (timingOn) => {
             if (timingOn) {
-              return dom('div', {style: 'display: flex; gap: 4px'},
-                cssPrimarySmallLink(
+              return dom('div',
+                cssPrimarySmallLinkSettings(
                   t('Stop timing...'),
                   urlState().setHref({docPage: 'timing'}),
                   {target: '_blank'},
@@ -141,7 +141,7 @@ export class DocSettingsPage extends Disposable {
                 )
               );
             } else {
-              return cssSmallButton(t('Start timing'),
+              return cssSmallButtonSettings(t('Start timing'),
                 dom.on('click', this._startTiming.bind(this)),
                 testId('timing-start')
               );
@@ -158,7 +158,7 @@ export class DocSettingsPage extends Disposable {
           id: 'reload',
           name: t('Reload'),
           description: t('Hard reset of data engine'),
-          value: cssSmallButton(t('Reload data engine'), dom.on('click', this._reloadEngine.bind(this, true))),
+          value: cssSmallButtonSettings(t('Reload data engine'), dom.on('click', this._reloadEngine.bind(this, true))),
           disabled: isDocEditor ? false : t('Only available to document editors'),
         }),
         canChangeEngine ? dom.create(AdminSectionItem, {
@@ -213,7 +213,7 @@ export class DocSettingsPage extends Disposable {
           id: 'api-console',
           name: t('API Console'),
           description: t('Try API calls from the browser'),
-          value: cssSmallLinkButton(t('API console'), {
+          value: cssSmallLinkButtonSettings(t('API console'), {
             target: '_blank',
             href: getApiConsoleLink(docPageModel),
           }),
@@ -222,7 +222,7 @@ export class DocSettingsPage extends Disposable {
           id: 'webhooks',
           name: t('Webhooks'),
           description: t('Notify other services on doc changes'),
-          value: cssSmallLinkButton(t('Manage webhooks'), urlState().setLinkUrl({docPage: 'webhook'})),
+          value: cssSmallLinkButtonSettings(t('Manage webhooks'), urlState().setLinkUrl({docPage: 'webhook'})),
         }),
       ]),
 
@@ -758,6 +758,24 @@ const cssHoverWrapper = styled('div', `
   height: 30px;
   align-items: center;
   position: relative;
+`);
+
+const cssSmallButtonSettings = styled(cssSmallButton, `
+  display: block;
+  margin-right: 0;
+  margin-left: auto;
+  width: 100%;
+`);
+
+const cssSmallLinkButtonSettings = styled(cssSmallLinkButton, `
+  display: block;
+  text-align: center;
+`);
+
+const cssPrimarySmallLinkSettings = styled(cssPrimarySmallLink, `
+  display: block;
+  width: 100%;
+  text-align:center;
 `);
 
 // This matches the style used in showProfileModal in app/client/ui/AccountWidget.

--- a/app/client/ui/DocumentSettings.ts
+++ b/app/client/ui/DocumentSettings.ts
@@ -744,7 +744,7 @@ const cssInput = styled('div', `
 `);
 
 const cssHoverWrapper = styled('div', `
-  max-width: 280px;
+  max-width: 170px;
   text-overflow: ellipsis;
   overflow: hidden;
   text-wrap: nowrap;

--- a/app/client/ui/DocumentSettings.ts
+++ b/app/client/ui/DocumentSettings.ts
@@ -910,7 +910,7 @@ const cssButton = styled(cssSmallButton, `
 `);
 
 const cssSmallSelect = styled(select, `
-  width: 100px;
+  width: 100%;
 `);
 
 const cssSelect = styled(select, `


### PR DESCRIPTION
Partially fixes #1289

## Context

#1015 [mockup](https://www.figma.com/design/wcpetFt6aOKzTszcvPPWLQ/%5B05%2F24%5D-Grist-Design?node-id=559-80548&t=qX4iHFYd8uzsW8kZ-1) is completed with some Document settings page enhancement.

## Proposed solution

The first proposal was in PR #1181. 
As suggested by @berhalak It  was removed from functional code to be done in this separate PR.

This PR only enroll Document setting page enhancements.

Two other PRs will propose:
* Check boxes component enhancements
* Modal component Enhancements

## Related issues

#1015
#1289

## Has this been tested?

- [x] 🙅 no, because this is not relevant here


