### PR TITLE
Theme variables: small fix for people with custom css

### DIFF
--- a/app/client/ui2018/cssVars.ts
+++ b/app/client/ui2018/cssVars.ts
@@ -137,7 +137,7 @@ export const vars = {
   controlFg: new CustomProp('control-fg', tokens.primary),
   controlFgHover: new CustomProp('primary-fg-hover', tokens.primaryMuted),
 
-  controlBorder: new CustomProp('control-border', '1px solid #11b683'),
+  controlBorder: new CustomProp('control-border', components.controlBorder),
   controlBorderRadius: new CustomProp('border-radius', tokens.controlBorderRadius),
 
   logoBg: new CustomProp('logo-bg', tokens.logoBg),

--- a/app/common/ThemePrefs.ts
+++ b/app/common/ThemePrefs.ts
@@ -626,6 +626,7 @@ export const legacyVarsMapping: {old: string, new: string}[] = [
   {old: '--grist-primary-bg', new: tokens.white.var()},
   {old: '--grist-primary-fg-hover', new: tokens.primaryMuted.var()},
   {old: '--grist-primary-fg', new: tokens.primary.var()},
+  {old: '--grist-control-border', new: components.controlBorder.var()},
   {old: '--grist-border-radius', new: tokens.controlBorderRadius.var()},
   {old: '--grist-logo-bg', new: tokens.logoBg.var()},
   {old: '--grist-logo-size', new: tokens.logoSize.var()},


### PR DESCRIPTION
## Context

When using custom CSS, if we detect you override old format theme vars, we add some css variables that map the old ones you overridden to the new ones.

The script doing that was missing one variable.

For self-hosters with custom CSS who updated to the latest grist version, but did not update their custom.css file content, it meant that some UI elements stopped getting the changes listed in the custom.css (here, the control-border css var).

## Proposed solution

Add the missing css vars in the list of legacy variables to handle, so that we automatically map it to new variables.

This fix helps preventing small UI issues (border color on a few elements), for people with custom css who didn't update their custom css file content after upgrading grist.

## Related issues

https://github.com/gristlabs/grist-core/pull/1340

## Has this been tested?

No tests were added, but existing test checks the content of the list that was updated.

