### PR TITLE
add "yarn cli sqlite query" utility

### DIFF
--- a/app/server/companion.ts
+++ b/app/server/companion.ts
@@ -266,7 +266,8 @@ export function addSqliteCommand(program: commander.Command) {
 
   sub.command('query <sqlite-file> <query-string>')
     .description('read data from a sqlite file that may contain Grist marshaling')
-    .action((filename, query) => new Gristifier(filename).query(query));
+    .option('--json', 'output as JSON')
+    .action((filename, query, options) => new Gristifier(filename).query(query, options));
 }
 
 export function addVersionCommand(program: commander.Command) {

--- a/app/server/companion.ts
+++ b/app/server/companion.ts
@@ -250,6 +250,7 @@ export function addDbCommand(program: commander.Command,
 // Add command related to sqlite:
 //   sqlite gristify <sqlite-file>
 //   sqlite clean <sqlite-file>
+//   sqlite query <sqlite-file> <query-string>
 export function addSqliteCommand(program: commander.Command) {
   const sub = program.command('sqlite')
     .description('commands for accessing sqlite files');
@@ -262,6 +263,10 @@ export function addSqliteCommand(program: commander.Command) {
   sub.command('clean <sqlite-file>')
     .description('remove grist metadata from an sqlite file')
     .action(filename => new Gristifier(filename).degristify());
+
+  sub.command('query <sqlite-file> <query-string>')
+    .description('read data from a sqlite file that may contain Grist marshaling')
+    .action((filename, query) => new Gristifier(filename).query(query));
 }
 
 export function addVersionCommand(program: commander.Command) {

--- a/app/server/utils/gristify.ts
+++ b/app/server/utils/gristify.ts
@@ -6,7 +6,7 @@ import {makeExceptionalDocSession, OptDocSession} from 'app/server/lib/DocSessio
 import {DocStorage} from 'app/server/lib/DocStorage';
 import {createDummyGristServer} from 'app/server/lib/GristServer';
 import {TrivialDocStorageManager} from 'app/server/lib/IDocStorageManager';
-import {DBMetadata, quoteIdent, SQLiteDB} from 'app/server/lib/SQLiteDB';
+import {DBMetadata, OpenMode, quoteIdent, SQLiteDB} from 'app/server/lib/SQLiteDB';
 
 /**
  * A utility class for modifying a SQLite file to be viewed/edited with Grist.
@@ -96,7 +96,7 @@ export class Gristifier {
    * Remove all Grist metadata tables. Warning: attachments are considered metadata.
    */
   public async degristify() {
-    const db = await SQLiteDB.openDBRaw(this._filename);
+    const db = await SQLiteDB.openDBRaw(this._filename, OpenMode.OPEN_READONLY);
     const tables = await db.all(
       `SELECT name FROM sqlite_master WHERE type='table' ` +
         `  AND name LIKE '_grist%'`

--- a/app/server/utils/gristify.ts
+++ b/app/server/utils/gristify.ts
@@ -126,12 +126,18 @@ export class Gristifier {
    * This will do the same it would from the sqlite3 utility,
    * except BLOBs will be expanded.
    */
-  public async query(queryString: string) {
+  public async query(queryString: string, options: {
+    json?: boolean,
+  }) {
     const db = await SQLiteDB.openDBRaw(this._filename, OpenMode.OPEN_READONLY);
     try {
       const results = await db.all(queryString);
       const decodedResults = results.map(row => DocStorage.decodeRowValues(row));
-      console.log(JSON.stringify(decodedResults, null, 2));
+      if (options.json) {
+        console.log(JSON.stringify(decodedResults, null, 2));
+      } else {
+        console.table(decodedResults);
+      }
     } finally {
       await db.close();
     }

--- a/app/server/utils/gristify.ts
+++ b/app/server/utils/gristify.ts
@@ -96,7 +96,7 @@ export class Gristifier {
    * Remove all Grist metadata tables. Warning: attachments are considered metadata.
    */
   public async degristify() {
-    const db = await SQLiteDB.openDBRaw(this._filename, OpenMode.OPEN_READONLY);
+    const db = await SQLiteDB.openDBRaw(this._filename);
     const tables = await db.all(
       `SELECT name FROM sqlite_master WHERE type='table' ` +
         `  AND name LIKE '_grist%'`
@@ -127,7 +127,7 @@ export class Gristifier {
    * except BLOBs will be expanded.
    */
   public async query(queryString: string) {
-    const db = await SQLiteDB.openDBRaw(this._filename);
+    const db = await SQLiteDB.openDBRaw(this._filename, OpenMode.OPEN_READONLY);
     try {
       const results = await db.all(queryString);
       const decodedResults = results.map(row => DocStorage.decodeRowValues(row));


### PR DESCRIPTION
Add a utility for runing a query on an SQLite file and passing the result through standard Grist decoding for BLOBs. This is handy for reading objects of the wrong type stored as BLOBs to protect them in a "cell", or for reading action history, e.g.

```sh
  yarn --silent cli sqlite query --json doc.grist \
    "select * from _gristsys_ActionHistory order by actionNum"
```

This will return the same content as the query would from the SQLite3 utility, except BLOBs will be expanded.
