### PR TITLE
Enhance build.sh to allow building using Webpack in dev mode

### DIFF
--- a/buildtools/build.sh
+++ b/buildtools/build.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 
-set -e
+set -eEu -o pipefail
 
 PROJECT=""
+WEBPACK_MODE="--mode production"
+MODE="${1:-}"
 if [[ -e ext/app ]]; then
   PROJECT="tsconfig-ext.json"
   echo "Using extra app directory"
-elif [[ "$1" == "prod" ]]; then
+elif [[ "${MODE}" == "prod" ]]; then
   PROJECT="tsconfig-prod.json"
   echo "Building for production"
 else
+  WEBPACK_MODE="--mode development"
   echo "No extra app directory found"
 fi
 
@@ -24,7 +27,7 @@ set -x
 node buildtools/sanitize_translations.js
 tsc --build $PROJECT
 buildtools/update_type_info.sh app
-webpack --config $WEBPACK_CONFIG --mode production
-webpack --config buildtools/webpack.check.js --mode production
-webpack --config buildtools/webpack.api.config.js --mode production
+webpack --config $WEBPACK_CONFIG $WEBPACK_MODE
+webpack --config buildtools/webpack.check.js $WEBPACK_MODE
+webpack --config buildtools/webpack.api.config.js $WEBPACK_MODE
 cat app/client/*.css app/client/*/*.css > static/bundle.css


### PR DESCRIPTION
## Context

Since fee42ae, `yarn build:prod` is meant to build the app in production mode (slower process) and `yarn build` in dev mode (faster).

But the mode has not been passed to webpack.

## Proposed solution

We either pass `--mode production` or `--mode development` to webpack depending on the arguments passed to the script.

With this commit, building in dev mode takes less than 10s (previously approx. 1 min).

## Related issues

None

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->