### PR TITLE
Fix some translations

### DIFF
--- a/app/client/components/Forms/MappedFieldsConfig.ts
+++ b/app/client/components/Forms/MappedFieldsConfig.ts
@@ -10,7 +10,7 @@ import {Computed, Disposable, dom, fromKo, makeTestId, Observable, styled} from 
 import * as ko from 'knockout';
 
 const testId = makeTestId('test-vfc-');
-const t = makeT('VisibleFieldsConfig');
+const t = makeT('MappedFieldsConfig');
 
 /**
  * This is a component used in the RightPanel. It replaces hidden fields section on other views, and adds

--- a/app/client/models/DocPageModel.ts
+++ b/app/client/models/DocPageModel.ts
@@ -476,7 +476,7 @@ function addMenu(importSources: ImportSource[], gristDoc: GristDoc, isReadonly: 
   return [
     menuItem(
       (elem) => openPageWidgetPicker(elem, gristDoc, (val) => gristDoc.addNewPage(val).catch(reportError),
-                                     {isNewPage: true, buttonLabel: 'Add Page'}),
+                                     {isNewPage: true, buttonLabel: t('Add Page')}),
       menuIcon("Page"), t("Add Page"), testId('dp-add-new-page'),
       dom.cls('disabled', isReadonly)
     ),

--- a/app/client/ui/RightPanel.ts
+++ b/app/client/ui/RightPanel.ts
@@ -945,14 +945,14 @@ export class RightPanel extends Disposable {
     return [
       cssLabel(t("Submit button label")),
       cssRow(
-        cssTextInput(submitButton, (val) => submitButton.set(val), {placeholder: 'Submit'}),
+        cssTextInput(submitButton, (val) => submitButton.set(val), {placeholder: t('Submit')}),
       ),
       cssLabel(t("Success text")),
       cssRow(
         cssTextArea(
           successText,
           {autoGrow: true, save: (val) => successText.set(val)},
-          {placeholder: 'Thank you! Your response has been recorded.'}
+          {placeholder: t('Thank you! Your response has been recorded.')}
         ),
       ),
       cssLabel(t("Submit another response")),


### PR DESCRIPTION
## Context

Some strings are not translated in the UI.

## Proposed solution
Wrapping the strings in the translation function
or
Adding the right scope to the translation function

## Related issues

[1379](https://github.com/gristlabs/grist-core/pull/1379)

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->



