### PR TITLE
Minio : pass size argument

### DIFF
--- a/app/server/lib/ExternalStorage.ts
+++ b/app/server/lib/ExternalStorage.ts
@@ -90,7 +90,7 @@ export class KeyMappedExternalStorage implements ExternalStorage {
     if (_ext.uploadStream !== undefined) {
       const extUploadStream = _ext.uploadStream;
       this.uploadStream =
-        (key, inStream, metadata) => extUploadStream.call(_ext, this._map(key), inStream, metadata);
+        (key, inStream, size, metadata) => extUploadStream.call(_ext, this._map(key), inStream, size, metadata);
     }
     if (_ext.downloadStream !== undefined) {
       const extDownloadStream = _ext.downloadStream;

--- a/app/server/lib/ExternalStorage.ts
+++ b/app/server/lib/ExternalStorage.ts
@@ -68,7 +68,7 @@ export interface ExternalStorage {
   // Close the storage object.
   close(): Promise<void>;
 
-  uploadStream?(key: string, inStream: stream.Readable, metadata?: ObjMetadata): Promise<string|null|typeof Unchanged>;
+  uploadStream?(key: string, inStream: stream.Readable, size?: number, metadata?: ObjMetadata): Promise<string|null|typeof Unchanged>;
   downloadStream?(key: string, snapshotId?: string ): Promise<StreamDownloadResult>;
 }
 

--- a/app/server/lib/ExternalStorage.ts
+++ b/app/server/lib/ExternalStorage.ts
@@ -68,7 +68,11 @@ export interface ExternalStorage {
   // Close the storage object.
   close(): Promise<void>;
 
-  uploadStream?(key: string, inStream: stream.Readable, size?: number, metadata?: ObjMetadata): Promise<string|null|typeof Unchanged>;
+  uploadStream?(key: string,
+                inStream: stream.Readable,
+                size?: number,
+                metadata?: ObjMetadata
+  ): Promise<string|null|typeof Unchanged>;
   downloadStream?(key: string, snapshotId?: string ): Promise<StreamDownloadResult>;
 }
 
@@ -173,7 +177,7 @@ export class ChecksummedExternalStorage implements ExternalStorage {
   constructor(public readonly label: string, private _ext: ExternalStorage, private _options: {
     maxRetries: number,         // how many time to retry inconsistent downloads
     initialDelayMs: number,     // how long to wait before retrying
-    localHash: PropStorage,     // key/value store for hashes of downloaded content (a file in persist/grist/docs/{docId}.grist-hash-{meta/doc})
+    localHash: PropStorage,     // key/value store for hashes of downloaded content (file {Id}.grist-hash-{meta/doc})
     sharedHash: PropStorage,    // key/value store for hashes of external content (typically Redis)
     latestVersion: PropStorage, // key/value store for snapshotIds of uploads (a JS map object)
     computeFileHash: (fname: string) => Promise<string>,  // compute hash for file

--- a/test/server/lib/AttachmentStoreProvider.ts
+++ b/test/server/lib/AttachmentStoreProvider.ts
@@ -117,7 +117,7 @@ class FakeExternalStorage implements ExternalStorage {
 
 class FakeAttachmentExternalStorage extends FakeExternalStorage implements ExternalStorageSupportingAttachments {
   public async uploadStream(
-    key: string, inStream: stream.Readable, metadata?: ObjMetadata | undefined
+    key: string, inStream: stream.Readable, size?: number, metadata?: ObjMetadata | undefined
   ): Promise<string | typeof Unchanged | null> {
     return null;
   }


### PR DESCRIPTION
Fixes #1488

Looking at the [MinIO.js client's code for putObject](https://github.com/minio/minio-js/blob/9d66e6aae808a060aa8897872c9a02cdb9172685/src/internal/client.ts#L1607), it looks like passing the `size` argument lets it be clever about whether to perform an upload in one part or as a multi-part.

I also threw some new comments in the codebase that were usefull to me when reading the code. Can revert or shove them in a separate PR if you'd prefer.