### PR TITLE
Re-enables copying for external attachment docs

### DIFF
--- a/app/server/lib/uploads.ts
+++ b/app/server/lib/uploads.ts
@@ -1,7 +1,7 @@
 import {ApiError} from 'app/common/ApiError';
 import {InactivityTimer} from 'app/common/InactivityTimer';
 import {FetchUrlOptions, FileUploadResult, UPLOAD_URL_PATH, UploadResult} from 'app/common/uploads';
-import {DocAttachmentsLocation, getUrlFromPrefix} from 'app/common/UserAPI';
+import {getUrlFromPrefix} from 'app/common/UserAPI';
 import {getAuthorizedUserId, getTransitiveHeaders, getUserId, isSingleUserMode,
         RequestWithLogin} from 'app/server/lib/Authorizer';
 import {expressWrap} from 'app/server/lib/expressWrap';
@@ -503,27 +503,6 @@ export async function fetchDoc(
   const { selfPrefix, docWorker } = await getDocWorkerInfoOrSelfPrefix(docId, docWorkerMap, server.getTag());
   const docWorkerUrl = docWorker ? docWorker.internalUrl : getUrlFromPrefix(server.getHomeInternalUrl(), selfPrefix);
   const apiBaseUrl = docWorkerUrl.replace(/\/*$/, '/');
-
-  // Documents with external attachments can't be copied right now. Check status and alert the user.
-  // Copying as a template is fine, as no attachments will be copied.
-  if (!template) {
-    const transferStatusResponse = await fetch(
-      new URL(`api/docs/${docId}/attachments/transferStatus`, apiBaseUrl).href,
-      {
-        headers: {
-          ...headers,
-          'Content-Type': 'application/json',
-        }
-      }
-    );
-    if (!transferStatusResponse.ok) {
-      throw new ApiError(await transferStatusResponse.text(), transferStatusResponse.status);
-    }
-    const attachmentsLocation: DocAttachmentsLocation = (await transferStatusResponse.json()).locationSummary;
-    if (attachmentsLocation !== 'internal' && attachmentsLocation !== 'none') {
-      throw new ApiError("Cannot copy a document with external attachments", 400);
-    }
-  }
 
   // Download the document, in full or as a template.
   const url = new URL(`api/docs/${docId}/download?template=${Number(template)}`, apiBaseUrl);

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -2988,12 +2988,12 @@ function testDocApi(settings: {
         assert.deepEqual(tarUploadResp.data, { error: "File is not a valid .tar" });
       });
 
-      it("POST /docs/{did}/copy fails when the document has external attachments", async function () {
+      it("POST /docs/{did}/copy doesn't throw when the document has external attachments", async function () {
         const worker1 = await userApi.getWorkerAPI(docId);
-        await assert.isRejected(worker1.copyDoc(docId, undefined, 'copy'), /status 400/);
+        await worker1.copyDoc(docId, undefined, 'copy');
       });
 
-      it("POST /docs/{did} with sourceDocId fails to copy a document with external attachments", async function () {
+      it("POST /docs/{did} with sourceDocId can copy a document with external attachments", async function () {
         const chimpyWs = await userApi.newWorkspace({name: "Chimpy's Workspace"}, ORG_NAME);
         const resp = await axios.post(`${homeUrl}/api/docs`, {
           sourceDocumentId: docId,
@@ -3001,8 +3001,9 @@ function testDocApi(settings: {
           asTemplate: false,
           workspaceId: chimpyWs
         }, chimpy);
-        assert.equal(resp.status, 400);
-        assert.match(resp.data.error, /external attachments/);
+        assert.equal(resp.status, 200);
+        assert.isString(resp.data);
+        // There's no expectation that the external attachments are copied - just that the document is.
       });
     });
   });


### PR DESCRIPTION
## Context

With the addition of the attachments archive UI (#1551), it's possible to successfully copy a document that's using an external attachments. This is done by manually restoring the attachments in the copied document.

## Proposed solution

This removes the checks for external attachments from the copy endpoints.

## Related issues

#1021 
#1551 

## Has this been tested?

- [X] 👍 yes, I added tests to the test suite
