### PR TITLE
Adds /docs/import endpoint, makes `/workspaces/{wid}/import` support files

### DIFF
--- a/app/gen-server/lib/DocApiForwarder.ts
+++ b/app/gen-server/lib/DocApiForwarder.ts
@@ -80,7 +80,9 @@ export class DocApiForwarder {
     app.use('/api/docs/:docId/timing/stop', withDoc);
     app.use('/api/docs/:docId/forms/:vsId', withDoc);
 
+    app.use('/api/docs/:docId/copy', withoutDoc);
     app.use('^/api/docs$', withoutDoc);
+    app.use('/api/workspaces/:wid/import', withoutDoc);
   }
 
   private async _forwardToDocWorker(


### PR DESCRIPTION
## Context

The current API for copying and uploading Grist documents is `POST /api/docs`. 

However, this method is heavily overloaded, doing all of:
- Copying an existing document
- Uploading a new document from a file
- Creating a new saved document
- Creating a new unsaved document

This makes it tricky to document and use.

## Proposed solution

This PR adds a new endpoint:
- `POST /api/docs/{docId}/copy`

And updates `POST /api/workspaces/{wid}/import` to support file uploads.

These accomplish the equivalent of `POST /api/docs`'s copy and import behaviour, respectively.

## Has this been tested?

- [X] 👍 yes, I added tests to the test suite
