### PR TITLE
Fixes error causing duplicate to fail on doc workers

### DIFF
--- a/app/server/lib/uploads.ts
+++ b/app/server/lib/uploads.ts
@@ -432,7 +432,7 @@ export async function fetchDoc(
   // Copying as a template is fine, as no attachments will be copied.
   if (!template) {
     const transferStatusResponse = await fetch(
-      new URL(`/api/docs/${docId}/attachments/transferStatus`, apiBaseUrl).href,
+      new URL(`api/docs/${docId}/attachments/transferStatus`, apiBaseUrl).href,
       {
         headers: {
           ...headers,


### PR DESCRIPTION
## Context

"Duplicate document" and "Save as copy" are failing on instances using doc workers.

This is caused by the path beginning with a "/", which results in the doc worker's prefix being removed from the URL.

## Proposed solution

Removes the leading "/" from the URL path to ensure the doc worker's prefix is respected.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

## Has this been tested?

I'm not sure how to best test this, given it's a doc-worker specific issue.

The non-doc-worker setup has been manually tested, and is already covered by unit tests.
