### PR TITLE
dbUtils: disable the Postgres JIT compiler

### DIFF
--- a/test/gen-server/seed.ts
+++ b/test/gen-server/seed.ts
@@ -25,7 +25,7 @@
 import {addPath} from 'app-module-path';
 import {Context} from 'mocha';
 import * as path from 'path';
-import {Connection, getConnectionManager, Repository} from 'typeorm';
+import {Connection, Repository} from 'typeorm';
 
 if (require.main === module) {
   addPath(path.dirname(path.dirname(__dirname)));
@@ -572,14 +572,8 @@ class Seed {
 // When running mocha on several test files at once, we need to reset our database connection
 // if it exists.  This is a little ugly since it is stored globally.
 export async function removeConnection() {
-  if (getConnectionManager().connections.length > 0) {
-    if (getConnectionManager().connections.length > 1) {
-      throw new Error("unexpected number of connections");
-    }
-    await getConnectionManager().connections[0].close();
-    // There is still no official way to delete connections that I've found.
-    (getConnectionManager() as any).connectionMap = new Map();
-  }
+  const connection = await getOrCreateConnection();
+  await connection.destroy();
 }
 
 export async function createInitialDb(connection?: Connection, migrateAndSeedData: boolean|'migrateOnly' = true) {


### PR DESCRIPTION
In #773 we discovered that the Postgres JIT compiler was slowing every operation down. Although only a few queries were obviously the culprit, there seems to be no downside to disabling it unconditionally in general.

## Context

Fixes #773. If this gets merged, we should probably amend the last paragraph [here](https://support.getgrist.com/self-managed/#what-is-a-home-database).

## Proposed solution

Disable JIT compilation for Postgres.

## Has this been tested?

I did manual testing and confirmed in the PostgreSQL query logs that transactions were running with `set local jit = off` and that this incurred a noticeable speedup.

Manual testing seemed more expedient than changing our testing framework to make PostgreSQL query logs available.

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
