### PR TITLE
Limit file extensions to be imported into a document

### DIFF
--- a/app/client/components/Importer.ts
+++ b/app/client/components/Importer.ts
@@ -11,7 +11,7 @@ import {makeTestId} from 'app/client/lib/domUtils';
 import {FocusLayer} from 'app/client/lib/FocusLayer';
 import {ImportSourceElement} from 'app/client/lib/ImportSourceElement';
 import {makeT} from 'app/client/lib/localization';
-import {fetchURL, isDriveUrl, selectFiles, uploadFiles} from 'app/client/lib/uploads';
+import {EXTENSIONS_IMPORTABLE_WITHIN_DOC, fetchURL, isDriveUrl, selectFiles, uploadFiles} from 'app/client/lib/uploads';
 import {reportError} from 'app/client/models/AppModel';
 import {ColumnRec, ViewFieldRec, ViewSectionRec} from 'app/client/models/DocModel';
 import {SortedRowSet} from 'app/client/models/rowset';
@@ -202,7 +202,10 @@ export async function importFromFile(gristDoc: GristDoc, createPreview: CreatePr
   let uploadResult: UploadResult|null = null;
   // Use the built-in file picker. On electron, it uses the native file selector (without
   // actually uploading anything), which is why this requires a slightly different flow.
-  const files: File[] = await openFilePicker({multiple: true});
+  const files: File[] = await openFilePicker({
+    multiple: true,
+    accept: EXTENSIONS_IMPORTABLE_WITHIN_DOC.join(","),
+  });
   // Important to fork first before trying to import, so we end up uploading to a
   // consistent doc worker.
   await gristDoc.forkIfNeeded();

--- a/app/client/lib/uploads.ts
+++ b/app/client/lib/uploads.ts
@@ -31,6 +31,9 @@ export interface SelectFileOptions extends UploadOptions {
                           // e.g. [".jpg", ".png"]
 }
 
+// This list coincides with the extensions defined in core/plugins/manifest.yml
+export const EXTENSIONS_IMPORTABLE_WITHIN_DOC = [".xlsx", ".json", ".csv", ".tsv", ".dsv"];
+
 export const EXTENSIONS_IMPORTABLE_AS_DOC = [".grist", ".csv", ".tsv", ".dsv", ".txt", ".xlsx", ".xlsm"];
 
 /**

--- a/app/client/lib/uploads.ts
+++ b/app/client/lib/uploads.ts
@@ -31,7 +31,7 @@ export interface SelectFileOptions extends UploadOptions {
                           // e.g. [".jpg", ".png"]
 }
 
-export const IMPORTABLE_EXTENSIONS = [".grist", ".csv", ".tsv", ".dsv", ".txt", ".xlsx", ".xlsm"];
+export const EXTENSIONS_IMPORTABLE_AS_DOC = [".grist", ".csv", ".tsv", ".dsv", ".txt", ".xlsx", ".xlsm"];
 
 /**
  * Shows the file-picker dialog with the given options, and uploads the selected files. If under

--- a/app/client/ui/CoreHomeImports.ts
+++ b/app/client/ui/CoreHomeImports.ts
@@ -4,7 +4,7 @@ import {PluginScreen} from 'app/client/components/PluginScreen';
 import {guessTimezone} from 'app/client/lib/guessTimezone';
 import {ImportSourceElement} from 'app/client/lib/ImportSourceElement';
 import {ImportProgress} from 'app/client/ui/ImportProgress';
-import {IMPORTABLE_EXTENSIONS} from 'app/client/lib/uploads';
+import {EXTENSIONS_IMPORTABLE_AS_DOC} from 'app/client/lib/uploads';
 import {openFilePicker} from 'app/client/ui/FileDialog';
 import {byteString} from 'app/common/gutil';
 import {uploadFiles} from 'app/client/lib/uploads';
@@ -20,7 +20,7 @@ export async function docImport(app: AppModel, workspaceId: number|"unsaved"): P
   // popup, or it would get blocked by default in a typical browser.
   const files: File[] = await openFilePicker({
     multiple: false,
-    accept: IMPORTABLE_EXTENSIONS.join(","),
+    accept: EXTENSIONS_IMPORTABLE_AS_DOC.join(","),
   });
 
   if (!files.length) { return null; }


### PR DESCRIPTION
## Context

Users have tried using the importer to add tables to an existing document, but without any indication of which file types are available for import, users may upload an incompatible file type and hit an error message.

## Proposed solution

Limit the file picker to only the `table-level` importable file types, analogous to the limits imposed on the document-level importable types.

Original commit messages:

* d917f5f6a884 uploads: add new constant, IMPORTABLE_TABLE_EXTENSIONS

  What makes sense to import into a document isn't the same as what
  makes sense for importing as a whole document.

* 28191b0257be Importer: limit list of acceptable files to `IMPORTABLE_TABLE_EXTENSIONS`

  This should reduce the possibility that our users will attempt to
  import the wrong kind of file.



## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

We don't have tests for OS-level dialogues that the web browser could open, so instead I did some manual testing to ensure that the dialogue only allows uploading this restricted set of file types.

## Screenshots / Screencasts

https://github.com/user-attachments/assets/ee828070-9f57-4c2d-96d7-81b830569c2b
