### PR TITLE
specify NODE_ENV=production by default in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -184,6 +184,11 @@ WORKDIR /grist
 # using the punycode functionality that may be removed in future
 # versions of node.
 #
+# "NODE_ENV=production" gives ActiveDoc operations more time to
+# complete, and the express webserver also does some streamlining
+# with this setting. If you don't want these, set NODE_ENV to
+# development.
+#
 ENV \
   PYTHON_VERSION_ON_CREATION=3 \
   GRIST_ORG_IN_PATH=true \
@@ -196,6 +201,7 @@ ENV \
   GVISOR_FLAGS="-unprivileged -ignore-cgroups" \
   GRIST_SANDBOX_FLAVOR=unsandboxed \
   NODE_OPTIONS="--no-deprecation" \
+  NODE_ENV=production \
   TYPEORM_DATABASE=/persist/home.sqlite3
 
 EXPOSE 8484


### PR DESCRIPTION
## Context

The express web framework that Grist uses is sensitive to a `NODE_ENV` environment variable. Grist also gives some operations more time when this variable is set. At Grist Labs we have this flag set for our SaaS, but until now it hasn't been set in the regular docker image.

## Has this been tested?

This setting is used in the Grist Labs SaaS at https://docs.getgrist.com