### PR TITLE
feat: Explicitly pin python setuptools version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,9 @@ RUN \
 # Fetch python3.11
 FROM python:3.11-slim-bookworm AS collector-py3
 ADD sandbox/requirements3.txt requirements3.txt
+# setuptools is installed explicitly to 75.8.1 to avoid vunerable 65.5.1
+# version installed by default. 75.8.1 is the up to date version compatible with
+# python >= 3.9
 RUN \
   pip3 install setuptools==75.8.1 && \
   pip3 install -r requirements3.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN \
 FROM python:3.11-slim-bookworm AS collector-py3
 ADD sandbox/requirements3.txt requirements3.txt
 RUN \
+  pip3 install setuptools==75.8.1 && \
   pip3 install -r requirements3.txt
 
 # Fetch <shame>python2.7</shame>


### PR DESCRIPTION
## Context

Python3 setuptools version (65.5.1) currently in grist-core docker images is vulnerable.
This version is the default one installed with python 3.11

## Proposed Solution
This PR propose to explicitly install it with a choosen version in the Dockerfile.

I did not put setuptools in requirements3.in -> requirements3.txt because it is not added in requirements.txt
and the following warning is displayed

```bash
#
# This file is autogenerated by pip-compile with Python 3.11
# by the following command:
#
#    pip-compile --output-file=sandbox/requirements12.txt sandbox/requirements3.in
#
astroid==3.3.8
    # via -r sandbox/requirements3.in
asttokens==3.0.0
    # via
...
unittest-xml-reporting==3.2.0
    # via -r sandbox/requirements3.in

# The following packages are considered to be unsafe in a requirements file:
# setuptools
```

## Related issues

none

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
