### PR TITLE
Fix dark theme loading flash

### DIFF
--- a/app/common/Themes.ts
+++ b/app/common/Themes.ts
@@ -35,12 +35,21 @@ export function getThemeBackgroundSnippet() {
   return `
 <script>
 try {
-  if (localStorage.getItem('appearance') === 'dark' && (window.gristConfig.features || []).includes('themes')) {
+  const appearance = localStorage.getItem('appearance');
+  const theme = localStorage.getItem('grist-theme');
+  const useThemes = (window.gristConfig.features || []).includes('themes');
+  if (useThemes) {
+    document.documentElement.setAttribute('data-grist-appearance', appearance);
+    document.documentElement.setAttribute('data-grist-theme', theme);
+  }
+  if (useThemes && appearance === 'dark') {
     const style = document.createElement('style');
-    style.setAttribute('id', 'grist-theme');
-    style.textContent = ':root {\\n' +
-      '  --grist-theme-bg: url("img/prismpattern.png");\\n' +
-      '  --grist-theme-bg-color: #333333;\\n' +
+    style.setAttribute('id', 'grist-theme-bg');
+    style.textContent = '@layer grist-theme {\\n' +
+      '  :root {\\n' +
+      '    --grist-theme-bg: url("img/prismpattern.png");\\n' +
+      '    --grist-theme-bg-color: #333333;\\n' +
+      '  }\\n' +
       '}';
     document.head.append(style);
   }

--- a/app/common/Themes.ts
+++ b/app/common/Themes.ts
@@ -35,14 +35,14 @@ export function getThemeBackgroundSnippet() {
   return `
 <script>
 try {
-  const appearance = localStorage.getItem('appearance');
-  const theme = localStorage.getItem('grist-theme');
   const useThemes = (window.gristConfig.features || []).includes('themes');
-  if (useThemes) {
-    document.documentElement.setAttribute('data-grist-appearance', appearance);
-    document.documentElement.setAttribute('data-grist-theme', theme);
+  if (!useThemes) { return; }
+
+  const appearance = localStorage.getItem('appearance');
+  if (appearance) {
+      document.documentElement.setAttribute('data-grist-appearance', appearance);
   }
-  if (useThemes && appearance === 'dark') {
+  if (appearance === 'dark') {
     const style = document.createElement('style');
     style.setAttribute('id', 'grist-theme-bg');
     style.textContent = '@layer grist-theme {\\n' +
@@ -52,6 +52,11 @@ try {
       '  }\\n' +
       '}';
     document.head.append(style);
+  }
+
+  const theme = localStorage.getItem('grist-theme');
+  if (theme) {
+      document.documentElement.setAttribute('data-grist-theme', theme);
   }
 } catch {
   /* Do nothing. */


### PR DESCRIPTION
## Context

When loading grist with a dark appearance, we already add a couple style rules that force a dark background, in order to prevent a flash of light to dark color.

It's my bad on this one, this was actually broken since my updates on themes a few weeks ago because of a conflict in html IDs. Because the dark-theme specific background snippet gets overridden when the theme has loaded, so there is a tiny bit of time where the light pattern img is shown before DOM content is rendered.

## Proposed solution

- there is no more ID conflict (the snippet is appended with `grist-theme-bg` id now)
- the CSS added by the snippet is in the `grist-theme` css @<!-- -->layer, to eases up custom CSS changes
- theme name, in addition to appearance, is stored in localstorage and is used as default fallback when trying to load current theme, before checking system prefs
- appearance/theme info is added early as html attributes to help custom CSS users modify the loading screen as they need

## Has this been tested?

I'm not sure trying to test "themes loading racing conditions" is really valuable here?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

Here are videos with slowed down loading to better see the issue/fix.

Before:

https://github.com/user-attachments/assets/4b9190ea-eec1-404b-acc3-42f8ce7675e3

After:

https://github.com/user-attachments/assets/683f50fd-8e17-4d21-831d-15d4119ea975

