### PR TITLE
Adds 'snapshot' mode to external attachments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, spoffy/external-attachments-transfers ]
 
   # Allows running this workflow manually from the Actions tab
   workflow_dispatch:

--- a/app/server/lib/AttachmentStore.ts
+++ b/app/server/lib/AttachmentStore.ts
@@ -106,10 +106,11 @@ export class AttachmentStoreCreationError extends Error {
 export interface ExternalStorageSupportingAttachments extends ExternalStorage {
   uploadStream: NonNullable<ExternalStorage['uploadStream']>;
   downloadStream: NonNullable<ExternalStorage['downloadStream']>;
+  removeAllWithPrefix: NonNullable<ExternalStorage['removeAllWithPrefix']>;
 }
 
 export function storageSupportsAttachments(storage: ExternalStorage): storage is ExternalStorageSupportingAttachments {
-  return Boolean(storage.uploadStream && storage.downloadStream);
+  return Boolean(storage.uploadStream && storage.downloadStream && storage.removeAllWithPrefix);
 }
 
 export class ExternalStorageAttachmentStore implements IAttachmentStore {
@@ -117,11 +118,7 @@ export class ExternalStorageAttachmentStore implements IAttachmentStore {
     public id: string,
     private _storage: ExternalStorageSupportingAttachments,
     private _prefixParts: string[]
-  ) {
-    if (!_storage.removeAllWithPrefix) {
-      throw new InvalidAttachmentExternalStorageError("ExternalStorage does not support removeAllWithPrefix");
-    }
-  }
+  ) {}
 
   public exists(docPoolId: string, fileId: string): Promise<boolean> {
     return this._storage.exists(this._getKey(docPoolId, fileId));
@@ -140,8 +137,7 @@ export class ExternalStorageAttachmentStore implements IAttachmentStore {
   }
 
   public async removePool(docPoolId: string): Promise<void> {
-    // Null assertion is safe because this should be checked before this class is instantiated.
-    await this._storage.removeAllWithPrefix!(this._getPoolPrefix(docPoolId));
+    await this._storage.removeAllWithPrefix(this._getPoolPrefix(docPoolId));
   }
 
   public async close(): Promise<void> {

--- a/app/server/lib/AttachmentStore.ts
+++ b/app/server/lib/AttachmentStore.ts
@@ -1,4 +1,7 @@
-import {joinKeySegments, StreamingExternalStorage} from 'app/server/lib/ExternalStorage';
+import {
+  ExternalStorage,
+  joinKeySegments,
+} from 'app/server/lib/ExternalStorage';
 import * as fse from 'fs-extra';
 import * as stream from 'node:stream';
 import * as path from 'path';
@@ -100,10 +103,19 @@ export class AttachmentStoreCreationError extends Error {
   }
 }
 
+export interface ExternalStorageSupportingAttachments extends ExternalStorage {
+  uploadStream: NonNullable<ExternalStorage['uploadStream']>;
+  downloadStream: NonNullable<ExternalStorage['downloadStream']>;
+}
+
+export function storageSupportsAttachments(storage: ExternalStorage): storage is ExternalStorageSupportingAttachments {
+  return Boolean(storage.uploadStream && storage.downloadStream);
+}
+
 export class ExternalStorageAttachmentStore implements IAttachmentStore {
   constructor(
     public id: string,
-    private _storage: StreamingExternalStorage,
+    private _storage: ExternalStorageSupportingAttachments,
     private _prefixParts: string[]
   ) {
     if (!_storage.removeAllWithPrefix) {

--- a/app/server/lib/AttachmentStoreProvider.ts
+++ b/app/server/lib/AttachmentStoreProvider.ts
@@ -167,8 +167,12 @@ export function getConfiguredStandardAttachmentStore(): string | undefined {
 export async function getConfiguredAttachmentStoreConfigs(): Promise<IAttachmentStoreConfig[]> {
   if (ATTACHMENT_STORE_MODE === 'snapshots') {
     const snapshotProvider = create.getAttachmentStoreOptions().snapshots;
-    if (snapshotProvider === undefined || !(await checkAvailabilityAttachmentStoreOption(snapshotProvider))) {
-      return [];
+    // This shouldn't happen - it could only happen if a version of Grist removes the snapshot provider from ICreate.
+    if (snapshotProvider === undefined) {
+      throw new Error("Snapshot provider is not available on this version of Grist");
+    }
+    if (!(await snapshotProvider.isAvailable())) {
+      throw new Error("The currently configured external storage does not support attachments");
     }
     return [{
       label: 'snapshots',

--- a/app/server/lib/AttachmentStoreProvider.ts
+++ b/app/server/lib/AttachmentStoreProvider.ts
@@ -1,11 +1,11 @@
 import {appSettings} from 'app/server/lib/AppSettings';
 import {FilesystemAttachmentStore, IAttachmentStore} from 'app/server/lib/AttachmentStore';
+import {create} from 'app/server/lib/create';
 import log from 'app/server/lib/log';
 import {ICreateAttachmentStoreOptions} from './ICreate';
 import * as fse from 'fs-extra';
 import path from 'path';
 import * as tmp from 'tmp-promise';
-import {create} from 'app/server/lib/create';
 
 export type AttachmentStoreId = string
 

--- a/app/server/lib/ExternalStorage.ts
+++ b/app/server/lib/ExternalStorage.ts
@@ -57,11 +57,9 @@ export interface ExternalStorage {
 
   // Close the storage object.
   close(): Promise<void>;
-}
 
-export interface StreamingExternalStorage extends ExternalStorage {
-  uploadStream(key: string, inStream: stream.Readable, metadata?: ObjMetadata): Promise<string|null|typeof Unchanged>;
-  downloadStream(key: string, outStream: stream.Writable, snapshotId?: string ): Promise<string>;
+  uploadStream?(key: string, inStream: stream.Readable, metadata?: ObjMetadata): Promise<string|null|typeof Unchanged>;
+  downloadStream?(key: string, outStream: stream.Writable, snapshotId?: string ): Promise<string>;
 }
 
 /**
@@ -381,7 +379,7 @@ export interface PropStorage {
 export const Unchanged = Symbol('Unchanged');
 
 export interface ExternalStorageSettings {
-  purpose: 'doc' | 'meta';
+  purpose: 'doc' | 'meta' | 'attachments';
   basePrefix?: string;
   extraPrefix?: string;
 }

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1392,10 +1392,11 @@ export class FlexServer implements GristServer {
 
     const pluginManager = await this._addPluginManager();
 
-    const storeOptions = await checkAvailabilityAttachmentStoreOptions(this.create.getAttachmentStoreOptions());
+    const allStoreOptions = Object.values(this.create.getAttachmentStoreOptions());
+    const checkedStoreOptions = await checkAvailabilityAttachmentStoreOptions(allStoreOptions);
     log.info("Attachment store backend availability", {
-      available: storeOptions.available.map(option => option.name),
-      unavailable: storeOptions.unavailable.map(option => option.name),
+      available: checkedStoreOptions.available.map(option => option.name),
+      unavailable: checkedStoreOptions.unavailable.map(option => option.name),
     });
 
     this._attachmentStoreProvider = this._attachmentStoreProvider || new AttachmentStoreProvider(

--- a/app/server/lib/ICreate.ts
+++ b/app/server/lib/ICreate.ts
@@ -79,7 +79,7 @@ export interface ICreate {
   // static page.
   getExtraHeadHtml?(): string;
   getStorageOptions?(name: string): ICreateStorageOptions|undefined;
-  getAttachmentStoreOptions(): ICreateAttachmentStoreOptions[];
+  getAttachmentStoreOptions(): {[key: string]: ICreateAttachmentStoreOptions | undefined};
   getSqliteVariant?(): SqliteVariant;
   getSandboxVariants?(): Record<string, SpawnFn>;
 
@@ -97,7 +97,7 @@ export interface ICreateStorageOptions {
   name: string;
   check(): boolean;
   checkBackend?(): Promise<void>;
-  create(purpose: 'doc'|'meta', extraPrefix: string): ExternalStorage|undefined;
+  create(purpose: 'doc'|'meta'|'attachments', extraPrefix: string): ExternalStorage|undefined;
 }
 
 export interface ICreateAttachmentStoreOptions {
@@ -174,8 +174,8 @@ export class BaseCreate implements ICreate {
   public getStorageOptions(name: string) {
     return this._storage.find(s => s.name === name);
   }
-  public getAttachmentStoreOptions(): ICreateAttachmentStoreOptions[] {
-    return [];
+  public getAttachmentStoreOptions() {
+    return {};
   }
   public async createInstallAdmin(dbManager: HomeDBManager): Promise<InstallAdmin> {
     return new SimpleInstallAdmin(dbManager);

--- a/app/server/lib/MinIOExternalStorage.ts
+++ b/app/server/lib/MinIOExternalStorage.ts
@@ -1,10 +1,10 @@
 import {ApiError} from 'app/common/ApiError';
 import {ObjMetadata, ObjSnapshotWithMetadata, toExternalMetadata, toGristMetadata} from 'app/common/DocSnapshot';
-import {StreamingExternalStorage} from 'app/server/lib/ExternalStorage';
 import {IncomingMessage} from 'http';
 import * as fse from 'fs-extra';
 import * as minio from 'minio';
 import * as stream from 'node:stream';
+import {ExternalStorage} from 'app/server/lib/ExternalStorage';
 
 // The minio-js v8.0.0 typings are sometimes incorrect. Here are some workarounds.
 interface MinIOClient extends
@@ -44,7 +44,7 @@ type RemoveObjectsResponse = null | undefined | {
  * An external store implemented using the MinIO client, which
  * will work with MinIO and other S3-compatible storage.
  */
-export class MinIOExternalStorage implements StreamingExternalStorage {
+export class MinIOExternalStorage implements ExternalStorage {
   // Specify bucket to use, and optionally the max number of keys to request
   // in any call to listObjectVersions (used for testing)
   constructor(

--- a/app/server/lib/MinIOExternalStorage.ts
+++ b/app/server/lib/MinIOExternalStorage.ts
@@ -1,10 +1,10 @@
 import {ApiError} from 'app/common/ApiError';
 import {ObjMetadata, ObjSnapshotWithMetadata, toExternalMetadata, toGristMetadata} from 'app/common/DocSnapshot';
+import {ExternalStorage} from 'app/server/lib/ExternalStorage';
 import {IncomingMessage} from 'http';
 import * as fse from 'fs-extra';
 import * as minio from 'minio';
 import * as stream from 'node:stream';
-import {ExternalStorage} from 'app/server/lib/ExternalStorage';
 
 // The minio-js v8.0.0 typings are sometimes incorrect. Here are some workarounds.
 interface MinIOClient extends

--- a/app/server/lib/configureMinIOExternalStorage.ts
+++ b/app/server/lib/configureMinIOExternalStorage.ts
@@ -2,9 +2,12 @@ import {wrapWithKeyMappedStorage} from 'app/server/lib/ExternalStorage';
 import {appSettings} from 'app/server/lib/AppSettings';
 import {MinIOExternalStorage} from 'app/server/lib/MinIOExternalStorage';
 
-export function configureMinIOExternalStorage(purpose: 'doc'|'meta', extraPrefix: string) {
+export function configureMinIOExternalStorage(purpose: 'doc'|'meta'|'attachments', extraPrefix: string) {
   const options = checkMinIOExternalStorage();
   if (!options?.bucket) { return undefined; }
+  if (purpose === 'attachments') {
+    return new MinIOExternalStorage(options.bucket, options);
+  }
   return wrapWithKeyMappedStorage(new MinIOExternalStorage(options.bucket, options), {
     basePrefix: options.prefix,
     extraPrefix,

--- a/app/server/lib/coreCreator.ts
+++ b/app/server/lib/coreCreator.ts
@@ -1,14 +1,13 @@
 import {
   AttachmentStoreCreationError,
-  ExternalStorageAttachmentStore
+  ExternalStorageAttachmentStore, storageSupportsAttachments
 } from 'app/server/lib/AttachmentStore';
 import {
   checkMinIOBucket,
   checkMinIOExternalStorage,
   configureMinIOExternalStorage
 } from 'app/server/lib/configureMinIOExternalStorage';
-import {BaseCreate, ICreateAttachmentStoreOptions, ICreateStorageOptions} from 'app/server/lib/ICreate';
-import {MinIOExternalStorage} from 'app/server/lib/MinIOExternalStorage';
+import {BaseCreate, ICreateStorageOptions} from 'app/server/lib/ICreate';
 import {Telemetry} from 'app/server/lib/Telemetry';
 import {HomeDBManager} from 'app/gen-server/lib/homedb/HomeDBManager';
 import {GristServer} from 'app/server/lib/GristServer';
@@ -26,24 +25,35 @@ export class CoreCreate extends BaseCreate {
     super('core', storage);
   }
 
-  public override getAttachmentStoreOptions(): ICreateAttachmentStoreOptions[] {
-    return [
-      {
-        name: 'minio',
-        isAvailable: async () => checkMinIOExternalStorage() !== undefined,
+  public override getAttachmentStoreOptions() {
+    return {
+      // 'snapshots' provider uses the ExternalStorage provider set up for doc snapshots for attachments
+      snapshots: {
+        name: 'snapshots',
+        isAvailable: async () => {
+          try {
+            const storage = this.ExternalStorage('attachments', '');
+            return storage ? storageSupportsAttachments(storage) : false;
+          } catch {
+            // Need to catch exceptions, as some storages won't support the 'attachments' purpose.
+            return false;
+          }
+        },
         create: async (storeId: string) => {
-          const options = checkMinIOExternalStorage();
-          if (!options) {
-            throw new AttachmentStoreCreationError('minio', storeId, 'MinIO storage not configured');
+          const storage = this.ExternalStorage('attachments', '');
+          // This *should* always pass due to the `isAvailable` check above being run earlier.
+          if (!(storage && storageSupportsAttachments(storage))) {
+            throw new AttachmentStoreCreationError('snapshots', storeId,
+                                                   'External storage does not support attachments');
           }
           return new ExternalStorageAttachmentStore(
             storeId,
-            new MinIOExternalStorage(options.bucket, options),
-            [options?.prefix || "", "attachments"]
+            storage,
+            [],
           );
         }
       }
-    ];
+    };
   }
 
   public override Telemetry(dbManager: HomeDBManager, gristServer: GristServer) {

--- a/test/server/lib/AttachmentStoreProvider.ts
+++ b/test/server/lib/AttachmentStoreProvider.ts
@@ -1,12 +1,14 @@
+import {ObjMetadata, ObjSnapshot, ObjSnapshotWithMetadata} from 'app/common/DocSnapshot';
+import {ExternalStorageSupportingAttachments} from 'app/server/lib/AttachmentStore';
+import {AttachmentStoreProvider} from 'app/server/lib/AttachmentStoreProvider';
+import {CoreCreate} from 'app/server/lib/coreCreator';
+import {ExternalStorage, Unchanged} from 'app/server/lib/ExternalStorage';
+import {makeTestingFilesystemStoreConfig} from 'test/server/lib/FilesystemAttachmentStore';
 import {assert} from 'chai';
-import {
-  AttachmentStoreProvider,
-} from 'app/server/lib/AttachmentStoreProvider';
-import {
-  makeTestingFilesystemStoreConfig,
-} from 'test/server/lib/FilesystemAttachmentStore';
+import {Readable, Writable} from 'form-data';
 
 const testInstallationUUID = "FAKE-UUID";
+
 function expectedStoreId(label: string) {
   return `${testInstallationUUID}-${label}`;
 }
@@ -50,3 +52,88 @@ describe('AttachmentStoreProvider', () => {
     assert(await provider.storeExists(expectedStoreId("filesystem1")));
   });
 });
+
+describe("Snapshot attachment store option", () => {
+  it("is not available if the external storage is undefined", async () => {
+    const create = new CoreCreatorExternalStorageStub(() => undefined);
+    const isAvailable = await create.getAttachmentStoreOptions().snapshots.isAvailable();
+    assert.isFalse(isAvailable);
+  });
+
+  it("is not available if the external storage doesn't implement the right methods", async () => {
+    const create = new CoreCreatorExternalStorageStub(() => new FakeExternalStorage());
+    const isAvailable = await create.getAttachmentStoreOptions().snapshots.isAvailable();
+    assert.isFalse(isAvailable);
+  });
+
+  it("is available if the external storage supports attachments", async () => {
+    const create = new CoreCreatorExternalStorageStub(() => new FakeAttachmentExternalStorage());
+    const isAvailable = await create.getAttachmentStoreOptions().snapshots.isAvailable();
+    assert.isTrue(isAvailable);
+  });
+
+  it("throws if the external storage is being used but doesn't support attachments", async () => {
+    const create = new CoreCreatorExternalStorageStub(() => new FakeExternalStorage());
+    await assert.isRejected(create.getAttachmentStoreOptions().snapshots.create("anything"));
+  });
+
+  it("can be used if the external storage supports attachments", async () => {
+    const create = new CoreCreatorExternalStorageStub(() => new FakeAttachmentExternalStorage());
+    const store = await create.getAttachmentStoreOptions().snapshots.create("anything");
+    // Exact method checked doesn't matter - just that we get a valid instance.
+    assert.isFalse(await store.exists("pool1", "doc1"));
+  });
+});
+
+class FakeExternalStorage implements ExternalStorage {
+  public async exists(key: string, snapshotId?: string | undefined): Promise<boolean> {
+    return false;
+  }
+  public async head(key: string, snapshotId?: string | undefined): Promise<ObjSnapshotWithMetadata | null> {
+    return null;
+  }
+  public async upload(
+    key: string, fname: string, metadata?: ObjMetadata | undefined
+  ): Promise<string | typeof Unchanged | null> {
+    return null;
+  }
+  public async download(key: string, fname: string, snapshotId?: string | undefined): Promise<string> {
+    return "";
+  }
+  public async remove(key: string, snapshotIds?: string[] | undefined): Promise<void> {
+    return;
+  }
+  public async versions(key: string): Promise<ObjSnapshot[]> {
+    return [];
+  }
+  public url(key: string): string {
+    return "";
+  }
+  public isFatalError(err: any): boolean {
+    return false;
+  }
+  public async close(): Promise<void> {}
+}
+
+class FakeAttachmentExternalStorage extends FakeExternalStorage implements ExternalStorageSupportingAttachments {
+  public async uploadStream(
+    key: string, inStream: Readable, metadata?: ObjMetadata | undefined
+  ): Promise<string | typeof Unchanged | null> {
+    return null;
+  }
+  public async downloadStream(key: string, outStream: Writable, snapshotId?: string | undefined): Promise<string> {
+    return "";
+  }
+  public async removeAllWithPrefix(prefix: string): Promise<void> {
+    return;
+  }
+}
+
+class CoreCreatorExternalStorageStub extends CoreCreate {
+  constructor(private _makeStore: () => ExternalStorage | undefined) {
+    super();
+  }
+  public override ExternalStorage(): ExternalStorage | undefined {
+    return this._makeStore();
+  }
+}

--- a/test/server/lib/ExternalStorageAttachmentStore.ts
+++ b/test/server/lib/ExternalStorageAttachmentStore.ts
@@ -1,0 +1,99 @@
+import {
+  ExternalStorageAttachmentStore,
+  ExternalStorageSupportingAttachments
+} from 'app/server/lib/AttachmentStore';
+import {MemoryWritableStream} from 'app/server/utils/MemoryWritableStream';
+
+import {assert} from 'chai';
+import * as stream from 'node:stream';
+import sinon from 'sinon';
+
+const testStoreId = "test-store-1";
+const testPathPrefix = ["folder1", "folder2"];
+const testPoolId = "pool1";
+const testFileId = "file1";
+const expectedPoolPrefix = "folder1/folder2/pool1";
+const testFileContents = "This is the contents of a file";
+const testFileBuffer = Buffer.from(testFileContents);
+const getExpectedFilePath = (fileId: string) => `${expectedPoolPrefix}/${fileId}`;
+
+describe('ExternalStorageAttachmentStore', () => {
+  it('can upload a file', async () => {
+    const fakeStorage = {
+      uploadStream: sinon.fake.resolves(undefined),
+    };
+
+    const storage = fakeStorage as unknown as ExternalStorageSupportingAttachments;
+
+    const store = new ExternalStorageAttachmentStore(testStoreId, storage, testPathPrefix);
+    const fileStream = stream.Readable.from(testFileBuffer);
+    await store.upload(testPoolId, testFileId, fileStream);
+
+    assert.isTrue(fakeStorage.uploadStream.calledOnce, "upload should be called exactly once");
+    const call = fakeStorage.uploadStream.getCalls()[0];
+    assert.equal(call.args[0], getExpectedFilePath(testFileId), "upload path is incorrect");
+    assert.equal(call.args[1], fileStream, "file stream is incorrect");
+  });
+
+  it('can download a file', async () => {
+    const fileStream = stream.Readable.from(testFileBuffer);
+    const fakeStorage = {
+      downloadStream: sinon.fake((_, outputStream: stream.Writable) => {
+        fileStream.pipe(outputStream);
+      })
+    };
+
+    const storage = fakeStorage as unknown as ExternalStorageSupportingAttachments;
+    const store = new ExternalStorageAttachmentStore(testStoreId, storage, testPathPrefix);
+    const output = new MemoryWritableStream();
+    await store.download(testPoolId, testFileId, output);
+
+    assert.isTrue(fakeStorage.downloadStream.calledOnce, "download should be called exactly once");
+    const call = fakeStorage.downloadStream.getCalls()[0];
+    assert.equal(call.args[0], getExpectedFilePath(testFileId), "download path is incorrect");
+    assert.equal(output.getBuffer().toString(), testFileContents, "downloaded file contents don't match");
+  });
+
+  it('can check if a file exists', async () => {
+    const fakeStorage = {
+      exists: sinon.fake.resolves(true),
+    };
+
+    const storage = fakeStorage as unknown as ExternalStorageSupportingAttachments;
+    const store = new ExternalStorageAttachmentStore(testStoreId, storage, testPathPrefix);
+    const exists = await store.exists(testPoolId, testFileId);
+
+    assert.isTrue(fakeStorage.exists.calledOnce, "exists should be called exactly once");
+    const call = fakeStorage.exists.getCalls()[0];
+    assert.equal(call.args[0], getExpectedFilePath(testFileId), "file path is incorrect");
+    assert.isTrue(exists, "correct exists value should be returned");
+  });
+
+  it('can delete a file', async () => {
+    const fakeStorage = {
+      remove: sinon.fake.resolves(undefined),
+    };
+
+    const storage = fakeStorage as unknown as ExternalStorageSupportingAttachments;
+    const store = new ExternalStorageAttachmentStore(testStoreId, storage, testPathPrefix);
+    await store.delete(testPoolId, testFileId);
+
+    assert.isTrue(fakeStorage.remove.calledOnce, "remove should be called exactly once");
+    const call = fakeStorage.remove.getCalls()[0];
+    assert.equal(call.args[0], getExpectedFilePath(testFileId), "file path is incorrect");
+  });
+
+  it('can remove an entire pool', async () => {
+    const fakeStorage = {
+      removeAllWithPrefix: sinon.fake.resolves(undefined),
+    };
+
+    const storage = fakeStorage as unknown as ExternalStorageSupportingAttachments;
+    const store = new ExternalStorageAttachmentStore(testStoreId, storage, testPathPrefix);
+    await store.removePool(testPoolId);
+
+    assert.isTrue(fakeStorage.removeAllWithPrefix.calledOnce, "removeAllWithPrefix should be called exactly once");
+    const call = fakeStorage.removeAllWithPrefix.getCalls()[0];
+    assert.equal(call.args[0], expectedPoolPrefix, "path of attachment pool is incorrect");
+  });
+});

--- a/test/server/lib/HostedStorageManager.ts
+++ b/test/server/lib/HostedStorageManager.ts
@@ -428,7 +428,8 @@ describe('HostedStorageManager', function() {
 
         tmpDir = await createTmpDir();
 
-        let externalStorageCreate: (purpose: 'doc'|'meta', extraPrefix: string) => ExternalStorage|undefined;
+        let externalStorageCreate:
+          (purpose: 'doc'|'meta'|'attachments', extraPrefix: string) => ExternalStorage|undefined;
         function requireStorage<T>(storage: T|undefined): T {
           if (storage === undefined) { throw new Error('storage not found'); }
           return storage;


### PR DESCRIPTION
## Context

External attachments only support a `test` mode, since the `GRIST_EXTERNAL_ATTACHMENTS_MODE` config was added. This prevents Grist being used with MinIO for testing. 

## Proposed solution

This adds the 'snapshot' option to `GRIST_EXTERNAL_ATTACHMENTS_MODE`, which makes Grist use the same storage for external attachments that document snapshots use.

## Related issues

#1358 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [X] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

