### PR TITLE
Implement "yarn cli history dump" command

### DIFF
--- a/app/server/companion.ts
+++ b/app/server/companion.ts
@@ -12,6 +12,7 @@ import { pruneActionHistory } from 'app/server/utils/pruneActionHistory';
 import { showAuditLogEvents } from 'app/server/utils/showAuditLogEvents';
 import * as commander from 'commander';
 import { Connection } from 'typeorm';
+import { dumpActionHistory } from './utils/dumpActionHistory';
 
 /**
  * Main entrypoint for a cli toolbox for configuring aspects of Grist
@@ -78,10 +79,15 @@ export function addHistoryCommand(program: commander.Command, options: CommandOp
     sectionDescription: 'fiddle with history of a Grist document',
     ...options,
   });
-  sub('prune <docId>')
+  sub('prune <docPath>')
     .description('remove all but last N actions from doc')
     .argument('[N]', 'number of actions to keep', parseIntForCommander, 1)
     .action(pruneActionHistory);
+  sub('dump <docPath>')
+    .description('Dump the lattest history actions')
+    .option('-m, --max-actions', 'number of actions to dump')
+    .option('-o, --output', 'The output file')
+    .action(dumpActionHistory);
 }
 
 // Add commands for general configuration

--- a/app/server/utils/dumpActionHistory.ts
+++ b/app/server/utils/dumpActionHistory.ts
@@ -1,0 +1,35 @@
+import {create} from "app/server/lib/create";
+import * as gutil from 'app/common/gutil';
+import {ActionHistoryImpl} from 'app/server/lib/ActionHistoryImpl';
+import {DocStorage} from 'app/server/lib/DocStorage';
+import log from "app/server/lib/log";
+
+import * as fs from 'node:fs/promises';
+
+export async function dumpActionHistory(docPath: string, options: {
+  maxActions?: number
+  output?: string
+  debug?: boolean
+}) {
+  const { maxActions, output: outputFile } = options;
+  if (!docPath || !gutil.endsWith(docPath, '.grist')) {
+    throw new Error('Invalid document: Document should be a valid .grist file');
+  }
+
+  log.transports.file.level = 'info';
+  const storageManager = await create.createLocalDocStorageManager(".", ".");
+  const docStorage = new DocStorage(storageManager, docPath);
+  await docStorage.openFile();
+  try {
+    const history = new ActionHistoryImpl(docStorage);
+    const actions = await history.getRecentActions(maxActions);
+    const dump = JSON.stringify(actions, null, 2);
+    if (outputFile) {
+      await fs.writeFile(outputFile, dump, {encoding: 'utf-8'});
+    } else {
+      console.info(dump);
+    }
+  } finally {
+    await docStorage.shutdown();
+  }
+}


### PR DESCRIPTION
This command is useful to dump in JSON the history actions which stored marshalled in the sqlite database. It is meant to be more handy to work with, especially to manipulate the result using tools like jq.

## Context

<!-- Please include a summary of the change, with motivation and context -->
<!-- Bonus: if you are comfortable writing one, please insert a user-story https://en.wikipedia.org/wiki/User_story#Common_templates -->

## Proposed solution

<!-- Describe here how you address the issue -->

## Related issues

Fixes #1483 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
