### PR TITLE
l10n: fix missing translations for attachments storage options #1464

### DIFF
--- a/app/client/ui/DocumentSettings.ts
+++ b/app/client/ui/DocumentSettings.ts
@@ -242,7 +242,7 @@ export class DocSettingsPage extends Disposable {
       // active doc has a chance to send us updates about the transfer.
       await this._gristDoc.docApi.setAttachmentStore(type);
     });
-    const storageOptions = [{value: INTERNAL, label: 'Internal'}, {value: EXTERNAL, label: 'External'}];
+    const storageOptions = [{value: INTERNAL, label: t('Internal')}, {value: EXTERNAL, label: t('External')}];
 
     const transfer = this._gristDoc.attachmentTransfer;
     const locationSummary = Computed.create(this, use => use(transfer)?.locationSummary);


### PR DESCRIPTION
## Context

In document Settings > Attachment Storage, the dropdown labels "External" and "Internal" were not translated.

## Proposed solution

Call the `t()` function for the labels.

## Related issues

Fixes #1464 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->