### PR TITLE
Adds 'attachments' prefix to external attachments using the `snapshot` provider

### DIFF
--- a/app/server/lib/AttachmentStore.ts
+++ b/app/server/lib/AttachmentStore.ts
@@ -117,7 +117,6 @@ export class ExternalStorageAttachmentStore implements IAttachmentStore {
   constructor(
     public id: string,
     private _storage: ExternalStorageSupportingAttachments,
-    private _prefixParts: string[]
   ) {}
 
   public exists(docPoolId: string, fileId: string): Promise<boolean> {
@@ -145,7 +144,7 @@ export class ExternalStorageAttachmentStore implements IAttachmentStore {
   }
 
   private _getPoolPrefix(docPoolId: string): string {
-    return joinKeySegments([...this._prefixParts, docPoolId]);
+    return docPoolId;
   }
 
   private _getKey(docPoolId: string, fileId: string): string {

--- a/app/server/lib/ExternalStorage.ts
+++ b/app/server/lib/ExternalStorage.ts
@@ -460,7 +460,7 @@ export function getExternalStorageKeyMap(settings: ExternalStorageSettings): (or
     fileNaming = docId => `assets/unversioned/${docId}/meta.json`;
   } else if (purpose === 'attachments') {
     // Prefix-only - attachments system handles exact naming
-    fileNaming = attachmentPath => attachmentPath;
+    fileNaming = attachmentPath => `attachments/${stripLeadingSlash(attachmentPath)}`;
   } else {
     throw new UnsupportedPurposeError(settings.purpose);
   }

--- a/app/server/lib/coreCreator.ts
+++ b/app/server/lib/coreCreator.ts
@@ -52,7 +52,6 @@ export class CoreCreate extends BaseCreate {
           return new ExternalStorageAttachmentStore(
             storeId,
             storage,
-            [],
           );
         }
       }

--- a/test/server/lib/ExternalStorageAttachmentStore.ts
+++ b/test/server/lib/ExternalStorageAttachmentStore.ts
@@ -9,10 +9,9 @@ import * as stream from 'node:stream';
 import sinon from 'sinon';
 
 const testStoreId = "test-store-1";
-const testPathPrefix = ["folder1", "folder2"];
 const testPoolId = "pool1";
 const testFileId = "file1";
-const expectedPoolPrefix = "folder1/folder2/pool1";
+const expectedPoolPrefix = "pool1";
 const testFileContents = "This is the contents of a file";
 const testFileBuffer = Buffer.from(testFileContents);
 const getExpectedFilePath = (fileId: string) => `${expectedPoolPrefix}/${fileId}`;
@@ -25,7 +24,7 @@ describe('ExternalStorageAttachmentStore', () => {
 
     const storage = fakeStorage as unknown as ExternalStorageSupportingAttachments;
 
-    const store = new ExternalStorageAttachmentStore(testStoreId, storage, testPathPrefix);
+    const store = new ExternalStorageAttachmentStore(testStoreId, storage);
     const fileStream = stream.Readable.from(testFileBuffer);
     await store.upload(testPoolId, testFileId, fileStream);
 
@@ -44,7 +43,7 @@ describe('ExternalStorageAttachmentStore', () => {
     };
 
     const storage = fakeStorage as unknown as ExternalStorageSupportingAttachments;
-    const store = new ExternalStorageAttachmentStore(testStoreId, storage, testPathPrefix);
+    const store = new ExternalStorageAttachmentStore(testStoreId, storage);
     const output = new MemoryWritableStream();
     await store.download(testPoolId, testFileId, output);
 
@@ -60,7 +59,7 @@ describe('ExternalStorageAttachmentStore', () => {
     };
 
     const storage = fakeStorage as unknown as ExternalStorageSupportingAttachments;
-    const store = new ExternalStorageAttachmentStore(testStoreId, storage, testPathPrefix);
+    const store = new ExternalStorageAttachmentStore(testStoreId, storage);
     const exists = await store.exists(testPoolId, testFileId);
 
     assert.isTrue(fakeStorage.exists.calledOnce, "exists should be called exactly once");
@@ -75,7 +74,7 @@ describe('ExternalStorageAttachmentStore', () => {
     };
 
     const storage = fakeStorage as unknown as ExternalStorageSupportingAttachments;
-    const store = new ExternalStorageAttachmentStore(testStoreId, storage, testPathPrefix);
+    const store = new ExternalStorageAttachmentStore(testStoreId, storage);
     await store.delete(testPoolId, testFileId);
 
     assert.isTrue(fakeStorage.remove.calledOnce, "remove should be called exactly once");
@@ -89,7 +88,7 @@ describe('ExternalStorageAttachmentStore', () => {
     };
 
     const storage = fakeStorage as unknown as ExternalStorageSupportingAttachments;
-    const store = new ExternalStorageAttachmentStore(testStoreId, storage, testPathPrefix);
+    const store = new ExternalStorageAttachmentStore(testStoreId, storage);
     await store.removePool(testPoolId);
 
     assert.isTrue(fakeStorage.removeAllWithPrefix.calledOnce, "removeAllWithPrefix should be called exactly once");


### PR DESCRIPTION
## Context

When attachments are stored in external storage using the `snapshot` provider, they aren't grouped together in external storage, so are harder to manage collectively.

## Proposed solution

Adds a path prefix when using the `snapshot` provider for external storage. 

## Has this been tested?

Manually locally.
