### PR TITLE
Disable webhooks on unsaved document copies

### DIFF
--- a/app/client/ui/DocumentSettings.ts
+++ b/app/client/ui/DocumentSettings.ts
@@ -218,7 +218,7 @@ export class DocSettingsPage extends Disposable {
             href: getApiConsoleLink(docPageModel),
           }),
         }),
-        dom.create(AdminSectionItem, {
+        this._gristDoc.docPageModel.isFork.get() ? null : dom.create(AdminSectionItem, {
           id: 'webhooks',
           name: t('Webhooks'),
           description: t('Notify other services on doc changes'),

--- a/app/client/ui/WebhookPage.ts
+++ b/app/client/ui/WebhookPage.ts
@@ -366,6 +366,11 @@ export class WebhookPage extends DisposableWithEvents {
   public buildDom() {
     const viewSectionModel = this.gristDoc.docModel.viewSections.getRowModel('vt_webhook_fs1' as any);
     ViewSectionHelper.create(this, this.gristDoc, viewSectionModel);
+    if (this.gristDoc.docPageModel.isFork.get()) {
+      return cssContainer(
+        cssHeader(t('Webhooks Unavailable In Unsaved Document Copies')),
+      );
+    }
     return cssContainer(
       cssHeader(t('Webhook Settings')),
       cssControlRow(

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -242,6 +242,8 @@ export class ActiveDoc extends EventEmitter {
   public readonly triggersLock: Mutex = new Mutex();
   public isTimingOn = false;
 
+  public isFork: boolean;
+
   protected _actionHistory: ActionHistory;
   protected _sharing: Sharing;
   // This lock is used to avoid reading sandbox state while it is being modified but before
@@ -302,8 +304,9 @@ export class ActiveDoc extends EventEmitter {
   ) {
     super();
     const { trunkId, forkId, snapshotId } = parseUrlId(_docName);
+    this.isFork = Boolean(forkId);
     this._isSnapshot = Boolean(snapshotId);
-    this._isForkOrSnapshot = Boolean(forkId || snapshotId);
+
     if (!this._isSnapshot) {
       /**
        * In cases where large numbers of documents are restarted simultaneously
@@ -367,7 +370,7 @@ export class ActiveDoc extends EventEmitter {
         });
       }
 
-      if (!this._isForkOrSnapshot) {
+      if (!(this.isFork || this._isSnapshot)) {
         /* Note: We don't currently persist usage for forks or snapshots anywhere, so
          * we need to hold off on setting _docUsage here. Normally, usage is set shortly
          * after initialization finishes, after data/attachments size has finished

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -345,6 +345,10 @@ export class DocWorkerApi {
     );
 
     const registerWebhook = async (activeDoc: ActiveDoc, req: RequestWithLogin, webhook: WebhookFields) => {
+      if (activeDoc.isFork) {
+        throw new ApiError('Unsaved document copies cannot have webhooks', 400);
+      }
+
       const {fields, url, authorization} = await getWebhookSettings(activeDoc, req, null, webhook);
       if (!fields.eventTypes?.length) {
         throw new ApiError(`eventTypes must be a non-empty array`, 400);

--- a/test/nbrowser/WebhookPage.ts
+++ b/test/nbrowser/WebhookPage.ts
@@ -290,6 +290,24 @@ describe('WebhookPage', function () {
     await gu.waitForServer();
     assert.equal(await getField(1, 'Memo'), '1234');
   });
+
+  it('does not allow adding webhooks to forks', async function () {
+    // First, let's make sure it's there to begin with.
+    await gu.wipeToasts();
+    await gu.openDocumentSettings();
+    await gu.scrollIntoView(driver.findContentWait('a', /API/i, 3000));
+    assert.equal(await driver.find('.test-admin-panel-item-name-webhooks').isPresent(), true);
+
+    // Now let's make sure it's not in a fork
+    await driver.find('.test-tb-share').click();
+    await driver.find('.test-work-on-copy').click();
+    await gu.waitForUrl(/~/);
+    await gu.waitForDocToLoad();
+    await gu.wipeToasts();
+    await gu.openDocumentSettings();
+    await gu.scrollIntoView(driver.findContentWait('a', /API/i, 3000));
+    assert.equal((await driver.findAll('.test-admin-panel-item-name-webhooks')).length, 0);
+  });
 });
 
 async function setField(rowNum: number, col: string, text: string) {

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -5375,6 +5375,22 @@ function testDocApi(settings: {
               watchedColIds: ['A']
             };
 
+            // make sure it doesn't work on forks.
+            const doc = userApi.getDocAPI(docId);
+            const fork = await doc.fork();
+            const {data: errorData} = await axios.post(
+              `${serverUrl}/api/docs/${fork.docId}/webhooks`,
+              {
+                webhooks: [{
+                  fields: {
+                    ...origFields,
+                    url: `${serving.url}/foo`
+                  }
+                }]
+              }, chimpy
+            );
+            assert.equal(errorData.error, 'Unsaved document copies cannot have webhooks');
+
             // subscribe
             const {data} = await axios.post(
               `${serverUrl}/api/docs/${docId}/webhooks`,


### PR DESCRIPTION
## Context

Adding webhooks to unsaved copies (internal jargon: "forks") results in missing secrets foreign key constraint violation in SQLite.

Original commit messages:

* 99985546f21d webhooks: hide from the UI in forks

  This is just the frontend side. If we can detect a document is a fork,
  we refuse to render the UI for adding webhooks to it.

* 38ab5c5edd64 webhooks: disable API for adding webhooks to forks

  The endpoint for adding webhooks to a fork is disabled.

  I deliberately left the endpoints for modifying or removing webhooks
  enabled. If you've somehow managed to add webhooks to a fork, you
  should be allowed to remove them.

## Proposed solution

Disable webhook on unsaved copies .

## Related issues

closes: #1577 

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

No "webhooks" menu item on forks.

![image](https://github.com/user-attachments/assets/1217d5d7-fd0c-4354-801c-6b1e539710cb)
