### PR TITLE
docs: add syntax highlighting to various code blocks

### DIFF
--- a/documentation/grainjs.md
+++ b/documentation/grainjs.md
@@ -18,7 +18,7 @@ You can find full documentation of knockout at https://knockoutjs.com/documentat
 
 Creating and using observables:
 
-```
+```js
 import * as ko from 'knockout';
 
 const kObs = ko.observable(17);
@@ -28,7 +28,7 @@ kObs();      // Returns 8
 kObs.peek(); // Returns 8
 ```
 
-```
+```js
 import {Computed, Observable} from 'grainjs';
 
 const gObs = Observable.create(null, 17)
@@ -40,11 +40,11 @@ gObs.get();     // Returns 8
 
 Creating and using computed observables
 
-```
+```js
 ko.computed(() => kObs() * 10);
 ```
 
-```
+```js
 Computed.create(null, use => use(gObs) * 10);
 ```
 
@@ -62,7 +62,7 @@ Methods `dom.onDispose`, and `dom.autoDispose` are analogous to GrainJS, but rel
 
 For DOM bindings, which allow tying DOM properties to observable values, there is a [`app/client/lib/koDom.js`](../app/client/lib/koDom.js) module. For example:
 
-```
+```js
 import * as dom from 'app/client/lib/dom';
 import * as kd from 'app/client/lib/koDom';
 

--- a/documentation/grist-data-format.md
+++ b/documentation/grist-data-format.md
@@ -45,6 +45,7 @@ The `name` is the name of the table. The `colinfo` array has an item to describe
 The `name` is the name of the column, and `type` is its type. The field `options` optionally specifies type-specific options that affect the column (e.g. the number of decimal places to display for a floating-point number).
 
 ### ColData
+
 ```javascript
    {
           <colName1>: ColValues,
@@ -53,15 +54,18 @@ The `name` is the name of the column, and `type` is its type. The field `options
    }
 ```
 
-The data in the table is represented as an object mapping a column name to an array of values for the column. This column-oriented representation allows for the representation of data to be more concise. 
+The data in the table is represented as an object mapping a column name to an array of values for the column. This column-oriented representation allows for the representation of data to be more concise.
 
 ### ColValues
+
 ```javascript
    [CellValue, CellValue, ...]
 ```
+
 ColValues is an array of all values for the column. We'll refer to the type of each value as `CellValue`. ColValues has an entry for each row in the table. In particular, each ColValues array in a ColData object has the same number of entries.
 
 ### CellValue
+
 CellValue represents the value in one cell. We support various types of values, documented below. When represented as JSON, CellValue is one  of the following JSON types:
   - string
   - number
@@ -74,6 +78,7 @@ The interpretation of CellValue is affected by the column’s type, and describe
 ## JSON Schema
 
 The description above can be summarized by this JSON Schema:
+
 ```json
 {
   "definitions": {

--- a/documentation/migrations.md
+++ b/documentation/migrations.md
@@ -3,7 +3,8 @@
 If you change Grist schema, i.e. the schema of the Grist metadata tables (in [`sandbox/grist/schema.py`](../sandbox/grist/schema.py)), you'll have to increment the `SCHEMA_VERSION` (on top of that file) and create a migration. A migration is a set of actions that would get applied to a document at the previous version, to make it satisfy the new schema.
 
 To add a migration, add a function to [`sandbox/grist/migrations.py`](../sandbox/grist/migrations.py), of this form (using the new version number):
-```lang=python
+
+```python
 @migration(schema_version=11)
 def migration11(tdset):
   return tdset.apply_doc_actions([
@@ -29,7 +30,7 @@ WARNING: Do not remove, modify, or rename metadata tables or columns.
 
 Mark old columns and tables as deprecated using a comment. We may want to add a feature to mark them in code, to prevent their use in new versions. For now, it's enough to add a comment and remove references to the deprecated entities throughout code. An important goal is to prevent adding same-named entities in the future, or reusing the same column with a different meaning. So please add a comment of the form:
 
-```lang=python
+```python
 # <columnName> is deprecated as of version XX. Do not remove or reuse.
 ```
 

--- a/documentation/overview.md
+++ b/documentation/overview.md
@@ -63,7 +63,7 @@ The authoritative list of available User Actions is the list of all the methods 
 
 Doc Actions are handled both in Python and Node. Here is the full list of Doc Actions:
 
-```
+```typescript
 // Data Actions
 export type AddRecord = ['AddRecord', string, number, ColValues];
 export type BulkAddRecord = ['BulkAddRecord', string, number[], BulkColValues];
@@ -90,7 +90,7 @@ export type RenameTable = ['RenameTable', string, string];
 
 Data actions take a string `tableId` and a numeric `rowId` (or a list of them, for “bulk” actions) and a set of values:
 
-```
+```typescript
 export interface ColValues { [colId: string]: CellValue; }
 export interface BulkColValues { [colId: string]: CellValue[]; }
 ```


### PR DESCRIPTION
## Context

<!-- Please include a summary of the change, with motivation and context -->
<!-- Bonus: if you are comfortable writing one, please insert a user-story https://en.wikipedia.org/wiki/User_story#Common_templates -->

Was just reading through the docs here on GH and saw some code blocks were missing syntax highlighting

## Details

<!-- Describe here how you address the issue -->

- the code blocks were either missing a language specifier entirely, or were using a different flavor of markdown from GH that has different specifiers
  - e.g. `lang=python` vs `python`

- also fix various small `markdownlint` issues
  - mainly whitespace around codeblocks and headings
  - there's more `markdownlint` issues, but I only applied some less obtrusive ones

- and fix a few grammatical errors and formatting errors
  - e.g. missing article ("the"), etc
  - extraneous paren after markdown link, etc

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

Made some other docs improvements in #1392

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [n/a] 👍 yes, I added tests to the test suite
- [n/a] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [n/a] 🙋 no, because I need help <!-- Detail how we can help you -->

I manually viewed the rendered markdown and ensured the code now had syntax highlighting. [Example](https://github.com/gristlabs/grist-core/blob/e70e8ff93a2904d739781d5fe3140c016bc632be/documentation/grainjs.md)
