### PR TITLE
Restoring support links in attachment's UI

### DIFF
--- a/app/client/ui/AdminPanelCss.ts
+++ b/app/client/ui/AdminPanelCss.ts
@@ -108,6 +108,7 @@ const cssItem = styled('div', `
 const cssItemShort = styled('div', `
   display: flex;
   flex-wrap: wrap;
+  row-gap: 4px;
   align-items: center;
   padding: 8px;
   margin: 0 -8px;

--- a/app/client/ui/DocumentSettings.ts
+++ b/app/client/ui/DocumentSettings.ts
@@ -636,7 +636,7 @@ function displayCurrentType(
 
 
 const learnMore = () => t(
-  '[Learn more]({{learnLink}})',
+  '[Learn more.]({{learnLink}})',
   {learnLink: commonUrls.attachmentStorage}
 );
 
@@ -657,10 +657,10 @@ function stillExternalCopy(inProgress: Observable<boolean>, ...args: IDomArgs<HT
   return dom.domComputed(inProgress, (yes) => {
     if (yes) {
       return cssMarkdownSpan(
-        `${someExternal()} ${newInInternal()} ${learnMore()}`, ...args, testId('transfer-message-in-progress'));
+        `${someExternal()} ${newInInternal()}\n\n${learnMore()}`, ...args, testId('transfer-message-in-progress'));
     } else {
       return cssMarkdownSpan(
-        `${someExternal()} ${startToInternal()} ${newInInternal()} ${learnMore()}`,
+        `${someExternal()} ${startToInternal()} ${newInInternal()}\n\n${learnMore()}`,
         ...args,
         testId('transfer-message-static'));
     }
@@ -684,13 +684,13 @@ function stillInternalCopy(inProgress: Observable<boolean>, ...args: IDomArgs<HT
   return dom.domComputed(inProgress, (yes) => {
     if (yes) {
       return cssMarkdownSpan(
-        `${someInternal()} ${newInExternal()} ${learnMore()}`,
+        `${someInternal()} ${newInExternal()}\n\n${learnMore()}`,
         testId('transfer-message-in-progress'),
         ...args
       );
     } else {
       return cssMarkdownSpan(
-        `${someInternal()} ${startToExternal()} ${newInExternal()} ${learnMore()}`,
+        `${someInternal()} ${startToExternal()} ${newInExternal()}\n\n${learnMore()}`,
         testId('transfer-message-static'),
         ...args
       );

--- a/app/client/ui/DocumentSettings.ts
+++ b/app/client/ui/DocumentSettings.ts
@@ -635,10 +635,15 @@ function displayCurrentType(
 }
 
 
+const learnMore = () => t(
+  '[learn more]({{learnLink}})',
+  {learnLink: commonUrls.attachmentStorage}
+);
 
 function stillExternalCopy(inProgress: Observable<boolean>, ...args: IDomArgs<HTMLSpanElement>) {
   const someExternal = () => t(
-    '**Some existing attachments are still external**.',
+    '**Some existing attachments are still [external]({{externalLink}})**.',
+    {externalLink: commonUrls.attachmentStorage}
   );
 
   const startToInternal = () => t(
@@ -652,10 +657,10 @@ function stillExternalCopy(inProgress: Observable<boolean>, ...args: IDomArgs<HT
   return dom.domComputed(inProgress, (yes) => {
     if (yes) {
       return cssMarkdownSpan(
-        `${someExternal()} ${newInInternal()}`, ...args, testId('transfer-message-in-progress'));
+        `${someExternal()} ${newInInternal()} ${learnMore()}`, ...args, testId('transfer-message-in-progress'));
     } else {
       return cssMarkdownSpan(
-        `${someExternal()} ${startToInternal()} ${newInInternal()}`,
+        `${someExternal()} ${startToInternal()} ${newInInternal()} ${learnMore()}`,
         ...args,
         testId('transfer-message-static'));
     }
@@ -664,7 +669,8 @@ function stillExternalCopy(inProgress: Observable<boolean>, ...args: IDomArgs<HT
 
 function stillInternalCopy(inProgress: Observable<boolean>, ...args: IDomArgs<HTMLSpanElement>) {
   const someInternal = () => t(
-    '**Some existing attachments are still internal** (stored in SQLite file).',
+    '**Some existing attachments are still [internal]({{internalLink}})** (stored in SQLite file).',
+    {internalLink: commonUrls.attachmentStorage}
   );
 
   const startToExternal = () => t(
@@ -678,13 +684,13 @@ function stillInternalCopy(inProgress: Observable<boolean>, ...args: IDomArgs<HT
   return dom.domComputed(inProgress, (yes) => {
     if (yes) {
       return cssMarkdownSpan(
-        `${someInternal()} ${newInExternal()}`,
+        `${someInternal()} ${newInExternal()} ${learnMore()}`,
         testId('transfer-message-in-progress'),
         ...args
       );
     } else {
       return cssMarkdownSpan(
-        `${someInternal()} ${startToExternal()} ${newInExternal()}`,
+        `${someInternal()} ${startToExternal()} ${newInExternal()} ${learnMore()}`,
         testId('transfer-message-static'),
         ...args
       );

--- a/app/client/ui/DocumentSettings.ts
+++ b/app/client/ui/DocumentSettings.ts
@@ -636,7 +636,7 @@ function displayCurrentType(
 
 
 const learnMore = () => t(
-  '[learn more]({{learnLink}})',
+  '[Learn more]({{learnLink}})',
   {learnLink: commonUrls.attachmentStorage}
 );
 

--- a/app/client/ui/GristTooltips.ts
+++ b/app/client/ui/GristTooltips.ts
@@ -199,7 +199,9 @@ see or edit which parts of your document.')
     cssMarkdownSpan(t(
       "Internal storage means all attachments are stored in the document SQLite file, " +
       "while external storage indicates all attachments are stored in the same " +
-      "external storage."
+      "external storage. [Learn more]({{link}}).", {
+        link: commonUrls.attachmentStorage
+      }
     )),
     ...args,
   ),

--- a/app/client/ui/GristTooltips.ts
+++ b/app/client/ui/GristTooltips.ts
@@ -199,7 +199,7 @@ see or edit which parts of your document.')
     cssMarkdownSpan(t(
       "Internal storage means all attachments are stored in the document SQLite file, " +
       "while external storage indicates all attachments are stored in the same " +
-      "external storage. [Learn more]({{link}}).", {
+      "external storage. [Learn more]({{link}})", {
         link: commonUrls.attachmentStorage
       }
     )),

--- a/app/client/ui/GristTooltips.ts
+++ b/app/client/ui/GristTooltips.ts
@@ -196,10 +196,15 @@ see or edit which parts of your document.')
     ...args,
   ),
   attachmentStorage: (...args: DomElementArg[]) => cssTooltipContent(
-    cssMarkdownSpan(t(
-      "Internal storage means all attachments are stored in the document SQLite file, " +
-      "while external storage indicates all attachments are stored in the same " +
-      "external storage. [Learn more]({{link}})", {
+    cssMarkdownSpan(
+      t(
+        "Internal storage means all attachments are stored in the document SQLite file, " +
+        "while external storage indicates all attachments are stored in the same " +
+        "external storage."
+      ) +
+      "\n\n" +
+      t(
+      "[Learn more.]({{link}})", {
         link: commonUrls.attachmentStorage
       }
     )),

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -118,8 +118,7 @@ export const commonUrls = {
   githubSponsorGristLabs: 'https://github.com/sponsors/gristlabs',
 
   versionCheck: 'https://api.getgrist.com/api/version',
-  // TODO: This should be a link to attachments configuration
-  attachmentStorage: 'https://support.getgrist.com',
+  attachmentStorage: 'https://support.getgrist.com/document-settings/#external-attachments',
 };
 
 export const ONBOARDING_VIDEO_YOUTUBE_EMBED_ID = '56AieR9rpww';

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -118,6 +118,8 @@ export const commonUrls = {
   githubSponsorGristLabs: 'https://github.com/sponsors/gristlabs',
 
   versionCheck: 'https://api.getgrist.com/api/version',
+  // TODO: This should be a link to attachments configuration
+  attachmentStorage: 'https://support.getgrist.com',
 };
 
 export const ONBOARDING_VIDEO_YOUTUBE_EMBED_ID = '56AieR9rpww';

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -383,7 +383,10 @@
         "Start transfer": "Start transfer",
         "External": "External",
         "Internal": "Internal",
-        "Transfer in progress": "Transfer in progress"
+        "Transfer in progress": "Transfer in progress",
+        "**Some existing attachments are still [external]({{externalLink}})**.": "**Some existing attachments are still [external]({{externalLink}})**.",
+        "**Some existing attachments are still [internal]({{internalLink}})** (stored in SQLite file).": "**Some existing attachments are still [internal]({{internalLink}})** (stored in SQLite file).",
+        "[Learn more.]({{learnLink}})": "[Learn more.]({{learnLink}})"
     },
     "DocumentUsage": {
         "Attachments Size": "Size of Attachments",
@@ -1256,7 +1259,8 @@
         "This limitation occurs when one column in a two-way reference has the Reference type.": "This limitation occurs when one column in a two-way reference has the Reference type.",
         "To allow multiple assignments, change the referenced column's type to Reference List.": "To allow multiple assignments, change the referenced column's type to Reference List.",
         "Two-way references are not currently supported for Formula or Trigger Formula columns": "Two-way references are not currently supported for Formula or Trigger Formula columns",
-        "The preview below this header shows how the selected user will see this document": "The preview below this header shows how the selected user will see this document"
+        "The preview below this header shows how the selected user will see this document": "The preview below this header shows how the selected user will see this document",
+        "[Learn more.]({{link}})": "[Learn more.]({{link}})"
     },
     "DescriptionConfig": {
         "DESCRIPTION": "DESCRIPTION"


### PR DESCRIPTION
Adding back links in external attachments UI that point to https://support.getgrist.com/document-settings/#external-attachments

## Context
Links where removed in the final PR as the help page was not ready.

## Has this been tested?
- [x] manual tests only

