### PR TITLE
Add backend scaffolding for automated updates

### DIFF
--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -1,4 +1,5 @@
 import {BillingPage, BillingSubPage, BillingTask} from 'app/common/BillingAPI';
+import {LatestVersionAvailable} from 'app/common/version';
 import {OpenDocMode} from 'app/common/DocListAPI';
 import {EngineCode} from 'app/common/DocumentSettings';
 import {encodeQueryParams, isAffirmative, removePrefix} from 'app/common/gutil';
@@ -846,6 +847,8 @@ export interface GristLoadConfig {
   tagManagerId?: string;
 
   activation?: ActivationState;
+
+  latestVersionAvailable?: LatestVersionAvailable;
 
   // List of enabled features.
   features?: IFeature[];

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1,4 +1,5 @@
 import {ApiError} from 'app/common/ApiError';
+import {LatestVersionAvailable} from 'app/common/version';
 import {ICustomWidget} from 'app/common/CustomWidget';
 import {delay} from 'app/common/delay';
 import {encodeUrl, getSlugIfNeeded, GristDeploymentType, GristDeploymentTypes,
@@ -201,6 +202,7 @@ export class FlexServer implements GristServer {
   private _jobs?: GristJobs;
   private _emitNotifier = new EmitNotifier();
   private _testPendingNotifications: number = 0;
+  private _latestVersionAvailable?: LatestVersionAvailable;
 
   constructor(public port: number, public name: string = 'flexServer',
               public readonly options: FlexServerOptions = {}) {
@@ -1985,6 +1987,15 @@ export class FlexServer implements GristServer {
 
     // Some configurations may add extra endpoints. This seems a fine time to add them.
     this.create.addExtraHomeEndpoints(this, this.app);
+  }
+
+  public getLatestVersionAvailable() {
+    return this._latestVersionAvailable;
+  }
+
+  public setLatestVersionAvailable(latestVersionAvailable: LatestVersionAvailable): void {
+    log.info(`Setting ${latestVersionAvailable.version} as the latest available version`);
+    this._latestVersionAvailable = latestVersionAvailable;
   }
 
   // Get the HTML template sent for document pages.

--- a/app/server/lib/GristServer.ts
+++ b/app/server/lib/GristServer.ts
@@ -30,6 +30,7 @@ import { ITelemetry } from 'app/server/lib/Telemetry';
 import * as express from 'express';
 import { IncomingMessage } from 'http';
 import { IGristCoreConfig, loadGristCoreConfig } from "./configCore";
+import { LatestVersionAvailable } from 'app/common/version';
 
 /**
  * Basic information about a Grist server.  Accessible in many
@@ -77,6 +78,8 @@ export interface GristServer {
   getInfo(key: string): any;
   getJobs(): GristJobs;
   getBilling(): IBilling;
+  getLatestVersionAvailable(): LatestVersionAvailable|undefined;
+  setLatestVersionAvailable(latestVersionAvailable: LatestVersionAvailable): void
   setRestrictedMode(restrictedMode?: boolean): void;
   getDocManager(): DocManager;
   isRestrictedMode(): boolean;
@@ -179,6 +182,8 @@ export function createDummyGristServer(): GristServer {
     getInfo(key: string) { return undefined; },
     getJobs(): GristJobs { throw new Error('no job system'); },
     getBilling() { throw new Error('no billing'); },
+    getLatestVersionAvailable() { throw new Error('no version checking'); },
+    setLatestVersionAvailable() { /* do nothing */ },
     setRestrictedMode() { /* do nothing */ },
     getDocManager() { throw new Error('no DocManager'); },
     isRestrictedMode() { return false; },

--- a/app/server/lib/GristServer.ts
+++ b/app/server/lib/GristServer.ts
@@ -80,6 +80,7 @@ export interface GristServer {
   getBilling(): IBilling;
   getLatestVersionAvailable(): LatestVersionAvailable|undefined;
   setLatestVersionAvailable(latestVersionAvailable: LatestVersionAvailable): void
+  publishLatestVersionAvailable(latestVersionAvailable: LatestVersionAvailable): Promise<void>;
   setRestrictedMode(restrictedMode?: boolean): void;
   getDocManager(): DocManager;
   isRestrictedMode(): boolean;
@@ -184,6 +185,7 @@ export function createDummyGristServer(): GristServer {
     getBilling() { throw new Error('no billing'); },
     getLatestVersionAvailable() { throw new Error('no version checking'); },
     setLatestVersionAvailable() { /* do nothing */ },
+    publishLatestVersionAvailable() { return Promise.resolve(); },
     setRestrictedMode() { /* do nothing */ },
     getDocManager() { throw new Error('no DocManager'); },
     isRestrictedMode() { return false; },

--- a/app/server/lib/sendAppPage.ts
+++ b/app/server/lib/sendAppPage.ts
@@ -98,6 +98,7 @@ export function makeGristConfig(options: MakeGristConfigOptions): GristLoadConfi
     survey: Boolean(process.env.DOC_ID_NEW_USER_INFO),
     tagManagerId: process.env.GOOGLE_TAG_MANAGER_ID,
     activation: (req as RequestWithLogin|undefined)?.activation,
+    latestVersionAvailable: server?.getLatestVersionAvailable(),
     enableCustomCss: isAffirmative(process.env.APP_STATIC_INCLUDE_CUSTOM_CSS),
     supportedLngs: readLoadedLngs(req?.i18n),
     namespaces: readLoadedNamespaces(req?.i18n),

--- a/app/server/lib/updateChecker.ts
+++ b/app/server/lib/updateChecker.ts
@@ -1,0 +1,32 @@
+import {commonUrls} from "app/common/gristUrls";
+import {version as installedVersion} from "app/common/version";
+import {GristServer} from "app/server/lib/GristServer";
+import {ApiError} from "app/common/ApiError";
+
+export async function checkForUpdates(gristServer: GristServer) {
+  // Prepare data for the telemetry that endpoint might expect.
+  const installationId = (await gristServer.getActivations().current()).id;
+  const deploymentType = gristServer.getDeploymentType();
+  const currentVersion = installedVersion;
+  const response = await fetch(
+    process.env.GRIST_TEST_VERSION_CHECK_URL || commonUrls.versionCheck,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        installationId,
+        deploymentType,
+        currentVersion,
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const errorData = response.headers.get("content-type")?.includes("application/json")
+      ? await response.json()
+      : await response.text();
+    throw new ApiError ('Version update checking failed', response.status, errorData);
+  }
+
+  return await response.json();
+}

--- a/stubs/app/common/version.ts
+++ b/stubs/app/common/version.ts
@@ -3,3 +3,8 @@ import packageJson from 'package.json';
 export const version = packageJson.version;
 export const channel = "core";
 export const gitcommit = "unknown";
+
+export interface LatestVersionAvailable {
+  version: string;
+  isNewer: boolean;
+}

--- a/test/server/lib/updateChecker.ts
+++ b/test/server/lib/updateChecker.ts
@@ -1,0 +1,118 @@
+import { LatestVersion } from "app/common/InstallAPI";
+import { version as installedVersion } from "app/common/version";
+import { TestServer } from 'test/gen-server/apiUtils';
+import { getGristConfig } from 'test/gen-server/testUtils';
+import * as testUtils from 'test/server/testUtils';
+
+import { assert } from 'chai';
+import * as sinon from 'sinon';
+import fetch from 'node-fetch';
+import { FlexServer } from "app/server/lib/FlexServer";
+import { Timings } from "app/gen-server/lib/Housekeeper";
+
+
+const fakeVersionUrl = 'https://whatever.computer/version';
+describe('updateChecker', () => {
+  testUtils.setTmpLogLevel('error');
+
+  let fetchStub: sinon.SinonStub;
+  let setVersionStub: sinon.SinonStub;
+  let sandbox: sinon.SinonSandbox;
+  let server: TestServer;
+  let homeUrl: string;
+
+  const oldServerEnv = new testUtils.EnvironmentSnapshot();
+
+  function setupTestServer(mockResponse: LatestVersion) {
+    beforeEach(async function () {
+      // Stub out the fetch to the external version API endpoint so we
+      // can specify what the latest publicly available version is.
+      fetchStub = sinon.stub(global, 'fetch');
+      fetchStub
+        .withArgs(fakeVersionUrl, sinon.match.any)
+        .resolves(new Response(
+          JSON.stringify(mockResponse),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          }
+        ))
+        .callThrough();
+
+      // Stub out FlexServer.setLatestVersionAvailable so we can await
+      // a promise that it's been called before we start running our tests.
+      let setVersionResolved: () => void;
+      const setVersionPromise: Promise<void> = new Promise<void>((resolve) => {
+        setVersionResolved = resolve;
+      });
+      const originalSetMethod = FlexServer.prototype.setLatestVersionAvailable;
+      setVersionStub = sinon.stub(FlexServer.prototype, 'setLatestVersionAvailable')
+        .callsFake(function (this: FlexServer, ...args){
+          originalSetMethod.apply(this, args);
+          setVersionResolved();
+        });
+
+      // Remove the waiting time to do the first version check at startup
+      sandbox = sinon.createSandbox();
+      sandbox.stub(Timings, 'VERSION_CHECK_OFFSET_MS').value(0);
+
+      process.env.GRIST_ALLOW_AUTOMATIC_VERSION_CHECKING = 'true';
+      process.env.GRIST_TEST_VERSION_CHECK_URL = fakeVersionUrl;
+      server = new TestServer(this);
+      homeUrl = await server.start();
+      await setVersionPromise;
+    });
+
+    afterEach(async function () {
+      await server.stop();
+      fetchStub.restore();
+      setVersionStub.restore();
+      oldServerEnv.restore();
+      sandbox.restore();
+    });
+    return {
+      server: () => server,
+      homeUrl: () => homeUrl
+    };
+  }
+
+  describe('when everything is up to date', () => {
+    const mockVersionResponse: LatestVersion = {
+      latestVersion: installedVersion,
+      updatedAt: '2025-02-18T22:11:09.455904Z',
+      isCritical: false,
+      updateURL: 'https://hub.docker.com/r/gristlabs/grist'
+    };
+    const {homeUrl} = setupTestServer(mockVersionResponse);
+
+    it('can get the latest available version information', async function () {
+      const doc = await fetch(homeUrl());
+      const pageBody = await doc.text();
+      const config = getGristConfig(pageBody);
+      const latestVersionAvailable = config.latestVersionAvailable;
+      assert.equal(latestVersionAvailable?.version, installedVersion);
+      assert.equal(latestVersionAvailable?.isNewer, false);
+    });
+  });
+
+  describe('when a newer version is available', () => {
+    const newestVersion = '99.99.99';
+    const mockVersionResponse: LatestVersion = {
+      latestVersion: newestVersion,
+      updatedAt: '2025-02-18T22:11:09.455904Z',
+      isCritical: false,
+      updateURL: 'https://hub.docker.com/r/gristlabs/grist'
+    };
+    const {homeUrl} = setupTestServer(mockVersionResponse);
+
+    it('can get the latest available version information', async function () {
+      const doc = await fetch(homeUrl());
+      const pageBody = await doc.text();
+      const config = getGristConfig(pageBody);
+      const latestVersionAvailable = config.latestVersionAvailable;
+      assert.equal(latestVersionAvailable?.version, newestVersion);
+      assert.equal(latestVersionAvailable?.isNewer, true);
+    });
+
+  });
+});


### PR DESCRIPTION
## Context

We would like to make our self-hosted admins better aware that a newer version of Grist might be available. We'll then display a dismissable banner that informs them in case the version they are running is out of date.

## Proposed solution

By default, we'll enable version checking for newer versions, save the results to the config database. This PR is just the backend. A future PR will write the frontend half of this feature.

Original commit messages:

* 65a3c90aff3c updateChecker: factor out logic from attachEarlyEndpoints

  We'll need this in its own place so we can call it without going
  through the install API.

* 9d1a29a90a39 Config: add new config key, "latest_version_available"

  This will be an admin-only config setting, which is fine, as only
  admins should be informed if there is a newer Grist version available.

* a5c827d1e2f5 FlexServer: add `_latestVersionAvailable` property

  We'll need to store this so that we don't hit the DB every time the
  frontend requests it.

  For now we store the property in-memory on the `FlexServer` object
  itself, but perhaps some day we'll fetch it from Redis or similar.

* e101409dc45f updateChecker: new function, `compareWithLatest`

  Simple function to hit the remote endpoint and save the result to the
  home db, so it's available to the config.

* c6e8bd1af744 FlexServer: check for updates at startup and every week thereafter

  We keep track of checking task so that we can disable it later when we
  have a user interface to enable or disable automated version checks.

* bb8ed9f38fcf GristLoadConfig: add a latestVersionAvailable property

  We'll now send this as part of the big `gristConfig` object to the
  frontend.

* f254e28f1594 sendAppPage: send `latestVersionAvailable` to the frontend

  Now that the frontend has access to this information on every page, we
  need to conditionally display a banner for it.

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
