### PR TITLE
Sort Access Rules Table List Alphabetically for Improved UX

### DIFF
--- a/app/client/aclui/AccessRules.ts
+++ b/app/client/aclui/AccessRules.ts
@@ -1,4 +1,16 @@
 /**
+ * AccessRules.ts
+ * 
+ * Manages the Grist Access Rules UI, including rule creation, display, and syncing logic.
+ * Handles user attributes, special rules, and granular permission sets.
+ *
+ * 🔧 MOD DMH — May 2025:
+ * - Sorts access rules table list alphabetically for improved UX
+ * - Replaces unsorted `rules.getAllTableIds()` with `.slice().sort(...)` in `update()`
+ * - Commented for PR clarity with `// MOD DMH` and `// end MOD DMH` tags
+ */
+
+/**
  * UI for managing granular ACLs.
  */
 import {aclColumnList} from 'app/client/aclui/ACLColumnList';
@@ -250,12 +262,41 @@ export class AccessRules extends Disposable {
     this._ruleProblems.set(aclResources.problems);
     if (this.isDisposed()) { return; }
 
+/**
+     * // MOD DMH
+     * 🔧 Custom Patch: Alphabetically sort access control table rules
+     *
+     *
+     *  Implementation:
+     *   - Adds `.slice().sort(...)` to alphabetize without mutating original array.
+     *   - Keeps filtering and mapping logic unchanged.
+     *   - Includes a `console.log` line for runtime confirmation of patch.
+     *
+     * Replaced:
+     *   rules.getAllTableIds()
+     *     .filter(...)
+     *     .map(...)
+     * 
+     */
+
+    // Original:
+    // this._tableRules.set(
+    //   rules.getAllTableIds()
+    //     .filter(tableId => (tableId !== SPECIAL_RULES_TABLE_ID))
+    //     .map(tableId => TableRules.create(this._tableRules,
+    //         tableId, this, rules.getAllColumnRuleSets(tableId), rules.getTableDefaultRuleSet(tableId)))
+    // );
+
+    // Patched version with alphabetical sort:
     this._tableRules.set(
       rules.getAllTableIds()
-      .filter(tableId => (tableId !== SPECIAL_RULES_TABLE_ID))
-      .map(tableId => TableRules.create(this._tableRules,
-          tableId, this, rules.getAllColumnRuleSets(tableId), rules.getTableDefaultRuleSet(tableId)))
+        .slice().sort((a, b) => a.localeCompare(b))   // MOD DMH: Alphabetical sorting
+        .filter(tableId => (tableId !== SPECIAL_RULES_TABLE_ID))
+        .map(tableId => TableRules.create(this._tableRules,
+            tableId, this, rules.getAllColumnRuleSets(tableId), rules.getTableDefaultRuleSet(tableId)))
     );
+    console.log("[Patch] ✅ Table rules sorted alphabetically by tableId");  
+    // MOD DMH
 
     const withDefaultRules = ['SeedRule'];
     const separateRules = ['SchemaEdit', 'FullCopies', 'AccessRules'];


### PR DESCRIPTION
## Context

This change improves the usability of the Access Rules editor in Grist by sorting the list of tables alphabetically. Previously, tables appeared in the order returned by `rules.getAllTableIds()`, which could be confusing and inefficient for users managing many tables.

**User story:**  
_As a document administrator, I want the list of access rule tables to be sorted alphabetically so I can quickly find the table I'm looking for without scanning a seemingly random order._

## Proposed solution

- Replaced the original unsorted `rules.getAllTableIds()` call with `.slice().sort(...)` in the `update()` method of `AccessRules.ts`
- Ensures alphabetical display without mutating the original array
- Change is marked with `// MOD DMH` comments for traceability
- Includes a `console.log()` line to confirm patch application at runtime

## Related issues

- No formal issue currently tracks this improvement
- This change is safe to merge independently

## Has this been tested?

- [x] 🙅 no, because this is not relevant here  
  _(This is a UI-only display order fix and does not affect logic or require test coverage.)_

## Files Changed

- `app/client/aclui/AccessRules.ts`

## Screenshots / Screencasts

_Not applicable — change affects only table order in dropdown list in the Access Rules UI._
