### PR TITLE
fix: Missing queried tableId in error when table not found

### DIFF
--- a/app/common/AttachmentColumns.ts
+++ b/app/common/AttachmentColumns.ts
@@ -24,7 +24,7 @@ export function getAttachmentColumns(metaDocData: DocData): AttachmentColumns {
     const tableId = table?.tableId;
     if (!tableId) {
       /* should never happen */
-      throw new Error('table not found');
+      throw new Error('table not found: ' + column.parentId);
     }
     if (!attachmentColumns.has(tableId)) {
       attachmentColumns.set(tableId, new Set());

--- a/app/server/lib/ExpandedQuery.ts
+++ b/app/server/lib/ExpandedQuery.ts
@@ -60,7 +60,7 @@ export function expandQuery(iquery: ServerQuery, docData: DocData, onDemandFormu
     const tables = docData.getMetaTable('_grist_Tables');
     const columns = docData.getMetaTable('_grist_Tables_column');
     const tableRef = tables.findRow('tableId', query.tableId);
-    if (!tableRef) { throw new ApiError('table not found', 404); }
+    if (!tableRef) { throw new ApiError('table not found: ' + query.tableId, 404); }
 
     // Find any references to other tables.
     const dataColumns = columns.filterRecords({parentId: tableRef, isFormula: false});

--- a/app/server/lib/GranularAccess.ts
+++ b/app/server/lib/GranularAccess.ts
@@ -2962,7 +2962,7 @@ export class CensorshipInfo {
       columnRefToColId.set(colRef, colId);
       if (uncensoredTables.has(tableRef)) { continue; }
       const tableId = tableRefToTableId.get(tableRef);
-      if (!tableId) { throw new Error('table not found'); }
+      if (!tableId) { throw new Error('table not found: ' + tableRef); }
       if (this.censoredTables.has(tableRef) ||
           (colId !== 'manualSort' && permInfo.getColumnAccess(tableId, colId).perms.read === 'deny')) {
         censoredColumnCodes.add(columnCode(tableRef, colId));


### PR DESCRIPTION
## Context

We had an error in production with a corrupted document which could not find a certain table. But there missed the queried table id or table ref in the error

## Proposed solution

Show what query was unsuccessful.

## Related issues

N/A

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->