### PR TITLE
Makes attachment storage respect prefixes

### DIFF
--- a/app/server/lib/configureMinIOExternalStorage.ts
+++ b/app/server/lib/configureMinIOExternalStorage.ts
@@ -5,9 +5,6 @@ import {MinIOExternalStorage} from 'app/server/lib/MinIOExternalStorage';
 export function configureMinIOExternalStorage(purpose: 'doc'|'meta'|'attachments', extraPrefix: string) {
   const options = checkMinIOExternalStorage();
   if (!options?.bucket) { return undefined; }
-  if (purpose === 'attachments') {
-    return new MinIOExternalStorage(options.bucket, options);
-  }
   return wrapWithKeyMappedStorage(new MinIOExternalStorage(options.bucket, options), {
     basePrefix: options.prefix,
     extraPrefix,


### PR DESCRIPTION
## Context

Attachment storage currently doesn't respect the configured MinIO prefix, because it bypasses the function that applies the prefixing.

## Proposed solution

Adapts external storage instantiation to be closer to its original implementation, by adapting KeyMappedExternalStorage to support the new ExternalStorage methods.

## Related issues


## Has this been tested?

No, because we don't have any tests currently that cover prefixing or KeyMappedExternalStorage, and this is a priority to merge in.
