### PR TITLE
Fix translations

### DIFF
--- a/app/client/components/Forms/Columns.ts
+++ b/app/client/components/Forms/Columns.ts
@@ -14,7 +14,7 @@ import {v4 as uuidv4} from 'uuid';
 
 const testId = makeTestId('test-forms-');
 
-const t = makeT('FormView');
+const t = makeT('Columns');
 
 export class ColumnsModel extends BoxModel {
   private _columnCount = Computed.create(this, use => use(this.children).length);

--- a/app/client/components/Forms/Editor.ts
+++ b/app/client/components/Forms/Editor.ts
@@ -10,7 +10,7 @@ import {icon} from 'app/client/ui2018/icons';
 import {BindableValue, dom, DomContents, IDomArgs, MultiHolder, Observable} from 'grainjs';
 
 const testId = makeTestId('test-forms-');
-const t = makeT('FormView.Editor');
+const t = makeT('Editor');
 
 interface Props {
   box: BoxModel,

--- a/app/client/components/Forms/Field.ts
+++ b/app/client/components/Forms/Field.ts
@@ -38,7 +38,7 @@ import * as ko from 'knockout';
 
 const testId = makeTestId('test-forms-');
 
-const t = makeT('FormView');
+const t = makeT('Field');
 
 /**
  * Container class for all fields.
@@ -133,7 +133,7 @@ export class FieldModel extends BoxModel {
         box: this,
         overlay,
         removeIcon: 'CrossBig',
-        removeTooltip: 'Hide',
+        removeTooltip: t('Hide'),
         editMode: this.edit,
         content,
       },

--- a/app/client/components/Forms/FormView.ts
+++ b/app/client/components/Forms/FormView.ts
@@ -965,5 +965,5 @@ defaults(FormView.prototype, BaseView.prototype);
 Object.assign(FormView.prototype, BackboneEvents);
 
 // Default values when form is reset.
-const FORM_TITLE = "## **Form Title**";
-const FORM_DESC = "Your form description goes here.";
+const FORM_TITLE = t("## **Form Title**");
+const FORM_DESC = t("Your form description goes here.");

--- a/app/client/components/Forms/Menu.ts
+++ b/app/client/components/Forms/Menu.ts
@@ -10,7 +10,7 @@ import {getColumnTypes as getNewColumnTypes} from 'app/client/ui/GridViewMenus';
 import * as menus from 'app/client/ui2018/menus';
 import {Computed, dom, IDomArgs, MultiHolder} from 'grainjs';
 
-const t = makeT('FormView');
+const t = makeT('Menu');
 const testId = makeTestId('test-forms-menu-');
 
 // New box to add, either a new column of type, an existing column (by column id), or a structure.
@@ -105,7 +105,7 @@ export function buildMenu(props: Props, ...args: IDomArgs<HTMLElement>): IDomArg
 
       const insertMenu = (where: typeof above) => () => {
         return [
-          menus.menuSubHeader('New question'),
+          menus.menuSubHeader(t('New question')),
           ...commonTypes()
             .filter(isQuick)
             .filter(isEnabled)
@@ -122,7 +122,7 @@ export function buildMenu(props: Props, ...args: IDomArgs<HTMLElement>): IDomArg
               )),
             {},
             menus.menuIcon('Dots'),
-            dom('span', "More", dom.style('margin-right', '8px'))
+            dom('span', t("More"), dom.style('margin-right', '8px'))
           ),
           dom.maybe(oneTo5, () => [
             menus.menuDivider(),

--- a/app/client/components/Forms/Section.ts
+++ b/app/client/components/Forms/Section.ts
@@ -13,7 +13,7 @@ import * as menus from 'app/client/ui2018/menus';
 import {dom, styled} from 'grainjs';
 import {v4 as uuidv4} from 'uuid';
 
-const t = makeT('FormView');
+const t = makeT('Section');
 
 const testId = makeTestId('test-forms-');
 
@@ -125,8 +125,8 @@ export function Section(...children: FormLayoutNode[]): FormLayoutNode {
     id: uuidv4(),
     type: 'Section',
     children: [
-      Paragraph('### **Header**'),
-      Paragraph('Description'),
+      Paragraph(t('### **Header**')),
+      Paragraph(t('Description')),
       ...children,
     ],
   };

--- a/app/client/ui/UserManager.ts
+++ b/app/client/ui/UserManager.ts
@@ -284,7 +284,7 @@ export class UserManager extends Disposable {
         // TODO: Consider adding a tooltip explaining inheritance. A brief text caption may
         // be used to fill whitespace in org UserManager.
         this._model.isOrg ? null : dom('span', { style: `float: left;` },
-          dom('span', 'Inherit access: '),
+          dom('span', t('Inherit access: ')),
           this._inheritRoleSelector()
         ),
         publicMember ? dom('span', { style: `float: right;` },

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -1361,7 +1361,8 @@
         "Once you have removed your own access, you will not be able to get it back without assistance from someone else with sufficient access to the {{resourceType}}.": "Once you have removed your own access, you will not be able to get it back without assistance from someone else with sufficient access to the {{resourceType}}.",
         "User has view access to {{resource}} resulting from manually-set access to resources inside. If removed here, this user will lose access to resources inside.": "User has view access to {{resource}} resulting from manually-set access to resources inside. If removed here, this user will lose access to resources inside.",
         "User inherits permissions from {{parent}}. To remove, set 'Inherit access' option to 'None'.": "User inherits permissions from {{parent}}. To remove, set 'Inherit access' option to 'None'.",
-        "You are about to remove your own access to this {{resourceType}}": "You are about to remove your own access to this {{resourceType}}"
+        "You are about to remove your own access to this {{resourceType}}": "You are about to remove your own access to this {{resourceType}}",
+        "Inherit access: ": "Inherit access: "
     },
     "SearchModel": {
         "Search all pages": "Search all pages",

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -1448,7 +1448,9 @@
         "Save your document to publish this form.": "Save your document to publish this form.",
         "Share": "Share",
         "Share this form": "Share this form",
-        "View": "View"
+        "View": "View",
+        "## **Form Title**": "## **Form Title**",
+        "Your form description goes here.": "Your form description goes here."
     },
     "Editor": {
         "Delete": "Delete"
@@ -1464,7 +1466,9 @@
         "Paste": "Paste",
         "Separator": "Separator",
         "Unmapped fields": "Unmapped fields",
-        "Header": "Header"
+        "Header": "Header",
+        "New question": "New question",
+        "More": "More"
     },
     "UnmappedFieldsConfig": {
         "Clear": "Clear",
@@ -1534,7 +1538,9 @@
     },
     "Section": {
         "Insert section above": "Insert section above",
-        "Insert section below": "Insert section below"
+        "Insert section below": "Insert section below",
+        "### **Header**": "### **Header**",
+        "Description": "Description"
     },
     "CreateTeamModal": {
         "Cancel": "Cancel",
@@ -1613,7 +1619,8 @@
     },
     "Field": {
         "No choices configured": "No choices configured",
-        "No values in show column of referenced table": "No values in show column of referenced table"
+        "No values in show column of referenced table": "No values in show column of referenced table",
+        "Hide": "Hide"
     },
     "Toggle": {
         "Checkbox": "Checkbox",


### PR DESCRIPTION
## Context

Some strings are not translated in the UI. It comes from the fact that:
- some strings are not wrapped in the **translation function**
- in some files, the strings are wrapped in the translation function - and most of the time they have been translated in [Weblate](https://hosted.weblate.org/projects/grist/glossary/) - but the translation function has the **wrong scope**, leading to a non-translated string on the UI

## Proposed solution
Here I fixed some "simple" cases that I can handle, specifically in the "form" module.  For more complex cases, I let @fflorent and other good developers take the lead :)
I will do more PRs for other strings.

The solution is:
- Wrapping the strings in the translation function
 and/or 
- adding the right scope to the translation function


## Related issues
https://github.com/gristlabs/grist-core/issues/627
https://github.com/gristlabs/grist-core/issues/962


## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

An example of untranslated strings on the French UI:

<img width="570" alt="Screenshot 2025-01-14 at 18 33 16" src="https://github.com/user-attachments/assets/9aee55bb-172e-4ad3-bc49-f96e23af5daa" />


