### PR TITLE
make "yarn cli" command available as "docker run ... cli" for non-devs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,6 +128,7 @@ COPY --from=builder /node_modules /node_modules
 COPY --from=builder /grist/node_modules_prod /grist/node_modules
 COPY --from=builder /grist/_build /grist/_build
 COPY --from=builder /grist/static /grist/static-built
+COPY --from=builder /grist/app/cli.sh /grist/cli
 
 # Copy python2 files.
 COPY --from=collector-py2 /usr/bin/python2.7 /usr/bin/python2.7
@@ -216,6 +217,16 @@ ENV \
   TYPEORM_DATABASE=/persist/home.sqlite3
 
 EXPOSE 8484
+
+# When run without any arguments, we run the Grist server within
+# a simple supervisor.
+# When arguments are supplied they are treated as a command to run,
+# as is default for docker. We arrange to have a "cli" command that
+# is the same as "yarn cli" run from the source code repo.
+# So you can do things like:
+# docker run --rm -v $PWD:$PWD -it gristlabs/grist \
+#   cli sqlite query $PWD/docs/4gtUhAEGbGAdsGNc52k4H6.grist \
+#  "select * from _grist_Tables"
 
 ENTRYPOINT ["./sandbox/docker_entrypoint.sh"]
 CMD ["node", "./sandbox/supervisor.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -226,7 +226,7 @@ EXPOSE 8484
 # So you can do things like:
 # docker run --rm -v $PWD:$PWD -it gristlabs/grist \
 #   cli sqlite query $PWD/docs/4gtUhAEGbGAdsGNc52k4H6.grist \
-#  "select * from _grist_Tables"
+#  --json "select * from _gristsys_ActionHistory"
 
 ENTRYPOINT ["./sandbox/docker_entrypoint.sh"]
 CMD ["node", "./sandbox/supervisor.mjs"]

--- a/app/cli.sh
+++ b/app/cli.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+NODE_PATH=_build:_build/stubs:_build/ext node _build/app/server/companion.js "$@"

--- a/app/server/companion.ts
+++ b/app/server/companion.ts
@@ -40,8 +40,7 @@ if (require.main === module) {
 export function getProgram(): commander.Command {
   const program = commander.program;
   program
-    .name('grist-toolbox')    // haven't really settled on a name yet.
-                              // want to reserve "grist" for electron app?
+    .name('grist-cli')
     .description('a toolbox of handy Grist-related utilities');
 
   addAuditLogsCommand(program, {nested: true});

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:smoke": "./test/test_env.sh mocha _build/test/nbrowser/Smoke.js",
     "test:docker": "./test/test_under_docker.sh",
     "test:python": "sandbox_venv3/bin/python sandbox/grist/runtests.py ${GREP_TESTS:+discover -p \"test*${GREP_TESTS}*.py\"}",
-    "cli": "NODE_PATH=_build:_build/stubs:_build/ext node _build/app/server/companion.js",
+    "cli": "./app/cli.sh",
     "lint": "eslint --cache --cache-strategy content .",
     "lint:fix": "eslint  --cache --cache-strategy=content --fix .",
     "lint:ci": "eslint --max-warnings=0 .",

--- a/sandbox/docker_entrypoint.sh
+++ b/sandbox/docker_entrypoint.sh
@@ -27,22 +27,23 @@ if [[ $current_user_id == 0 ]]; then
   exec setpriv --reuid "$target_user" --regid "$target_group" --init-groups /usr/bin/env bash "$0" "$@"
 fi
 
-# Printing the user helps with setting volume permissions.
-echo "Running Grist as user $(id -u) with primary group $(id -g)"
-
 # Validate that this user has access to the top level of each important directory.
 # There might be a benefit to testing individual files, but this is simpler as the dir may start empty.
 for dir in "${important_read_dirs[@]}"; do
   if ! { test -r "$dir" ;} ; then
+    echo "Running Grist as user $(id -u) with primary group $(id -g)"
     echo "Invalid permissions, cannot read '$dir'. Aborting." >&2
     exit 1
   fi
 done
 for dir in "${important_write_dirs[@]}"; do
   if ! { test -r "$dir" && test -w "$dir" ;} ; then
+    echo "Running Grist as user $(id -u) with primary group $(id -g)"
     echo "Invalid permissions, cannot write '$dir'. Aborting." >&2
     exit 1
   fi
 done
 
+# Allow running commands in the current directory, specifically "cli".
+export PATH=$PWD:$PATH
 exec /usr/bin/tini -s -- "$@"

--- a/sandbox/supervisor.mjs
+++ b/sandbox/supervisor.mjs
@@ -3,6 +3,12 @@ import {spawn} from 'child_process';
 let grist;
 
 function startGrist(newConfig={}) {
+  // Printing the user helps with setting volume permissions if
+  // using a container.
+  const uid = process.getuid();
+  const gid = process.getgid();
+  console.log(`Running Grist as user ${uid} with primary group ${gid}`);
+
   // H/T https://stackoverflow.com/a/36995148/11352427
   grist = spawn('./sandbox/run.sh', {
     stdio: ['inherit', 'inherit', 'inherit', 'ipc'],


### PR DESCRIPTION
There is a utility called "yarn cli" available if you have built Grist yourself and have developer tools installed. It isn't a particularly well thought out or carefully planned utility, but it comes in handy, so this change makes it available via docker, so people comfortable with containers but not building from source code can use it. Example of use to dump the history of actions embedded in a document:

```sh
docker run --rm -v $PWD:$PWD -it gristlabs/grist \
   cli sqlite query $PWD/docs/4gtUhAEGbGAdsGNc52k4H6.grist \
  --json "select * from _gristsys_ActionHistory"
```

For help:

```sh
docker run --rm -v $PWD:$PWD -it gristlabs/grist cli -h
```
