### PR TITLE
VersionUpdateBanner: new component

### DIFF
--- a/app/client/components/CoreBanners.ts
+++ b/app/client/components/CoreBanners.ts
@@ -1,10 +1,12 @@
 import {AppModel} from 'app/client/models/AppModel';
 import {DocPageModel} from 'app/client/models/DocPageModel';
+import {VersionUpdateBanner} from 'app/client/components/VersionUpdateBanner';
+import {dom} from 'grainjs';
 
-export function buildHomeBanners(_app: AppModel) {
-  return null;
+export function buildHomeBanners(app: AppModel) {
+  return dom.create(VersionUpdateBanner, app);
 }
 
-export function buildDocumentBanners(_docPageModel: DocPageModel) {
-  return null;
+export function buildDocumentBanners(docPageModel: DocPageModel) {
+  return dom.create(VersionUpdateBanner, docPageModel.appModel);
 }

--- a/app/client/components/VersionUpdateBanner.ts
+++ b/app/client/components/VersionUpdateBanner.ts
@@ -1,0 +1,69 @@
+import {Banner, buildBannerMessage} from 'app/client/components/Banner';
+import {makeT} from 'app/client/lib/localization';
+import {localStorageJsonObs} from 'app/client/lib/localStorageObs';
+import {getGristConfig} from 'app/common/urlUtils';
+import {Disposable, dom, makeTestId, Observable} from 'grainjs';
+import {AppModel} from 'app/client/models/AppModel';
+
+const t = makeT("VersionUpdateBanner");
+const testId = makeTestId('test-version-update-banner-');
+
+interface ShowVersionUpdateBannerPrefer {
+  dismissed: boolean,
+  version?: string,
+}
+
+export class VersionUpdateBanner extends Disposable {
+  // Session storage observable. Set to false to dismiss the banner for the session.
+  private _showVersionUpdateBannerPref: Observable<ShowVersionUpdateBannerPrefer>;
+
+  constructor(private _appModel: AppModel) {
+    super();
+    const userId = this._appModel.currentUser?.id ?? 0;
+    const {latestVersionAvailable} = getGristConfig();
+
+    this._showVersionUpdateBannerPref = localStorageJsonObs(
+      `u=${userId}:showVersionUpdateBanner`,
+      {
+        dismissed: false,
+        version: latestVersionAvailable?.version
+      }
+    );
+  }
+
+  public buildDom() {
+    return dom.maybe(this._appModel.isInstallAdmin(), () => {
+      return dom.domComputed(use => {
+        const {latestVersionAvailable} = getGristConfig();
+        if(!latestVersionAvailable?.isNewer) {
+          return null;
+        }
+
+        const bannerPref = use(this._showVersionUpdateBannerPref);
+        // Need to check that *this* specific version has already been
+        // dismissed.
+        //
+        // Although we only store one version as being dismissed at a
+        // time, that should be okay. Conceptually, there is only one
+        // "latest" version at a time that needs to be dismissed.
+        if (bannerPref.version === latestVersionAvailable.version && bannerPref.dismissed) {
+          return null;
+        }
+
+        return dom.create(Banner, {
+          content: buildBannerMessage(
+            t(`Your Grist version is outdated. ` +
+              `Consider upgrading to version ${latestVersionAvailable.version} as soon as possible.`),
+            testId('text')
+          ),
+          style: 'warning',
+          showCloseButton: true,
+          onClose: () => this._showVersionUpdateBannerPref.set({
+            dismissed: true,
+            version: latestVersionAvailable.version,
+          }),
+        });
+      });
+    });
+  }
+}

--- a/app/client/ui/PagePanels.ts
+++ b/app/client/ui/PagePanels.ts
@@ -115,7 +115,7 @@ export function pagePanels(page: PageContents) {
     dom.autoDispose(sub2),
     dom.autoDispose(commandsGroup),
     dom.autoDispose(leftOverlap),
-    dom('div', page.contentTop, elem => { contentTopDom = elem; }),
+    dom('div', testId('top-panel'), page.contentTop, elem => { contentTopDom = elem; }),
     dom.maybe(page.banner, () => {
       let elem: HTMLElement;
       const updateTop = () => {

--- a/app/gen-server/lib/Housekeeper.ts
+++ b/app/gen-server/lib/Housekeeper.ts
@@ -2,6 +2,7 @@ import { ApiError } from 'app/common/ApiError';
 import { delay } from 'app/common/delay';
 import { buildUrlId } from 'app/common/gristUrls';
 import { normalizedDateTimeString } from 'app/common/normalizedDateTimeString';
+import { isAffirmative } from "app/common/gutil";
 import { Document } from 'app/gen-server/entity/Document';
 import { Organization } from 'app/gen-server/entity/Organization';
 import { Workspace } from 'app/gen-server/entity/Workspace';
@@ -79,7 +80,7 @@ export class Housekeeper {
     }, Timings.LOG_METRICS_PERIOD_MS);
     this._checkVersionUpdatesTimeout = setTimeout(() => {
       this.checkVersionUpdates().catch(log.warn.bind(log));
-    }, Timings.VERSION_CHECK_OFFSET_MS);
+    }, isAffirmative(process.env.GRIST_TEST_IMMEDIATE_VERSION_CHECK) ? 0 : Timings.VERSION_CHECK_OFFSET_MS);
     this._checkVersionUpdatesInterval = setInterval(() => {
       this.checkVersionUpdatesExclusively().catch(log.warn.bind(log));
     }, Timings.VERSION_CHECK_PERIOD_MS);

--- a/test/nbrowser/VersionUpdateBanner.ts
+++ b/test/nbrowser/VersionUpdateBanner.ts
@@ -1,0 +1,86 @@
+import { version as installedVersion } from "app/common/version";
+import * as testUtils from 'test/server/testUtils';
+import * as gu from 'test/nbrowser/gristUtils';
+import {server, setupTestSuite} from 'test/nbrowser/testUtils';
+import {FakeUpdateServer, startFakeUpdateServer} from 'test/server/customUtil';
+import {assert, driver} from 'mocha-webdriver';
+
+describe('VersionUpdateBanner', function() {
+  this.timeout(300000);
+  setupTestSuite();
+
+  let oldEnv: testUtils.EnvironmentSnapshot;
+  let session: gu.Session;
+  let fakeServer: FakeUpdateServer;
+
+  afterEach(() => gu.checkForErrors());
+
+  before(async function() {
+    oldEnv = new testUtils.EnvironmentSnapshot();
+    process.env.GRIST_ALLOW_AUTOMATIC_VERSION_CHECKING = 'true';
+    process.env.GRIST_TEST_IMMEDIATE_VERSION_CHECK = 'true';
+    process.env.GRIST_DEFAULT_EMAIL = gu.session().email;
+    fakeServer = await startFakeUpdateServer();
+    process.env.GRIST_TEST_VERSION_CHECK_URL = `${fakeServer.url()}/version`;
+
+  });
+
+  beforeEach(async function() {
+    fakeServer.payload = null;
+    await server.restart();
+    assert.isNotNull(fakeServer.payload, 'fake server should have received a version payload');
+  });
+
+  after(async function() {
+    await fakeServer.close();
+    oldEnv.restore();
+    await server.restart();
+  });
+
+  it('should not be shown to non-managers', async () => {
+    session = await gu.session().user('user2').personalSite.login({freshAccount: true});
+    await driver.executeScript('window.localStorage.clear();');
+    await session.loadDocMenu('/');
+
+    await driver.findWait('.test-top-panel', 100);
+    assert.equal((await driver.findAll('.test-version-update-banner-text')).length, 0);
+  });
+
+  it('should be shown to managers', async () => {
+    session = await gu.session().personalSite.login({freshAccount: true});
+    await driver.executeScript('window.localStorage.clear();');
+    await session.loadDocMenu('/');
+
+    await driver.findWait('.test-top-panel', 100);
+    assert.equal(await driver.find('.test-version-update-banner-text').isDisplayed(), true);
+
+    // Should be dismissable
+    await driver.find('.test-banner-close').click();
+    assert.equal((await driver.findAll('.test-version-update-banner-text')).length, 0);
+
+    // Let's make sure it's still not there after being dismissed once
+    await driver.navigate().refresh();
+    await session.loadDocMenu('/');
+    await driver.findWait('.test-top-panel', 100);
+    assert.equal((await driver.findAll('.test-version-update-banner-text')).length, 0);
+
+    // Update the version, the banner should come back
+    fakeServer.bumpVersion();
+    await server.restart(false);
+    session = await gu.session().personalSite.login({freshAccount: false});
+    await session.loadDocMenu('/');
+    assert.equal(await driver.find('.test-version-update-banner-text').isDisplayed(), true);
+  });
+
+  it('should not be shown to managers when there is no newer version', async () => {
+    fakeServer.latestVersion = installedVersion;
+    await server.restart(true);
+    session = await gu.session().personalSite.login({freshAccount: true});
+    await driver.executeScript('window.localStorage.clear();');
+    await session.loadDocMenu('/');
+
+    await driver.findWait('.test-top-panel', 100);
+    assert.equal((await driver.findAll('.test-version-update-banner-text')).length, 0);
+  });
+
+});

--- a/test/server/customUtil.ts
+++ b/test/server/customUtil.ts
@@ -1,3 +1,4 @@
+import {version as installedVersion} from "app/common/version";
 import {getAppRoot} from 'app/server/lib/places';
 import {fromCallback, listenPromise} from 'app/server/lib/serverUtils';
 import express from 'express';
@@ -91,4 +92,71 @@ export class Defer {
   public reject(err: any) {
     this._reject(err);
   }
+}
+
+export async function startFakeUpdateServer() {
+  let mutex: Defer|null = null;
+  const API: FakeUpdateServer = {
+    latestVersion: bumpVersion(installedVersion),
+    failNext: false,
+    payload: null,
+    close: async () => {
+      mutex?.resolve();
+      mutex = null;
+      await server?.shutdown();
+      server = null;
+    },
+    pause: () => {
+      mutex = new Defer();
+    },
+    resume: () => {
+      mutex?.resolve();
+      mutex = null;
+    },
+    url: () => {
+      return server!.url;
+    },
+    bumpVersion: () => {
+      API.latestVersion = bumpVersion(API.latestVersion);
+    },
+  };
+
+  let server: Serving|null = await serveSomething((app) => {
+    app.use(express.json());
+    app.post('/version', async (req, res, next) => {
+      API.payload = req.body;
+      try {
+        await mutex;
+        if (API.failNext) {
+          res.status(500).json({error: 'some error'});
+          API.failNext = false;
+          return;
+        }
+        res.json({latestVersion: API.latestVersion});
+      } catch(ex) {
+        next(ex);
+      }
+    });
+  });
+
+  return API;
+}
+
+function bumpVersion(version: string) {
+  const parts = version.split('.').map((part) => {
+    return Number(part.replace(/\D/g, ''));
+  });
+  parts[parts.length - 1] += 1;
+  return parts.join('.');
+}
+
+export interface FakeUpdateServer {
+  latestVersion: string;
+  failNext: boolean;
+  payload: any;
+  close: () => Promise<void>;
+  pause: () => void;
+  resume: () => void;
+  url: () => string;
+  bumpVersion: () => void;
 }


### PR DESCRIPTION
This is a simple banner that shows up when a newer version is available. It is dismissable and should not come back until the next, newer version is released.

## Context

This is still disabled and an intermediate step towards having more integrated automated version updates. We still need to do admin integration before we can enable this for all users.

## Related issues

A follow-up to #1508.

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

Dismissable banner on top

![image](https://github.com/user-attachments/assets/0d8fb1cb-ebc3-4187-9c2f-0c22c736a751)

