### PR TITLE
External Attachments - Basic config + API endpoint updates

### DIFF
--- a/app/plugin/DocApiTypes-ti.ts
+++ b/app/plugin/DocApiTypes-ti.ts
@@ -90,6 +90,10 @@ export const SqlPost = t.iface([], {
   "timeout": t.opt("number"),
 });
 
+export const SetAttachmentStorePost = t.iface([], {
+  "type": t.union(t.lit("internal"), t.lit("external")),
+});
+
 const exportedTypeSuite: t.ITypeSuite = {
   NewRecord,
   NewRecordWithStringId,
@@ -108,5 +112,6 @@ const exportedTypeSuite: t.ITypeSuite = {
   TablesPost,
   TablesPatch,
   SqlPost,
+  SetAttachmentStorePost,
 };
 export default exportedTypeSuite;

--- a/app/plugin/DocApiTypes.ts
+++ b/app/plugin/DocApiTypes.ts
@@ -120,3 +120,7 @@ export interface SqlPost {
                      // other queued queries on same document, because of
                      // limitations of API node-sqlite3 exposes.
 }
+
+export interface SetAttachmentStorePost {
+  type: "internal" | "external"
+}

--- a/app/server/generateInitialDocSql.ts
+++ b/app/server/generateInitialDocSql.ts
@@ -34,11 +34,13 @@ export async function main(baseName: string) {
     if (await fse.pathExists(fname)) {
       await fse.remove(fname);
     }
-    const docManager = new DocManager(storageManager, pluginManager, null as any, new AttachmentStoreProvider([], ""), {
-      create,
-      getAuditLogger() { return createNullAuditLogger(); },
-      getTelemetry() { return createDummyTelemetry(); },
-    } as any);
+    const docManager = new DocManager(storageManager, pluginManager, null as any,
+      new AttachmentStoreProvider([], ""), {
+        create,
+        getAuditLogger() { return createNullAuditLogger(); },
+        getTelemetry() { return createDummyTelemetry(); },
+      } as any
+    );
     const activeDoc = new ActiveDoc(docManager, baseName);
     const session = makeExceptionalDocSession('nascent');
     await activeDoc.createEmptyDocWithDataEngine(session);

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -286,7 +286,7 @@ export class ActiveDoc extends EventEmitter {
   constructor(
     private readonly _docManager: DocManager,
     private _docName: string,
-    externalAttachmentStoreProvider?: IAttachmentStoreProvider,
+    private _attachmentStoreProvider?: IAttachmentStoreProvider,
     private _options?: ICreateActiveDocOptions
   ) {
     super();
@@ -392,11 +392,11 @@ export class ActiveDoc extends EventEmitter {
       loadTable: this._rawPyCall.bind(this, 'load_table'),
     });
 
-    // This will throw errors if _options?.doc or externalAttachmentStoreProvider aren't provided,
+    // This will throw errors if _options?.doc or _attachmentStoreProvider aren't provided,
     // and ActiveDoc tries to use an external attachment store.
     this._attachmentFileManager = new AttachmentFileManager(
       this.docStorage,
-      externalAttachmentStoreProvider,
+      _attachmentStoreProvider,
       _options?.doc,
     );
 
@@ -977,10 +977,25 @@ export class ActiveDoc extends EventEmitter {
       await this._attachmentFileManager.allTransfersCompleted();
   }
 
-  public async setAttachmentStore(docSession: OptDocSession, id: string): Promise<void> {
+
+  public async setAttachmentStore(docSession: OptDocSession, id: string | undefined): Promise<void> {
     const docSettings = await this._getDocumentSettings();
     docSettings.attachmentStoreId = id;
     await this._updateDocumentSettings(docSession, docSettings);
+  }
+
+  /**
+   * Sets the document attachment store using the store's label.
+   * This avoids needing to know the exact store ID, which can be challenging to calculate in all
+   * the places we might want to set the store.
+   */
+  public async setAttachmentStoreFromLabel(docSession: OptDocSession, label: string | undefined): Promise<void> {
+    const id = label === undefined ? undefined : this._attachmentStoreProvider?.getStoreIdFromLabel(label);
+    return this.setAttachmentStore(docSession, id);
+  }
+
+  public async getAttachmentStore(): Promise<string | undefined> {
+    return (await this._getDocumentSettings()).attachmentStoreId;
   }
 
   /**

--- a/app/server/lib/AttachmentStoreProvider.ts
+++ b/app/server/lib/AttachmentStoreProvider.ts
@@ -123,7 +123,8 @@ export async function checkAvailabilityAttachmentStoreOptions(options: ICreateAt
 }
 
 // Make a filesystem store that will be cleaned up on process exit.
-// Can be replaced by the full config in the future - this is temporary until then.
+// This is only used when external attachments are in 'test' mode, which is used for some unit tests.
+// TODO: Remove this when setting up a filesystem store is possible using normal configuration options
 export async function makeTempFilesystemStoreSpec(
   name: string = "filesystem"
 ) {

--- a/app/server/lib/AttachmentStoreProvider.ts
+++ b/app/server/lib/AttachmentStoreProvider.ts
@@ -1,6 +1,10 @@
-import {IAttachmentStore} from 'app/server/lib/AttachmentStore';
+import {appSettings} from 'app/server/lib/AppSettings';
+import {FilesystemAttachmentStore, IAttachmentStore} from 'app/server/lib/AttachmentStore';
 import log from 'app/server/lib/log';
 import {ICreateAttachmentStoreOptions} from './ICreate';
+import * as fse from 'fs-extra';
+import path from 'path';
+import * as tmp from 'tmp-promise';
 
 export type AttachmentStoreId = string
 
@@ -15,8 +19,10 @@ export type AttachmentStoreId = string
  * to store/retrieve them as long as that store exists on the document's installation.
  */
 export interface IAttachmentStoreProvider {
+  getStoreIdFromLabel(label: string): string;
+
   // Returns the store associated with the given id, returning null if no store with that id exists.
-  getStore(id: AttachmentStoreId): Promise<IAttachmentStore | null>
+  getStore(id: AttachmentStoreId): Promise<IAttachmentStore | null>;
 
   getAllStores(): Promise<IAttachmentStore[]>;
 
@@ -25,56 +31,76 @@ export interface IAttachmentStoreProvider {
   listAllStoreIds(): AttachmentStoreId[];
 }
 
+// All the information needed to instantiate an instance of a particular store type
 export interface IAttachmentStoreSpecification {
   name: string,
   create: (storeId: string) => Promise<IAttachmentStore>,
 }
 
-interface IAttachmentStoreDetails {
-  id: string;
+// All the information needed to create a particular store instance
+export interface IAttachmentStoreConfig {
+  // This is the name for the store, but it also used to construct the store ID.
+  label: string;
   spec: IAttachmentStoreSpecification;
 }
 
+/**
+ * Provides access to instances of attachment stores.
+ *
+ * Stores can be accessed using ID or Label.
+ *
+ * Labels are a convenient/user-friendly way to refer to stores.
+ * Each label is unique within a Grist instance, but other instances may have stores that use
+ * the same label.
+ * E.g "my-s3" or "myFolder".
+ *
+ * IDs are globally unique - and are created by prepending the label with the installation UUID.
+ * E.g "22ec6867-67bc-414e-a707-da9204c84cab-my-s3" or "22ec6867-67bc-414e-a707-da9204c84cab-myFolder"
+ */
 export class AttachmentStoreProvider implements IAttachmentStoreProvider {
-  private _storeDetailsById: { [storeId: string]: IAttachmentStoreDetails } = {};
+  private _storeDetailsById: Map<string, IAttachmentStoreConfig> = new Map();
 
   constructor(
-    _backends: IAttachmentStoreSpecification[],
-    _installationUuid: string
+    storeConfigs: IAttachmentStoreConfig[],
+    private _installationUuid: string
   ) {
-    // In the current setup, we automatically generate store IDs based on the installation ID.
-    // The installation ID is guaranteed to be unique, and we only allow one store of each backend type.
-    // This gives us a way to reproducibly generate a unique ID for the stores.
-    _backends.forEach((storeSpec) => {
-      const storeId = `${_installationUuid}-${storeSpec.name}`;
-      this._storeDetailsById[storeId] = {
-        id: storeId,
-        spec: storeSpec,
-      };
+    // It's convenient to have stores with a globally unique ID, so there aren't conflicts as
+    // documents are moved between installations. This is achieved by prepending the store labels
+    // with the installation ID. Enforcing that using AttachmentStoreProvider makes it
+    // much harder to accidentally bypass this constraint, as the provider should be the only way of
+    // accessing stores.
+    storeConfigs.forEach((storeConfig) => {
+      this._storeDetailsById.set(this.getStoreIdFromLabel(storeConfig.label), storeConfig);
     });
 
-    const storeIds = Object.values(this._storeDetailsById).map(storeDetails => storeDetails.id);
+    const storeIds = Array.from(this._storeDetailsById.keys());
     log.info(`AttachmentStoreProvider initialised with stores: ${storeIds}`);
   }
 
+  public getStoreIdFromLabel(label: string): string {
+    return `${this._installationUuid}-${label}`;
+  }
+
   public async getStore(id: AttachmentStoreId): Promise<IAttachmentStore | null> {
-    const storeDetails = this._storeDetailsById[id];
+    const storeDetails = this._storeDetailsById.get(id);
     if (!storeDetails) { return null; }
     return storeDetails.spec.create(id);
   }
 
   public async getAllStores(): Promise<IAttachmentStore[]> {
     return await Promise.all(
-      Object.values(this._storeDetailsById).map(storeDetails => storeDetails.spec.create(storeDetails.id))
+      Array.from(this._storeDetailsById.entries()).map(
+        ([storeId, storeConfig]) => storeConfig.spec.create(storeId)
+      )
     );
   }
 
   public async storeExists(id: AttachmentStoreId): Promise<boolean> {
-    return id in this._storeDetailsById;
+    return this._storeDetailsById.has(id);
   }
 
   public listAllStoreIds(): string[] {
-    return Object.keys(this._storeDetailsById);
+    return Array.from(this._storeDetailsById.keys());
   }
 }
 
@@ -94,4 +120,46 @@ export async function checkAvailabilityAttachmentStoreOptions(options: ICreateAt
     available: options.filter((option, index) => availability[index]),
     unavailable: options.filter((option, index) => !availability[index]),
   };
+}
+
+// Make a filesystem store that will be cleaned up on process exit.
+// Can be replaced by the full config in the future - this is temporary until then.
+export async function makeTempFilesystemStoreSpec(
+  name: string = "filesystem"
+) {
+  const tempFolder = await tmp.dir();
+  const tempDir = await fse.mkdtemp(path.join(tempFolder.path, 'filesystem-store-test-'));
+  return {
+    rootDirectory: tempDir,
+    name,
+    create: async (storeId: string) => (new FilesystemAttachmentStore(storeId, tempDir))
+  };
+}
+
+const settings = appSettings.section("attachmentStores");
+const ATTACHMENT_STORE_MODE = settings.flag("mode").readString({
+  envVar: "GRIST_EXTERNAL_ATTACHMENTS_MODE",
+  defaultValue: "none",
+});
+
+export function getConfiguredStandardAttachmentStore(): string | undefined {
+  switch (ATTACHMENT_STORE_MODE) {
+    case "test":
+      return 'test-filesystem';
+    default:
+      return undefined;
+  }
+}
+
+export async function getConfiguredAttachmentStoreConfigs(): Promise<IAttachmentStoreConfig[]> {
+  switch (ATTACHMENT_STORE_MODE) {
+    // This mode should be removed once stores can be configured fully via env vars.
+    case "test":
+      return [{
+        label: 'test-filesystem',
+        spec: await makeTempFilesystemStoreSpec(),
+      }];
+    default:
+      return [];
+  }
 }

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -542,12 +542,11 @@ export class DocWorkerApi {
       });
     }));
 
-    // Returns the status of any current / pending attachment transfers
     this._app.get('/api/docs/:docId/attachments/store', isOwner,
       withDoc(async (activeDoc, req, res) => {
         const storeId = await activeDoc.getAttachmentStore();
         res.json({
-          type: storeId? 'external' : 'internal',
+          type: storeId ? 'external' : 'internal',
         });
       })
     );
@@ -568,7 +567,9 @@ export class DocWorkerApi {
           await activeDoc.setAttachmentStoreFromLabel(docSessionFromRequest(req), storeLabel);
         }
 
-        res.json(null);
+        res.json({
+          store: await activeDoc.getAttachmentStore()
+        });
       })
     );
 

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -47,7 +47,10 @@ import {ActiveDoc, colIdToRef as colIdToReference, getRealTableId, tableIdToRef}
 import {appSettings} from "app/server/lib/AppSettings";
 import {sendForCompletion} from 'app/server/lib/Assistance';
 import {getDocPoolIdFromDocInfo} from 'app/server/lib/AttachmentStore';
-import {IAttachmentStoreProvider} from 'app/server/lib/AttachmentStoreProvider';
+import {
+  getConfiguredStandardAttachmentStore,
+  IAttachmentStoreProvider
+} from 'app/server/lib/AttachmentStoreProvider';
 import {
   assertAccess,
   getAuthorizedUserId,
@@ -137,6 +140,7 @@ const {
   ColumnsPost, ColumnsPatch, ColumnsPut,
   SqlPost,
   TablesPost, TablesPatch,
+  SetAttachmentStorePost,
 } = t.createCheckers(DocApiTypesTI, GristDataTI);
 
 for (const checker of [RecordsPatch, RecordsPost, RecordsPut, ColumnsPost, ColumnsPatch,
@@ -538,6 +542,36 @@ export class DocWorkerApi {
       });
     }));
 
+    // Returns the status of any current / pending attachment transfers
+    this._app.get('/api/docs/:docId/attachments/store', isOwner,
+      withDoc(async (activeDoc, req, res) => {
+        const storeId = await activeDoc.getAttachmentStore();
+        res.json({
+          type: storeId? 'external' : 'internal',
+        });
+      })
+    );
+
+    this._app.post('/api/docs/:docId/attachments/store', isOwner, validate(SetAttachmentStorePost),
+      withDoc(async (activeDoc, req, res) => {
+        const body = req.body as Types.SetAttachmentStorePost;
+        if (body.type === 'internal') {
+          await activeDoc.setAttachmentStoreFromLabel(docSessionFromRequest(req), undefined);
+        }
+
+        if (body.type === 'external') {
+          const storeLabel = getConfiguredStandardAttachmentStore();
+          if (storeLabel === undefined) {
+            throw new ApiError("server is not configured with an external store", 400);
+          }
+          // This store might not exist - that's acceptable, and should be handled elsewhere.
+          await activeDoc.setAttachmentStoreFromLabel(docSessionFromRequest(req), storeLabel);
+        }
+
+        res.json(null);
+      })
+    );
+
     // Returns cleaned metadata for a given attachment ID (i.e. a rowId in _grist_Attachments table).
     this._app.get('/api/docs/:docId/attachments/:attId', canView, withDoc(async (activeDoc, req, res) => {
       const attId = integerParam(req.params.attId, 'attId');
@@ -919,7 +953,8 @@ export class DocWorkerApi {
     );
 
     /**
-     @deprecated please call to POST /webhooks instead, this endpoint is only for sake of backward compatibility
+     @deprecated please call to POST /webhooks instead, this endpoint is only for sake of backward
+        compatibility
      */
     this._app.post('/api/docs/:docId/tables/:tableId/_subscribe', isOwner, validate(WebhookSubscribe),
       withDocTriggersLock(async (activeDoc, req, res) => {
@@ -944,7 +979,8 @@ export class DocWorkerApi {
     );
 
     /**
-     @deprecated please call to DEL /webhooks instead, this endpoint is only for sake of backward compatibility
+     @deprecated please call to DEL /webhooks instead, this endpoint is only for sake of backward
+        compatibility
      */
     this._app.post('/api/docs/:docId/tables/:tableId/_unsubscribe', canEdit,
       withDocTriggersLock(removeWebhook)
@@ -1908,7 +1944,8 @@ export class DocWorkerApi {
   }
 
   /**
-   * Creates a middleware that checks the current usage of a limit and rejects the request if it is exceeded.
+   * Creates a middleware that checks the current usage of a limit and rejects the request if it is
+   * exceeded.
    */
   private async _checkLimit(limit: LimitType, req: Request, res: Response, next: NextFunction) {
     await this._dbManager.increaseUsage(getDocScope(req), limit, {dryRun: true, delta: 1});
@@ -1944,8 +1981,8 @@ export class DocWorkerApi {
 
   /**
    * Check if user is an owner of the document.
-   * If acceptTrunkForSnapshot is set, being an owner of the trunk of the document (if it is a snapshot)
-   * is sufficient. Uses cachedDoc, which could be stale if access has changed recently.
+   * If acceptTrunkForSnapshot is set, being an owner of the trunk of the document (if it is a
+   * snapshot) is sufficient. Uses cachedDoc, which could be stale if access has changed recently.
    */
   private async _isOwner(req: Request, options?: { acceptTrunkForSnapshot?: boolean }) {
     const scope = getDocScope(req);
@@ -2618,12 +2655,15 @@ export function docPeriodicApiUsageKey(docId: string, current: boolean, period: 
  * Maintain up to 5 buckets: current day, next day, current hour, next hour, current minute.
  * For each API request, check in order:
  * - if current_day < DAILY_LIMIT, allow; increment all 3 current buckets
- * - else if current_hour < DAILY_LIMIT/24, allow; increment next_day, current_hour, and current_minute buckets.
- * - else if current_minute < DAILY_LIMIT/24/60, allow; increment next_day, next_hour, and current_minute buckets.
+ * - else if current_hour < DAILY_LIMIT/24, allow; increment next_day, current_hour, and
+ * current_minute buckets.
+ * - else if current_minute < DAILY_LIMIT/24/60, allow; increment next_day, next_hour, and
+ * current_minute buckets.
  * - else reject.
  * I think it has pretty good properties:
  * - steady low usage may be maintained even if a burst exhausted the daily limit
- * - user could get close to twice the daily limit on the first day with steady usage after a burst,
+ * - user could get close to twice the daily limit on the first day with steady usage after a
+ * burst,
  *   but would then be limited to steady usage the next day.
  */
 export function getDocApiUsageKeysToIncr(

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -28,7 +28,10 @@ import {attachAppEndpoint} from 'app/server/lib/AppEndpoint';
 import {appSettings} from 'app/server/lib/AppSettings';
 import {attachEarlyEndpoints} from 'app/server/lib/attachEarlyEndpoints';
 import {
-  AttachmentStoreProvider, checkAvailabilityAttachmentStoreOptions, IAttachmentStoreProvider
+  AttachmentStoreProvider,
+  checkAvailabilityAttachmentStoreOptions,
+  getConfiguredAttachmentStoreConfigs,
+  IAttachmentStoreProvider
 } from 'app/server/lib/AttachmentStoreProvider';
 import {addRequestUser, getTransitiveHeaders, getUser, getUserId, isAnonymousUser,
         isSingleUserMode, redirectToLoginUnconditionally} from 'app/server/lib/Authorizer';
@@ -1396,7 +1399,7 @@ export class FlexServer implements GristServer {
     });
 
     this._attachmentStoreProvider = this._attachmentStoreProvider || new AttachmentStoreProvider(
-      storeOptions.available,
+      await getConfiguredAttachmentStoreConfigs(),
       (await this.getActivations().current()).id,
     );
     this._docManager = this._docManager || new DocManager(this._storageManager,

--- a/app/server/utils/gristify.ts
+++ b/app/server/utils/gristify.ts
@@ -53,7 +53,8 @@ export class Gristifier {
     // Open the file as an empty Grist document, creating Grist metadata
     // tables.
     const docManager = new DocManager(
-      new TrivialDocStorageManager(), null, null, new AttachmentStoreProvider([], ""), createDummyGristServer()
+      new TrivialDocStorageManager(), null, null,
+      new AttachmentStoreProvider([], ""), createDummyGristServer()
     );
     const activeDoc = new ActiveDoc(docManager, this._filename);
     const docSession = makeExceptionalDocSession('system');

--- a/test/server/lib/ActiveDoc.ts
+++ b/test/server/lib/ActiveDoc.ts
@@ -25,7 +25,7 @@ import * as sinon from 'sinon';
 import {createDocTools} from 'test/server/docTools';
 import * as testUtils from 'test/server/testUtils';
 import {EnvironmentSnapshot} from 'test/server/testUtils';
-import {makeTestingFilesystemStoreSpec} from 'test/server/lib/FilesystemAttachmentStore';
+import {makeTestingFilesystemStoreConfig} from 'test/server/lib/FilesystemAttachmentStore';
 import * as tmp from 'tmp';
 
 const execFileAsync = promisify(child_process.execFile);
@@ -41,11 +41,8 @@ describe('ActiveDoc', async function() {
   testUtils.setTmpLogLevel('warn');
 
   const attachmentStoreProvider = new AttachmentStoreProvider(
-    [
-      await makeTestingFilesystemStoreSpec("filesystem"),
-    ],
+    [await makeTestingFilesystemStoreConfig("filesystem")],
     "TEST-INSTALLATION-UUID"
-    // TEST-INSTALLATION-UUID-filesystem
   );
 
   const docTools = createDocTools({ attachmentStoreProvider });

--- a/test/server/lib/AttachmentFileManager.ts
+++ b/test/server/lib/AttachmentFileManager.ts
@@ -7,15 +7,15 @@ import {
 } from "app/server/lib/AttachmentFileManager";
 import { getDocPoolIdFromDocInfo } from "app/server/lib/AttachmentStore";
 import { AttachmentStoreProvider, IAttachmentStoreProvider } from "app/server/lib/AttachmentStoreProvider";
-import { makeTestingFilesystemStoreSpec } from "./FilesystemAttachmentStore";
+import { makeTestingFilesystemStoreConfig } from "test/server/lib/FilesystemAttachmentStore";
 import { assert } from "chai";
 import * as sinon from "sinon";
 import * as stream from "node:stream";
 
 // Minimum features of doc storage that are needed to make AttachmentFileManager work.
-type IMinimalDocStorage = Pick<
-  DocStorage,
-  'docName' | 'getFileInfo' | 'getFileInfoNoData' | 'attachFileIfNew' | 'attachOrUpdateFile' | 'listAllFiles' | 'requestVacuum'
+type IMinimalDocStorage = Pick<DocStorage,
+  'docName' | 'getFileInfo' | 'getFileInfoNoData' | 'attachFileIfNew' | 'attachOrUpdateFile'
+  | 'listAllFiles' | 'requestVacuum'
 >
 
 // Implements the minimal functionality needed for the AttachmentFileManager to work.
@@ -84,8 +84,8 @@ function createDocStorageFake(docName: string): DocStorage {
 async function createFakeAttachmentStoreProvider(): Promise<IAttachmentStoreProvider> {
   return new AttachmentStoreProvider(
     [
-      await makeTestingFilesystemStoreSpec("filesystem"),
-      await makeTestingFilesystemStoreSpec("filesystem-alt"),
+      await makeTestingFilesystemStoreConfig("filesystem"),
+      await makeTestingFilesystemStoreConfig("filesystem-alt"),
     ],
     "TEST-INSTALLATION-UUID"
   );

--- a/test/server/lib/AttachmentStoreProvider.ts
+++ b/test/server/lib/AttachmentStoreProvider.ts
@@ -1,37 +1,52 @@
 import {assert} from 'chai';
-import {AttachmentStoreProvider} from 'app/server/lib/AttachmentStoreProvider';
-import {makeTestingFilesystemStoreSpec} from './FilesystemAttachmentStore';
+import {
+  AttachmentStoreProvider,
+} from 'app/server/lib/AttachmentStoreProvider';
+import {
+  makeTestingFilesystemStoreConfig,
+} from 'test/server/lib/FilesystemAttachmentStore';
 
 const testInstallationUUID = "FAKE-UUID";
-function expectedStoreId(type: string) {
-  return `${testInstallationUUID}-${type}`;
+function expectedStoreId(label: string) {
+  return `${testInstallationUUID}-${label}`;
 }
 
 describe('AttachmentStoreProvider', () => {
-  it('constructs stores using the installations UUID and store type', async () => {
-    const filesystemType1 = await makeTestingFilesystemStoreSpec("filesystem1");
-    const filesystemType2 = await makeTestingFilesystemStoreSpec("filesystem2");
+  it('constructs stores using the installations UID and store type', async () => {
+    const storesConfig = [
+      await makeTestingFilesystemStoreConfig("filesystem1"),
+      await makeTestingFilesystemStoreConfig("filesystem2")
+    ];
 
-    const provider = new AttachmentStoreProvider([filesystemType1, filesystemType2], testInstallationUUID);
+    const provider = new AttachmentStoreProvider(storesConfig, testInstallationUUID);
     const allStores = await provider.getAllStores();
     const ids = allStores.map(store => store.id);
 
-    assert.includeMembers(ids, [expectedStoreId("filesystem1"), expectedStoreId("filesystem2")]);
+    assert.deepEqual(ids, [expectedStoreId("filesystem1"), expectedStoreId("filesystem2")]);
+
+    const allStoreIds = provider.listAllStoreIds();
+    assert.deepEqual(allStoreIds, [expectedStoreId("filesystem1"), expectedStoreId("filesystem2")]);
   });
 
   it("can retrieve a store if it exists", async () => {
-    const filesystemSpec = await makeTestingFilesystemStoreSpec("filesystem");
-    const provider = new AttachmentStoreProvider([filesystemSpec], testInstallationUUID);
+    const storesConfig = [
+      await makeTestingFilesystemStoreConfig("filesystem1"),
+    ];
+
+    const provider = new AttachmentStoreProvider(storesConfig, testInstallationUUID);
 
     assert.isNull(await provider.getStore("doesn't exist"), "store shouldn't exist");
 
-    assert(await provider.getStore(expectedStoreId("filesystem")), "store not present");
+    assert(await provider.getStore(expectedStoreId("filesystem1")), "store not present");
   });
 
   it("can check if a store exists", async () => {
-    const filesystemSpec = await makeTestingFilesystemStoreSpec("filesystem");
-    const provider = new AttachmentStoreProvider([filesystemSpec], testInstallationUUID);
+    const storesConfig = [
+      await makeTestingFilesystemStoreConfig("filesystem1"),
+    ];
 
-    assert(await provider.storeExists(expectedStoreId("filesystem")));
+    const provider = new AttachmentStoreProvider(storesConfig, testInstallationUUID);
+
+    assert(await provider.storeExists(expectedStoreId("filesystem1")));
   });
 });

--- a/test/server/lib/FilesystemAttachmentStore.ts
+++ b/test/server/lib/FilesystemAttachmentStore.ts
@@ -6,6 +6,7 @@ import {assert} from 'chai';
 import {mkdtemp, pathExists} from 'fs-extra';
 import * as stream from 'node:stream';
 import * as path from 'path';
+import {IAttachmentStoreConfig} from 'app/server/lib/AttachmentStoreProvider';
 
 const testingDocPoolId = "1234-5678";
 const testingFileId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.grist";
@@ -28,6 +29,15 @@ export async function makeTestingFilesystemStoreSpec(
     rootDirectory: tempDir,
     name,
     create: async (storeId: string) => (new FilesystemAttachmentStore(storeId, tempDir))
+  };
+}
+
+export async function makeTestingFilesystemStoreConfig(
+  name: string = "test-filesystem"
+): Promise<IAttachmentStoreConfig> {
+  return {
+    label: name,
+    spec: await makeTestingFilesystemStoreSpec(name),
   };
 }
 

--- a/test/server/lib/FilesystemAttachmentStore.ts
+++ b/test/server/lib/FilesystemAttachmentStore.ts
@@ -1,4 +1,5 @@
 import {FilesystemAttachmentStore} from 'app/server/lib/AttachmentStore';
+import {IAttachmentStoreConfig} from 'app/server/lib/AttachmentStoreProvider';
 import {MemoryWritableStream} from 'app/server/utils/MemoryWritableStream';
 import {createTmpDir} from 'test/server/docTools';
 
@@ -6,7 +7,6 @@ import {assert} from 'chai';
 import {mkdtemp, pathExists} from 'fs-extra';
 import * as stream from 'node:stream';
 import * as path from 'path';
-import {IAttachmentStoreConfig} from 'app/server/lib/AttachmentStoreProvider';
 
 const testingDocPoolId = "1234-5678";
 const testingFileId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.grist";

--- a/test/server/lib/HostedStorageManager.ts
+++ b/test/server/lib/HostedStorageManager.ts
@@ -315,7 +315,8 @@ class TestStore {
         return result;
     };
 
-    const attachmentStoreProvider = this._attachmentStoreProvider ?? new AttachmentStoreProvider([], "TESTINSTALL");
+    const attachmentStoreProvider =
+      this._attachmentStoreProvider ?? new AttachmentStoreProvider([],  "TESTINSTALL");
 
     const storageManager = new HostedStorageManager(this._localDirectory,
                                                     this._workerId,


### PR DESCRIPTION
## Context

The previous external attachments PR which adds transfer support adds a set of endpoints to DocApi.

These endpoints can't be tested, as DocApi's tests start up a grist server, and we have no easy / standard way of configuring external attachments on that server.

## Proposed solution

This adds basic configuration support to external attachments, enabling DocApi endpoints to be tested.

It adds a number of additional endpoints to DocAPI to make interacting with and testing external attachments easier.

## Related issues

#1358 

## Has this been tested?

- [X] 👍 yes, I added tests to the test suite
