### PR TITLE
Update GoogleAuth.ts to account for self-hosted instances

### DIFF
--- a/app/server/lib/GoogleAuth.ts
+++ b/app/server/lib/GoogleAuth.ts
@@ -74,7 +74,7 @@ const AUTH_SUBDOMAIN = process.env.GRIST_ID_PREFIX ? `docs-${process.env.GRIST_I
 function getFullAuthEndpointUrl(): string {
   const homeUrl = process.env.APP_HOME_URL;
   // if homeUrl is localhost - (in dev environment) - use the development url
-  if (homeUrl && new URL(homeUrl).hostname === "localhost") {
+  if (homeUrl) {
     return `${homeUrl}${authHandlerPath}`;
   }
   const homeBaseDomain = homeUrl && parseSubdomain(new URL(homeUrl).host).base;


### PR DESCRIPTION

## Context

https://github.com/gristlabs/grist-core/issues/1549#issue-2972170839

## Proposed solution

Always use the `APP_HOME_URL` env variable (if set) to create the Auth Redirect url.

## Related issues

https://github.com/gristlabs/grist-core/issues/1549#issue-2972170839

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [x] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
