### PR TITLE
chore: Fix webpack version import warning

### DIFF
--- a/stubs/app/common/version.ts
+++ b/stubs/app/common/version.ts
@@ -1,4 +1,4 @@
-import * as packageJson from 'package.json';
+import packageJson from 'package.json';
 
 export const version = packageJson.version;
 export const channel = "core";


### PR DESCRIPTION
## Context

The webpack build warns about incoming changes in package.json import.

```javascript
WARNING in ./stubs/app/common/version.ts 2:23-42
Should not import the named export 'version' (imported as 'packageJson') from default-exporting module (only default export is available soon)
 @ ./app/client/ui/AppHeader.ts 5:0-46 51:29-44 51:50-67 51:89-106
 @ ./app/client/ui/errorPages.ts 3:0-52 90:25-34
 @ ./app/client/errorMain.ts 2:0-57 3:28-41

webpack 5.97.1 compiled with 1 warning in 4928 ms
```
This PR adresses this.

## Proposed solution

I follow advice in the warning to change the way we import package.json.

## Has this been tested?

- [x] 👍 yes, locally
Version still displays in the UI.
