### PR TITLE
Install Chrome manually in workflows

### DIFF
--- a/.github/workflows/docker_latest.yml
+++ b/.github/workflows/docker_latest.yml
@@ -124,8 +124,12 @@ jobs:
         if: ${{ !inputs.disable_tests }}
         run: yarn run build:prod
 
-      - name: Install Google Chrome for Testing
-        run: ./test/test_env.sh node_modules/selenium-webdriver/bin/linux/selenium-manager
+      - name: Install Google Chrome and chromedriver
+        run: |
+          curl -sS -o /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_132.0.6834.110-1_amd64.deb \
+            && sudo apt-get install -y /tmp/chrome.deb \
+            && rm /tmp/chrome.deb
+          ./node_modules/selenium-webdriver/bin/linux/selenium-manager --driver chromedriver
 
       - name: Run tests with default settings
         if: ${{ !inputs.disable_tests }}

--- a/.github/workflows/docker_latest.yml
+++ b/.github/workflows/docker_latest.yml
@@ -125,11 +125,7 @@ jobs:
         run: yarn run build:prod
 
       - name: Install Google Chrome and chromedriver
-        run: |
-          curl -sS -o /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_132.0.6834.110-1_amd64.deb \
-            && sudo apt-get install -y /tmp/chrome.deb \
-            && rm /tmp/chrome.deb
-          ./node_modules/selenium-webdriver/bin/linux/selenium-manager --driver chromedriver
+        run: buildtools/install_chrome_for_tests.sh -y
 
       - name: Run tests with default settings
         if: ${{ !inputs.disable_tests }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,11 +75,7 @@ jobs:
 
       - name: Install Google Chrome and chromedriver
         if: contains(matrix.tests, ':nbrowser-') || contains(matrix.tests, ':smoke:') || contains(matrix.tests, ':stubs:')
-        run: |
-          curl -sS -o /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_132.0.6834.110-1_amd64.deb \
-            && sudo apt-get install -y /tmp/chrome.deb \
-            && rm /tmp/chrome.deb
-          ./node_modules/selenium-webdriver/bin/linux/selenium-manager --driver chromedriver
+        run: buildtools/install_chrome_for_tests.sh -y
 
       - name: Run smoke test
         if: contains(matrix.tests, ':smoke:')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,9 +73,13 @@ jobs:
       - name: Build Node.js code
         run: yarn run build:prod
 
-      - name: Install Google Chrome for Testing
+      - name: Install Google Chrome and chromedriver
         if: contains(matrix.tests, ':nbrowser-') || contains(matrix.tests, ':smoke:') || contains(matrix.tests, ':stubs:')
-        run: ./test/test_env.sh ./node_modules/selenium-webdriver/bin/linux/selenium-manager
+        run: |
+          curl -sS -o /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_132.0.6834.110-1_amd64.deb \
+            && sudo apt install -y /tmp/chrome.deb \
+            && rm /tmp/chrome.deb
+          ./node_modules/selenium-webdriver/bin/linux/selenium-manager --driver chromedriver
 
       - name: Run smoke test
         if: contains(matrix.tests, ':smoke:')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
         if: contains(matrix.tests, ':nbrowser-') || contains(matrix.tests, ':smoke:') || contains(matrix.tests, ':stubs:')
         run: |
           curl -sS -o /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_132.0.6834.110-1_amd64.deb \
-            && sudo apt install -y /tmp/chrome.deb \
+            && sudo apt-get install -y /tmp/chrome.deb \
             && rm /tmp/chrome.deb
           ./node_modules/selenium-webdriver/bin/linux/selenium-manager --driver chromedriver
 

--- a/buildtools/install_chrome_for_tests.sh
+++ b/buildtools/install_chrome_for_tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+CHROME_VERSION="132.0.6834.110-1"
+
+if [[ "$1" != "-y" ]]; then
+  echo "Usage: $0 -y"
+  echo "Installs Google Chrome and chromedriver for running end-to-end Selenium tests in GitHub."
+  exit 1
+fi
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "Error: This script can only be run on Linux."
+  exit 1
+fi
+if [[ "$(uname -m)" != "x86_64" ]]; then
+  echo "Error: This script can only be run on amd64 architecture."
+  exit 1
+fi
+
+curl -sS -o /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
+  && sudo apt-get install -y /tmp/chrome.deb \
+  && rm /tmp/chrome.deb \
+  && node_modules/selenium-webdriver/bin/linux/selenium-manager --driver chromedriver

--- a/test/test_env.sh
+++ b/test/test_env.sh
@@ -2,7 +2,6 @@
 
 export GRIST_SESSION_COOKIE="grist_test_cookie"
 export LANGUAGE="en_US"
-export MOCHA_WEBDRIVER_ARGS="--no-sandbox"
 export TEST_CLEAN_DATABASE="true"
 export TEST_SUPPORT_API_KEY="api_key_for_support"
 

--- a/test/test_env.sh
+++ b/test/test_env.sh
@@ -2,10 +2,7 @@
 
 export GRIST_SESSION_COOKIE="grist_test_cookie"
 export LANGUAGE="en_US"
-export SE_BROWSER="chrome"
-export SE_BROWSER_VERSION="131"
-export SE_DRIVER="chrome-driver"
-export SE_DRIVER_VERSION="131.0.6778.69"
+export MOCHA_WEBDRIVER_ARGS="--no-sandbox"
 export TEST_CLEAN_DATABASE="true"
 export TEST_SUPPORT_API_KEY="api_key_for_support"
 


### PR DESCRIPTION
## Context

CI began experiencing failures after the version of Google Chrome used by GitHub Actions workers was upgraded to 132. The root cause turned out to be a problem with the version of Chrome for Testing downloaded by Selenium Manager requiring the "--no-sandbox" argument to work.

Adding the argument revealed another problem: tests have become very unreliable in recent versions of Chrome for Testing, which appears to differ slightly from the regular version of Chrome. The root cause is currently unknown.

## Proposed solution

Switch to manually installed versions of Chrome in workflows. Selenium Manager will still download an appropriate version of chromedriver for the installed version of Chrome.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

