### PR TITLE
Improves behaviour for erroring archive downloads

### DIFF
--- a/app/server/lib/Archive.ts
+++ b/app/server/lib/Archive.ts
@@ -25,10 +25,8 @@ export interface Archive {
   fileExtension: string;
   /**
    * Starts packing files into the archive.
-   * This will block indefinitely if dataStream is never read from.
+   * This will block indefinitely if the data stream is never read from.
    * This resolves when all files are processed, or an error occurs.
-   * This will not close the destination stream. This is to allow the caller to decide how to handle
-   * error situations.
    * @returns {Promise<void>}
    */
   packInto: (destination: stream.Writable, options?: ArchivePackingOptions) => Promise<void>;

--- a/app/server/lib/Archive.ts
+++ b/app/server/lib/Archive.ts
@@ -11,6 +11,15 @@ export interface ArchiveEntry {
   data: stream.Readable | Buffer;
 }
 
+export interface ArchivePackingOptions {
+  // Whether the destination stream should be closed once the archive has been written.
+  endDestStream: boolean;
+}
+
+const defaultPackingOptions: ArchivePackingOptions = {
+  endDestStream: true,
+};
+
 export interface Archive {
   mimeType: string;
   fileExtension: string;
@@ -22,7 +31,7 @@ export interface Archive {
    * error situations.
    * @returns {Promise<void>}
    */
-  packInto: (destination: stream.Writable) => Promise<void>;
+  packInto: (destination: stream.Writable, options?: ArchivePackingOptions) => Promise<void>;
 }
 
 export const CreatableArchiveFormats = StringUnion('zip', 'tar');
@@ -33,20 +42,22 @@ export type CreatableArchiveFormats = typeof CreatableArchiveFormats.type;
  * Creates a streamable zip archive, reading files on-demand from the entries iterator.
  * Entries are provided as an async iterable, to ensure the archive is constructed
  * correctly. A generator can be used for convenience.
- * @param {ZipStreamOptions} options - Settings for the zip archive
+ * @param {ZipStreamOptions} zipOptions - Settings for the zip archive
  * @param {AsyncIterable<ArchiveEntry>} entries - Entries to add.
  * @returns {Archive}
  */
-export async function create_zip_archive(
-  options: ZipStreamOptions, entries: AsyncIterable<ArchiveEntry>
-): Promise<Archive> {
-  const archive = new ZipStream(options);
-
+export function create_zip_archive(
+  zipOptions: ZipStreamOptions, entries: AsyncIterable<ArchiveEntry>
+): Archive {
   return {
     mimeType: "application/zip",
     fileExtension: "zip",
-    async packInto(destination: stream.Writable) {
+    async packInto(destination: stream.Writable, options: ArchivePackingOptions = defaultPackingOptions) {
+      const archive = new ZipStream(zipOptions);
+      let pipeline: Promise<void> | undefined;
       try {
+        // `as any` cast required with @types/node 18.X due to the `end` parameter missing from the type declaration.
+        pipeline = stream.promises.pipeline(archive, destination, { end: options.endDestStream } as any);
         for await (const entry of entries) {
           // ZipStream will break if multiple entries try to be added at the same time.
           await addEntryToZipArchive(archive, entry);
@@ -57,7 +68,7 @@ export async function create_zip_archive(
       } finally {
         // This ensures any errors in the stream (e.g. from destroying it above) are handled.
         // Without this, node will see the stream as having an uncaught error, and complain or crash.
-        await stream.promises.finished(archive);
+        await pipeline;
       }
     }
   };
@@ -82,22 +93,22 @@ function addEntryToZipArchive(archive: ZipStream, file: ArchiveEntry): Promise<Z
  * @param {AsyncIterable<ArchiveEntry>} entries - Entries to add.
  * @returns {Archive}
  */
-export async function create_tar_archive(
+export function create_tar_archive(
   entries: AsyncIterable<ArchiveEntry>
-): Promise<Archive> {
+): Archive {
   return {
     mimeType: "application/x-tar",
     fileExtension: "tar",
-    async packInto(destination: stream.Writable) {
+    async packInto(destination: stream.Writable, options: ArchivePackingOptions = defaultPackingOptions) {
       const archive = tar.pack();
       const passthrough = new stream.PassThrough();
-      let pipeline: Promise<void> | undefined = undefined;
+      let pipeline: Promise<void> | undefined;
       try {
         // 'end' prevents `destination` being closed when completed, or if an error occurs in archive.
-        // This is necessary to allow for partial/failed downloads (see DocAPI archive for more details).
         // Passthrough stream is needed as the tar-stream library doesn't implement the 'end' parameter,
         // piping to the passthrough stream fixes this and prevents `destination` being closed.
-        pipeline = stream.promises.pipeline(archive, passthrough, destination, { end: false } as any);
+        // Cast is required due to a bug with @types/node 18.X missing the parameter
+        pipeline = stream.promises.pipeline(archive, passthrough, destination, { end: options.endDestStream } as any);
         for await (const entry of entries) {
           const entryStream = archive.entry({ name: entry.name, size: entry.size });
           await stream.promises.pipeline(entry.data, entryStream);

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -616,6 +616,7 @@ export class DocWorkerApi {
         await stream.promises.pipeline(stream.Readable.from("Internal server error"), res, { end: false } as any);
         res.destroy(err);
       }
+      res.end();
     }));
 
     this._app.post('/api/docs/:docId/attachments/archive', isOwner, withDoc(async (activeDoc, req, res) => {

--- a/test/server/lib/ActiveDoc.ts
+++ b/test/server/lib/ActiveDoc.ts
@@ -1221,7 +1221,7 @@ describe('ActiveDoc', async function() {
       for (const archiveType of CreatableArchiveFormats.values) {
         const archive = await activeDoc1.getAttachmentsArchive(fakeTransferSession, archiveType);
         const archiveMemoryStream = new MemoryWritableStream();
-        await stream.promises.pipeline(archive.dataStream, archiveMemoryStream);
+        await archive.packInto(archiveMemoryStream);
 
         await assertArchiveContents(archiveMemoryStream.getBuffer(), archiveType, testAttachments);
       }
@@ -1240,7 +1240,7 @@ describe('ActiveDoc', async function() {
 
       const attachmentsArchive = await activeDoc.getAttachmentsArchive(fakeSession, "tar");
       const attachmentsTarStream = new MemoryWritableStream();
-      await stream.promises.pipeline(attachmentsArchive.dataStream, attachmentsTarStream);
+      await attachmentsArchive.packInto(attachmentsTarStream);
       const attachmentsTar = attachmentsTarStream.getBuffer();
 
       const store = (await provider.getStore(storeId))!;

--- a/test/server/lib/Archive.ts
+++ b/test/server/lib/Archive.ts
@@ -1,6 +1,6 @@
 import {
   Archive,
-  ArchiveEntry,
+  ArchiveEntry, ArchivePackingOptions,
   create_tar_archive,
   create_zip_archive
 } from 'app/server/lib/Archive';
@@ -31,16 +31,6 @@ async function* generateTestArchiveContents() {
   }
 }
 
-async function assertArchiveCompletedSuccessfully(archive: Archive) {
-  await assert.isFulfilled(archive.completed);
-  assert.isTrue(archive.dataStream.destroyed, "archive data stream was not finished");
-}
-
-async function assertArchiveFailedWithError(archive: Archive) {
-  await assert.isRejected(archive.completed);
-  assert.isTrue(archive.dataStream.destroyed, "archive data stream was not finished");
-}
-
 async function assertArchiveContainsTestFiles(archiveData: Buffer) {
   const files = await decompress(archiveData);
   assert.equal(files.length, testFiles.length);
@@ -52,17 +42,14 @@ async function assertArchiveContainsTestFiles(archiveData: Buffer) {
   }
 }
 
-type ArchiveCreator = (entries: AsyncIterable<ArchiveEntry>) => Promise<Archive>;
+type ArchiveCreator = (entries: AsyncIterable<ArchiveEntry>, options?: ArchivePackingOptions) => Archive;
 
 function testArchive(type: string, makeArchive: ArchiveCreator) {
   it(`should create a ${type} archive`, async function () {
-    const archive = await makeArchive(generateTestArchiveContents());
+    const archive = makeArchive(generateTestArchiveContents());
     const output = new MemoryWritableStream();
-    archive.dataStream.pipe(output);
-    await assertArchiveCompletedSuccessfully(archive);
-
+    await archive.packInto(output);
     const archiveData = output.getBuffer();
-
     await assertArchiveContainsTestFiles(archiveData);
   });
 
@@ -73,9 +60,32 @@ function testArchive(type: string, makeArchive: ArchiveCreator) {
     }
 
     // Shouldn't error here - as this just starts the packing.
-    const archive = await makeArchive(throwErrorGenerator());
-    await assert.isRejected(archive.completed, "Test error");
-    await assertArchiveFailedWithError(archive);
+    const output = new MemoryWritableStream();
+    const archive = makeArchive(throwErrorGenerator());
+    await assert.isRejected(archive.packInto(output), "Test error");
+  });
+
+  it('respects the "endDestStream" option', async function () {
+    async function* throwErrorGenerator() {
+      throw new Error("Test error");
+      yield {name: 'Test', size: 0, data: Buffer.from([])};
+    }
+
+    const test = async (archive: Archive, end: boolean, name: string) => {
+      const output = new MemoryWritableStream();
+      try {
+        await archive.packInto(output, { endDestStream: end });
+      } catch(err) {
+        // Do nothing, don't care about this error.
+      } finally {
+        assert.equal(output.closed, end, `expected ${name} to be ${ end ? "closed" : "open" }`);
+      }
+    };
+
+    await test(makeArchive(generateTestArchiveContents()), false, "successful archive");
+    await test(makeArchive(generateTestArchiveContents()), true, "successful archive");
+    await test(makeArchive(throwErrorGenerator()), false, "erroring archive");
+    await test(makeArchive(throwErrorGenerator()), true, "erroring archive");
   });
 }
 

--- a/test/server/lib/Archive.ts
+++ b/test/server/lib/Archive.ts
@@ -1,6 +1,7 @@
 import {
   Archive,
-  ArchiveEntry, ArchivePackingOptions,
+  ArchiveEntry,
+  ArchivePackingOptions,
   create_tar_archive,
   create_zip_archive
 } from 'app/server/lib/Archive';


### PR DESCRIPTION
## Context

Currently if an error occurs during archive generation, the zip/tar libraries will cause the `Response` stream to be destroyed. 

For a user, this often results in a new tab opening with a "Connection was reset" message. This happens when the connection resets before the HTTP headers have been sent to the client. 

In Express, headers are typically sent to the client only when data starts to be written to the stream. This means this scenario can occur whenever the archiving code errors before it outputs any data (e.g. an error in generator function).

There are potentially other error cases where streams can error before handlers are installed, that risk crashing the node process. However, this didn't seem to occur in any real-world scenarios I tested (only when artificially forced via code changes). 

### Why can't we send a 500 error?

Since we're streaming, unexpected errors can occur mid-way through producing the body. At that point, the headers have already been sent and it's locked to a 200 status code. The only option for sensible error handling is to force a connection reset.

### Why can't we cause an integrity failure?

We don't know the size or hash of the archive ahead of time, which means it can't be bundled in the HTTP headers. Nor can it be sent as a [request trailer](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Trailer) because apparently browsers don't actually do anything with them, and we've got no clientside code that can verify the archive.

## Proposed solution

This:
* Restructures the archiving code to handle the errors from any of the streams involved.
* Adds an option to prevent archives from closing their destination stream, allowing the API an opportunity to correct issues.
* Adds an error handler to the /archive endpoint that ensures headers are pushed in any error scenario.

The result is that browsers show "Download failed" instead of opening a new tab with an error message that would be cryptic to most people.

## Has this been tested?

- [X] 👍 yes, I added tests to the test suite

## Screenshots / Screencasts

![image](https://github.com/user-attachments/assets/901fa70b-ef50-4700-a3de-d7f547d9652d)
