### PR TITLE
choice tokens: change bg/text shade automatically to improve readability

### DIFF
--- a/app/client/widgets/ChoiceToken.ts
+++ b/app/client/widgets/ChoiceToken.ts
@@ -1,7 +1,10 @@
 import {Style} from 'app/client/models/Styles';
 import {theme, vars} from 'app/client/ui2018/cssVars';
 import {dom, DomContents, DomElementArg, styled} from 'grainjs';
+import {colord, extend} from "colord";
+import a11yPlugin from "colord/plugins/a11y";
 
+extend([a11yPlugin]);
 export const DEFAULT_BACKGROUND_COLOR = theme.choiceTokenBg.toString();
 export const DEFAULT_COLOR = theme.choiceTokenFg.toString();
 
@@ -9,6 +12,8 @@ export interface IChoiceTokenOptions extends Style {
   invalid?: boolean;
   blank?: boolean;
 }
+
+const contrastCalculationsCache: Record<string, string> = {};
 
 /**
  * Creates a colored token representing a choice (e.g. Choice and Choice List values).
@@ -31,10 +36,25 @@ export function choiceToken(
 ): DomContents {
   const {fillColor, textColor, fontBold, fontItalic, fontUnderline,
          fontStrikethrough, invalid, blank} = options;
+  const hasCustomBg = fillColor !== undefined;
+  const hasCustomText = textColor !== undefined;
+  let bg = DEFAULT_BACKGROUND_COLOR;
+  let fg = DEFAULT_COLOR;
+  if (hasCustomBg && hasCustomText) {
+    bg = fillColor;
+    fg = textColor;
+  } else if (hasCustomText) {
+    bg = findMatchingShade(textColor, '#E8E8E8', '#70707d');
+    fg = textColor;
+  } else if (hasCustomBg) {
+    bg = fillColor;
+    fg = findMatchingShade(fillColor, '#ffffff', '#000000');
+  }
+
   return cssChoiceToken(
     label,
-    dom.style('background-color', fillColor ?? DEFAULT_BACKGROUND_COLOR),
-    dom.style('color', textColor ?? DEFAULT_COLOR),
+    dom.style('background-color', bg),
+    dom.style('color', fg),
     dom.cls('font-bold', fontBold ?? false),
     dom.cls('font-underline', fontUnderline ?? false),
     dom.cls('font-italic', fontItalic ?? false),
@@ -43,6 +63,22 @@ export function choiceToken(
     blank ? cssChoiceToken.cls('-blank') : null,
     ...args
   );
+}
+
+function findMatchingShade(color: string, lightShade: string, darkShade: string) {
+  const c = colord(color);
+  const cache = contrastCalculationsCache;
+  const cacheKey = `${color}-${lightShade}-${darkShade}`;
+  if (cache[cacheKey] !== undefined) {
+    return cache[cacheKey];
+  }
+  const withLightShade = c.contrast(lightShade);
+  const withDarkShade = c.contrast(darkShade);
+  const matchingShade = (withLightShade >= 4.5 || withLightShade > withDarkShade)
+    ? lightShade
+    : darkShade;
+  cache[cacheKey] = matchingShade;
+  return matchingShade;
 }
 
 export const cssChoiceToken = styled('div', `

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "bullmq": "5.8.7",
     "collect-js-deps": "^0.1.1",
     "color-convert": "2.0.1",
+    "colord": "2.9.3",
     "commander": "9.3.0",
     "components-jqueryui": "1.12.1",
     "connect-redis": "6.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2851,6 +2851,11 @@ color-support@^1.1.2, color-support@^1.1.3:
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
+colord@2.9.3:
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.3.tgz#4f8ce919de456f1d5c1c368c307fe20f3e59fb43"
+  integrity sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==
+
 colorette@^2.0.14:
   version "2.0.19"
   resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz"


### PR DESCRIPTION
## Context

Choice token text or background, when not explicitly overridden by the user, changes depending on light/dark theme.

For now, this can be an issue when a custom background color is set, while text color is not, or vice versa.

For example, a choice with yellow background, and default text color, would look good in light theme, because text is automatically black ; but become unreadable in dark theme, as the yellow would stay, and the text would automatically change to white.

## Proposed solution

The idea is to automatically switch to light or dark text when only the bg is user-defined, depending on the defined bg. To do that, we check contrast ratio of text and bg and change the shades so that the ratio matches WCAG advised value.

And act the same if only the text is user-defined.

:warning: This fix is not ideal for now, because now automatically-improved colors don't rely anymore on the `choiceTokenBg` and `choiceTokenFg` theme variables. I felt like showing this first now was better than trying to do a perfect solution for now, while we discuss if this is a viable solution or not.

## Related issues

Fixes #1155 (at least, a try at it).

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

_Note: don't mind some non-matching colors of same "2/3/dark" names between columns, I just messed up the choice names_

Before this PR, light theme:

![image](https://github.com/user-attachments/assets/55193ae7-55a7-478f-93a0-6a734155b7d4)

Before this PR, dark theme:

![image](https://github.com/user-attachments/assets/7901fa43-30e3-4d7e-a40f-c2cedf79be80)


With this PR, dark theme:

![image](https://github.com/user-attachments/assets/b766692a-f900-4d77-b5eb-91888157f55b)

With this PR, light theme:

![image](https://github.com/user-attachments/assets/dca52b89-0c9e-42d2-8ffe-c0f9e85733f2)

