### PR TITLE
Fixing records card test

### DIFF
--- a/test/nbrowser/RecordCards.ts
+++ b/test/nbrowser/RecordCards.ts
@@ -54,7 +54,7 @@ describe('RecordCards', function() {
       await (await gu.openRowMenu(1)).findContent('li', /View as card/).click();
       assert.isTrue(await driver.findWait('.test-record-card-popup-overlay', 100).isDisplayed());
       await gu.sendKeys(Key.chord(await gu.modKey(), Key.DELETE));
-      await driver.find('.test-confirm-save').click();
+      await gu.confirm(true);
       await gu.waitForServer();
       assert.isFalse(await driver.find('.test-record-card-popup-overlay').isPresent());
     });


### PR DESCRIPTION
## Context

Fixing RecordCard tests that were recently broken by adding new test for on demand tables.

## Proposed solution

RecordCard expected popups to be visible, but some tests (in this case OnDemand test suit) dismiss them. Now this test will first check if the popup is visible and then dismiss it.

## Has this been tested?
- [X] 👍 yes, I added tests to the test suite