### PR TITLE
themes visually breaking bug: one variable was wrongly set

### DIFF
--- a/app/common/ThemePrefs.ts
+++ b/app/common/ThemePrefs.ts
@@ -336,7 +336,7 @@ export const componentsCssMapping = {
   inputInvalid: 'input-invalid',
   inputFocus: 'input-focus',
   inputReadonlyBg: 'input-readonly-bg',
-  inputReadonlyBorder: 'themes-input-readonly-border',
+  inputReadonlyBorder: 'input-readonly-border',
   choiceTokenFg: 'choice-token-fg',
   choiceTokenBlankFg: 'choice-token-blank-fg',
   choiceTokenBg: 'choice-token-bg',

--- a/test/common/ThemePrefs.ts
+++ b/test/common/ThemePrefs.ts
@@ -50,11 +50,12 @@ describe('ThemePrefs', function() {
     const invalidVars = [...tokensCssVars, ...componentsCssVars].filter(cssVar =>
       cssVar.startsWith('grist-')
       || cssVar.startsWith('theme-')
+      || cssVar.startsWith('themes-')
       || cssVar.startsWith('--')
     );
     if (invalidVars.length) {
       assert.fail(
-        'CSS variable names must not start with "grist-", "theme-" or "--".\n' +
+        'CSS variable names must not start with "grist-", "theme-", "themes-" or "--".\n' +
         'Change these in ThemePrefs: ' + invalidVars.join(', ')
       );
     }


### PR DESCRIPTION
After the migration to new theme variables, one theme variables was wrongfully named. Existing tests missed it (updated them just in case). Certainly a typo made by myself that I missed. Sorry!

Thanks @jarek for the heads up.

Before:

![image](https://github.com/user-attachments/assets/40121ad6-e9ef-41e0-9dc4-81ff03a1c10c)

After:

![image](https://github.com/user-attachments/assets/a3ee76e4-a1ad-4d99-93bf-cf2fe656950a)
