### PR TITLE
add a confirmation modal to all DELETE operations on API console

### DIFF
--- a/app/client/apiconsole.ts
+++ b/app/client/apiconsole.ts
@@ -324,7 +324,7 @@ async function requestInterceptor(request: SwaggerUI.Request) {
         t('Confirm Deletion'), {
           btnText: t('Delete'),
           placeholder: t('Type DELETE here if you wish to proceed.'),
-          extraBody: [
+          body: [
             dom(
               'p',
               t('Are you sure you want to delete the following?')

--- a/app/client/components/GristDoc.ts
+++ b/app/client/components/GristDoc.ts
@@ -1674,7 +1674,11 @@ export class GristDocImpl extends DisposableWithEvents implements GristDoc {
   }
 
   private async _promptForName() {
-    return await invokePrompt("Table name", "Create", '', "Default table name");
+    return await invokePrompt("Table name", {
+      btnText: "Create",
+      initial: "",
+      placeholder: "Default table name",
+    });
   }
 
   private async _replaceViewSection(

--- a/app/client/ui/createAppPage.ts
+++ b/app/client/ui/createAppPage.ts
@@ -30,6 +30,7 @@ export function createAppPage(
 
   // Add globals needed by test utils.
   G.window.gristApp = {
+    topAppModel,
     testNumPendingApiRequests: () => BaseAPI.numPendingRequests(),
   };
   dom.update(document.body, dom.maybe(topAppModel.appObs, (appModel) => {

--- a/app/client/ui2018/modals.ts
+++ b/app/client/ui2018/modals.ts
@@ -430,7 +430,8 @@ export function promptModal(
   btnText?: string,
   initial?: string,
   placeholder?: string,
-  onCancel?: () => void
+  onCancel?: () => void,
+  extraBody?: DomElementArg,
 ): void {
   saveModal((ctl, owner): ISaveModalOptions => {
     let confirmed = false;
@@ -438,7 +439,7 @@ export function promptModal(
     const txtInput = input(text, { onInput : true }, { placeholder }, cssInput.cls(''), testId('modal-prompt'));
     const options: ISaveModalOptions = {
       title,
-      body: txtInput,
+      body: [extraBody, txtInput],
       saveLabel: btnText || t('Save'),
       saveFunc: () => {
         // Mark that confirm was invoked.
@@ -467,25 +468,29 @@ export function promptModal(
  *  }
  *
  * @param title: Prompt text.
- * @param btnText: Text of the confirm button, default is "Ok".
- * @param initial: Initial value in the input element.
- * @param placeholder: Placeholder for the input element.
+ * @param options.btnText: Text of the confirm button, default is "Ok".
+ * @param options.initial: Initial value in the input element.
+ * @param options.placeholder: Placeholder for the input element.
+ * @param options.extraBody: More material before the input element.
  */
 export function invokePrompt(
   title: string,
-  btnText?: string,
-  initial?: string,
-  placeholder?: string
+  options?: {
+    btnText?: string,
+    initial?: string,
+    placeholder?: string,
+    extraBody?: DomElementArg,
+  }
 ): Promise<string|undefined> {
   let onResolve: (text: string|undefined) => any;
   const prom = new Promise<string|undefined>((resolve) => {
     onResolve = resolve;
   });
-  promptModal(title, onResolve!, btnText ?? t("Ok"), initial, placeholder, () => {
+  promptModal(title, onResolve!, options?.btnText ?? t("Ok"), options?.initial, options?.placeholder, () => {
     if (onResolve) {
       onResolve(undefined);
     }
-  });
+  }, options?.extraBody);
   return prom;
 }
 

--- a/app/client/ui2018/modals.ts
+++ b/app/client/ui2018/modals.ts
@@ -431,7 +431,7 @@ export function promptModal(
   initial?: string,
   placeholder?: string,
   onCancel?: () => void,
-  extraBody?: DomElementArg,
+  body?: DomElementArg,
 ): void {
   saveModal((ctl, owner): ISaveModalOptions => {
     let confirmed = false;
@@ -439,7 +439,7 @@ export function promptModal(
     const txtInput = input(text, { onInput : true }, { placeholder }, cssInput.cls(''), testId('modal-prompt'));
     const options: ISaveModalOptions = {
       title,
-      body: [extraBody, txtInput],
+      body: [body, txtInput],
       saveLabel: btnText || t('Save'),
       saveFunc: () => {
         // Mark that confirm was invoked.
@@ -471,15 +471,15 @@ export function promptModal(
  * @param options.btnText: Text of the confirm button, default is "Ok".
  * @param options.initial: Initial value in the input element.
  * @param options.placeholder: Placeholder for the input element.
- * @param options.extraBody: More material before the input element.
+ * @param options.body: More material before the input element.
  */
 export function invokePrompt(
   title: string,
-  options?: {
+  options: {
     btnText?: string,
     initial?: string,
     placeholder?: string,
-    extraBody?: DomElementArg,
+    body?: DomElementArg,
   }
 ): Promise<string|undefined> {
   let onResolve: (text: string|undefined) => any;
@@ -490,7 +490,7 @@ export function invokePrompt(
     if (onResolve) {
       onResolve(undefined);
     }
-  }, options?.extraBody);
+  }, options?.body);
   return prom;
 }
 

--- a/test/nbrowser/ApiConsole.ts
+++ b/test/nbrowser/ApiConsole.ts
@@ -1,0 +1,79 @@
+import difference from 'lodash/difference';
+import {assert, driver} from 'mocha-webdriver';
+import * as gu from 'test/nbrowser/gristUtils';
+import {setupTestSuite} from 'test/nbrowser/testUtils';
+
+describe('ApiConsole', function () {
+  this.timeout(20000);
+  const cleanup = setupTestSuite();
+
+  before(async function () {
+    const session = await gu.session().user('user1').login();
+    await session.tempDoc(cleanup, 'Hello.grist');
+    await gu.dismissWelcomeTourIfNeeded();
+  });
+
+  it('confirms delete operations before doing them', async function() {
+    const myTab = await gu.myTab();
+    await openApiConsolePage();
+
+    try {
+      // Start a DELETE operation but cancel it
+      await gu.scrollIntoView(driver.find('div#operations-orgs-deleteOrg')).click();
+      await driver.findWait('button.try-out__btn', 3000).click();
+      await driver.findWait('button.execute', 3000).click();
+      assert.equal(await driver.findWait('.test-modal-title', 3000).getText(),
+                   'Confirm Deletion');
+      await driver.findWait('button.test-modal-cancel', 3000).click();
+      let toasts = await gu.getToasts();
+      assert.equal(toasts.length, 1);
+      assert.match(toasts[0], /Deletion was not confirmed/);
+      await gu.wipeToasts();
+
+      // Start a DELETE operation and confirm it without writing "DELETE"
+      await driver.findWait('button.try-out__btn.cancel', 3000).click();
+      await driver.findWait('button.try-out__btn:not(.cancel)', 3000).click();
+      await driver.findWait('button.execute', 3000).click();
+      await driver.findWait('button.test-modal-confirm', 3000).click();
+      toasts = await gu.getToasts();
+      assert.equal(toasts.length, 1);
+      assert.match(toasts[0], /Deletion was not confirmed/);
+      await gu.wipeToasts();
+
+      // Start a DELETE operation and confirm it without writing "DELETE" correctly
+      await driver.findWait('button.try-out__btn.cancel', 3000).click();
+      await driver.findWait('button.try-out__btn:not(.cancel)', 3000).click();
+      await driver.findWait('button.execute', 3000).click();
+      await driver.findWait('input.test-modal-prompt', 3000).sendKeys('DELETENO');
+      await driver.findWait('button.test-modal-confirm', 3000).click();
+      toasts = await gu.getToasts();
+      assert.equal(toasts.length, 1);
+      assert.match(toasts[0], /Deletion was not confirmed/);
+      await gu.wipeToasts();
+
+      // Start a DELETE operation and confirm it with "DELETE"
+      await driver.findWait('button.try-out__btn.cancel', 3000).click();
+      await driver.findWait('button.try-out__btn:not(.cancel)', 3000).click();
+      await driver.findWait('button.execute', 3000).click();
+      await driver.findWait('input.test-modal-prompt', 3000).sendKeys('DELETE');
+      await driver.findWait('button.test-modal-confirm', 3000).click();
+      toasts = await gu.getToasts();
+      assert.equal(toasts.length, 0);
+    } finally {    
+      // There is an extra browser tab open for the api console.    
+      await driver.close();
+      await myTab.open();
+    }
+  });
+});
+
+async function openApiConsolePage() {
+  await gu.wipeToasts();
+  await gu.openDocumentSettings();
+  const tabs = await driver.getAllWindowHandles();
+  await gu.scrollIntoView(driver.findContentWait('a', /API console/i, 3000)).click();
+  const newTab = difference(await driver.getAllWindowHandles(), tabs)[0];
+  assert.isDefined(newTab);
+  await driver.switchTo().window(newTab);
+  await driver.findContentWait('p', /An API for manipulating Grist/, 3000);
+}

--- a/test/nbrowser/ApiConsole.ts
+++ b/test/nbrowser/ApiConsole.ts
@@ -59,8 +59,8 @@ describe('ApiConsole', function () {
       await driver.findWait('button.test-modal-confirm', 3000).click();
       toasts = await gu.getToasts();
       assert.equal(toasts.length, 0);
-    } finally {    
-      // There is an extra browser tab open for the api console.    
+    } finally {
+      // There is an extra browser tab open for the api console.
       await driver.close();
       await myTab.open();
     }

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -2155,6 +2155,8 @@ export function getToasts(): Promise<string[]> {
 }
 
 export async function wipeToasts(): Promise<void> {
+  // call clearAppErrors if in a proper Grist window (and not, for
+  // example, in the API Console window).
   await driver.executeScript('window.gristApp.topAppModel.notifier.clearAppErrors()');
   return driver.executeScript(
     "for (const e of document.getElementsByClassName('test-notifier-toast-wrapper')) { e.remove(); }");

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -2155,8 +2155,6 @@ export function getToasts(): Promise<string[]> {
 }
 
 export async function wipeToasts(): Promise<void> {
-  // call clearAppErrors if in a proper Grist window (and not, for
-  // example, in the API Console window).
   await driver.executeScript('window.gristApp.topAppModel.notifier.clearAppErrors()');
   return driver.executeScript(
     "for (const e of document.getElementsByClassName('test-notifier-toast-wrapper')) { e.remove(); }");


### PR DESCRIPTION
The API console page has a lot of endpoints on it, straight from they grist.yml specification, and some of them could do a lot of harm if you don't know what they are. This adds a confirmation modal to the DELETE operations.

## Context

A user clicked through all the steps of doing an org deletion, without realizing it would delete their team site. That endpoint isn't great, and needs better documentation, but also it would be good to flag deletions as something you should only do if you're confident in your understanding.