### PR TITLE
Proper way for clicking in the header on admin section

### DIFF
--- a/test/nbrowser/AdminPanel.ts
+++ b/test/nbrowser/AdminPanel.ts
@@ -375,7 +375,7 @@ export function itemElement(itemId: string) {
 }
 
 export async function toggleItem(itemId: string) {
-  const header = itemElement(itemId);
+  const header = itemElement(itemId).find(`.test-admin-panel-item-name-${itemId}`);
   await header.click();
   await driver.sleep(500);    // Time to expand or collapse.
   return header;


### PR DESCRIPTION
## Context

Fixing bug introduced lately by accident. Function that was expanding admin section was by default clicking in the middle of the div. With the new UI, one of the section had a help link there which was when clicked was opening additional browser windows.


## Related issues

https://github.com/gristlabs/grist-core/pull/1376

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [X] 👍 yes, existing tests are enough
