### PR TITLE
FIX CI failing on install_chrome_for_tests

### DIFF
--- a/buildtools/install_chrome_for_tests.sh
+++ b/buildtools/install_chrome_for_tests.sh
@@ -19,6 +19,6 @@ if [[ "$(uname -m)" != "x86_64" ]]; then
 fi
 
 curl -sS -o /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
-  && sudo apt-get install -y /tmp/chrome.deb \
+  && sudo apt-get install --allow-downgrades -y /tmp/chrome.deb \
   && rm /tmp/chrome.deb \
   && node_modules/selenium-webdriver/bin/linux/selenium-manager --driver chromedriver


### PR DESCRIPTION
## Context

The CI Fails on install_chrome_for_tests.sh
The error indicates that
```bash
E: Packages were downgraded and -y was used without --allow-downgrades.
```

## Proposed solution

The option was added to `apt-get`

## Related issues

The PR fixes #1421

## Has this been tested?

By running the CI while proposing PR
