### PR TITLE
DB: add group_users created_at column

### DIFF
--- a/app/gen-server/migration/1749454162428-GroupUsersCreatedAt.ts
+++ b/app/gen-server/migration/1749454162428-GroupUsersCreatedAt.ts
@@ -1,0 +1,21 @@
+import * as sqlUtils from "app/gen-server/sqlUtils";
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class GroupUsersCreatedAt1749454162428 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    const dbType = queryRunner.connection.driver.options.type;
+    const datetime = sqlUtils.datetime(dbType);
+    const now = sqlUtils.now(dbType);
+    await queryRunner.addColumn('group_users', new TableColumn({
+      name: 'created_at',
+      comment: 'When the user has been added to the associated group. This column is not exposed to the ORM.',
+      type: datetime,
+      default: now,
+      isNullable: true
+    }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.dropColumn('group_users', 'created_at');
+  }
+}

--- a/test/gen-server/migrations.ts
+++ b/test/gen-server/migrations.ts
@@ -52,6 +52,8 @@ import {LoginsEmailsIndex1729754662550
 import {GracePeriod1732103776245 as GracePeriod} from 'app/gen-server/migration/1732103776245-GracePeriod';
 import {UserCreatedAt1738912357827 as UserCreatedAt} from 'app/gen-server/migration/1738912357827-UserCreatedAt';
 import {DocPref1746246433628 as DocPref} from 'app/gen-server/migration/1746246433628-DocPref';
+import {GroupUsersCreatedAt1749454162428
+  as GroupUsersCreatedAt} from 'app/gen-server/migration/1749454162428-GroupUsersCreatedAt';
 
 const home: HomeDBManager = new HomeDBManager();
 
@@ -62,7 +64,7 @@ const migrations = [Initial, Login, PinDocs, UserPicture, DisplayEmail, DisplayE
                     DocumentUsage, Activations, UserConnectId, UserUUID, UserUniqueRefUUID,
                     Forks, ForkIndexes, ActivationPrefs, AssistantLimit, Shares, BillingFeatures,
                     UserLastConnection, ActivationEnabled, Configs, LoginsEmailsIndex, GracePeriod,
-                    UserCreatedAt, DocPref];
+                    UserCreatedAt, DocPref, GroupUsersCreatedAt];
 
 // Assert that the "members" acl rule and group exist (or not).
 function assertMembersGroup(org: Organization, exists: boolean) {


### PR DESCRIPTION
## Context

We want to know when a user has been granted a role to a document, workspace or an org.

## Proposed solution

We introduce a `created_at` column on the `group_users` which stores the creation date of the record (thus the moment when the role has been set / modified for a user).

We don't expose to the ORM, this property is meant to remain available for queries to external tools.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->