### PR TITLE
Fix server crash when `intarray` PG extension is enabled

### DIFF
--- a/app/gen-server/sqlUtils.ts
+++ b/app/gen-server/sqlUtils.ts
@@ -67,7 +67,7 @@ export function hasOnlyTheseIdsOrNull(dbType: DatabaseType, ids: number[], colum
 export function hasAtLeastOneOfTheseIds(dbType: DatabaseType, ids: number[], columns: string[]): string {
   switch (dbType) {
     case 'postgres':
-      return `array[${ids.join(',')}] && array[${columns.join(',')}]`;
+      return `array[${ids.join(',')}] OPERATOR(pg_catalog.&&) array[${columns.join(',')}]`;
     case 'sqlite':
       return ids.map(id => `${id} in (${columns.join(',')})`).join(' OR ');
     default:


### PR DESCRIPTION
## Context

Hi!
I am trying to run Grist on [Clever Cloud](https://www.clever-cloud.com/)using the official Docker image and PostgreSQL 17.
I made good progress but as I encountered a blocking issue, I'm reporting it!

After authentication, when accessing Grist, the server always crashed like this:

```
2025-05-17 16:23:55 2025-05-17 14:23:55.657 - error: UNHANDLED ERROR unhandledRejection (0): QueryFailedError: array must not contain nulls
2025-05-17 16:23:55     at PostgresQueryRunner.query (/grist/node_modules/typeorm/driver/postgres/PostgresQueryRunner.js:211:19)
2025-05-17 16:23:55     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
2025-05-17 16:23:55     at async SelectQueryBuilder.loadRawResults (/grist/node_modules/typeorm/query-builder/SelectQueryBuilder.js:2183:25)
2025-05-17 16:23:55     at async SelectQueryBuilder.executeEntitiesAndRawResults (/grist/node_modules/typeorm/query-builder/SelectQueryBuilder.js:2034:26)
2025-05-17 16:23:55     at async SelectQueryBuilder.getRawAndEntities (/grist/node_modules/typeorm/query-builder/SelectQueryBuilder.js:684:29)
2025-05-17 16:23:55     at async HomeDBManager._verifyAclPermissions (/grist/_build/app/gen-server/lib/homedb/HomeDBManager.js:3601:25)
2025-05-17 16:23:55     at async HomeDBManager.getMergedOrgs (/grist/_build/app/gen-server/lib/homedb/HomeDBManager.js:664:24)
2025-05-17 16:23:55     at async FlexServer._redirectToOrg (/grist/_build/app/server/lib/FlexServer.js:2127:24) {
2025-05-17 16:23:55   query: `SELECT "orgs"."name" AS "orgs_name", "orgs"."created_at" AS "orgs_created_at", "orgs"."updated_at" AS "orgs_updated_at", "orgs"."id" AS "orgs_id", "orgs"."domain" AS "orgs_domain", "orgs"."billing_account_id" AS "orgs_billing_account_id", "orgs"."host" AS "orgs_host", "orgs"."owner_id" AS "orgs_owner_id", "users"."id" AS "users_id", "users"."name" AS "users_name", "users"."api_key" AS "users_api_key", "users"."picture" AS "users_picture", "users"."first_login_at" AS "users_first_login_at", "users"."last_connection_at" AS "users_last_connection_at", "users"."is_first_time_user" AS "users_is_first_time_user", "users"."options" AS "users_options", "users"."connect_id" AS "users_connect_id", "users"."ref" AS "users_ref", "users"."created_at" AS "users_created_at", (SELECT bit_or((case when array[3,1] && array[gu0.user_id,gu1.user_id,gu2.user_id,gu3.user_id] then 128 else 0 end | "acl_rules"."permissions" | case when coalesce("gu0"."user_id",gu1.user_id,gu2.user_id,gu3.user_id) is null then "acl_rules"."permissions" else 0 end)) AS "permissions" FROM "acl_rules" "acl_rules" LEFT JOIN "group_groups" "gg1" ON "gg1"."group_id" = "acl_rules"."group_id"  LEFT JOIN "group_groups" "gg2" ON "gg2"."group_id" = "gg1"."subgroup_id"  LEFT JOIN "group_groups" "gg3" ON "gg3"."group_id" = "gg2"."subgroup_id"  LEFT JOIN "group_users" "gu3" ON "gg3"."subgroup_id" = "gu3"."group_id"  LEFT JOIN "group_users" "gu2" ON "gg2"."subgroup_id" = "gu2"."group_id"  LEFT JOIN "group_users" "gu1" ON "gg1"."subgroup_id" = "gu1"."group_id"  LEFT JOIN "group_users" "gu0" ON "acl_rules"."group_id" = "gu0"."group_id" WHERE (5 IN ("gu0"."user_id", "gu1"."user_id", "gu2"."user_id", "gu3"."user_id") OR 3 IN ("gu0"."user_id", "gu1"."user_id", "gu2"."user_id", "gu3"."user_id")) AND "acl_rules"."org_id" = "orgs"."id") AS "orgs_permissions" FROM "orgs" "orgs" LEFT JOIN "users" "users" ON "users"."id"="orgs"."owner_id" AND ("orgs"."owner_id" = "users"."id")  LEFT JOIN "acl_rules" "acl_rules" ON "acl_rules"."org_id"="orgs"."id" AND "acl_rules"."type"='AclRuleOrg'  LEFT JOIN "groups" "groups" ON "groups"."id"="acl_rules"."group_id"  LEFT JOIN "group_users" "groups_members" ON "groups_members"."group_id"="groups"."id" LEFT JOIN "users" "members" ON "members"."id"="groups_members"."user_id" WHERE ("members"."id" = $1 OR ("members"."id" = $2)) ORDER BY (coalesce("users"."id",0) = $3) DESC, "users"."name" ASC, "orgs"."name" ASC`,
2025-05-17 16:23:55   parameters: [ 5, 3, 5 ],
2025-05-17 16:23:55   driverError: error: array must not contain nulls
2025-05-17 16:23:55       at Parser.parseErrorMessage (/grist/node_modules/pg-protocol/dist/parser.js:287:98)
2025-05-17 16:23:55       at Parser.handlePacket (/grist/node_modules/pg-protocol/dist/parser.js:126:29)
2025-05-17 16:23:55       at Parser.parse (/grist/node_modules/pg-protocol/dist/parser.js:39:38)
2025-05-17 16:23:55       at Socket.<anonymous> (/grist/node_modules/pg-protocol/dist/index.js:11:42)
2025-05-17 16:23:55       at Socket.emit (node:events:518:28)
2025-05-17 16:23:55       at Socket.emit (node:domain:489:12)
2025-05-17 16:23:55       at addChunk (node:internal/streams/readable:561:12)
2025-05-17 16:23:55       at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
2025-05-17 16:23:55       at Readable.push (node:internal/streams/readable:392:5)
2025-05-17 16:23:55       at TCP.onStreamRead (node:internal/stream_base_commons:189:23) {
2025-05-17 16:23:55     length: 86,
2025-05-17 16:23:55     severity: 'ERROR',
2025-05-17 16:23:55     code: '22004',
2025-05-17 16:23:55     detail: undefined,
2025-05-17 16:23:55     hint: undefined,
2025-05-17 16:23:55     position: undefined,
2025-05-17 16:23:55     internalPosition: undefined,
2025-05-17 16:23:55     internalQuery: undefined,
2025-05-17 16:23:55     where: undefined,
2025-05-17 16:23:55     schema: undefined,
2025-05-17 16:23:55     table: undefined,
2025-05-17 16:23:55     column: undefined,
2025-05-17 16:23:55     dataType: undefined,
2025-05-17 16:23:55     constraint: undefined,
2025-05-17 16:23:55     file: '_int_op.c',
2025-05-17 16:23:55     line: '106',
2025-05-17 16:23:55     routine: '_int_overlap'
2025-05-17 16:23:55   },
2025-05-17 16:23:55   length: 86,
2025-05-17 16:23:55   severity: 'ERROR',
2025-05-17 16:23:55   code: '22004',
2025-05-17 16:23:55   detail: undefined,
2025-05-17 16:23:55   hint: undefined,
2025-05-17 16:23:55   position: undefined,
2025-05-17 16:23:55   internalPosition: undefined,
2025-05-17 16:23:55   internalQuery: undefined,
2025-05-17 16:23:55   where: undefined,
2025-05-17 16:23:55   schema: undefined,
2025-05-17 16:23:55   table: undefined,
2025-05-17 16:23:55   column: undefined,
2025-05-17 16:23:55   dataType: undefined,
2025-05-17 16:23:55   constraint: undefined,
2025-05-17 16:23:55   file: '_int_op.c',
2025-05-17 16:23:55   line: '106',
2025-05-17 16:23:55   routine: '_int_overlap'
2025-05-17 16:23:55 }
2025-05-17 16:23:55 2025-05-17 14:23:55.657 - info: Server grist[25] cleaning up
2025-05-17 16:23:55 2025-05-17 14:23:55.658 - info: UploadSet: cleaning up all 0 uploads in set
2025-05-17 16:23:55 2025-05-17 14:23:55.658 - info: DocWorkerMap.setWorkerAvailability testDocWorkerId_8080 false
2025-05-17 16:23:55 2025-05-17 14:23:55.663 - info: DocWorkerMap.removeWorker testDocWorkerId_8080
2025-05-17 16:23:55 2025-05-17 14:23:55.676 - info: FlexServer shutdown is complete
2025-05-17 16:23:55 2025-05-17 14:23:55.676 - info: Server grist[25] exiting with code 1
```

I discovered that the PostgreSQL extension [intarray](https://www.postgresql.org/docs/current/intarray.html) was the cause of this issue as it overrides the stock `&&` operator with one that apparently does not tolerate null values.
In Clever Cloud's managed PostgreSQL databases, some extensions like `intarray` are installed and activated by default on the `public` schema and users cannot disable them (which I believe is going to change in the coming years, but I had to find a solution a lot sooner 😄).

## Proposed solution

I replaced the problematic use of the `&&` operator by `OPERATOR(pg_catalog.&&)` which should target the same stock `&&` operator whether `intarray` is enabled or not.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

## Has this been tested?

I patched this locally and successfully tested it on Clever Cloud's managed PostgreSQL databases.

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
