### PR TITLE
refine the interaction between backups and main document connections

### DIFF
--- a/app/server/lib/SqliteCommon.ts
+++ b/app/server/lib/SqliteCommon.ts
@@ -84,6 +84,7 @@ export interface Backup {
   failed: boolean;
   step(pages: number,
        callback?: (err: Error | null) => void): void;
+  finish(callback?: (err: Error | null) => void): void;
 }
 
 /**

--- a/app/server/lib/SqliteNode.ts
+++ b/app/server/lib/SqliteNode.ts
@@ -82,7 +82,7 @@ export class NodeSqlite3DatabaseAdapter implements MinDB {
   }
 
   public async close() {
-    this._db.close();
+    await fromCallback(cb => this._db.close(cb));
   }
 
   public async interrupt(): Promise<void> {

--- a/stubs/app/server/declarations.d.ts
+++ b/stubs/app/server/declarations.d.ts
@@ -12,6 +12,7 @@ declare module "@gristlabs/sqlite3" {
     public readonly completed: boolean;
     public readonly failed: boolean;
     public step(pages: number, callback?: (err: Error|null) => void): void;
+    public finish(callback?: (err: Error | null) => void): void;
   }
   export class DatabaseWithBackup extends Database {
     public backup(filename: string, callback?: (err: Error|null) => void): Backup;


### PR DESCRIPTION
## Context

Recently we changed backups to use the main document connection, when available, since then they can complete even while the document is changing constantly. The system making the backups and the system managing the document are quite loosely coupled, so the main document connection can get closed at any time, even during a backup. The backup process was written to expect this, but a problem appeared on the closing side: SQLite will refuse to close if a backup is in progress, and that error was entirely uncaught due to a missing await.

## Proposed solution

This adds the needed await. It also adds some explicit robustness on both sides

## Related issues

https://github.com/gristlabs/grist-core/pull/1380
https://github.com/gristlabs/grist-core/issues/1427

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
