### PR TITLE
Use the same host as origin for single-server setups

### DIFF
--- a/app/client/models/AppModel.ts
+++ b/app/client/models/AppModel.ts
@@ -553,22 +553,28 @@ export function getConfiguredHomeUrl(): string {
 }
 
 /**
- * Get the home URL, using fallback if on admin page rather
- * than trusting back end configuration.
+ * Get the home URL, using fallback on the admin case and in the
+ * single-domain case case.
  */
 export function getPreferredHomeUrl(): string|undefined {
   const gristUrl = urlState().state.get();
-  if (gristUrl.adminPanel) {
+  const gristConfig: GristLoadConfig = (window as any).gristConfig;
+  if (gristUrl.adminPanel || gristConfig.serveSameOrigin) {
     // On the admin panel, we should not trust configuration much,
     // since we want the user to be able to access it to diagnose
     // problems with configuration. So we access the API via the
     // site we happen to be on rather than anything configured on
-    // the back end. Couldn't we just always do this? Maybe!
-    // It could require adjustments for calls that are meant
-    // to be site-neutral if the domain has an org encoded in it.
-    // But that's a small price to pay. Grist Labs uses a setup
-    // where api calls go to a dedicated domain distinct from all
-    // other sites, but there's no particular advantage to it.
+    // the back end.
+    //
+    // We can also do this in the common self-hosted case of a single
+    // domain, no orgs encoded in subdomains.
+    //
+    // Couldn't we just always do this? Maybe! It could require
+    // adjustments for calls that are meant to be site-neutral if the
+    // domain has an org encoded in it. But that's a small price to
+    // pay. Grist Labs uses a setup where api calls go to a dedicated
+    // domain distinct from all other sites, but there's no particular
+    // advantage to it.
     return getFallbackHomeUrl();
   }
   return getConfiguredHomeUrl();

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -732,6 +732,10 @@ export interface GristLoadConfig {
   // on this for custom domains, but set it generally for all pages.
   org?: string;
 
+  // Makes the Grist frontend access the Grist instance using its current URL in the browser, rather than APP_HOME_URL.
+  // Used to simplify setup of single-domain (no subdomain / doc worker) installations.
+  serveSameOrigin?: boolean;
+
   // Base domain for constructing new URLs, should start with "." and not include port, e.g.
   // ".getgrist.com". It should be unset for localhost operation and in single-org mode.
   baseDomain?: string;

--- a/app/server/lib/GristServer.ts
+++ b/app/server/lib/GristServer.ts
@@ -146,7 +146,7 @@ export function createDummyGristServer(): GristServer {
     getOwnUrl() { return 'http://localhost:4242'; },
     getPermitStore() { throw new Error('no permit store'); },
     getExternalPermitStore() { throw new Error('no external permit store'); },
-    getGristConfig() { return { homeUrl: '', timestampMs: 0 }; },
+    getGristConfig() { return { homeUrl: '', timestampMs: 0, serveSameOrigin: true }; },
     getOrgUrl() { return Promise.resolve(''); },
     getResourceUrl() { return Promise.resolve(''); },
     getSessions() { throw new Error('no sessions'); },

--- a/app/server/lib/sendAppPage.ts
+++ b/app/server/lib/sendAppPage.ts
@@ -72,6 +72,8 @@ export function makeGristConfig(options: MakeGristConfigOptions): GristLoadConfi
     homeUrl,
     org: process.env.GRIST_SINGLE_ORG || (mreq && mreq.org),
     baseDomain,
+   // True if no subdomains or separate servers are defined for the home servers or doc workers.
+    serveSameOrigin: !baseDomain && pathOnly,
     singleOrg: process.env.GRIST_SINGLE_ORG,
     helpCenterUrl: getHelpCenterUrl(),
     termsOfServiceUrl: getTermsOfServiceUrl(),

--- a/test/gen-server/AuthCaching.ts
+++ b/test/gen-server/AuthCaching.ts
@@ -56,7 +56,6 @@ describe('AuthCaching', function() {
     await homeMS.run();
     homeServer = homeMS.flexServer;
     homeUrl = homeServer.getOwnUrl();
-    process.env.APP_HOME_URL = homeUrl;
     const docsMS = await MergedServer.create(0, ['docs'],
       {logToConsole: false, externalStorage: false});
     await docsMS.run();
@@ -80,7 +79,6 @@ describe('AuthCaching', function() {
 
   after(async function() {
     delete process.env.GRIST_DATA_DIR;
-    delete process.env.APP_HOME_URL;
     sandbox.restore();
     await testUtils.captureLog('warn', async () => {
       await docsServer.close();

--- a/test/nbrowser/testServer.ts
+++ b/test/nbrowser/testServer.ts
@@ -123,7 +123,6 @@ export class TestServerMerged extends EventEmitter implements IMochaServer {
       GRIST_SERVE_SAME_ORIGIN: 'true',
       // Run with HOME_PORT, STATIC_PORT, DOC_PORT, DOC_WORKER_COUNT in the environment to override.
       ...(useSinglePort ? {
-        APP_HOME_URL: this.getHost(),
         GRIST_SINGLE_PORT: 'true',
       } : (isCore ? {
         HOME_PORT: corePort,


### PR DESCRIPTION
## Context

Self-hosters often immediately face an obstacle by not setting `APP_HOME_URL` and getting a broken installation. There is no reason why this URL should be set in the most common case of a single server.

## Proposed solution

We check to see if the user has not set `APP_HOME_URL` or encoded organisations as subdomains. In that case, we serve back the same origin as what we obtained from the browser request.

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help

I removed the `APP_HOME_URL` setting from the tests that didn't need it and they still pass.