### PR TITLE
delete forks owned by a user before deleting that user

### DIFF
--- a/app/common/UserAPI.ts
+++ b/app/common/UserAPI.ts
@@ -431,6 +431,7 @@ export interface UserAPI {
   updateAllowGoogleLogin(allowGoogleLogin: boolean): Promise<void>;
   updateIsConsultant(userId: number, isConsultant: boolean): Promise<void>;
   getWorker(key: string): Promise<string>;
+  getWorkerFull(key: string): Promise<PublicDocWorkerUrlInfo>;
   getWorkerAPI(key: string): Promise<DocWorkerAPI>;
   getBillingAPI(): BillingAPI;
   getDocAPI(docId: string): DocAPI;
@@ -849,11 +850,16 @@ export class UserAPIImpl extends BaseAPI implements UserAPI {
   }
 
   public async getWorker(key: string): Promise<string> {
+    const full = await this.getWorkerFull(key);
+    return getPublicDocWorkerUrl(this._homeUrl, full);
+  }
+
+  public async getWorkerFull(key: string): Promise<PublicDocWorkerUrlInfo> {
     const json = (await this.requestJson(`${this._url}/api/worker/${key}`, {
       method: 'GET',
       credentials: 'include'
     })) as PublicDocWorkerUrlInfo;
-    return getPublicDocWorkerUrl(this._homeUrl, json);
+    return json;
   }
 
   public async getWorkerAPI(key: string): Promise<DocWorkerAPI> {
@@ -1287,9 +1293,11 @@ export interface AttachmentTransferStatus {
 export type PublicDocWorkerUrlInfo = {
   selfPrefix: string;
   docWorkerUrl: null;
+  docWorkerId: null;
 } | {
   selfPrefix: null;
   docWorkerUrl: string;
+  docWorkerId: string;
 }
 
 export function getUrlFromPrefix(homeUrl: string, prefix: string) {

--- a/app/gen-server/lib/Housekeeper.ts
+++ b/app/gen-server/lib/Housekeeper.ts
@@ -122,6 +122,16 @@ export class Housekeeper {
       // and then deleting it without ceremony.  But, for consistency, and because
       // it will be useful for other purposes, we work through the api using special
       // temporary permits.
+      try {
+        await this._server.hardDeleteDoc(doc.id);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          log.error(`failed to delete document ${doc.id}: error status ${err.status} ${err.message}`);
+        } else {
+          log.error(`failed to delete document ${doc.id}: error status ${String(err)}`);
+        }
+      }
+
       const permitKey = await this._permitStore.setPermit({docId: doc.id});
       try {
         const result = await fetch(await this._server.getHomeUrlByDocId(doc.id, `/api/docs/${doc.id}`), {

--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -70,6 +70,7 @@ import {
 } from 'app/gen-server/sqlUtils';
 import {appSettings} from 'app/server/lib/AppSettings';
 import {getOrCreateConnection} from 'app/server/lib/dbUtils';
+import {StorageCoordinator} from 'app/server/lib/GristServer';
 import {makeId} from 'app/server/lib/idUtils';
 import {EmptyNotifier, INotifier} from 'app/server/lib/INotifier';
 import log from 'app/server/lib/log';
@@ -290,7 +291,8 @@ export class HomeDBManager {
     return this._connection.driver.options.type;
   }
 
-  public constructor(private _notifier: INotifier = EmptyNotifier) {
+  public constructor(public storageCoordinator?: StorageCoordinator,
+                     private _notifier: INotifier = EmptyNotifier) {
   }
 
   public usersManager() {

--- a/app/gen-server/lib/homedb/UsersManager.ts
+++ b/app/gen-server/lib/homedb/UsersManager.ts
@@ -1,6 +1,7 @@
 import { ApiError } from 'app/common/ApiError';
 import { normalizeEmail } from 'app/common/emails';
 import { PERSONAL_FREE_PLAN } from 'app/common/Features';
+import { buildUrlId } from 'app/common/gristUrls';
 import { UserOrgPrefs } from 'app/common/Prefs';
 import * as roles from 'app/common/roles';
 import {
@@ -26,7 +27,7 @@ import { Permissions } from 'app/gen-server/lib/Permissions';
 import { Pref } from 'app/gen-server/entity/Pref';
 
 import flatten from 'lodash/flatten';
-import { EntityManager } from 'typeorm';
+import { EntityManager, IsNull, Not } from 'typeorm';
 
 // A special user allowed to add/remove both the EVERYONE_EMAIL and ANONYMOUS_USER_EMAIL to/from a resource.
 export const SUPPORT_EMAIL = appSettings.section('access').flag('supportEmail').requireString({
@@ -504,6 +505,37 @@ export class UsersManager {
     if (userIdDeleting !== userIdToDelete) {
       throw new ApiError('not permitted to delete this user', 403);
     }
+
+    // Deleting a user leaves their forks orphaned, inaccessible.
+    // Worse, even Grist loses track of how to access them on
+    // disk and in external storage, since they are identified
+    // using a composite key that includes the user id. So we
+    // delete the forks now. Deleting can be a relatively slow
+    // operation, since in general it needs to work via
+    // communication with doc workers. So we do it outside
+    // the main transaction for deleting the user. Within
+    // the transaction, we simply check that no forks have
+    // since appeared. Staying outside the transaction is
+    // important also for single-process Grist combining
+    // home server and doc worker.
+    const forksToDelete = await this._connection.getRepository(Document).find({
+      where: {
+        createdBy: userIdToDelete,
+        trunkId: Not(IsNull()),
+      }});
+    // Delete external storage for orphaned forks.
+    // This might take some time, if there's a lot of them.
+    for (const doc of forksToDelete) {
+      // In tests the storage coordinator may not be present and
+      // that's usually fine. But if we're deleting forks it had
+      // better be there.
+      if (!this._homeDb.storageCoordinator) {
+        throw new Error('no mechanism available to delete forks');
+      }
+      const fullId = buildUrlId({trunkId: doc.trunkId!, forkId: doc.id, forkUserId: doc.createdBy!});
+      await this._homeDb.storageCoordinator.hardDeleteDoc(fullId);
+    }
+
     return await this._connection.transaction(async manager => {
       const user = await manager.findOne(User, {where: {id: userIdToDelete},
                                                 relations: ["logins", "personalOrg", "prefs"]});
@@ -518,7 +550,15 @@ export class UsersManager {
       // Unset 'created_by' on any documents created by this user. It's sad to lose this info, but
       // we can't leave an invalid reference (and violate the foreign-key constraint)
       const docs = await manager.getRepository(Document).find({where: {createdBy: userIdToDelete}});
-      docs.forEach(doc => { doc.createdBy = null; });
+      docs.forEach(doc => {
+        if (doc.trunkId) {
+          // We tried cleaning up forks before starting the
+          // transaction but one snuck back in? Just bail.
+          throw new ApiError('Untimely document addition? Please retry.', 503);
+        } else {
+          doc.createdBy = null;
+        }
+      });
       await manager.save(docs);
 
       await manager.remove([...user.logins]);

--- a/app/server/MergedServer.ts
+++ b/app/server/MergedServer.ts
@@ -59,6 +59,10 @@ interface ServerOptions extends FlexServerOptions {
   // If set, documents saved to external storage such as s3 (default is to check environment variables,
   // which get set in various ways in dev/test entry points)
   externalStorage?: boolean;
+
+  // If set, add this many extra dedicated doc workers,
+  // at ports above the main server.
+  extraWorkers?: number;
 }
 
 export class MergedServer {
@@ -134,6 +138,10 @@ export class MergedServer {
   public readonly flexServer: FlexServer;
   private readonly _serverTypes: ServerType[];
   private readonly _options: ServerOptions;
+  // It can be useful to start up a bunch of extra workers within,
+  // a single process mostly for testing purposes, but conceivably
+  // for real too.
+  private readonly _extraWorkers: MergedServer[] = [];
 
   private constructor(port: number, serverTypes: ServerType[], options: ServerOptions = {}) {
     this._serverTypes = serverTypes;
@@ -197,10 +205,47 @@ export class MergedServer {
       this.flexServer.checkOptionCombinations();
       this.flexServer.summary();
       this.flexServer.ready();
+
+      if (this._options.extraWorkers) {
+        if (!process.env.REDIS_URL) {
+          throw new Error('Redis needed to support multiple workers');
+        }
+        const port = this.flexServer.port;
+        for (let i = 1; i <= this._options.extraWorkers; i++) {
+          const server = await MergedServer.create(port + i, ['docs'], {
+            ...this._options,
+            extraWorkers: undefined,
+          });
+          await server.run();
+          this._extraWorkers.push(server);
+        }
+      }
     } catch(e) {
-      await this.flexServer.close();
+      await this.close();
       throw e;
     }
+  }
+
+  public async close() {
+    for (const worker of this._extraWorkers) {
+      await worker.flexServer.close();
+    }
+    await this.flexServer.close();
+  }
+
+  /**
+   * Look up a worker from its id in Redis.
+   */
+  public testGetWorkerFromId(docWorkerId: string): MergedServer {
+    if (this.flexServer.worker?.id === docWorkerId) {
+      return this;
+    }
+    for (const worker of this._extraWorkers || []) {
+      if (worker.flexServer.worker.id === docWorkerId) {
+        return worker;
+      }
+    }
+    throw new Error('Worker not found');
   }
 }
 
@@ -216,7 +261,15 @@ export async function startMain() {
 
     const port = parseInt(process.env.GRIST_PORT, 10);
 
-    const server = await MergedServer.create(port, serverTypes);
+    let extraWorkers = 0;
+    if (process.env.DOC_WORKER_COUNT) {
+      extraWorkers = parseInt(process.env.DOC_WORKER_COUNT, 10);
+      if (serverTypes.includes('docs')) { extraWorkers--; }
+    }
+
+    const server = await MergedServer.create(port, serverTypes, {
+      extraWorkers
+    });
     await server.run();
 
     const opt = process.argv[2];

--- a/app/server/MergedServer.ts
+++ b/app/server/MergedServer.ts
@@ -138,7 +138,7 @@ export class MergedServer {
   public readonly flexServer: FlexServer;
   private readonly _serverTypes: ServerType[];
   private readonly _options: ServerOptions;
-  // It can be useful to start up a bunch of extra workers within,
+  // It can be useful to start up a bunch of extra workers within
   // a single process mostly for testing purposes, but conceivably
   // for real too.
   private readonly _extraWorkers: MergedServer[] = [];
@@ -240,7 +240,7 @@ export class MergedServer {
     if (this.flexServer.worker?.id === docWorkerId) {
       return this;
     }
-    for (const worker of this._extraWorkers || []) {
+    for (const worker of this._extraWorkers) {
       if (worker.flexServer.worker.id === docWorkerId) {
         return worker;
       }

--- a/app/server/MergedServer.ts
+++ b/app/server/MergedServer.ts
@@ -264,6 +264,8 @@ export async function startMain() {
     let extraWorkers = 0;
     if (process.env.DOC_WORKER_COUNT) {
       extraWorkers = parseInt(process.env.DOC_WORKER_COUNT, 10);
+      // If the main server functions also as a doc worker, then
+      // we need one fewer extra servers.
       if (serverTypes.includes('docs')) { extraWorkers--; }
     }
 

--- a/app/server/lib/AppEndpoint.ts
+++ b/app/server/lib/AppEndpoint.ts
@@ -58,9 +58,12 @@ export function attachAppEndpoint(options: AttachOptions): void {
       req.params.docId, docWorkerMap, gristServer.getTag()
     );
     const info: PublicDocWorkerUrlInfo = selfPrefix ?
-      { docWorkerUrl: null, selfPrefix } :
-      { docWorkerUrl: customizeDocWorkerUrl(docWorker!.publicUrl, req), selfPrefix: null };
-
+      { docWorkerUrl: null, docWorkerId: null, selfPrefix } :
+      {
+        docWorkerUrl: customizeDocWorkerUrl(docWorker!.publicUrl, req),
+        docWorkerId: docWorker!.id,
+        selfPrefix: null
+      };
     return res.json(info);
   }));
 

--- a/app/server/lib/ExternalStorage.ts
+++ b/app/server/lib/ExternalStorage.ts
@@ -48,6 +48,7 @@ export interface ExternalStorage {
   // Remove content for this key from the store, if it exists.  Can delete specific versions
   // if specified.  If no version specified, all versions are removed.  If versions specified,
   // newest should be given first.
+  // If the content specified is not present on the store, no error is thrown.
   remove(key: string, snapshotIds?: string[]): Promise<void>;
 
   // Removes all keys which start with the given prefix

--- a/app/server/lib/GristServer.ts
+++ b/app/server/lib/GristServer.ts
@@ -39,7 +39,7 @@ import { IncomingMessage } from 'http';
  *
  */
 export interface StorageCoordinator {
-  hardDeleteDoc(docId:string): Promise<void>;
+  hardDeleteDoc(docId: string): Promise<void>;
 }
 
 /**

--- a/app/server/lib/GristServer.ts
+++ b/app/server/lib/GristServer.ts
@@ -33,10 +33,20 @@ import * as express from 'express';
 import { IncomingMessage } from 'http';
 
 /**
+ *
+ * Coordinate storage for documents across file systems,
+ * external storage, and the home database.
+ *
+ */
+export interface StorageCoordinator {
+  hardDeleteDoc(docId:string): Promise<void>;
+}
+
+/**
  * Basic information about a Grist server.  Accessible in many
  * contexts, including request handlers and ActiveDoc methods.
  */
-export interface GristServer {
+export interface GristServer extends StorageCoordinator {
   readonly create: ICreate;
   readonly testPending: boolean;
   settings?: IGristCoreConfig;
@@ -193,6 +203,7 @@ export function createDummyGristServer(): GristServer {
     isRestrictedMode() { return false; },
     onUserChange() { /* do nothing */ },
     onStreamingDestinationsChange() { /* do nothing */ },
+    hardDeleteDoc() { return Promise.resolve(); },
   };
 }
 

--- a/stubs/app/server/server.ts
+++ b/stubs/app/server/server.ts
@@ -20,7 +20,9 @@ if (!debugging) {
 setDefaultEnv('GRIST_SESSION_COOKIE', 'grist_core2');
 
 setDefaultEnv('GRIST_SERVE_SAME_ORIGIN', 'true');
-setDefaultEnv('GRIST_SINGLE_PORT', 'true');
+if (!process.env.DOC_WORKER_COUNT) {
+  setDefaultEnv('GRIST_SINGLE_PORT', 'true');
+}
 setDefaultEnv('GRIST_DEFAULT_PRODUCT', 'Free');
 
 if (!process.env.GRIST_SINGLE_ORG) {

--- a/test/fixtures/projects/helpers/MockUserAPI.ts
+++ b/test/fixtures/projects/helpers/MockUserAPI.ts
@@ -396,8 +396,16 @@ export class MockUserAPI implements UserAPI, DocWorkerAPI {
     window.location.href = window.location.origin;
   }
 
-  public async getWorker(key: string): Promise<string> {
+  public async getWorker(): Promise<string> {
     return "/";
+  }
+
+  public async getWorkerFull() {
+    return {
+      selfPrefix: '/',
+      docWorkerUrl: null,
+      docWorkerId: null,
+    };
   }
 
   public async getWorkerAPI(key: string): Promise<DocWorkerAPI> {

--- a/test/gen-server/lib/homedb/UsersManager.ts
+++ b/test/gen-server/lib/homedb/UsersManager.ts
@@ -1208,7 +1208,7 @@ describe('UsersManager', function () {
       process.env.REDIS_URL = process.env.TEST_REDIS_URL;
       dataDir = await createTestDir('UsersManager');
       // TODO: may need to manage the port range here if it
-      // could stop on some other parallel test, but I think
+      // could stomp on some other parallel test, but I think
       // this may be currently OK for gen-server tests.
       server = await MergedServer.create(34365, ['home'], {
         extraWorkers: 5,
@@ -1295,7 +1295,7 @@ describe('UsersManager', function () {
           [{name: 'doc-name'}]
         );
 
-        // Delete the user, and make sure the fork is deleted.
+        // Delete the user.
         await db.deleteUser({userId: userToDelete.id}, userToDelete.id);
 
         // Confirm the fork is no longer listed in the home db.
@@ -1303,6 +1303,7 @@ describe('UsersManager', function () {
           await db.connection.query("select name from docs where id = $1", [fork.forkId]),
           []
         );
+        // Confirm the fork is no longer on the file system.
         assert.isFalse(await fse.pathExists(docPath));
 
         // Confirm the user is gone.

--- a/test/gen-server/lib/homedb/UsersManager.ts
+++ b/test/gen-server/lib/homedb/UsersManager.ts
@@ -1,5 +1,6 @@
+import { buildUrlId, parseUrlId } from 'app/common/gristUrls';
 import { FullUser, UserProfile } from 'app/common/LoginSessionAPI';
-import { ANONYMOUS_USER_EMAIL, EVERYONE_EMAIL, PREVIEWER_EMAIL, UserOptions } from 'app/common/UserAPI';
+import { ANONYMOUS_USER_EMAIL, EVERYONE_EMAIL, PREVIEWER_EMAIL, UserAPIImpl, UserOptions } from 'app/common/UserAPI';
 import { AclRuleOrg } from 'app/gen-server/entity/AclRule';
 import { Document } from 'app/gen-server/entity/Document';
 import { Group } from 'app/gen-server/entity/Group';
@@ -13,15 +14,18 @@ import { GetUserOptions, NonGuestGroup, Resource } from 'app/gen-server/lib/home
 import { SUPPORT_EMAIL, UsersManager } from 'app/gen-server/lib/homedb/UsersManager';
 import { updateDb } from 'app/server/lib/dbUtils';
 import { EmitNotifier } from 'app/server/lib/FlexServer';
-import { EnvironmentSnapshot } from 'test/server/testUtils';
+import { MergedServer } from 'app/server/MergedServer';
+import { createTestDir, EnvironmentSnapshot } from 'test/server/testUtils';
 import { createInitialDb, removeConnection, setUpDB } from 'test/gen-server/seed';
 
 import log from 'app/server/lib/log';
 import { assert } from 'chai';
+import * as fse from 'fs-extra';
 import Sinon, { SinonSandbox, SinonSpy } from 'sinon';
 import { EntityManager } from 'typeorm';
 import winston from 'winston';
 import omit from 'lodash/omit';
+import fetch from 'node-fetch';
 
 import { delay } from 'app/common/delay';
 
@@ -206,6 +210,7 @@ describe('UsersManager', function () {
     let db: HomeDBManager;
     let notifier: EmitNotifier;
     let sandbox: SinonSandbox;
+    let docDeletes: Array<string> = [];
     const uniqueLocalPart = new Set<string>();
 
 
@@ -257,7 +262,22 @@ describe('UsersManager', function () {
       process.env.TEST_CLEAN_DATABASE = 'true';
       setUpDB(this);
       notifier = new EmitNotifier();
-      db = new HomeDBManager(notifier);
+      db = new HomeDBManager(
+        {
+          /**
+           * This is called if a document row should be deleted
+           * in the database and we want to make sure any associated
+           * storage is cleaned up. There is S3 cleanup, and file system
+           * cleanup, which is coordinated with some doc worker.
+           * We mock that here and just delete from home db.
+           */
+          async hardDeleteDoc(docId: string) {
+            const parts = parseUrlId(docId);
+            await db.connection.query('delete from docs where id = ?', [parts.forkId || parts.trunkId]);
+            docDeletes.push(docId);
+          }
+        },
+        notifier);
       await createInitialDb();
       await db.connect();
       await db.initializeSpecialIds();
@@ -710,7 +730,7 @@ describe('UsersManager', function () {
         assert.notExists(await db.getExistingUserByLogin(email));
 
         const before = Date.now();
-        // We are storing time without miliseconds, so make sure at least 1 second has passed
+        // We are storing time without milliseconds, so make sure at least 1 second has passed
         await delay(2000);
         const user = await db.getUserByLogin(makeEmail(localPart.toUpperCase()));
         const after = Date.now();
@@ -718,7 +738,7 @@ describe('UsersManager', function () {
         assert.equal(user.loginEmail, email);
         assert.equal(user.logins[0].displayEmail, makeEmail(localPart.toUpperCase()));
         assert.equal(user.name, '');
-        asssertBetween(before, user.lastConnectionAt?.getTime(), after);
+        assertBetween(before, user.lastConnectionAt?.getTime(), after);
       });
 
       it('should create a personnal organization for the new user', async function () {
@@ -928,6 +948,70 @@ describe('UsersManager', function () {
         });
       });
 
+      it('should remove the user and their forks', async function () {
+        const localPart = 'deleteuser-removes-forks';
+        const userToDelete = await createUniqueUser(localPart, {
+          profile: {
+            name: 'someone to delete',
+            email: makeEmail(localPart),
+          }
+        });
+
+        // Make a little org owned by someone else, to hold a doc
+        // owned by that someone else, which our user will fork.
+        const support = (await db.getUser(db.getSupportUserId()))!;
+        await db.addOrg(support, {
+          name: 'deleteuser-org',
+          domain: 'deleteuser-org',
+        }, {
+          setUserAsOwner: false,
+          useNewPlan: true,
+        });
+        // Grant everyone access to org.
+        await db.updateOrgPermissions({userId: support.id},
+                                      'deleteuser-org', {
+                                        users: {
+                                          'everyone@getgrist.com': 'owners'
+                                        }
+                                      });
+        // Get the default workspace.
+        const ws = db.unwrapQueryResult(
+          await db.getOrgWorkspaces({userId: support.id},
+                                    'deleteuser-org')
+        )[0];
+        // Add a document to the workspace.
+        const doc = db.unwrapQueryResult(
+          await db.addDocument({userId: support.id}, ws.id,
+                               {name: 'doc-name'})
+        );
+        // Have our user-to-delete fork the document.
+        const forkId = db.unwrapQueryResult(
+          await db.forkDoc(userToDelete.id, doc, 'xyz')
+        );
+        const urlId = buildUrlId({trunkId: doc.id, forkId, forkUserId: userToDelete.id});
+
+        // Check the fork is listed in the home db.
+        assert.deepEqual(
+          await db.connection.query("select name from docs where id = 'xyz'"),
+          [{name: 'doc-name'}]
+        );
+
+        // Delete the user, and make sure the fork is deleted.
+        docDeletes.length = 0;
+        await db.deleteUser({userId: userToDelete.id}, userToDelete.id);
+        assert.lengthOf(docDeletes, 1);
+        assert.deepEqual(docDeletes, [urlId]);
+
+        // Confirm the fork is no longer listed in the home db.
+        assert.deepEqual(
+          await db.connection.query("select name from docs where id = 'xyz'"),
+          []
+        );
+
+        // Confirm the user is gone.
+        assert.notExists(await db.getUser(userToDelete.id));
+      });
+
       it("should remove the user when passed name corresponds to the user's name", async function () {
         const userName = 'someone to delete';
         const localPart = 'deleteuser-removes-user-when-name-matches';
@@ -1104,7 +1188,127 @@ describe('UsersManager', function () {
         }
       });
     });
+  });
 
+  /**
+   * Run selected tests in the context of multiple workers.
+   * This tests document deletion more thoroughly. Requires
+   * Redis.
+   */
+  describe('multi-worker', function () {
+    let server: MergedServer;
+    let env: EnvironmentSnapshot;
+    let db: HomeDBManager;
+    let dataDir: string;
+    before(async function() {
+      if (!process.env.TEST_REDIS_URL) { this.skip(); }
+      setUpDB(this);
+      await createInitialDb();
+      env = new EnvironmentSnapshot();
+      process.env.REDIS_URL = process.env.TEST_REDIS_URL;
+      dataDir = await createTestDir('UsersManager');
+      // TODO: may need to manage the port range here if it
+      // could stop on some other parallel test, but I think
+      // this may be currently OK for gen-server tests.
+      server = await MergedServer.create(34365, ['home'], {
+        extraWorkers: 5,
+        dataDir,
+      });
+      await server.run();
+      db = server.flexServer.getHomeDBManager();
+      process.env.APP_HOME_URL = server.flexServer.getOwnUrl();
+    });
+
+    after(async function() {
+      env.restore();
+      await server.close();
+      if (dataDir) {
+        await fse.remove(dataDir);
+      }
+    });
+
+    describe('deleteUser()', function () {
+
+      it('should remove the user and their forks', async function () {
+        const apiKey = 'youllneverguess';
+        const userToDelete = await db.getUserByLogin(
+          'deleteuser-removes-forks-multi@getgrist.com',
+        );
+        userToDelete.apiKey = apiKey;
+        await userToDelete.save();
+        const api = new UserAPIImpl(server.flexServer.getDefaultHomeUrl(), {
+          fetch: fetch as any,
+          headers: {
+            Authorization: `Bearer ${apiKey}`
+          }
+        });
+
+        // Make a little org owned by someone else, to hold a doc
+        // owned by that someone else, which our user will fork.
+        const support = (await db.getUser(db.getSupportUserId()))!;
+        await db.addOrg(support, {
+          name: 'deleteuser-org-multi',
+          domain: 'deleteuser-org-multi',
+        }, {
+          setUserAsOwner: false,
+          useNewPlan: true,
+        });
+        // Grant everyone access to org.
+        await db.updateOrgPermissions({userId: support.id},
+                                      'deleteuser-org-multi', {
+                                        users: {
+                                          'everyone@getgrist.com': 'owners'
+                                        }
+                                      });
+        // Get the default workspace.
+        const ws = db.unwrapQueryResult(
+          await db.getOrgWorkspaces({userId: support.id},
+                                    'deleteuser-org-multi')
+        )[0];
+        // Add a document to the workspace.
+        // Created by user-to-delete, but belongs to workspace.
+        const doc = await api.newDoc({
+          name: 'doc-name',
+        }, ws.id);
+        // Have our user-to-delete fork the document.
+        const fork = await api.getDocAPI(doc).fork();
+        //const urlId = buildUrlId({trunkId: doc.id, forkId, forkUserId: userToDelete.id});
+        const urlId = fork.docId;
+
+        // Check the fork exists.
+        const rows = await api.getDocAPI(urlId).getRows('_grist_Tables');
+        assert.deepEqual(rows.tableId, ['Table1']);
+
+        // Ok, tricky part, let's find where the doc is stored on disk.
+        const worker = await api.getWorkerFull(urlId);
+        const dw = server.testGetWorkerFromId(worker.docWorkerId!);
+        // Storage paths as configured here don't actually vary
+        // between workers (but they could if external
+        // storage were available).
+        const storage = dw.flexServer.getStorageManager();
+        const docPath = storage.getPath(urlId);
+        assert.isTrue(await fse.pathExists(docPath));
+
+        // Check the fork is listed in the home db.
+        assert.deepEqual(
+          await db.connection.query("select name from docs where id = ?", [fork.forkId]),
+          [{name: 'doc-name'}]
+        );
+
+        // Delete the user, and make sure the fork is deleted.
+        await db.deleteUser({userId: userToDelete.id}, userToDelete.id);
+
+        // Confirm the fork is no longer listed in the home db.
+        assert.deepEqual(
+          await db.connection.query("select name from docs where id = ?", [fork.forkId]),
+          []
+        );
+        assert.isFalse(await fse.pathExists(docPath));
+
+        // Confirm the user is gone.
+        assert.notExists(await db.getUser(userToDelete.id));
+      });
+    });
   });
 });
 
@@ -1112,13 +1316,13 @@ describe('UsersManager', function () {
 * Works around lacks of type narrowing after asserting the value is defined.
 * This is fixed in latest versions of @types/chai
 *
-* FIXME: once upgrading @types/chai to 4.3.17 or higher, remove this function which would not be usefull anymore
+* FIXME: once upgrading @types/chai to 4.3.17 or higher, remove this function which would not be useful anymore
 */
 function assertExists<T>(value?: T, message?: string): asserts value is T {
   assert.exists(value, message);
 }
 
-function asssertBetween(min: number, value: number|null|undefined, max: number, message?: string) {
+function assertBetween(min: number, value: number|null|undefined, max: number, message?: string) {
   assert.isNotNull(value, message);
   assert.isDefined(value, message);
   if (value !== null && value !== undefined) {

--- a/test/gen-server/lib/homedb/UsersManager.ts
+++ b/test/gen-server/lib/homedb/UsersManager.ts
@@ -273,7 +273,7 @@ describe('UsersManager', function () {
            */
           async hardDeleteDoc(docId: string) {
             const parts = parseUrlId(docId);
-            await db.connection.query('delete from docs where id = ?', [parts.forkId || parts.trunkId]);
+            await db.connection.query('delete from docs where id = $1', [parts.forkId || parts.trunkId]);
             docDeletes.push(docId);
           }
         },
@@ -1291,7 +1291,7 @@ describe('UsersManager', function () {
 
         // Check the fork is listed in the home db.
         assert.deepEqual(
-          await db.connection.query("select name from docs where id = ?", [fork.forkId]),
+          await db.connection.query("select name from docs where id = $1", [fork.forkId]),
           [{name: 'doc-name'}]
         );
 
@@ -1300,7 +1300,7 @@ describe('UsersManager', function () {
 
         // Confirm the fork is no longer listed in the home db.
         assert.deepEqual(
-          await db.connection.query("select name from docs where id = ?", [fork.forkId]),
+          await db.connection.query("select name from docs where id = $1", [fork.forkId]),
           []
         );
         assert.isFalse(await fse.pathExists(docPath));

--- a/test/gen-server/lib/homedb/UsersManager.ts
+++ b/test/gen-server/lib/homedb/UsersManager.ts
@@ -210,7 +210,7 @@ describe('UsersManager', function () {
     let db: HomeDBManager;
     let notifier: EmitNotifier;
     let sandbox: SinonSandbox;
-    let docDeletes: Array<string> = [];
+    const docDeletes: Array<string> = [];
     const uniqueLocalPart = new Set<string>();
 
 


### PR DESCRIPTION
Currently, if a user is deleted, forks they owned slip through the cracks and are reported by the Housekeeper as undeletable. This is because we lose track of the user id associated with the forks, and that happens to be used as part of the composite identifier for forks, determining where they are stored on disk and in external storage.

With this change, forks are deleted immediately. There isn't much point holding onto a fork if it has become inaccessible. Deletion of forks needs to be done somewhat carefully, to coordinate the deletion from a listing in the database, and the corresponding storage of the document contents.

To simplify testing of this kind of feature, I ported support of `DOC_WORKER_COUNT` from `devServerMain` to `MergedServer`.
