### PR TITLE
Alphabetically Sort @grist.UserTable Blocks in Code View

### DIFF
--- a/app/client/components/CodeEditorPanel.ts
+++ b/app/client/components/CodeEditorPanel.ts
@@ -1,7 +1,7 @@
 
 /**
  * CodeEditorPanel.ts
- * 
+ *
  * Renders the "Code View" panel in Grist for displaying the schema of the current document.
  * Uses highlight.js to provide syntax highlighting for Python-style Grist schema output.
  *

--- a/app/client/components/CodeEditorPanel.ts
+++ b/app/client/components/CodeEditorPanel.ts
@@ -1,3 +1,4 @@
+
 /**
  * CodeEditorPanel.ts
  * 
@@ -75,26 +76,32 @@ export class CodeEditorPanel extends DisposableWithEvents {
         this._schema.set(schema);
         */
 
-        // 🔧 [Custom Patch] Sort @grist.UserTable blocks alphabetically by class name (v0.3)
+        // MOD DMH - 🔧 [Custom Patch] Sort @grist.UserTable blocks alphabetically by class name
         const lines = schema.split("\n");
         const blocks: string[][] = [];
         let current: string[] = [];
-        for (let line of lines) {
+        for (const line of lines) {
           if (line.startsWith("@grist.UserTable")) {
-            if (current.length) blocks.push(current);
+            if (current.length) {
+              blocks.push(current);
+            }
             current = [line];
           } else {
             current.push(line);
           }
         }
-        if (current.length) blocks.push(current);
+        if (current.length) { blocks.push(current); }
         const sorted = blocks.sort((a, b) => {
-          const nameA = a.find(l => l.trim().startsWith("class")) ?? "";
-          const nameB = b.find(l => l.trim().startsWith("class")) ?? "";
+          const nameA = a.find(l => {
+            return l.trim().startsWith("class");
+          }) ?? "";
+          const nameB = b.find(l => {
+            return l.trim().startsWith("class");
+          }) ?? "";
           return nameA.localeCompare(nameB);
         });
         const pretty = sorted.map(b => b.join("\n")).join("\n\n");
-        console.log("✅ [Custom Patch] CodeEditorPanel.ts");
+        console.log("[Custom Patch] CodeEditorPanel.ts ✅ Sorted @grist.UserTable blocks by class name (v0.3)");
         this._schema.set(pretty);
 
         this._denied.set(false);


### PR DESCRIPTION
## Context

The Code View in Grist shows the document schema as Python-style code, but the order of table definitions is unsorted, making it hard to locate specific tables in large documents.

**User story:**  
_As a developer or admin viewing schema in Code View, I want the `@grist.UserTable` blocks to be sorted alphabetically by class name so that I can find and scan table definitions more easily._

## Proposed solution

- Replaces the default `this._schema.set(schema)` call with logic that:
  - Splits the schema into `@grist.UserTable` blocks
  - Sorts blocks alphabetically by the class definition line (e.g., `class Foo:`)
  - Rejoins the blocks with double line breaks
- The patch is clearly marked with `// MOD DMH` for traceability
- Includes a `console.log` for runtime confirmation

## Related issues

- No open issue; this is a standalone UI enhancement
- This change does not affect permissions, editing, or schema logic

## Has this been tested?

- [x] 🙅 no, because this is not relevant here  
  _(Change only affects display logic in the read-only Code View panel)_

## Files Changed

- `app/client/components/CodeEditorPanel.ts`

## Screenshots / Screencasts

_Not applicable — change affects text ordering in Code View only_
