### PR TITLE
hold writes on a document if needed, to get a backup made

### DIFF
--- a/app/server/lib/SQLiteDB.ts
+++ b/app/server/lib/SQLiteDB.ts
@@ -260,7 +260,7 @@ export class SQLiteDB implements ISQLiteDB {
   private _closed: boolean = false;
   private _paused: Promise<void>|undefined = undefined;
   private _pauseResolve: (() => void)|undefined = undefined;
-  private _pauseReject: (() => void)|undefined = undefined;
+  private _pauseReject: ((reason?: any) => void)|undefined = undefined;
 
   private constructor(protected _db: MinDB, private _dbPath: string) {
   }
@@ -375,7 +375,7 @@ export class SQLiteDB implements ISQLiteDB {
     const alreadyClosed = this._closed;
     this._closed = true;
     if (!alreadyClosed) {
-      this._pauseReject?.();
+      this._pauseReject?.(new Error('SQLiteDB closing, writes should stop'));
       let tries: number = 0;
       // We might not be able to close immediately if a backup is in
       // progress. We will retry for about 10 seconds. Worst case is
@@ -497,6 +497,7 @@ export class SQLiteDB implements ISQLiteDB {
     this._pauseResolve?.();
     this._pauseResolve = undefined;
     this._pauseReject = undefined;
+    this._paused = undefined;
   }
 
   // Implementation of execTransction.

--- a/test/server/lib/SQLiteDB.ts
+++ b/test/server/lib/SQLiteDB.ts
@@ -7,6 +7,7 @@ import * as tmp from 'tmp';
 import {delay} from 'app/common/delay';
 import {OpenMode, SchemaInfo, SQLiteDB} from 'app/server/lib/SQLiteDB';
 import * as testUtils from 'test/server/testUtils';
+import { timeoutReached } from 'app/common/gutil';
 
 tmp.setGracefulCleanup();
 
@@ -465,6 +466,66 @@ describe('SQLiteDB', function() {
     await assert.isRejected(db1.exec(`ATTACH '${dbPath('testAttach0')}' AS zing`),
                             /SQLITE_ERROR: too many attached databases - max 0/);
     await db1.close();
+  });
+
+  it("should honor pauses", async function() {
+    const sdb = await SQLiteDB.openDB(dbPath('testPause'), schemaInfo, OpenMode.OPEN_CREATE);
+
+    // Modification should happen immediately.
+    assert.isFalse(await timeoutReached(
+      100,
+      sdb.exec("CREATE TABLE Foo1(id INTEGER)")
+    ));
+
+    // Modification should not happen immediately once paused.
+    sdb.pause();
+    assert.isTrue(await timeoutReached(
+      100,
+      sdb.exec("CREATE TABLE Foo2(id INTEGER)")
+    ));
+
+    // After unpausing we should be back to immediate.
+    sdb.unpause();
+    assert.isFalse(await timeoutReached(
+      100,
+      sdb.exec("CREATE TABLE Foo3(id INTEGER)")
+    ));
+
+    // And we should be able to pause again.
+    sdb.pause();
+    assert.isTrue(await timeoutReached(
+      100,
+      sdb.exec("CREATE TABLE Foo4(id INTEGER)")
+    ));
+
+    // Check that all tables were made eventually once we
+    // unpause and wait a little bit, since the exec() calls
+    // above are never cancelled.
+    sdb.unpause();
+    await delay(100);
+    await assert.isRejected(sdb.all("SELECT * FROM Foo0"));
+    await assert.isFulfilled(sdb.all("SELECT * FROM Foo1"));
+    await assert.isFulfilled(sdb.all("SELECT * FROM Foo2"));
+    await assert.isFulfilled(sdb.all("SELECT * FROM Foo3"));
+    await assert.isFulfilled(sdb.all("SELECT * FROM Foo4"));
+
+    // Pause and start a write before closing.
+    sdb.pause();
+    assert.isTrue(await timeoutReached(
+      100,
+      sdb.exec("CREATE TABLE Foo5(id INTEGER)")
+    ));
+
+    await sdb.close();
+    // Take a little time to give that last write a chance (we don't
+    // expect it to write though, it should be cancelled).
+    await delay(100);
+
+    // Check the last write didn't happen.
+    const sdb2 = await SQLiteDB.openDB(dbPath('testPause'), schemaInfo, OpenMode.OPEN_EXISTING);
+    await assert.isFulfilled(sdb2.all("SELECT * FROM Foo4"));
+    await assert.isRejected(sdb2.all("SELECT * FROM Foo5"));
+    await sdb2.close();
   });
 });
 


### PR DESCRIPTION
If SQLite writes are taking a long time, and are happening a lot, then backups may get delayed. This adds a way for the backup system to hold writes for a while if it isn't progressing. The threshold I have for that here may be overly aggressive? In our SaaS, we see that delayed backups even for very busy documents are already rare. This change could result in occasional slower editing on documents that are currently fine.
