### PR TITLE
Attach user from access token after checks

### DIFF
--- a/app/gen-server/lib/homedb/Interfaces.ts
+++ b/app/gen-server/lib/homedb/Interfaces.ts
@@ -109,6 +109,11 @@ export interface DocAuthResult {
   // write access. Null on error.
   error?: ApiError;
   cachedDoc?: Document;       // For cases where stale info is ok.
+
+  // If access is granted by virtue of an "auth" token in the URL, this is the user whose access
+  // was used. The overall Request remains for an anonymous user to avoid accidentally granting
+  // auth-token requests more access than intended. See getOrSetDocAuth() in Authorizer.ts.
+  authTokenUser?: User;
 }
 
 // Defines a subset of HomeDBManager used for logins. In practice we still just pass around

--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -576,7 +576,7 @@ export async function getOrSetDocAuth(
       }
 
       const authTokenUser = await dbManager.getUser(effectiveUserId);
-      mreq.docAuth = {...mreq.docAuth, authTokenUser};
+      mreq.docAuth = { ...mreq.docAuth, authTokenUser };
     }
 
     // A permit with a user set to the anonymous user and linked to this document

--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -574,6 +574,9 @@ export async function getOrSetDocAuth(
       if (tokenObj.readOnly) {
         mreq.docAuth = { ...mreq.docAuth, access: getWeakestRole("viewers", mreq.docAuth.access) };
       }
+      const userId = tokenObj.userId;
+      const user = await dbManager.getUser(userId);
+      setRequestUser(mreq, dbManager, user!);
     }
 
     // A permit with a user set to the anonymous user and linked to this document

--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -574,9 +574,9 @@ export async function getOrSetDocAuth(
       if (tokenObj.readOnly) {
         mreq.docAuth = { ...mreq.docAuth, access: getWeakestRole("viewers", mreq.docAuth.access) };
       }
-      const userId = tokenObj.userId;
-      const user = await dbManager.getUser(userId);
-      setRequestUser(mreq, dbManager, user!);
+
+      const authTokenUser = await dbManager.getUser(effectiveUserId);
+      mreq.docAuth = {...mreq.docAuth, authTokenUser};
     }
 
     // A permit with a user set to the anonymous user and linked to this document

--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -679,9 +679,9 @@ export async function getOrSetDocAuth(
       if (tokenObj.readOnly) {
         mreq.docAuth = { ...mreq.docAuth, access: getWeakestRole("viewers", mreq.docAuth.access) };
       }
-      const userId = tokenObj.userId;
-      const user = await dbManager.getUser(userId);
-      setRequestUser(mreq, dbManager, user!);
+
+      const authTokenUser = await dbManager.getUser(effectiveUserId);
+      mreq.docAuth = {...mreq.docAuth, authTokenUser};
     }
 
     // A permit with a user set to the anonymous user and linked to this document

--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -681,7 +681,7 @@ export async function getOrSetDocAuth(
       }
 
       const authTokenUser = await dbManager.getUser(effectiveUserId);
-      mreq.docAuth = {...mreq.docAuth, authTokenUser};
+      mreq.docAuth = { ...mreq.docAuth, authTokenUser };
     }
 
     // A permit with a user set to the anonymous user and linked to this document

--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -679,6 +679,9 @@ export async function getOrSetDocAuth(
       if (tokenObj.readOnly) {
         mreq.docAuth = { ...mreq.docAuth, access: getWeakestRole("viewers", mreq.docAuth.access) };
       }
+      const userId = tokenObj.userId;
+      const user = await dbManager.getUser(userId);
+      setRequestUser(mreq, dbManager, user!);
     }
 
     // A permit with a user set to the anonymous user and linked to this document

--- a/app/server/lib/GranularAccess.ts
+++ b/app/server/lib/GranularAccess.ts
@@ -55,7 +55,7 @@ import { IPermissionInfo, MixedPermissionSetWithContext,
 import { TablePermissionSetWithContext } from "app/server/lib/PermissionInfo";
 import { integerParam } from "app/server/lib/requestUtils";
 import { getRelatedRows } from "app/server/lib/RowAccess";
-import { getDocSessionAccess, getDocSessionShare } from "app/server/lib/sessionUtils";
+import { getDocSessionAccess, getDocSessionDocAuth, getDocSessionShare } from "app/server/lib/sessionUtils";
 import { quoteIdent } from "app/server/lib/SQLiteDB";
 
 import cloneDeep from "lodash/cloneDeep";
@@ -372,7 +372,14 @@ export class GranularAccess implements GranularAccessForBundle {
       // Note: This is half-baked and doesn't account for other types of shares besides forms.
       fullUser = this._homeDbManager?.makeFullUser(this._homeDbManager.getAnonymousUser()) ?? null;
     } else {
-      fullUser = docSession.fullUser;
+      // If it's a request with an auth token, the access role will already reflect it, but
+      // respect also the user in the request.
+      const authTokenUser = getDocSessionDocAuth(docSession)?.authTokenUser;
+      if (authTokenUser && this._homeDbManager) {
+        fullUser = this._homeDbManager.makeFullUser(authTokenUser);
+      } else {
+        fullUser = docSession.fullUser;
+      }
     }
     const user = new User();
     user.Access = access;

--- a/app/server/lib/GranularAccess.ts
+++ b/app/server/lib/GranularAccess.ts
@@ -55,7 +55,7 @@ import { IPermissionInfo, MixedPermissionSetWithContext,
 import { TablePermissionSetWithContext } from "app/server/lib/PermissionInfo";
 import { integerParam } from "app/server/lib/requestUtils";
 import { getRelatedRows } from "app/server/lib/RowAccess";
-import { getDocSessionAccess, getDocSessionShare } from "app/server/lib/sessionUtils";
+import { getDocSessionAccess, getDocSessionDocAuth, getDocSessionShare } from "app/server/lib/sessionUtils";
 import { quoteIdent } from "app/server/lib/SQLiteDB";
 
 import cloneDeep from "lodash/cloneDeep";
@@ -377,7 +377,14 @@ export class GranularAccess implements GranularAccessForBundle {
       // Note: This is half-baked and doesn't account for other types of shares besides forms.
       fullUser = this._homeDbManager?.makeFullUser(this._homeDbManager.getAnonymousUser()) ?? null;
     } else {
-      fullUser = docSession.fullUser;
+      // If it's a request with an auth token, the access role will already reflect it, but
+      // respect also the user in the request.
+      const authTokenUser = getDocSessionDocAuth(docSession)?.authTokenUser;
+      if (authTokenUser && this._homeDbManager) {
+        fullUser = this._homeDbManager.makeFullUser(authTokenUser);
+      } else {
+        fullUser = docSession.fullUser;
+      }
     }
     const user = new User();
     user.Access = access;

--- a/app/server/lib/sessionUtils.ts
+++ b/app/server/lib/sessionUtils.ts
@@ -1,7 +1,7 @@
 import { DocumentUsage } from "app/common/DocUsage";
 import { Role } from "app/common/roles";
 import { Document } from "app/gen-server/entity/Document";
-import {DocAuthResult} from 'app/gen-server/lib/homedb/Interfaces';
+import { DocAuthResult } from "app/gen-server/lib/homedb/Interfaces";
 import { RequestWithLogin } from "app/server/lib/Authorizer";
 import { AuthSession } from "app/server/lib/AuthSession";
 import { OptDocSession } from "app/server/lib/DocSession";
@@ -103,7 +103,7 @@ export function getDocSessionUsage(docSession: OptDocSession): DocumentUsage | n
   return getDocSessionDocAuth(docSession)?.cachedDoc?.usage || null;
 }
 
-export function getDocSessionDocAuth(docSession: OptDocSession): DocAuthResult|null {
+export function getDocSessionDocAuth(docSession: OptDocSession): DocAuthResult | null {
   if (docSession.authorizer) {
     return docSession.authorizer.getCachedAuth() || null;
   }

--- a/app/server/lib/sessionUtils.ts
+++ b/app/server/lib/sessionUtils.ts
@@ -1,6 +1,7 @@
 import { DocumentUsage } from "app/common/DocUsage";
 import { Role } from "app/common/roles";
 import { Document } from "app/gen-server/entity/Document";
+import {DocAuthResult} from 'app/gen-server/lib/homedb/Interfaces';
 import { RequestWithLogin } from "app/server/lib/Authorizer";
 import { AuthSession } from "app/server/lib/AuthSession";
 import { OptDocSession } from "app/server/lib/DocSession";
@@ -90,7 +91,7 @@ export function getDocSessionAccess(docSession: OptDocSession): Role {
 }
 
 export function getDocSessionShare(docSession: OptDocSession): string | null {
-  return _getCachedDoc(docSession)?.linkId || null;
+  return getDocSessionDocAuth(docSession)?.cachedDoc?.linkId || null;
 }
 
 /**
@@ -99,17 +100,14 @@ export function getDocSessionShare(docSession: OptDocSession): string | null {
  * (although we do recheck access periodically).
  */
 export function getDocSessionUsage(docSession: OptDocSession): DocumentUsage | null {
-  return _getCachedDoc(docSession)?.usage || null;
+  return getDocSessionDocAuth(docSession)?.cachedDoc?.usage || null;
 }
 
-function _getCachedDoc(docSession: OptDocSession): Document | null {
+export function getDocSessionDocAuth(docSession: OptDocSession): DocAuthResult|null {
   if (docSession.authorizer) {
-    return docSession.authorizer.getCachedAuth().cachedDoc || null;
+    return docSession.authorizer.getCachedAuth() || null;
   }
-  if (docSession.req) {
-    return docSession.req.docAuth?.cachedDoc || null;
-  }
-  return null;
+  return docSession.req?.docAuth || null;
 }
 
 export function getDocSessionAccessOrNull(docSession: OptDocSession): Role | null {

--- a/test/server/lib/AccessTokens.ts
+++ b/test/server/lib/AccessTokens.ts
@@ -117,5 +117,12 @@ describe("AccessTokens", function() {
     assert.equal(result.status, 401);
     result = await fetch(home.serverUrl + `/api/docs/${docId}/tables/Table1/records?auth=${token}`);
     assert.equal(result.status, 200);
+
+    // Token is not used outside of /api/docs/${docId}
+    // Anonymous access generates valid responses
+    result = await fetch(home.serverUrl + `/api/profile/user?auth=${token}`);
+    assert.equal(result.status, 200);
+    const payload = await result.json()
+    assert.equal(payload.anonymous, true);
   });
 });

--- a/test/server/lib/AccessTokens.ts
+++ b/test/server/lib/AccessTokens.ts
@@ -122,7 +122,7 @@ describe("AccessTokens", function() {
     // Anonymous access generates valid responses
     result = await fetch(home.serverUrl + `/api/profile/user?auth=${token}`);
     assert.equal(result.status, 200);
-    const payload = await result.json()
+    const payload = await result.json();
     assert.equal(payload.anonymous, true);
   });
 });

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -3854,10 +3854,10 @@ describe("GranularAccess", function() {
     await assert.isRejected(postAttachment(editor, docId, readTokenResult.token, "dataError", "error.txt"));
 
     const tokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: false})).data;
-    const i7 = await postAttachment(editor, docId, tokenResult.token, "data7", "7.txt");
+    const i7 = await postAttachment(editor, docId, tokenResult.token, "content7", "7.txt");
     await assert.isFulfilled(getAttachment(owner, docId, i7));
     //await assert.isFulfilled(getAttachment(editor, docId, i7));
-    await editor.getDocAPI(docId).updateRows('Data1', {id: [1], Pics: [[GristObjCode.List, i7]]});
+    await editor.getDocAPI(docId).updateRows('Data1', {id: [1], Texts: [[GristObjCode.List, i7]]});
     await assert.isFulfilled(getAttachment(editor, docId, i7));
 
     // Attachment check is not applied for undos of actions by the same user.

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -3850,6 +3850,16 @@ describe("GranularAccess", function() {
       { id: [1], MoreTexts: [[GristObjCode.List, i6]] },
     ), /403.*Cannot access attachment/);
 
+    const readTokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: true})).data;
+    await assert.isRejected(postAttachment(editor, docId, readTokenResult.token, "dataError", "error.txt"))
+
+    const tokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: false})).data;
+    const i7 = await postAttachment(editor, docId, tokenResult.token, "data7", "7.txt")
+    await assert.isFulfilled(getAttachment(owner, docId, i7));
+    //await assert.isFulfilled(getAttachment(editor, docId, i7));
+    await editor.getDocAPI(docId).updateRows('Data1', {id: [1], Pics: [[GristObjCode.List, i7]]});
+    await assert.isFulfilled(getAttachment(editor, docId, i7));
+
     // Attachment check is not applied for undos of actions by the same user.
     const ownerProfile = await owner.getUserProfile();
     const editorProfile = await editor.getUserProfile();
@@ -4573,6 +4583,22 @@ async function getAttachment(api: UserAPI, docId: string, attId: number) {
     },
   );
   return result.text();
+}
+
+// Upload an attachment.
+async function postAttachment(api: UserAPI, docId: string, token: string, content: string, filename: string) {
+  const formData = new FormData();
+  formData.append('upload', new Blob([content]), filename);
+  const url = api.getBaseUrl() + `/api/docs/${docId}/attachments?auth=${token}`;
+  const response = await axios.request({
+    url,
+    method: 'POST',
+    data: formData,
+    headers: {
+      "X-Requested-With": "XMLHttpRequest",
+    },
+  });
+  return response.data[0];
 }
 
 async function assertFlux(check: Promise<any>) {

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -3851,10 +3851,10 @@ describe("GranularAccess", function() {
     ), /403.*Cannot access attachment/);
 
     const readTokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: true})).data;
-    await assert.isRejected(postAttachment(editor, docId, readTokenResult.token, "dataError", "error.txt"))
+    await assert.isRejected(postAttachment(editor, docId, readTokenResult.token, "dataError", "error.txt"));
 
     const tokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: false})).data;
-    const i7 = await postAttachment(editor, docId, tokenResult.token, "data7", "7.txt")
+    const i7 = await postAttachment(editor, docId, tokenResult.token, "data7", "7.txt");
     await assert.isFulfilled(getAttachment(owner, docId, i7));
     //await assert.isFulfilled(getAttachment(editor, docId, i7));
     await editor.getDocAPI(docId).updateRows('Data1', {id: [1], Pics: [[GristObjCode.List, i7]]});

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -3856,7 +3856,8 @@ describe("GranularAccess", function() {
     const tokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: false})).data;
     const i7 = await postAttachment(editor, docId, tokenResult.token, "content7", "7.txt");
     await assert.isFulfilled(getAttachment(owner, docId, i7));
-    //await assert.isFulfilled(getAttachment(editor, docId, i7));
+    // New attachments are not accessible through the web API
+    // await assert.isFulfilled(getAttachment(editor, docId, i7));
     await editor.getDocAPI(docId).updateRows('Data1', {id: [1], Texts: [[GristObjCode.List, i7]]});
     await assert.isFulfilled(getAttachment(editor, docId, i7));
 

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -3850,15 +3850,15 @@ describe("GranularAccess", function() {
       { id: [1], MoreTexts: [[GristObjCode.List, i6]] },
     ), /403.*Cannot access attachment/);
 
-    const readTokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: true})).data;
+    const readTokenResult = (await cliEditor.send("getAccessToken", 0, { readOnly: true })).data;
     await assert.isRejected(postAttachment(editor, docId, readTokenResult.token, "dataError", "error.txt"));
 
-    const tokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: false})).data;
+    const tokenResult = (await cliEditor.send("getAccessToken", 0, { readOnly: false })).data;
     const i7 = await postAttachment(editor, docId, tokenResult.token, "content7", "7.txt");
     await assert.isFulfilled(getAttachment(owner, docId, i7));
     // New attachments are not accessible through the web API
     // await assert.isFulfilled(getAttachment(editor, docId, i7));
-    await editor.getDocAPI(docId).updateRows('Data1', {id: [1], Texts: [[GristObjCode.List, i7]]});
+    await editor.getDocAPI(docId).updateRows("Data1", { id: [1], Texts: [[GristObjCode.List, i7]] });
     await assert.isFulfilled(getAttachment(editor, docId, i7));
 
     // Attachment check is not applied for undos of actions by the same user.
@@ -4589,11 +4589,11 @@ async function getAttachment(api: UserAPI, docId: string, attId: number) {
 // Upload an attachment.
 async function postAttachment(api: UserAPI, docId: string, token: string, content: string, filename: string) {
   const formData = new FormData();
-  formData.append('upload', new Blob([content]), filename);
+  formData.append("upload", new Blob([content]), filename);
   const url = api.getBaseUrl() + `/api/docs/${docId}/attachments?auth=${token}`;
   const response = await axios.request({
     url,
-    method: 'POST',
+    method: "POST",
     data: formData,
     headers: {
       "X-Requested-With": "XMLHttpRequest",

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -29,6 +29,7 @@ import { createDocTools } from "test/server/docTools";
 import { GristClient, openClient } from "test/server/gristClient";
 import * as testUtils from "test/server/testUtils";
 
+import axios from "axios";
 import { assert } from "chai";
 import { cloneDeep, isMatch, pick } from "lodash";
 import * as sinon from "sinon";

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -3890,6 +3890,16 @@ describe("GranularAccess", function() {
       { id: [1], MoreTexts: [[GristObjCode.List, i6]] },
     ), /403.*Cannot access attachment/);
 
+    const readTokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: true})).data;
+    await assert.isRejected(postAttachment(editor, docId, readTokenResult.token, "dataError", "error.txt"))
+
+    const tokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: false})).data;
+    const i7 = await postAttachment(editor, docId, tokenResult.token, "data7", "7.txt")
+    await assert.isFulfilled(getAttachment(owner, docId, i7));
+    //await assert.isFulfilled(getAttachment(editor, docId, i7));
+    await editor.getDocAPI(docId).updateRows('Data1', {id: [1], Pics: [[GristObjCode.List, i7]]});
+    await assert.isFulfilled(getAttachment(editor, docId, i7));
+
     // Attachment check is not applied for undos of actions by the same user.
     const ownerProfile = await owner.getUserProfile();
     const editorProfile = await editor.getUserProfile();
@@ -4613,6 +4623,22 @@ async function getAttachment(api: UserAPI, docId: string, attId: number) {
     },
   );
   return result.text();
+}
+
+// Upload an attachment.
+async function postAttachment(api: UserAPI, docId: string, token: string, content: string, filename: string) {
+  const formData = new FormData();
+  formData.append('upload', new Blob([content]), filename);
+  const url = api.getBaseUrl() + `/api/docs/${docId}/attachments?auth=${token}`;
+  const response = await axios.request({
+    url,
+    method: 'POST',
+    data: formData,
+    headers: {
+      "X-Requested-With": "XMLHttpRequest",
+    },
+  });
+  return response.data[0];
 }
 
 async function assertFlux(check: Promise<any>) {

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -3890,15 +3890,15 @@ describe("GranularAccess", function() {
       { id: [1], MoreTexts: [[GristObjCode.List, i6]] },
     ), /403.*Cannot access attachment/);
 
-    const readTokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: true})).data;
+    const readTokenResult = (await cliEditor.send("getAccessToken", 0, { readOnly: true })).data;
     await assert.isRejected(postAttachment(editor, docId, readTokenResult.token, "dataError", "error.txt"));
 
-    const tokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: false})).data;
+    const tokenResult = (await cliEditor.send("getAccessToken", 0, { readOnly: false })).data;
     const i7 = await postAttachment(editor, docId, tokenResult.token, "content7", "7.txt");
     await assert.isFulfilled(getAttachment(owner, docId, i7));
     // New attachments are not accessible through the web API
     // await assert.isFulfilled(getAttachment(editor, docId, i7));
-    await editor.getDocAPI(docId).updateRows('Data1', {id: [1], Texts: [[GristObjCode.List, i7]]});
+    await editor.getDocAPI(docId).updateRows("Data1", { id: [1], Texts: [[GristObjCode.List, i7]] });
     await assert.isFulfilled(getAttachment(editor, docId, i7));
 
     // Attachment check is not applied for undos of actions by the same user.
@@ -4629,11 +4629,11 @@ async function getAttachment(api: UserAPI, docId: string, attId: number) {
 // Upload an attachment.
 async function postAttachment(api: UserAPI, docId: string, token: string, content: string, filename: string) {
   const formData = new FormData();
-  formData.append('upload', new Blob([content]), filename);
+  formData.append("upload", new Blob([content]), filename);
   const url = api.getBaseUrl() + `/api/docs/${docId}/attachments?auth=${token}`;
   const response = await axios.request({
     url,
-    method: 'POST',
+    method: "POST",
     data: formData,
     headers: {
       "X-Requested-With": "XMLHttpRequest",

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -3897,8 +3897,12 @@ describe("GranularAccess", function() {
     const tokenResult = (await cliEditor.send("getAccessToken", 0, { readOnly: false })).data;
     const i7 = await postAttachment(editor, docId, tokenResult.token, "content7", "7.txt");
     await assert.isFulfilled(getAttachment(owner, docId, i7));
-    // New attachments are not accessible through the web API
-    // await assert.isFulfilled(getAttachment(editor, docId, i7));
+    // Without ?maybeNew=true, the web API has no way to prove access to a not-yet-
+    // referenced attachment, so editor is denied.
+    await assert.isRejected(getAttachment(editor, docId, i7));
+    // With ?maybeNew=true, the upload-tracking path lets the editor download the
+    // attachment they just uploaded via their access token.
+    await assert.isFulfilled(getAttachment(editor, docId, i7, { maybeNew: true }));
     await editor.getDocAPI(docId).updateRows("Data1", { id: [1], Texts: [[GristObjCode.List, i7]] });
     await assert.isFulfilled(getAttachment(editor, docId, i7));
 
@@ -4617,10 +4621,11 @@ async function assertDeniedFor(check: Promise<any>, memos: string[], test = /acc
 }
 
 // Read the content of an attachment, as text.
-async function getAttachment(api: UserAPI, docId: string, attId: number) {
+async function getAttachment(api: UserAPI, docId: string, attId: number, options?: { maybeNew?: boolean }) {
   const userApi = api as UserAPIImpl;
+  const query = options?.maybeNew ? "?maybeNew=true" : "";
   const result = await userApi.testRequest(
-    userApi.getBaseUrl() + `/api/docs/${docId}/attachments/${attId}/download`, {
+    userApi.getBaseUrl() + `/api/docs/${docId}/attachments/${attId}/download${query}`, {
       headers: userApi.defaultHeadersWithoutContentType(),
     },
   );

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -3891,10 +3891,10 @@ describe("GranularAccess", function() {
     ), /403.*Cannot access attachment/);
 
     const readTokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: true})).data;
-    await assert.isRejected(postAttachment(editor, docId, readTokenResult.token, "dataError", "error.txt"))
+    await assert.isRejected(postAttachment(editor, docId, readTokenResult.token, "dataError", "error.txt"));
 
     const tokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: false})).data;
-    const i7 = await postAttachment(editor, docId, tokenResult.token, "data7", "7.txt")
+    const i7 = await postAttachment(editor, docId, tokenResult.token, "data7", "7.txt");
     await assert.isFulfilled(getAttachment(owner, docId, i7));
     //await assert.isFulfilled(getAttachment(editor, docId, i7));
     await editor.getDocAPI(docId).updateRows('Data1', {id: [1], Pics: [[GristObjCode.List, i7]]});

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -3896,7 +3896,8 @@ describe("GranularAccess", function() {
     const tokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: false})).data;
     const i7 = await postAttachment(editor, docId, tokenResult.token, "content7", "7.txt");
     await assert.isFulfilled(getAttachment(owner, docId, i7));
-    //await assert.isFulfilled(getAttachment(editor, docId, i7));
+    // New attachments are not accessible through the web API
+    // await assert.isFulfilled(getAttachment(editor, docId, i7));
     await editor.getDocAPI(docId).updateRows('Data1', {id: [1], Texts: [[GristObjCode.List, i7]]});
     await assert.isFulfilled(getAttachment(editor, docId, i7));
 

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -3894,10 +3894,10 @@ describe("GranularAccess", function() {
     await assert.isRejected(postAttachment(editor, docId, readTokenResult.token, "dataError", "error.txt"));
 
     const tokenResult = (await cliEditor.send("getAccessToken", 0, {readOnly: false})).data;
-    const i7 = await postAttachment(editor, docId, tokenResult.token, "data7", "7.txt");
+    const i7 = await postAttachment(editor, docId, tokenResult.token, "content7", "7.txt");
     await assert.isFulfilled(getAttachment(owner, docId, i7));
     //await assert.isFulfilled(getAttachment(editor, docId, i7));
-    await editor.getDocAPI(docId).updateRows('Data1', {id: [1], Pics: [[GristObjCode.List, i7]]});
+    await editor.getDocAPI(docId).updateRows('Data1', {id: [1], Texts: [[GristObjCode.List, i7]]});
     await assert.isFulfilled(getAttachment(editor, docId, i7));
 
     // Attachment check is not applied for undos of actions by the same user.


### PR DESCRIPTION
## Context and related issues

I built a custom widget to upload documents.

It relies on access tokens based requests.

Access token generated unauthenticated requests (logged in as anonymous) which leads to impossible attachment manipulation. (Anonymous user "made" the upload, but I want to add it to a row as user X, user X is not authorized, because of a check that limits who can access a yet-unreferenced attachment.)

----

To replicate the issue
1. have a table with an attachment column
2. have a row in that table
3. Use an access token (with write access) to add an attachment (and get an attachment id back from grist)
4. Use that same access token to link the new attachment to the row (try to add the id in the correct column)

1, 2 and 3 are ok but 4 fails. Well actually it fails when you are not the owner of the doc (because as a owner you have all the rights).

That's the reason why I would like the access token to authenticate as the user of the widget and therefore attach user information to the request in such a case.

(Many thanks to @fflorent)

----

To give more context, here is a working exemple. It highlights a slightly different issue.
https://grist.numerique.gouv.fr/o/docs/daZkkLK5fpoZ/Demo-limit-widget

https://docs.getgrist.com/c3nzPGK4VHbZ/Demo-limit-widget1

Here is the [custom widget code](https://github.com/betagouv/grist-budget-agriculture/blob/main/pages/demo-limit.js#L19-L35).

I created this custom widget to show the difference between record addition via the widget and via the access token.

As an unlogged user both buttons generate record related to anon@getgrist.com.
As a logged-in user records added with the widget are correcly linked but via the access token, records are linked to anon@getgrist.com.


## Proposed solution

Attach the user after verification that the access is legitimate at the document level.


## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
