### PR TITLE
Update outdated comment in ChecksummedExternalStorage

### DIFF
--- a/app/server/lib/ExternalStorage.ts
+++ b/app/server/lib/ExternalStorage.ts
@@ -266,7 +266,7 @@ export class ChecksummedExternalStorage implements ExternalStorage {
           }
         }
 
-        // If successful, rename the temporary file to its proper name. The destination should NOT
+        // Rename the temporary file to its proper name. The destination should NOT
         // exist in this case, and this should fail if it does.
         await fse.move(tmpPath, fname, {overwrite: false});
         if (fromKey === toKey) {


### PR DESCRIPTION
The piece of code after the comment is executed regardless of whether the above check fails or not.