### PR TITLE
OIDConfig.getLogoutRedirectUrl: use redirectURL when possible

### DIFF
--- a/app/server/lib/OIDCConfig.ts
+++ b/app/server/lib/OIDCConfig.ts
@@ -279,20 +279,19 @@ export class OIDCConfig {
     });
   }
 
-  public async getLogoutRedirectUrl(req: express.Request): Promise<string> {
-    const session: SessionObj|undefined = (req as RequestWithLogin).session;
-    const stableRedirectUri = new URL('/signed-out', getOriginUrl(req)).href;
-    // For IdPs that don't have end_session_endpoint, we just redirect to the logout page.
+  public async getLogoutRedirectUrl(req: express.Request, redirectUrl: URL): Promise<string> {
+    // For IdPs that don't have end_session_endpoint, we just redirect to the requested page.
     if (this._skipEndSessionEndpoint) {
-      // Ignore redirectUrl because OIDC providers don't allow variable redirect URIs
-      return stableRedirectUri;
+      return redirectUrl.href;
     }
     // Alternatively, we could use a logout URL specified by configuration.
     if (this._endSessionEndpoint) {
       return this._endSessionEndpoint;
     }
+    // Ignore redirectUrl because OIDC providers don't allow variable redirect URIs
+    const stableRedirectUri = new URL('/signed-out', getOriginUrl(req)).href;
+    const session: SessionObj|undefined = (req as RequestWithLogin).session;
     return this._client.endSessionUrl({
-      // Ignore redirectUrl because OIDC providers don't allow variable redirect URIs
       post_logout_redirect_uri: stableRedirectUri,
       id_token_hint: session?.oidc?.idToken,
     });

--- a/test/server/lib/OIDCConfig.ts
+++ b/test/server/lib/OIDCConfig.ts
@@ -752,6 +752,7 @@ describe('OIDCConfig', () => {
   });
 
   describe('getLogoutRedirectUrl', () => {
+    const REDIRECT_URL = new URL('http://localhost:8484/docs/signed-out');
     const STABLE_LOGOUT_URL = new URL('http://localhost:8484/signed-out');
     const URL_RETURNED_BY_CLIENT = 'http://localhost:8484/logout_url_from_issuer';
     const ENV_VALUE_GRIST_OIDC_IDP_END_SESSION_ENDPOINT = 'http://localhost:8484/logout';
@@ -767,7 +768,7 @@ describe('OIDCConfig', () => {
         env: {
           GRIST_OIDC_IDP_SKIP_END_SESSION_ENDPOINT: 'true',
         },
-        expectedUrl: STABLE_LOGOUT_URL.href,
+        expectedUrl: REDIRECT_URL.href,
       }, {
         itMsg: 'should use the GRIST_OIDC_IDP_END_SESSION_ENDPOINT when it is set',
         env: {
@@ -803,7 +804,7 @@ describe('OIDCConfig', () => {
           },
           session: 'session' in ctx ? ctx.session : FAKE_SESSION
         } as unknown as RequestWithLogin;
-        const url = await config.getLogoutRedirectUrl(req);
+        const url = await config.getLogoutRedirectUrl(req, REDIRECT_URL);
         assert.equal(url, ctx.expectedUrl);
         if (ctx.expectedLogoutParams) {
           assert.isTrue(clientStub.endSessionUrl.calledOnce);


### PR DESCRIPTION
## Context

In #1276 we fixed the issue that OIDC logouts failed because of Grist using a variable post-logout URI.

Looking at the code again, we realized that when the user had disabled OIDC logouts by setting `GRIST_OIDC_IDP_SKIP_END_SESSION_ENDPOINT` to `true`, Grist could actually use the requested post-logout URI.

## Proposed solution

When `GRIST_OIDC_IDP_SKIP_END_SESSION_ENDPOINT` is set to `true`, use the provided URL as the post-logout URI.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
