### PR TITLE
Dockerfile: copy over the assets if they exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,10 @@ COPY --from=builder /grist/node_modules_prod /grist/node_modules
 COPY --from=builder /grist/_build /grist/_build
 COPY --from=builder /grist/static /grist/static-built
 COPY --from=builder /grist/app/cli.sh /grist/cli
+# Patterm match here is to copy assets only if it exists in the
+# builder stage, otherwise matches nothing.
+# https://stackoverflow.com/a/70096420/11352427
+COPY --from=builder /grist/ext/asset[s] /grist/ext/assets
 
 # Copy python2 files.
 COPY --from=collector-py2 /usr/bin/python2.7 /usr/bin/python2.7


### PR DESCRIPTION
This only matters for the hybrid build. The line should do nothing for the OSS build.

## Context

There are new email assets in the hybrid build, but they weren't being copied over to the Docker image.

## Has this been tested?

Tested locally. I'll re-run the Docker builds from this branch to make sure it also works on Github actions.