### PR TITLE
add a Contributor License Agreement workflow

### DIFF
--- a/.github/cla/individual-cla.md
+++ b/.github/cla/individual-cla.md
@@ -13,6 +13,9 @@ below. This agreement is for your protection as a Contributor as well
 as the protection of Grist and its users. It does not change your
 rights to use your own Contributions for any other purpose.
 
+Contributions entirely composed of commits with authorship at
+`*.gouv.fr` domains fall outside the scope of this agreement.
+
 You accept and agree to the following terms and conditions for Your
 Contributions (present and future) that you submit to Grist. Except
 for the license granted herein to Grist and recipients of software

--- a/.github/cla/individual-cla.md
+++ b/.github/cla/individual-cla.md
@@ -1,6 +1,8 @@
 # Individual Contributor License Agreement ("Agreement"), v1.0
 
-(based on https://www.apache.org/licenses/icla.pdf)
+(Based on https://www.apache.org/licenses/icla.pdf by the Apache
+Foundation. Contact support@getgrist.com if you wish to execute a
+Corporate CLA.)
 
 Thank you for your interest in contributing to software projects made
 available by Grist Labs Inc ("Grist"). To clarify the intellectual

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,29 @@
+# Workflow body from https://github.com/contributor-assistant/github-action
+
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: '.github/cla/signatures.json'
+          path-to-document: 'https://github.com/gristlabs/grist-core/blob/main/.github/cla/individual-cla.md'
+          branch: 'main'
+          allowlist: github-actions[bot],dependabot[bot]


### PR DESCRIPTION
Follow up to https://github.com/gristlabs/grist-core/pull/1546

This adds a workflow to point new contributors to the CLA and check they have accepted it prior to landing PRs. Since the individual CLA agreement refers to executing a Corporate CLA if needed, I added a note on how to execute one.

You can try it out by making a dummy PR to https://github.com/paulfitz/grist-core/
