### PR TITLE
Fix attachment upload from custom widget with ACL

### DIFF
--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -1616,7 +1616,7 @@ export class ActiveDoc extends EventEmitter {
   public async getAccessToken(docSession: OptDocSession, options: AccessTokenOptions): Promise<AccessTokenResult> {
     const tokens = this._server.getAccessTokens();
     const user = await this._granularAccess.getUser(docSession);
-    const userId = user!.UserID;
+    const userId = user.UserID;
     const docId = this.docName;
     const access = getDocSessionAccess(docSession);
     // If we happen to be using a "readOnly" connection, max out at "readOnly"

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -1615,7 +1615,8 @@ export class ActiveDoc extends EventEmitter {
 
   public async getAccessToken(docSession: OptDocSession, options: AccessTokenOptions): Promise<AccessTokenResult> {
     const tokens = this._server.getAccessTokens();
-    const userId = getUserId(docSession);
+    const user = await this._granularAccess.getUser(docSession);
+    const userId = user!.UserID;
     const docId = this.docName;
     const access = getDocSessionAccess(docSession);
     // If we happen to be using a "readOnly" connection, max out at "readOnly"

--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -165,7 +165,7 @@ export async function addRequestUser(
   if (auth) {
     const tokens = options.gristServer.getAccessTokens();
     const token = await tokens.verify(auth);
-    const userId = token.userId
+    const userId = token.userId;
     const user = await dbManager.getUser(userId);
     mreq.accessToken = token;
     mreq.user = user;

--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -165,9 +165,11 @@ export async function addRequestUser(
   if (auth) {
     const tokens = options.gristServer.getAccessTokens();
     const token = await tokens.verify(auth);
+    const userId = token.userId
+    const user = await dbManager.getUser(userId);
     mreq.accessToken = token;
-    // Once an accessToken is supplied, we don't consider anything else.
-    // User is treated as anonymous apart from having an accessToken.
+    mreq.user = user;
+    mreq.userId = userId;
     authDone = true;
   }
 

--- a/app/server/lib/GranularAccess.ts
+++ b/app/server/lib/GranularAccess.ts
@@ -2386,7 +2386,7 @@ export class GranularAccess implements GranularAccessForBundle {
     const attIds = await this._gatherAttachmentChanges(cursor);
     for (const attId of attIds) {
       if (!await this.isAttachmentUploadedByUser(docSession, attId) &&
-        !await this.findAttachmentCellForUser(docSession, attId)) {
+        ((await this._docStorage.findAttachmentReferences(attId)).length && !await this.findAttachmentCellForUser(docSession, attId))) {
         throw new ErrorWithCode('ACL_DENY', 'Cannot access attachment', {
           status: 403,
         });

--- a/app/server/lib/GranularAccess.ts
+++ b/app/server/lib/GranularAccess.ts
@@ -2386,7 +2386,8 @@ export class GranularAccess implements GranularAccessForBundle {
     const attIds = await this._gatherAttachmentChanges(cursor);
     for (const attId of attIds) {
       if (!await this.isAttachmentUploadedByUser(docSession, attId) &&
-        ((await this._docStorage.findAttachmentReferences(attId)).length && !await this.findAttachmentCellForUser(docSession, attId))) {
+        ((await this._docStorage.findAttachmentReferences(attId)).length &&
+          !await this.findAttachmentCellForUser(docSession, attId))) {
         throw new ErrorWithCode('ACL_DENY', 'Cannot access attachment', {
           status: 403,
         });


### PR DESCRIPTION
## Context

I am building a custom widget to sign PDF (not electronically, yet?) and I had issues when access rules apply.

## Proposed solution

Fixing auth related bugs. :grimacing: 

## Related issues

First of all, it was hard to get a minimal failing test.
To get a working bogus example
- Create a new doc
- Update column A to be of attachment type
- Add an editor
- Add an ACL rule to prevent editors from editing
- Add a table specific ACL rule to allow editors edition
- Add a custom widget to your view (for instance https://betagouv.github.io/grist-previsionnel/signer-pdf)
    - (link it to Table1 to select)
- Create a new row adding a PDF in column A
- It should display the PDF document in the custom widget
- Click on « create and add updated PDF »
- Nothing should happen
- In the browser console, the « Error: Cannot access attachment » error should appeared.


![image](https://github.com/user-attachments/assets/d31c9107-7f25-4b3f-8368-755b68fef721)


## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [x] 🙋 no, because I need help  I don't really know where to look at to add a test (or multiple)

## Screenshots / Screencasts

<!-- delete if not relevant -->
