### PR TITLE
fly-deploy: allow passing extra env vars via `process.env`

### DIFF
--- a/buildtools/fly-template.toml
+++ b/buildtools/fly-template.toml
@@ -16,6 +16,7 @@ processes = []
   ALLOWED_WEBHOOK_DOMAINS="webhook.site"
   PORT = "8080"
   FLY_DEPLOY_EXPIRATION = "{FLY_DEPLOY_EXPIRATION}"
+  # <FLY_ENV__> -- fly-deploy.js will insert extra env variables here.
 
 [experimental]
   allowed_public_ports = []


### PR DESCRIPTION
In certain situations, it's more convenient to pass in extra environment variables more dynamically without need to modify `fly-templates.env`

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

Will be doing some manual testing in this PR.