### PR TITLE
chokidar is no longer used

### DIFF
--- a/app/server/declarations.d.ts
+++ b/app/server/declarations.d.ts
@@ -21,9 +21,6 @@ declare module "bluebird" {
 // Used in one place, and the typings are almost entirely unhelpful.
 declare module "multiparty";
 
-// Used in one place, for one call.
-declare module "chokidar";
-
 // Used in one place
 declare module "mime-types";
 


### PR DESCRIPTION
## Context

I'm trying to add `grist-core` to nixpkgs and during testing it became clear that `chokidar` is only available as a dev dependency.

## Proposed solution

Remove the import and use of `chokidar` as it's no longer used as per https://github.com/gristlabs/grist-core/issues/1399#issuecomment-2610448592

## Related issues

closes #1399

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
