### PR TITLE
improve snapshot generation under load

### DIFF
--- a/app/common/KeyedOps.ts
+++ b/app/common/KeyedOps.ts
@@ -30,12 +30,18 @@ export class KeyedOps {
    *
    *   - logError: called when errors occur, with a count of number of failures so
    *     far.
+   *   - scheduleFromFirstAdd: if set, a call to addOperation won't
+   *     reschedule work that hasn't started yet. Set this if you
+   *     want the operation to start at a fixed delay from the
+   *     first time it is added, rather than the last. Otherwise,
+   *     by default, adding will reset the delay.
    */
   constructor(private _op: (key: string) => Promise<void>, private _options: {
     delayBeforeOperationMs?: number,
     minDelayBetweenOperationsMs?: number,
     retry?: boolean,
-    logError?: (key: string, failureCount: number, err: Error) => void
+    logError?: (key: string, failureCount: number, err: Error) => void,
+    scheduleFromFirstAdd?: boolean,
   }) {
   }
 
@@ -126,6 +132,9 @@ export class KeyedOps {
     const status = this._getOperationStatus(key);
     if (status.promise) { return; }
     if (status.timeout) {
+      if (this._options.scheduleFromFirstAdd) {
+        return;
+      }
       clearTimeout(status.timeout);
       delete status.timeout;
     }

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -600,6 +600,7 @@ export class ActiveDoc extends EventEmitter {
     this._log.debug(docSession, "createEmptyDocWithDataEngine");
     await this._docManager.storageManager.prepareToCreateDoc(this.docName);
     await this.docStorage.createFile();
+    this._registerSQLiteDB();
     await this._rawPyCall('load_empty');
     // This init action is special. It creates schema tables, and is used to init the DB, but does
     // not go through other steps of a regular action (no ActionHistory or broadcasting).
@@ -666,6 +667,7 @@ export class ActiveDoc extends EventEmitter {
             return this._afterMigration(docSession, 'storage',  newVersion, success);
           },
         });
+        this._registerSQLiteDB();
       }
 
       await this._loadOpenDoc(docSession);
@@ -2168,6 +2170,7 @@ export class ActiveDoc extends EventEmitter {
           // tests.
           await timeoutReached(3000, this.waitForInitialization());
         }
+        this._docManager.registerSQLiteDB(this.docName);
         await Promise.all([
           this.docStorage.shutdown(),
           this.docPluginManager?.shutdown(),
@@ -3020,6 +3023,15 @@ export class ActiveDoc extends EventEmitter {
         lastActivity: document.updatedAt,
       },
     });
+  }
+
+  /**
+   * Register the underlying SQLiteDB we have so that it can
+   * be used for backup operations. It is important to use
+   * the same SQLite connection for all operations.
+   */
+  private _registerSQLiteDB() {
+    this._docManager.registerSQLiteDB(this.docName, this.docStorage.getDB());
   }
 }
 

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -667,8 +667,8 @@ export class ActiveDoc extends EventEmitter {
             return this._afterMigration(docSession, 'storage',  newVersion, success);
           },
         });
-        this._registerSQLiteDB();
       }
+      this._registerSQLiteDB();
 
       await this._loadOpenDoc(docSession);
       const metaTableData = await this._tableMetadataLoader.fetchTablesAsActions();
@@ -2170,7 +2170,7 @@ export class ActiveDoc extends EventEmitter {
           // tests.
           await timeoutReached(3000, this.waitForInitialization());
         }
-        this._docManager.registerSQLiteDB(this.docName);
+        this._docManager.unregisterSQLiteDB(this.docName);
         await Promise.all([
           this.docStorage.shutdown(),
           this.docPluginManager?.shutdown(),

--- a/app/server/lib/DocManager.ts
+++ b/app/server/lib/DocManager.ts
@@ -471,12 +471,15 @@ export class DocManager extends EventEmitter {
    * up in a loop or hung if you are checking during document
    * initialization.
    */
-  public registerSQLiteDB(docName: string, db?: SQLiteDB) {
-    if (db) {
-      this._sqliteDbs.set(docName, db);
-    } else {
-      this._sqliteDbs.delete(docName);
-    }
+  public registerSQLiteDB(docName: string, db: SQLiteDB) {
+    this._sqliteDbs.set(docName, db);
+  }
+
+  /**
+   * Remove any registered SQLiteDB for the document.
+   */
+  public unregisterSQLiteDB(docName: string) {
+    this._sqliteDbs.delete(docName);
   }
 
   /**
@@ -488,7 +491,7 @@ export class DocManager extends EventEmitter {
   }
 
   public removeActiveDoc(activeDoc: ActiveDoc): void {
-    this.registerSQLiteDB(activeDoc.docName);
+    this.unregisterSQLiteDB(activeDoc.docName);
     this._activeDocs.delete(activeDoc.docName);
   }
 
@@ -504,7 +507,7 @@ export class DocManager extends EventEmitter {
         this.registerSQLiteDB(newName, db);
       }
       this._activeDocs.delete(oldName);
-      this.registerSQLiteDB(oldName);
+      this.unregisterSQLiteDB(oldName);
     } else {
       await this.storageManager.renameDoc(oldName, newName);
     }

--- a/app/server/lib/DocStorage.ts
+++ b/app/server/lib/DocStorage.ts
@@ -1488,6 +1488,10 @@ export class DocStorage implements ISQLiteDB, OnDemandStorage {
     return undefined;
   }
 
+  public getDB(): SQLiteDB {
+    return this._getDB();
+  }
+
   public async hasPluginDataItem(pluginId: string, key: string): Promise<any> {
     const row = await this.get('SELECT value from _gristsys_PluginData WHERE pluginId=? and key=?', pluginId, key);
     return typeof row !== 'undefined';

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1376,7 +1376,8 @@ export class FlexServer implements GristServer {
       const docWorkerId = await this._addSelfAsWorker(workers);
 
       const storageManager = await this.create.createHostedDocStorageManager(
-        this.docsRoot, docWorkerId, this._disableExternalStorage, workers, this._dbManager, this.create.ExternalStorage
+        this, this.docsRoot, docWorkerId, this._disableExternalStorage,
+        workers, this._dbManager, this.create.ExternalStorage
       );
       this._storageManager = storageManager;
     } else {

--- a/app/server/lib/GristServer.ts
+++ b/app/server/lib/GristServer.ts
@@ -13,6 +13,7 @@ import { IAccessTokens } from 'app/server/lib/AccessTokens';
 import { RequestWithLogin } from 'app/server/lib/Authorizer';
 import { Comm } from 'app/server/lib/Comm';
 import { create } from 'app/server/lib/create';
+import { DocManager } from 'app/server/lib/DocManager';
 import { Hosts } from 'app/server/lib/extractOrg';
 import { GristJobs } from 'app/server/lib/GristJobs';
 import { createNullAuditLogger, IAuditLogger } from 'app/server/lib/IAuditLogger';
@@ -76,6 +77,7 @@ export interface GristServer {
   getJobs(): GristJobs;
   getBilling(): IBilling;
   setRestrictedMode(restrictedMode?: boolean): void;
+  getDocManager(): DocManager;
 }
 
 export interface GristLoginSystem {
@@ -173,6 +175,7 @@ export function createDummyGristServer(): GristServer {
     getJobs(): GristJobs { throw new Error('no job system'); },
     getBilling() { throw new Error('no billing'); },
     setRestrictedMode() { /* do nothing */ },
+    getDocManager() { throw new Error('no DocManager'); },
   };
 }
 

--- a/app/server/lib/ICreate.ts
+++ b/app/server/lib/ICreate.ts
@@ -47,6 +47,7 @@ export const DEFAULT_SESSION_SECRET =
 export type LocalDocStorageManagerCreator =
   (docsRoot: string, samplesRoot?: string, comm?: Comm, shell?: IShell) => Promise<IDocStorageManager>;
 export type HostedDocStorageManagerCreator = (
+    gristServer: GristServer,
     docsRoot: string,
     docWorkerId: string,
     disableS3: boolean,
@@ -250,6 +251,7 @@ export function makeSimpleCreator(opts: {
 }
 
 async function createDefaultHostedStorageManager(
+  gristServer: GristServer,
   docsRoot: string,
   docWorkerId: string,
   disableS3: boolean,
@@ -259,6 +261,7 @@ async function createDefaultHostedStorageManager(
   options?: HostedStorageOptions
 ) {
   return new HostedStorageManager(
+    gristServer,
     docsRoot,
     docWorkerId,
     disableS3,

--- a/app/server/lib/SQLiteDB.ts
+++ b/app/server/lib/SQLiteDB.ts
@@ -269,7 +269,7 @@ export class SQLiteDB implements ISQLiteDB {
     if (!this._db.backup) {
       throw new Error('SQLite wrapper does not support backups');
     }
-    return this._db.backup?.(filename);
+    return this._db.backup(filename);
   }
 
   public getOptions(): MinDBOptions|undefined {

--- a/app/server/lib/SQLiteDB.ts
+++ b/app/server/lib/SQLiteDB.ts
@@ -72,8 +72,9 @@ import {timeFormat} from 'app/common/timeFormat';
 import {create} from 'app/server/lib/create';
 import * as docUtils from 'app/server/lib/docUtils';
 import log from 'app/server/lib/log';
-import {MinDB, MinDBOptions, MinRunResult, PreparedStatement, ResultRow,
-        SqliteVariant, Statement} from 'app/server/lib/SqliteCommon';
+import {
+  Backup, MinDB, MinDBOptions, MinRunResult, PreparedStatement, ResultRow,
+  SqliteVariant, Statement} from 'app/server/lib/SqliteCommon';
 import {NodeSqliteVariant} from 'app/server/lib/SqliteNode';
 import assert from 'assert';
 import * as fse from 'fs-extra';
@@ -141,6 +142,7 @@ export interface ISQLiteDB {
   execTransaction<T>(callback: () => Promise<T>): Promise<T>;
   runAndGetId(sql: string, ...params: any[]): Promise<number>;
   requestVacuum(): Promise<boolean>;
+  backup?(filename: string): Backup;
 }
 
 /**
@@ -254,12 +256,20 @@ export class SQLiteDB implements ISQLiteDB {
   private _migrationBackupPath: string|null = null;
   private _migrationError: Error|null = null;
   private _needVacuum: boolean = false;
+  private _closed: boolean = false;
 
   private constructor(protected _db: MinDB, private _dbPath: string) {
   }
 
   public async interrupt(): Promise<void> {
     return this._db.interrupt?.();
+  }
+
+  public backup(filename: string): Backup {
+    if (!this._db.backup) {
+      throw new Error('SQLite wrapper does not support backups');
+    }
+    return this._db.backup?.(filename);
   }
 
   public getOptions(): MinDBOptions|undefined {
@@ -351,8 +361,16 @@ export class SQLiteDB implements ISQLiteDB {
   }
 
   public async close(): Promise<void> {
-    await this._db.close();
-    SQLiteDB._addOpens(this._dbPath, -1);
+    const alreadyClosed = this._closed;
+    this._closed = true;
+    if (!alreadyClosed) {
+      await this._db.close();
+      SQLiteDB._addOpens(this._dbPath, -1);
+    }
+  }
+
+  public isClosed(): boolean {
+    return this._closed;
   }
 
   /**

--- a/app/server/lib/SqliteCommon.ts
+++ b/app/server/lib/SqliteCommon.ts
@@ -56,6 +56,8 @@ export interface MinDB {
    * Get some facts about the wrapper.
    */
   getOptions?(): MinDBOptions;
+
+  backup?(filename: string): Backup;
 }
 
 export interface MinRunResult {
@@ -75,6 +77,13 @@ export interface PreparedStatement {
 
 export interface SqliteVariant {
   opener(dbPath: string, mode: OpenMode): Promise<MinDB>;
+}
+
+export interface Backup {
+  remaining: number;
+  failed: boolean;
+  step(pages: number,
+       callback?: (err: Error | null) => void): void;
 }
 
 /**

--- a/app/server/lib/SqliteNode.ts
+++ b/app/server/lib/SqliteNode.ts
@@ -1,6 +1,7 @@
 import * as sqlite3 from '@gristlabs/sqlite3';
 import { fromCallback } from 'app/server/lib/serverUtils';
-import { MinDB, MinDBOptions, PreparedStatement, ResultRow, SqliteVariant } from 'app/server/lib/SqliteCommon';
+import { Backup, MinDB, MinDBOptions, PreparedStatement,
+         ResultRow, SqliteVariant } from 'app/server/lib/SqliteCommon';
 import { OpenMode, RunResult } from 'app/server/lib/SQLiteDB';
 
 export class NodeSqliteVariant implements SqliteVariant {
@@ -86,6 +87,10 @@ export class NodeSqlite3DatabaseAdapter implements MinDB {
 
   public async interrupt(): Promise<void> {
     this._db.interrupt();
+  }
+
+  public backup(filename: string): Backup {
+    return (this._db as sqlite3.DatabaseWithBackup).backup(filename);
   }
 
   public getOptions(): MinDBOptions {


### PR DESCRIPTION
## Context

Grist uses the SQLite API to make backups. This PR reorganizes the code so that the SQLite connection used by ActiveDoc (the main class representing an open document) is also the one used for backups. Otherwise, if the document is under continuous modification (e.g. because of some automation), attempting to perform the backup may not terminate since SQLite may keep restarting the backup under the hood.

With this change, it is now also worth beginning the backup even if the document is busy, so the PR also does that.

In testing, when a document is under heavy load, the last step call in the SQLite backup API may be relatively slow, perhaps as all changes that accumulated are flushed also to the backup. But since a since SQLite connection is being used now, there should not be any new SQLite-level busy timeouts.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
