### PR TITLE
fix: TYPEORM_EXTRA env override by jit=off

### DIFF
--- a/app/server/lib/dbUtils.ts
+++ b/app/server/lib/dbUtils.ts
@@ -167,8 +167,8 @@ export function getTypeORMSettings(overrideConf?: Partial<DataSourceOptions>): D
     "subscribers": [
       `${codeRoot}/app/gen-server/subscriber/*.js`
     ],
-    ...JSON.parse(process.env.TYPEORM_EXTRA || "{}"),
     ...cache,
     ...overrideConf,
+    ...JSON.parse(process.env.TYPEORM_EXTRA || "{}"),
   };
 }


### PR DESCRIPTION
## Context

`server/lib/dbUtils.ts:86:        settings = getTypeORMSettings({ extra: { options: "-c jit=off" } });` 
declaration breaks 
`TYPEORM_EXTRA: '{"ssl": true, "extra": {"ssl": {"rejectUnauthorized": false}}}'` declared as env variable.

In 1.5.0 jit=off breaks any redeclaration of `extra` key in `TYPEORM_EXTRA`

## Proposed solution

Our point of view is that selfhoster env overriding must always have the final word.
It's selfhoster responsability to keep `jit=off` if he overrides that variable.
This PR takes this point of view.

Another approach can be to merge this part of conf if extra is declared twice (by env and by app internal logic).

Depending on of what approach will remain, a modification of README.md `TYPEORM_EXTRA` description can be a great idea.

## Related issues

none

## Has this been tested?

- [X] 👍 yes, Locally with a self signed pgsql docker conatiner

