### PR TITLE
onRecord: add an `expandRefs` boolean option

### DIFF
--- a/app/client/components/WidgetFrame.ts
+++ b/app/client/components/WidgetFrame.ts
@@ -457,9 +457,11 @@ export class GristViewImpl implements GristView {
     const columns: ColumnRec[] = this._visibleColumns(options);
     const rowIds = this._baseView.sortedRows.getKoArray().peek().filter(id => id != 'new');
     const data: BulkColValues = {};
+    const expandRefs = options.expandRefs !== false;
     for (const column of columns) {
-      // Use the colId of the displayCol, which may be different in case of Reference columns.
-      const colId: string = column.displayColModel.peek().colId.peek();
+      // Use the colId of the displayCol when expanding references, so
+      // we don't get the underlying refId instead.
+      const colId: string = expandRefs ? column.displayColModel.peek().colId.peek() : column.colId.peek();
       const getter = this._baseView.tableModel.tableData.getRowPropFunc(colId)!;
       const typeInfo = extractInfoFromColType(column.type.peek());
       data[column.colId.peek()] = rowIds.map(r => reencodeAsAny(getter(r)!, typeInfo));
@@ -476,9 +478,10 @@ export class GristViewImpl implements GristView {
     // information here.
     const columns: ColumnRec[] = this._visibleColumns(options);
     const data: RowRecord = {id: rowId};
+    const expandRefs = options.expandRefs !== false;
     for (const column of columns) {
-      const colId: string = column.displayColModel.peek().colId.peek();
       const typeInfo = extractInfoFromColType(column.type.peek());
+      const colId: string = expandRefs ? column.displayColModel.peek().colId.peek() : column.colId.peek();
       data[column.colId.peek()] = reencodeAsAny(
         this._baseView.tableModel.tableData.getValue(rowId, colId)!,
         typeInfo

--- a/app/plugin/GristAPI-ti.ts
+++ b/app/plugin/GristAPI-ti.ts
@@ -35,6 +35,7 @@ export const FetchSelectedOptions = t.iface([], {
   "keepEncoded": t.opt("boolean"),
   "format": t.opt(t.union(t.lit('rows'), t.lit('columns'))),
   "includeColumns": t.opt(t.union(t.lit('shown'), t.lit('normal'), t.lit('all'))),
+  "expandRefs": t.opt("boolean"),
 });
 
 export const GristView = t.iface([], {

--- a/app/plugin/GristAPI.ts
+++ b/app/plugin/GristAPI.ts
@@ -171,6 +171,13 @@ export interface FetchSelectedOptions {
    * - `all`: also return special invisible columns like `manualSort` and display helper columns.
    */
   includeColumns?: 'shown' | 'normal' | 'all';
+
+  /**
+   *
+   * - `true` (default): the returned data will show the contents of references, not their rowIds
+   * - `false`: the returned data will only display rowIds for references
+   */
+  expandRefs?: boolean
 }
 
 /**

--- a/test/fixtures/sites/types-raw-refs/index.html
+++ b/test/fixtures/sites/types-raw-refs/index.html
@@ -1,0 +1,16 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="/grist-plugin-api.js"></script>
+    <script src="page.js"></script>
+  </head>
+  <body>
+    <h1>Types</h1>
+    <div>
+      onRecord() matches a record in table?
+      <div id="match"></div>
+    </div>
+    <h2>record</h2>
+    <div id="record"></div>
+  </body>
+</html>

--- a/test/fixtures/sites/types-raw-refs/page.js
+++ b/test/fixtures/sites/types-raw-refs/page.js
@@ -1,0 +1,19 @@
+/* global document, grist, window */
+
+function setup() {
+  let lastRecords = [];
+  grist.ready();
+  grist.onRecords(function(records) { lastRecords = records; });
+  grist.onRecord(function(rec) {
+    document.getElementById('record').innerHTML = JSON.stringify(rec);
+
+    // Check that there is an identical object in lastRecords, to ensure that onRecords() returns
+    // the same kind of representation.
+    const rowInRecords = lastRecords.find(r => (r.id === rec.id));
+    const match = JSON.stringify(rowInRecords) === JSON.stringify(rec);
+    document.getElementById('match').textContent = JSON.stringify(match);
+
+  }, {expandRefs: false});
+}
+
+window.onload = setup;


### PR DESCRIPTION
This is named after the similar `expand_refs` kwarg of the `RECORD` function. By default and for backwards compatibility, `expandRefs` is `true`. It can be set to `false` to return the reference IDs themselves instead of the dereferenced values.

Note that for a single column of type `Reference`, this returns an object such as

```
  {
    tableId: 'TheReferencedTable',
    rowId: 2
  }
```

whereas for a `ReferenceList` column, it returns a list of IDs such as `[1, 2, 3]`.

## Context

Fixes: #1430 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
