### PR TITLE
attempt to make the Importer2 tests more reliable

### DIFF
--- a/test/nbrowser/Importer2.ts
+++ b/test/nbrowser/Importer2.ts
@@ -735,15 +735,7 @@ describe('Importer2', function() {
         { source: 'Skip', destination: 'Pop. \'000' },
       ]);
       await waitForDiffPreviewToLoad();
-      // Click any cell that we see to set the focus.
-      await driver.findWait('.test-importer-preview .field_clip', 100).click();
-      // Wait for the focus to be set.
-      await driver.findWait('.test-importer-preview .field_clip.has_cursor', 100);
-      // Go to the first row.
-      await gu.sendKeys(Key.chord(await gu.modKey(), Key.UP));
-      // Make sure we see the first row.
       await driver.findContentWait('.test-importer-preview .field_clip', 'Kabul', 100);
-
       assert.deepEqual(await getPreviewDiffCellValues([0, 1, 2, 3, 4], [1, 2, 3, 4, 5]), [
         'Kabul', 'Kabol', [undefined, undefined, '1780000'], '', [undefined, undefined, '1780'],
         'Qandahar', 'Qandahar', [undefined, undefined, '237500'], [undefined, undefined, '2'],

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -1049,7 +1049,10 @@ export async function uploadFiles(...files: string[]) {
 export async function importFileDialog(filePath: string): Promise<void> {
   await fileDialogUpload(filePath, async () => {
     await driver.wait(() => driver.find('.test-dp-add-new').isDisplayed(), 3000);
-    await driver.findWait('.test-dp-add-new', 1000).doClick();
+    // Sometimes the button won't click straight off, I'm not sure why.
+    await waitToPass(async () => {
+      await driver.findWait('.test-dp-add-new', 1000).doClick();
+    }, 5000);
     await findOpenMenuItem('.test-dp-import-option', /Import from file/i).doClick();
   });
   await driver.findWait('.test-importer-dialog', 5000);


### PR DESCRIPTION
The Importer2 tests have been unreliable for a long time. A few people (including myself) have looked at it and not been able to pin down exactly what is up. To be clear, the import behavior looks fine, it is just something a little erratic in focus or scrolling in the test. This change introduces a brute force attempt at taming the test. With this change, the test has been observed to pass 20 times in succession under github runner conditions.

(see last run of https://github.com/gristlabs/grist-core/pull/1597, which runs Importer* tests 20 times)