### PR TITLE
Add a light high contrast theme

### DIFF
--- a/app/client/ui/RightPanel.ts
+++ b/app/client/ui/RightPanel.ts
@@ -49,6 +49,7 @@ import {textInput} from 'app/client/ui2018/editableLabel';
 import {icon} from 'app/client/ui2018/icons';
 import {select} from 'app/client/ui2018/menus';
 import {FieldBuilder} from 'app/client/widgets/FieldBuilder';
+import {components} from 'app/common/ThemePrefs';
 import {isFullReferencingType} from "app/common/gristTypes";
 import {not} from 'app/common/gutil';
 import {StringUnion} from 'app/common/StringUnion';
@@ -1253,16 +1254,16 @@ const cssSubTab = styled('div', `
 
   &-selected {
     color: ${theme.rightPanelSubtabSelectedFg};
-    border-bottom: 1px solid ${theme.rightPanelSubtabSelectedUnderline};
+    border-bottom: ${components.rightPanelSubtabUnderlineSize} solid ${theme.rightPanelSubtabSelectedUnderline};
   }
   &:not(&-selected):hover {
     color: ${theme.rightPanelSubtabHoverFg};
   }
   &:hover {
-    border-bottom: 1px solid ${theme.rightPanelSubtabHoverUnderline};
+    border-bottom: ${components.rightPanelSubtabUnderlineSize} solid ${theme.rightPanelSubtabHoverUnderline};
   }
   .${cssSubTabContainer.className}:hover > &-selected:not(:hover) {
-    border-bottom: 1px solid ${theme.pagePanelsBorder};
+    border-bottom: ${components.rightPanelSubtabUnderlineSize} solid ${theme.pagePanelsBorder};
   }
 `);
 

--- a/app/client/ui/ThemeConfig.ts
+++ b/app/client/ui/ThemeConfig.ts
@@ -48,6 +48,7 @@ export class ThemeConfig extends Disposable {
             [
               {value: 'GristLight', label: 'Light'},
               {value: 'GristDark', label: 'Dark'},
+              {value: 'HighContrastLight', label: 'Light (High Contrast)'},
             ],
             {
               disabled: this._syncWithOS,
@@ -84,5 +85,5 @@ export class ThemeConfig extends Disposable {
 }
 
 const cssAppearanceSelect = styled('div', `
-  width: 120px;
+  width: 180px;
 `);

--- a/app/client/ui/ThemeConfig.ts
+++ b/app/client/ui/ThemeConfig.ts
@@ -4,7 +4,7 @@ import * as css from 'app/client/ui/AccountPageCss';
 import {labeledSquareCheckbox} from 'app/client/ui2018/checkbox';
 import {prefersColorSchemeDarkObs} from 'app/client/ui2018/theme';
 import {select} from 'app/client/ui2018/menus';
-import {ThemeAppearance} from 'app/common/ThemePrefs';
+import {ThemeName, themeNameAppearances} from 'app/common/ThemePrefs';
 import {Computed, Disposable, dom, makeTestId, styled} from 'grainjs';
 
 const testId = makeTestId('test-theme-config-');
@@ -17,18 +17,22 @@ export class ThemeConfig extends Disposable {
     return prefs.syncWithOS;
   }).onWrite((value) => this._updateSyncWithOS(value));
 
-  private _appearance = Computed.create(this,
+  private _themeName = Computed.create(this,
     this._themePrefs,
     this._syncWithOS,
     prefersColorSchemeDarkObs(),
     (_use, prefs, syncWithOS, prefersColorSchemeDark) => {
       if (syncWithOS) {
-        return prefersColorSchemeDark ? 'dark' : 'light';
+        return prefersColorSchemeDark ? 'GristDark' : 'GristLight';
       } else {
-        return prefs.appearance;
+        // The user theme name is stored in both colors.light and colors.dark, just take one of them
+        // This is a bit weird but this rather contained weirdness is preferred to changing the user prefs schema.
+        return prefs.colors.light as ThemeName;
       }
     })
-    .onWrite((value) => this._updateAppearance(value));
+    .onWrite((themeName) => {
+      this._updateTheme(themeName);
+    });
 
   constructor(private _appModel: AppModel) {
     super();
@@ -40,10 +44,10 @@ export class ThemeConfig extends Disposable {
       css.dataRow(
         cssAppearanceSelect(
           select(
-            this._appearance,
+            this._themeName,
             [
-              {value: 'light', label: 'Light'},
-              {value: 'dark', label: 'Dark'},
+              {value: 'GristLight', label: 'Light'},
+              {value: 'GristDark', label: 'Dark'},
             ],
             {
               disabled: this._syncWithOS,
@@ -63,8 +67,15 @@ export class ThemeConfig extends Disposable {
     );
   }
 
-  private _updateAppearance(appearance: ThemeAppearance) {
-    this._themePrefs.set({...this._themePrefs.get(), appearance});
+  private _updateTheme(themeName: ThemeName) {
+    this._themePrefs.set({
+      ...this._themePrefs.get(),
+      appearance: themeNameAppearances[themeName],
+      // Important note: the `colors` property is not actually used for its original purpose.
+      // It's currently our way to store the theme name in user prefs (without having to change the user prefs schema).
+      // This is why we just repeat the name in both `light` and `dark` properties.
+      colors: {light: themeName, dark: themeName},
+    });
   }
 
   private _updateSyncWithOS(syncWithOS: boolean) {

--- a/app/client/ui2018/theme.ts
+++ b/app/client/ui2018/theme.ts
@@ -133,6 +133,10 @@ function getThemeFromPrefs(themePrefs: ThemePrefs, userAgentPrefersDarkTheme: bo
     nameOrTokens = urlParams?.themeName;
   }
 
+  if (syncWithOS) {
+    nameOrTokens = userAgentPrefersDarkTheme ? 'GristDark' : 'GristLight';
+  }
+
   let themeTokens: ThemeTokens;
   if (typeof nameOrTokens === 'string') {
     themeTokens = getThemeTokens(nameOrTokens);

--- a/app/client/widgets/TextBox.css
+++ b/app/client/widgets/TextBox.css
@@ -31,7 +31,7 @@
   }
 
   .formula_field .field-icon, .formula_field_edit::before {
-    background-color: #D0D0D0;
+    background-color: var(--grist-theme-formula-icon, #D0D0D0);
   }
   .formula_field_edit:not(.readonly)::before {
     background-color: var(--grist-color-cursor);

--- a/app/common/ThemePrefs.ts
+++ b/app/common/ThemePrefs.ts
@@ -577,6 +577,7 @@ export const componentsCssMapping = {
   cardButtonBorder: 'card-button-border',
   cardButtonBorderSelected: 'card-button-border-selected',
   cardButtonShadow: 'card-button-shadow',
+  formulaIcon: 'formula-icon',
 } as const;
 
 export const tokens = Object.fromEntries(
@@ -1300,6 +1301,7 @@ export interface BaseThemeTokens {
     appHeaderBg: Token;
     cardButtonBorderSelected: Token;
     cardButtonShadow: Token;
+    formulaIcon: Token;
   };
 }
 

--- a/app/common/ThemePrefs.ts
+++ b/app/common/ThemePrefs.ts
@@ -322,6 +322,7 @@ export const componentsCssMapping = {
   rightPanelSubtabFg: 'right-panel-subtab-fg',
   rightPanelSubtabSelectedFg: 'right-panel-subtab-selected-fg',
   rightPanelSubtabSelectedUnderline: 'right-panel-subtab-selected-underline',
+  rightPanelSubtabUnderlineSize: 'right-panel-subtab-selected-underline-size',
   rightPanelSubtabHoverFg: 'right-panel-subtab-hover-fg',
   rightPanelSubtabHoverUnderline: 'right-panel-subtab-hover-underline',
   rightPanelDisabledOverlay: 'right-panel-disabled-overlay',
@@ -1148,6 +1149,7 @@ export interface BaseThemeTokens {
     rightPanelSubtabFg: Token;
     rightPanelSubtabSelectedFg: Token;
     rightPanelSubtabSelectedUnderline: Token;
+    rightPanelSubtabUnderlineSize: Token;
     rightPanelSubtabHoverUnderline: Token;
     rightPanelDisabledOverlay: Token;
     rightPanelToggleButtonEnabledFg: Token;

--- a/app/common/ThemePrefs.ts
+++ b/app/common/ThemePrefs.ts
@@ -720,37 +720,106 @@ export const convertThemeKeysToCssVars = (theme: Theme): ThemeWithCssVars => {
  * tokens that a given theme must always define
  */
 export interface SpecificThemeTokens {
+  /**
+   * main body text
+   */
   body: Token;
+
+  /**
+   * pronounced text
+   */
   emphasis: Token;
+
+  /**
+   * secondary, less visually pronounced text
+   */
   secondary: Token;
+
+  /**
+   * text that is always light, whatever the current appearance (light or dark theme)
+   */
   veryLight: Token;
 
+  /**
+   * default body bg color
+   */
   bg: Token;
+
+  /**
+   * bg color mostly used on panels
+   */
   bgSecondary: Token;
+
+  /**
+   * transparent bg, mostly used on hover effects
+   */
   bgTertiary: Token;
+
+  /**
+   * pronounced bg color, mostly used on selected items
+   */
   bgEmphasis: Token;
 
+  /**
+   * main decoration color, mostly used on borders
+   */
   decoration: Token;
+
+  /**
+   * less pronounced decoration color
+   */
   decorationSecondary: Token;
+
+  /**
+   * even less pronounced decoration color
+   */
   decorationTertiary: Token;
 
+  /**
+   * main accent color used mostly on interactive elements
+   */
   primary: Token;
+
+  /**
+   * alternative primary color, mostly used on hover effects
+   */
   primaryMuted: Token;
+
+  /**
+   * dimmer primary color, rarely used
+   */
   primaryDim: Token;
+
+  /**
+   * more pronounced primary color variant, rarely used
+   */
   primaryEmphasis: Token;
 
   controlBorderRadius: Token;
 
+  /**
+   * cursor color in widgets
+   */
   cursor: Token;
   cursorInactive: Token;
 
+  /**
+   * transparent background of selected cells
+   */
   selection: Token;
   selectionOpaque: Token;
   selectionDarkerOpaque: Token;
   selectionDarker: Token;
   selectionDarkest: Token;
 
+  /**
+   * non-transparent hover effect color, rarely used
+   */
   hover: Token;
+
+  /**
+   * transparent modal backdrop bg color
+   */
   backdrop: Token;
 
   components: {

--- a/app/common/ThemePrefs.ts
+++ b/app/common/ThemePrefs.ts
@@ -17,6 +17,25 @@ export type ThemeNameOrTokens = ThemeName | ThemeTokens;
 export const themeNames = ['GristLight', 'GristDark'] as const;
 export type ThemeName = typeof themeNames[number];
 
+export const themeNameAppearances = {
+  GristLight: 'light',
+  GristDark: 'dark',
+} as const;
+
+export function getDefaultThemePrefs(): ThemePrefs {
+  return {
+    appearance: 'light',
+    syncWithOS: true,
+    colors: {
+      // Note: the colors object is not used for its original purpose.
+      // It's currently our way to store the theme name in user prefs (without having to change the user prefs schema).
+      // This is why we just repeat the name in both `light` and `dark` properties.
+      light: 'GristLight',
+      dark: 'GristLight',
+    }
+  };
+}
+
 export interface Theme {
   appearance: ThemeAppearance;
   colors: ThemeTokens;
@@ -1216,16 +1235,4 @@ export interface ThemeTokens extends
   Omit<BaseThemeTokens, 'components'>,
   Omit<SpecificThemeTokens, 'components'> {
   components: BaseThemeTokens['components'] & SpecificThemeTokens['components'];
-}
-
-
-export function getDefaultThemePrefs(): ThemePrefs {
-  return {
-    appearance: 'light',
-    syncWithOS: true,
-    colors: {
-      light: 'GristLight',
-      dark: 'GristDark',
-    }
-  };
 }

--- a/app/common/ThemePrefs.ts
+++ b/app/common/ThemePrefs.ts
@@ -14,12 +14,13 @@ export type ThemeAppearance = typeof themeAppearances[number];
 
 export type ThemeNameOrTokens = ThemeName | ThemeTokens;
 
-export const themeNames = ['GristLight', 'GristDark'] as const;
+export const themeNames = ['GristLight', 'GristDark', 'HighContrastLight'] as const;
 export type ThemeName = typeof themeNames[number];
 
 export const themeNameAppearances = {
   GristLight: 'light',
   GristDark: 'dark',
+  HighContrastLight: 'light',
 } as const;
 
 export function getDefaultThemePrefs(): ThemePrefs {

--- a/app/common/Themes.ts
+++ b/app/common/Themes.ts
@@ -1,10 +1,12 @@
 import {ThemeName, ThemeTokens} from 'app/common/ThemePrefs';
 import {GristDark} from 'app/common/themes/GristDark';
 import {GristLight} from 'app/common/themes/GristLight';
+import {HighContrastLight} from 'app/common/themes/HighContrastLight';
 
 const THEMES: Readonly<Record<ThemeName, ThemeTokens>> = {
   GristLight,
   GristDark,
+  HighContrastLight,
 };
 
 export function getThemeTokens(themeName: ThemeName): ThemeTokens {

--- a/app/common/themes/Base.ts
+++ b/app/common/themes/Base.ts
@@ -489,5 +489,7 @@ export const Base: BaseThemeTokens = {
     /* Card Button */
     cardButtonBorderSelected: tokens.primary,
     cardButtonShadow: 'rgba(0,0,0,0.1)',
+
+    formulaIcon: '#D0D0D0',
   }
 };

--- a/app/common/themes/Base.ts
+++ b/app/common/themes/Base.ts
@@ -262,6 +262,7 @@ export const Base: BaseThemeTokens = {
     rightPanelSubtabFg: tokens.primary,
     rightPanelSubtabSelectedFg: tokens.body,
     rightPanelSubtabSelectedUnderline: tokens.primary,
+    rightPanelSubtabUnderlineSize: '1px',
     rightPanelSubtabHoverUnderline: tokens.primary,
     rightPanelDisabledOverlay: tokens.bgSecondary,
     rightPanelToggleButtonEnabledFg: tokens.white,

--- a/app/common/themes/HighContrastLight.ts
+++ b/app/common/themes/HighContrastLight.ts
@@ -36,5 +36,6 @@ export const HighContrastLight: ThemeTokens = {
     rightPanelSubtabSelectedFg: '#000',
     rightPanelSubtabSelectedUnderline: '#000',
     rightPanelSubtabUnderlineSize: '2px',
+    formulaIcon: tokens.decoration,
   }
 };

--- a/app/common/themes/HighContrastLight.ts
+++ b/app/common/themes/HighContrastLight.ts
@@ -1,0 +1,39 @@
+import {ThemeTokens, tokens} from 'app/common/ThemePrefs';
+import {GristLight} from 'app/common/themes/GristLight';
+
+/**
+ * High Contrast Light theme. Uses the default Grist theme as base.
+ */
+export const HighContrastLight: ThemeTokens = {
+  ...GristLight,
+
+  secondary: '#717178',
+
+  decoration: '#8F8F8F',
+  decorationSecondary: '#cfcfcf',
+  decorationTertiary: '#dfdfdf',
+
+  primary: '#0f7b51',
+  primaryMuted: '#196C47',
+  primaryDim: '#196C47',
+
+  components: {
+    ...GristLight.components,
+    appHeaderBorder: tokens.decoration,
+    pagePanelsBorder: tokens.decorationSecondary,
+    tooltipBg: '#000',
+    controlBorder: '1px solid #0f7b51',
+    controlSecondaryHoverBg: tokens.decorationTertiary,
+    buttonGroupBgHover: tokens.decorationSecondary,
+    tableHeaderBorder: tokens.decoration,
+    tableHeaderSelectedBg: tokens.decorationSecondary,
+    selectionHeader: tokens.decorationSecondary,
+    tableBodyBorder: tokens.decorationSecondary,
+    choiceTokenBg: tokens.decorationTertiary,
+    cardFormBorder: tokens.decoration,
+    accessRulesFormulaEditorBgDisabled: tokens.decorationTertiary,
+    rightPanelTabBorder: tokens.decoration,
+    rightPanelSubtabSelectedFg: '#000',
+    rightPanelSubtabSelectedUnderline: '#000',
+  }
+};

--- a/app/common/themes/HighContrastLight.ts
+++ b/app/common/themes/HighContrastLight.ts
@@ -35,5 +35,6 @@ export const HighContrastLight: ThemeTokens = {
     rightPanelTabBorder: tokens.decoration,
     rightPanelSubtabSelectedFg: '#000',
     rightPanelSubtabSelectedUnderline: '#000',
+    rightPanelSubtabUnderlineSize: '2px',
   }
 };

--- a/test/nbrowser/CustomWidgets.ts
+++ b/test/nbrowser/CustomWidgets.ts
@@ -313,7 +313,7 @@ describe('CustomWidgets', function () {
       assert.equal(await getWidgetColor(), 'rgba(38, 38, 51, 1)');
 
       // Switch the theme to GristDark.
-      await gu.setGristTheme({appearance: 'dark', syncWithOS: false});
+      await gu.setGristTheme({themeName: 'GristDark', syncWithOS: false});
       await driver.navigate().back();
       await gu.waitForDocToLoad();
 
@@ -321,7 +321,7 @@ describe('CustomWidgets', function () {
       assert.equal(await getWidgetColor(), 'rgba(239, 239, 239, 1)');
 
       // Switch back to GristLight.
-      await gu.setGristTheme({appearance: 'light', syncWithOS: true});
+      await gu.setGristTheme({themeName: 'GristLight', syncWithOS: false});
       await driver.navigate().back();
       await gu.waitForDocToLoad();
 

--- a/test/nbrowser/Themes.ts
+++ b/test/nbrowser/Themes.ts
@@ -1,0 +1,108 @@
+import { assert, By, ChromiumWebDriver, driver } from 'mocha-webdriver';
+import * as gu from "test/nbrowser/gristUtils";
+import { setupTestSuite } from 'test/nbrowser/testUtils';
+
+const findSyncWithOSCheckbox = () => driver.find('.test-theme-config-sync-with-os');
+const appearanceSelectCssSelector = '.test-theme-config-appearance .test-select-open:not(.disabled)';
+const appearanceSelectDisabledCssSelector = '.test-theme-config-appearance .test-select-open.disabled';
+/**
+ * To verify current theme is correctly applied, we check the text color of breadcrumb first item,
+ * because it is different for each theme.
+ */
+const getCurrentlyAppliedTheme = async () => {
+  const theme = await driver.find('.test-account-page-home');
+  const color = await theme.getCssValue('color');
+  switch (color) {
+    case 'rgba(22, 179, 120, 1)':
+      return 'GristLight';
+    case 'rgba(23, 179, 120, 1)':
+      return 'GristDark';
+    case 'rgba(15, 123, 81, 1)':
+      return 'HighContrastLight';
+    default:
+      throw new Error(`Current theme has unexpected .test-account-page-home color: ${color}`);
+  }
+};
+
+describe('Themes', function () {
+  this.timeout(20000);
+
+  setupTestSuite();
+
+  beforeEach(async function () {
+    const session = await gu.session().teamSite.login();
+    await session.loadDocMenu("/");
+  });
+
+  it('should follow OS preferences by default', async function () {
+    await gu.openProfileSettingsPage();
+
+    // verify that the sync with OS checkbox is checked
+    const syncWithOSCheckbox = await findSyncWithOSCheckbox();
+    assert.isTrue(await syncWithOSCheckbox.isSelected());
+
+    // then verify that the theme select is disabled
+    const activeAppearanceSelect = await driver.findElements(
+      By.css(appearanceSelectCssSelector)
+    );
+    const disabledAppearanceSelect = await driver.findElements(
+      By.css(appearanceSelectDisabledCssSelector)
+    );
+    assert.isEmpty(activeAppearanceSelect, 'Appearance select should be disabled');
+    assert.exists(disabledAppearanceSelect[0], 'Appearance select should be disabled');
+  });
+
+  it('should apply system appearance when sync with OS is enabled', async function() {
+    await gu.openProfileSettingsPage();
+    const syncWithOSCheckbox = await findSyncWithOSCheckbox();
+    const isSelected = await syncWithOSCheckbox.isSelected();
+    if (!isSelected) {
+      await syncWithOSCheckbox.click();
+    }
+
+    // default test env has system light theme set
+    assert.equal(await getCurrentlyAppliedTheme(), 'GristLight');
+
+    // if using chromium web driver, fake the system color scheme to dark and wait for the theme to change
+    if ((driver as ChromiumWebDriver).sendDevToolsCommand) {
+      await (driver as ChromiumWebDriver).sendDevToolsCommand('Emulation.setEmulatedMedia', {features: [
+        {name: 'prefers-color-scheme', value: 'dark'}
+      ]});
+      await driver.sleep(500);
+      assert.equal(await getCurrentlyAppliedTheme(), 'GristDark');
+
+      // reset back to default light system appearance
+      await (driver as ChromiumWebDriver).sendDevToolsCommand('Emulation.setEmulatedMedia', {features: [
+        {name: 'prefers-color-scheme', value: 'light'}
+      ]});
+      await driver.sleep(500);
+      assert.equal(await getCurrentlyAppliedTheme(), 'GristLight');
+    }
+  });
+
+  it('should allow user to select between 3 themes when sync with OS is disabled', async function() {
+    await gu.openProfileSettingsPage();
+
+    const syncWithOSCheckbox = await findSyncWithOSCheckbox();
+    await syncWithOSCheckbox.click();
+    assert.isFalse(await syncWithOSCheckbox.isSelected());
+
+    await gu.scrollIntoView(driver.find(appearanceSelectCssSelector));
+    await driver.find(appearanceSelectCssSelector).click();
+    assert.deepEqual(
+      await gu.findOpenMenuAllItems('li', el => el.getText()),
+      ['Light', 'Dark', 'Light (High Contrast)']
+    );
+  });
+
+  it('should apply the selected theme', async function() {
+    await gu.setGristTheme({themeName: 'GristLight', syncWithOS: false});
+    assert.equal(await getCurrentlyAppliedTheme(), 'GristLight');
+
+    await gu.setGristTheme({themeName: 'GristDark', syncWithOS: false});
+    assert.equal(await getCurrentlyAppliedTheme(), 'GristDark');
+
+    await gu.setGristTheme({themeName: 'HighContrastLight', syncWithOS: false});
+    assert.equal(await getCurrentlyAppliedTheme(), 'HighContrastLight');
+  });
+});

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -3728,11 +3728,11 @@ export async function downloadSectionCsvGridCells(
 }
 
 export async function setGristTheme(options: {
-  appearance: 'light' | 'dark',
+  themeName: 'GristLight' | 'GristDark' | 'HighContrastLight',
   syncWithOS: boolean,
   skipOpenSettingsPage?: boolean,
 }) {
-  const {appearance, syncWithOS, skipOpenSettingsPage} = options;
+  const {themeName, syncWithOS, skipOpenSettingsPage} = options;
   if (!skipOpenSettingsPage) {
     await openProfileSettingsPage();
   }
@@ -3747,7 +3747,9 @@ export async function setGristTheme(options: {
   if (!syncWithOS) {
     await scrollIntoView(driver.find('.test-theme-config-appearance .test-select-open'));
     await driver.find('.test-theme-config-appearance .test-select-open').click();
-    await findOpenMenuItem('li', appearance === 'light' ? 'Light' : 'Dark')
+    await findOpenMenuItem('li', themeName === 'GristLight'
+      ? 'Light' : themeName === 'GristDark'
+      ? 'Dark' : 'Light (High Contrast)')
       .click();
     await waitForServer();
   }


### PR DESCRIPTION
## Context

The light theme has a few color contrast ratio issues here and there. We should aim to match the ratios described in the Web content accessibility guidelines (WCAG). The gist of it is:

- text and background combinations should have a 4.5:1 color contrast ratio,
- sibling colors that are necessary to understand things should have a 3:1 ratio. For example, action icons, or text inputs.

## Proposed solution

Here is some code to add a new theme: a light "high contrast" theme. This theme matches the required WCAG ratios.

At first I imagined updating the default theme so that Grist has WCAG-compliant shades by default. [In the related issue](https://github.com/gristlabs/grist-core/issues/1243), that lead to some discussion about a "legacy theme" for existing users who would want to keep Grist as they know it. And that lead to a few questions about what shades of grey to use, where we would stick to WCAG and where we would not… well, it lead to a few questions that I'm sure would still take a bit of time to be resolved as of right now.

Since we are all pretty busy, I think, as a first step at least, creating a different theme made for this is the best way to get started.

@georgegevoian, this solution implements what we talked about on slack, the first commit should peak your interest.

## Related issues

(https://github.com/gristlabs/grist-core/issues/1243)

## Has this been tested?

Tests were added to make sure theme is changed when we select one or make sure "syncWithOS" checkbox actually listens to the OS (by emulating `prefers-color-scheme` media).

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

![Screen Shot 2025-05-16 at 13 07 46](https://github.com/user-attachments/assets/29de9cd8-87af-4dc7-8a1c-a0bf9545e6f1)
