### PR TITLE
Showing warning toast message when exporting from settings pages

### DIFF
--- a/app/client/models/NotifyModel.ts
+++ b/app/client/models/NotifyModel.ts
@@ -56,6 +56,8 @@ export type MessageType = string | (() => DomElementArg);
 // Identifies supported actions. These are implemented in NotifyUI.
 export type NotifyAction = 'upgrade' | 'renew' | 'personal' | 'report-problem'
                            | 'ask-for-help' | 'manage' | CustomAction;
+export type NotificationLevel = 'message' | 'info' | 'success' | 'warning' | 'error';
+
 export interface INotifyOptions {
   message: MessageType;     // A string, or a function that builds dom.
   timestamp?: number;
@@ -65,7 +67,7 @@ export interface INotifyOptions {
   inDropdown?: boolean;
   expireSec?: number;
   badgeCounter?: boolean;
-  level: 'message' | 'info' | 'success' | 'warning' | 'error';
+  level: NotificationLevel;
 
   memos?: string[];  // A list of relevant notes.
 

--- a/app/client/models/errors.ts
+++ b/app/client/models/errors.ts
@@ -1,6 +1,6 @@
 import {get as getBrowserGlobals} from 'app/client/lib/browserGlobals';
 import * as log from 'app/client/lib/log';
-import {INotification, INotifyOptions, MessageType, NotificationLevel, Notifier} from 'app/client/models/NotifyModel';
+import {INotification, INotifyOptions, MessageType, Notifier} from 'app/client/models/NotifyModel';
 import {ErrorTooltips} from 'app/client/ui/GristTooltips';
 import {ApiErrorDetails} from 'app/common/ApiError';
 import {fetchFromHome, pageHasHome} from 'app/common/urlUtils';
@@ -23,11 +23,9 @@ export class MutedError extends Error {
 export class UserError extends Error {
   public name: string = "UserError";
   public key?: string;
-  public level?: NotificationLevel;
-  constructor(message: string, options: {key?: string, level?: NotificationLevel} = {}) {
+  constructor(message: string, options: {key?: string} = {}) {
     super(message);
     this.key = options.key;
-    this.level = options.level;
   }
 }
 
@@ -165,10 +163,7 @@ export function reportError(err: Error|string, ev?: ErrorEvent): void {
       // This is explicitly a user error, or one in the "Client Error" range, so treat it as user
       // error rather than a bug. Using message as the key causes same-message notifications to
       // replace previous ones rather than accumulate.
-      const options: Partial<INotifyOptions> = {
-        key: (err as UserError).key || message,
-        level: (err as UserError).level
-      };
+      const options: Partial<INotifyOptions> = {key: (err as UserError).key || message};
       if (details && details.tips && details.tips.some(tip => tip.action === 'ask-for-help')) {
         options.actions = ['ask-for-help'];
       }

--- a/app/client/models/errors.ts
+++ b/app/client/models/errors.ts
@@ -1,6 +1,6 @@
 import {get as getBrowserGlobals} from 'app/client/lib/browserGlobals';
 import * as log from 'app/client/lib/log';
-import {INotification, INotifyOptions, MessageType, Notifier} from 'app/client/models/NotifyModel';
+import {INotification, INotifyOptions, MessageType, NotificationLevel, Notifier} from 'app/client/models/NotifyModel';
 import {ErrorTooltips} from 'app/client/ui/GristTooltips';
 import {ApiErrorDetails} from 'app/common/ApiError';
 import {fetchFromHome, pageHasHome} from 'app/common/urlUtils';
@@ -23,9 +23,11 @@ export class MutedError extends Error {
 export class UserError extends Error {
   public name: string = "UserError";
   public key?: string;
-  constructor(message: string, options: {key?: string} = {}) {
+  public level?: NotificationLevel;
+  constructor(message: string, options: {key?: string, level?: NotificationLevel} = {}) {
     super(message);
     this.key = options.key;
+    this.level = options.level;
   }
 }
 
@@ -163,7 +165,10 @@ export function reportError(err: Error|string, ev?: ErrorEvent): void {
       // This is explicitly a user error, or one in the "Client Error" range, so treat it as user
       // error rather than a bug. Using message as the key causes same-message notifications to
       // replace previous ones rather than accumulate.
-      const options: Partial<INotifyOptions> = {key: (err as UserError).key || message};
+      const options: Partial<INotifyOptions> = {
+        key: (err as UserError).key || message,
+        level: (err as UserError).level
+      };
       if (details && details.tips && details.tips.some(tip => tip.action === 'ask-for-help')) {
         options.actions = ['ask-for-help'];
       }

--- a/app/client/ui/ShareMenu.ts
+++ b/app/client/ui/ShareMenu.ts
@@ -287,7 +287,7 @@ function menuExports(doc: Document, pageModel: DocPageModel) {
       e.preventDefault();
       // Show warning.
       setTimeout(() => reportError(new UserError(
-        t("Exporting is only available from data pages. Please select a data page and try again."),
+        t("Exporting is only available from document pages. Please select a document page and try again."),
         {
           key: 'exporting-not-available',
           level: 'warning'

--- a/app/client/ui/ShareMenu.ts
+++ b/app/client/ui/ShareMenu.ts
@@ -3,7 +3,7 @@ import {loadUserManager} from 'app/client/lib/imports';
 import {makeT} from 'app/client/lib/localization';
 import {AppModel, reportError} from 'app/client/models/AppModel';
 import {DocInfo, DocPageModel} from 'app/client/models/DocPageModel';
-import {reportWarning, UserError} from 'app/client/models/errors';
+import {reportWarning} from 'app/client/models/errors';
 import {docUrl, getLoginOrSignupUrl, urlState} from 'app/client/models/gristUrlState';
 import {downloadDocModal, makeCopy, replaceTrunkWithFork} from 'app/client/ui/MakeCopyMenu';
 import {sendToDrive} from 'app/client/ui/sendToDrive';

--- a/app/client/ui/ShareMenu.ts
+++ b/app/client/ui/ShareMenu.ts
@@ -3,7 +3,7 @@ import {loadUserManager} from 'app/client/lib/imports';
 import {makeT} from 'app/client/lib/localization';
 import {AppModel, reportError} from 'app/client/models/AppModel';
 import {DocInfo, DocPageModel} from 'app/client/models/DocPageModel';
-import {UserError} from 'app/client/models/errors';
+import {reportWarning, UserError} from 'app/client/models/errors';
 import {docUrl, getLoginOrSignupUrl, urlState} from 'app/client/models/gristUrlState';
 import {downloadDocModal, makeCopy, replaceTrunkWithFork} from 'app/client/ui/MakeCopyMenu';
 import {sendToDrive} from 'app/client/ui/sendToDrive';
@@ -286,13 +286,12 @@ function menuExports(doc: Document, pageModel: DocPageModel) {
       // Disable navigation.
       e.preventDefault();
       // Show warning.
-      setTimeout(() => reportError(new UserError(
+      setTimeout(() => reportWarning(
         t("Exporting is only available from document pages. Please select a document page and try again."),
         {
           key: 'exporting-not-available',
-          level: 'warning'
         },
-      )), 0);
+      ));
     }
   });
 


### PR DESCRIPTION
Summary:
Export as option works only when user is on a data page. Showing a warning toast for any other pages when user clicks one of this option.

Alternative solutions like removing this option or disabling it were rejected.

Test Plan: Manual
