### PR TITLE
Upgrade Dependency connect-redis from 3.4.0 to 6.1.3

### DIFF
--- a/app/server/lib/gristSessions.ts
+++ b/app/server/lib/gristSessions.ts
@@ -60,7 +60,6 @@ function createSessionStoreFactory(sessionsDB: string): () => SessionStore {
     promisifyAll(RedisStore.prototype);
     return () => {
       const client = createClient(process.env.REDIS_URL);
-      client.unref();
       client.on('error',
         (err: unknown)=> {
           log.error(`createSessionStoreFactory: redisClient error`, String(err));

--- a/app/server/lib/gristSessions.ts
+++ b/app/server/lib/gristSessions.ts
@@ -62,8 +62,8 @@ function createSessionStoreFactory(sessionsDB: string): () => SessionStore {
       const client = createClient(process.env.REDIS_URL);
       client.unref();
       client.on('error',
-        (e: any)=> {
-          log.error(`[createSessionStoreFactory]: ${e}`);
+        (err: unknown)=> {
+          log.error(`createSessionStoreFactory: redisClient error`, String(err));
         }
       );
       const store = new RedisStore({client});

--- a/app/server/lib/gristSessions.ts
+++ b/app/server/lib/gristSessions.ts
@@ -11,7 +11,7 @@ import * as crypto from 'crypto';
 import * as express from 'express';
 import assignIn = require('lodash/assignIn');
 import * as path from 'path';
-import { createClient } from 'redis';
+import {createClient} from 'redis';
 
 export const cookieName = process.env.GRIST_SESSION_COOKIE || 'grist_sid';
 

--- a/app/server/lib/gristSessions.ts
+++ b/app/server/lib/gristSessions.ts
@@ -3,6 +3,7 @@ import {parseSubdomain} from 'app/common/gristUrls';
 import {isNumber} from 'app/common/gutil';
 import {RequestWithOrg} from 'app/server/lib/extractOrg';
 import {GristServer} from 'app/server/lib/GristServer';
+import {log} from 'app/server/lib/log';
 import {fromCallback} from 'app/server/lib/serverUtils';
 import {Sessions} from 'app/server/lib/Sessions';
 import {promisifyAll} from 'bluebird';
@@ -10,7 +11,6 @@ import * as crypto from 'crypto';
 import * as express from 'express';
 import assignIn = require('lodash/assignIn');
 import * as path from 'path';
-
 
 export const cookieName = process.env.GRIST_SESSION_COOKIE || 'grist_sid';
 
@@ -55,12 +55,16 @@ export interface IGristSession {
 function createSessionStoreFactory(sessionsDB: string): () => SessionStore {
   if (process.env.REDIS_URL) {
     // Note that ./build excludes this module from the electron build.
+    const redis = require('redis');
     const RedisStore = require('connect-redis')(session);
     promisifyAll(RedisStore.prototype);
     return () => {
-      const store = new RedisStore({
+      const client = redis.createClient({
         url: process.env.REDIS_URL,
       });
+      client.unref();
+      client.on('error', log);
+      const store = new RedisStore({client});
       return assignIn(store, {
         async close() {
           // Quit the client, so that it doesn't attempt to reconnect (which matters for some

--- a/app/server/lib/gristSessions.ts
+++ b/app/server/lib/gristSessions.ts
@@ -11,6 +11,7 @@ import * as crypto from 'crypto';
 import * as express from 'express';
 import assignIn = require('lodash/assignIn');
 import * as path from 'path';
+import { createClient } from 'redis';
 
 export const cookieName = process.env.GRIST_SESSION_COOKIE || 'grist_sid';
 
@@ -55,13 +56,10 @@ export interface IGristSession {
 function createSessionStoreFactory(sessionsDB: string): () => SessionStore {
   if (process.env.REDIS_URL) {
     // Note that ./build excludes this module from the electron build.
-    const redis = require('redis');
     const RedisStore = require('connect-redis')(session);
     promisifyAll(RedisStore.prototype);
     return () => {
-      const client = redis.createClient({
-        url: process.env.REDIS_URL,
-      });
+      const client = createClient(process.env.REDIS_URL);
       client.unref();
       client.on('error',
         (e: any)=> {

--- a/app/server/lib/gristSessions.ts
+++ b/app/server/lib/gristSessions.ts
@@ -3,7 +3,7 @@ import {parseSubdomain} from 'app/common/gristUrls';
 import {isNumber} from 'app/common/gutil';
 import {RequestWithOrg} from 'app/server/lib/extractOrg';
 import {GristServer} from 'app/server/lib/GristServer';
-import {log} from 'app/server/lib/log';
+import log from 'app/server/lib/log';
 import {fromCallback} from 'app/server/lib/serverUtils';
 import {Sessions} from 'app/server/lib/Sessions';
 import {promisifyAll} from 'bluebird';
@@ -63,7 +63,11 @@ function createSessionStoreFactory(sessionsDB: string): () => SessionStore {
         url: process.env.REDIS_URL,
       });
       client.unref();
-      client.on('error', log);
+      client.on('error',
+        (e: any)=> {
+          log.error(`[createSessionStoreFactory]: ${e}`);
+        }
+      );
       const store = new RedisStore({client});
       return assignIn(store, {
         async close() {

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "prom-client": "14.2.0",
     "qrcode": "1.5.0",
     "randomcolor": "0.5.3",
-    "redis": "3.1.1",
+    "redis": "~3.1.2",
     "redlock": "3.1.2",
     "saml2-js": "4.0.2",
     "scimmy": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "color-convert": "2.0.1",
     "commander": "9.3.0",
     "components-jqueryui": "1.12.1",
-    "connect-redis": "5.2.0",
+    "connect-redis": "6.1.3",
     "cookie": "0.7.0",
     "cookie-parser": "1.4.7",
     "csv": "6.3.8",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "color-convert": "2.0.1",
     "commander": "9.3.0",
     "components-jqueryui": "1.12.1",
-    "connect-redis": "3.4.0",
+    "connect-redis": "5.2.0",
     "cookie": "0.7.0",
     "cookie-parser": "1.4.7",
     "csv": "6.3.8",

--- a/stubs/app/server/declarations.d.ts
+++ b/stubs/app/server/declarations.d.ts
@@ -61,7 +61,6 @@ declare module "redis" {
     public lrangeAsync(key: string, start: number, end: number): Promise<string[]>;
     public rpushAsync(key: string, ...vals: string[]): Promise<number>;
     public pingAsync(): Promise<string>;
-    public unref(): void;
   }
 
   class Multi {

--- a/stubs/app/server/declarations.d.ts
+++ b/stubs/app/server/declarations.d.ts
@@ -61,6 +61,7 @@ declare module "redis" {
     public lrangeAsync(key: string, start: number, end: number): Promise<string[]>;
     public rpushAsync(key: string, ...vals: string[]): Promise<number>;
     public pingAsync(): Promise<string>;
+    public unref(): void;
   }
 
   class Multi {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2926,13 +2926,10 @@ concat-stream@~1.5.0, concat-stream@~1.5.1:
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
 
-connect-redis@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-3.4.0.tgz#4040dd3755bddbf93478fb84937a74052c31b965"
-  integrity sha512-YKPSO9tLwzUr8jzhsGMdSJUxevWrDt0ggXRcTMb+mtnJ/vWGlWV7RC4VUMgqvZv3uTGDFye8Bf7d6No0oSVkOQ==
-  dependencies:
-    debug "^4.0.1"
-    redis "^2.8.0"
+connect-redis@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-5.2.0.tgz#d38e173f2e2cccecb89b8757ce7627ecdb8e3b94"
+  integrity sha512-wcv1lZWa2K7RbsdSlrvwApBQFLQx+cia+oirLIeim0axR3D/9ZJbHdeTM/j8tJYYKk34dVs2QPAuAqcIklWD+Q==
 
 console-browserify@^1.1.0:
   version "1.2.0"
@@ -3228,7 +3225,7 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@~4.3.1:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@~4.3.1:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"
   integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
@@ -3524,7 +3521,7 @@ dotenv@^16.0.3:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
   integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
 
-double-ended-queue@2.1.0-0, double-ended-queue@^2.1.0-0:
+double-ended-queue@2.1.0-0:
   version "2.1.0-0"
   resolved "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
@@ -7152,7 +7149,7 @@ rechoir@^0.7.0:
   dependencies:
     resolve "^1.9.0"
 
-redis-commands@^1.2.0, redis-commands@^1.7.0:
+redis-commands@^1.7.0:
   version "1.7.0"
   resolved "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz"
   integrity sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==
@@ -7161,11 +7158,6 @@ redis-errors@^1.0.0, redis-errors@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz"
   integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
-
-redis-parser@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz"
-  integrity sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=
 
 redis-parser@^3.0.0:
   version "3.0.0"
@@ -7183,15 +7175,6 @@ redis@3.1.1:
     redis-commands "^1.7.0"
     redis-errors "^1.2.0"
     redis-parser "^3.0.0"
-
-redis@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz"
-  integrity sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==
-  dependencies:
-    double-ended-queue "^2.1.0-0"
-    redis-commands "^1.2.0"
-    redis-parser "^2.6.0"
 
 redlock@3.1.2:
   version "3.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2926,10 +2926,10 @@ concat-stream@~1.5.0, concat-stream@~1.5.1:
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
 
-connect-redis@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-5.2.0.tgz#d38e173f2e2cccecb89b8757ce7627ecdb8e3b94"
-  integrity sha512-wcv1lZWa2K7RbsdSlrvwApBQFLQx+cia+oirLIeim0axR3D/9ZJbHdeTM/j8tJYYKk34dVs2QPAuAqcIklWD+Q==
+connect-redis@6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-6.1.3.tgz#0a83c953f9ece45ae37d304a8e8d1c3c6a60b4b9"
+  integrity sha512-aaNluLlAn/3JPxRwdzw7lhvEoU6Enb+d83xnokUNhC9dktqBoawKWL+WuxinxvBLTz6q9vReTnUDnUslaz74aw==
 
 console-browserify@^1.1.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7166,10 +7166,10 @@ redis-parser@^3.0.0:
   dependencies:
     redis-errors "^1.0.0"
 
-redis@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/redis/-/redis-3.1.1.tgz"
-  integrity sha512-QhkKhOuzhogR1NDJfBD34TQJz2ZJwDhhIC6ZmvpftlmfYShHHQXjjNspAJ+Z2HH5NwSBVYBVganbiZ8bgFMHjg==
+redis@~3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-3.1.2.tgz#766851117e80653d23e0ed536254677ab647638c"
+  integrity sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==
   dependencies:
     denque "^1.5.0"
     redis-commands "^1.7.0"


### PR DESCRIPTION
## Context

This PR is a follow-up of #1368
It manage to upgrade redis-connect to it's latest release

## Proposed solution

The following strategy has been chosen.

* Upgrade following breaking changes and migration documentations provided by redis-connect project.

### Bump [connect-redis](https://github.com/tj/connect-redis) from 3.4.0 to 6.1.3

Applies migration following https://github.com/tj/connect-redis/blob/c951850eb72759f387d4ae0c249aca8e1e9fc244/migration-to-v4.md

- [Releases](https://github.com/tj/connect-redis/releases)
- [Commits](https://github.com/tj/connect-redis/compare/3.4.0...v6.1.3)

## Has this been tested?

- [x] 👍 yes, By running automated test of this PR
