### PR TITLE
Tests: move some functions from `gristUtils` to `gristWebDriverUtils`

### DIFF
--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -13,7 +13,6 @@ import * as path from 'path';
 import * as PluginApi from 'app/plugin/grist-plugin-api';
 
 import { BaseAPI } from 'app/common/BaseAPI';
-import {CommandName} from 'app/client/components/commandList';
 import {csvDecodeRow} from 'app/common/csvFormat';
 import { AccessLevel } from 'app/common/CustomWidget';
 import { decodeUrl } from 'app/common/gristUrls';
@@ -96,6 +95,7 @@ export const isAlertShown = webdriverUtils.isAlertShown.bind(webdriverUtils);
 export const waitForDocToLoad = webdriverUtils.waitForDocToLoad.bind(webdriverUtils);
 export const reloadDoc = webdriverUtils.reloadDoc.bind(webdriverUtils);
 export const sendActions = webdriverUtils.sendActions.bind(webdriverUtils);
+export const sendCommand = webdriverUtils.sendCommand.bind(webdriverUtils);
 
 export const fixturesRoot: string = testUtils.fixturesRoot;
 
@@ -4023,21 +4023,6 @@ class Clipboard implements IClipboard {
     const menuItemName = action.charAt(0).toUpperCase() + action.slice(1);
     await findOpenMenuItem('li', menuItemName).click();
   }
-}
-
-/**
- * Runs a Grist command in the browser window.
- */
-export async function sendCommand(name: CommandName, argument: any = null) {
-  await driver.executeAsyncScript((name: any, argument: any, done: any) => {
-    const result = (window as any).gristApp.allCommands[name].run(argument);
-    if (result?.finally) {
-      result.finally(done);
-    } else {
-      done();
-    }
-  }, name, argument);
-  await waitForServer();
 }
 
 /**

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -105,6 +105,7 @@ export const undo = webdriverUtils.undo.bind(webdriverUtils);
 export const bigScreen = webdriverUtils.bigScreen.bind(webdriverUtils);
 export const narrowScreen = webdriverUtils.narrowScreen.bind(webdriverUtils);
 export const exactMatch = webdriverUtils.exactMatch.bind(webdriverUtils);
+export const getSection = webdriverUtils.getSection.bind(webdriverUtils);
 
 export const fixturesRoot: string = testUtils.fixturesRoot;
 
@@ -234,16 +235,6 @@ export async function dismissWelcomeTourIfNeeded() {
 // Selects all text when a text element is currently active.
 export async function selectAll() {
   await driver.executeScript('document.activeElement.select()');
-}
-
-/**
- * Returns a WebElementPromise for the .viewsection_content element for the section which contains
- * the given text (case insensitive) content.
- */
-export function getSection(sectionOrTitle: string|WebElement): WebElement|WebElementPromise {
-  if (typeof sectionOrTitle !== 'string') { return sectionOrTitle; }
-  return driver.findContent(`.test-viewsection-title`, new RegExp("^" + escapeRegExp(sectionOrTitle) + "$", 'i'))
-    .findClosest('.viewsection_content');
 }
 
 /**

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -98,6 +98,7 @@ export const sendActions = webdriverUtils.sendActions.bind(webdriverUtils);
 export const sendCommand = webdriverUtils.sendCommand.bind(webdriverUtils);
 export const openAccountMenu = webdriverUtils.openAccountMenu.bind(webdriverUtils);
 export const openProfileSettingsPage = webdriverUtils.openProfileSettingsPage.bind(webdriverUtils);
+export const undo = webdriverUtils.undo.bind(webdriverUtils);
 
 export const fixturesRoot: string = testUtils.fixturesRoot;
 
@@ -1508,18 +1509,6 @@ export async function removeTable(tableId: string, options: {dismissTips?: boole
   await driver.findWait(".test-modal-confirm", 100).click();
   await waitForServer();
 }
-
-/**
- * Click the Undo button and wait for server. If optCount is given, click Undo that many times.
- */
-export async function undo(optCount: number = 1, optTimeout?: number) {
-  await waitForServer(optTimeout);
-  for (let i = 0; i < optCount; ++i) {
-    await driver.find('.test-undo').doClick();
-    await waitForServer(optTimeout);
-  }
-}
-
 
 /**
  * Returns a function to undo all user actions from a particular point in time.

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -96,6 +96,7 @@ export const waitForDocToLoad = webdriverUtils.waitForDocToLoad.bind(webdriverUt
 export const reloadDoc = webdriverUtils.reloadDoc.bind(webdriverUtils);
 export const sendActions = webdriverUtils.sendActions.bind(webdriverUtils);
 export const sendCommand = webdriverUtils.sendCommand.bind(webdriverUtils);
+export const openAccountMenu = webdriverUtils.openAccountMenu.bind(webdriverUtils);
 
 export const fixturesRoot: string = testUtils.fixturesRoot;
 
@@ -2946,15 +2947,6 @@ export function addSamplesForSuite(includeTutorial = false) {
   after(async function() {
     await removeTemplatesOrg();
   });
-}
-
-export async function openAccountMenu() {
-  await driver.findWait('.test-dm-account', 2000).click();
-  // Since the AccountWidget loads orgs and the user data asynchronously, the menu
-  // can expand itself causing the click to land on a wrong button.
-  await waitForServer();
-  await driver.findWait('.test-site-switcher-org', 2000);
-  await driver.sleep(250);  // There's still some jitter (scroll-bar? other user accounts?)
 }
 
 export async function openProfileSettingsPage() {

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -26,8 +26,9 @@ import { Product } from 'app/gen-server/entity/Product';
 import { create } from 'app/server/lib/create';
 import { getAppRoot } from 'app/server/lib/places';
 
-import { noCleanup as _noCleanup, GristWebDriverUtils, IColsSelect, IColSelect,
-         PageWidgetPickerOptions, WindowDimensions as WindowDimensionsBase } from 'test/nbrowser/gristWebDriverUtils';
+import { ICellSelect as _ICellSelect, noCleanup as _noCleanup, GristWebDriverUtils,
+         IColSelect, IColsSelect, PageWidgetPickerOptions,
+         WindowDimensions as WindowDimensionsBase } from 'test/nbrowser/gristWebDriverUtils';
 import { APIConstructor, HomeUtil } from 'test/nbrowser/homeUtil';
 import { server } from 'test/nbrowser/testServer';
 import type { Cleanup } from 'test/nbrowser/testUtils';
@@ -41,7 +42,9 @@ import { lock } from 'proper-lockfile';
 // Wrap in a namespace so that we can apply stackWrapOwnMethods to all the exports together.
 namespace gristUtils {
 
+// Re-export types imported from gristWebDriverUtils
 export const noCleanup = _noCleanup;
+export type ICellSelect = _ICellSelect;
 
 // Allow overriding the global 'driver' to use in gristUtil.
 let _driver: WebDriver|undefined;
@@ -107,6 +110,7 @@ export const narrowScreen = webdriverUtils.narrowScreen.bind(webdriverUtils);
 export const exactMatch = webdriverUtils.exactMatch.bind(webdriverUtils);
 export const getSection = webdriverUtils.getSection.bind(webdriverUtils);
 export const getVisibleGridCells = webdriverUtils.getVisibleGridCells.bind(webdriverUtils);
+export const getCell = webdriverUtils.getCell.bind(webdriverUtils);
 
 export const fixturesRoot: string = testUtils.fixturesRoot;
 
@@ -116,12 +120,6 @@ export type WindowDimensions = WindowDimensionsBase;
 // code changes.
 server.simulateLogin = simulateLogin;
 server.removeLogin = removeLogin;
-
-export interface ICellSelect {
-  col: number|string;
-  rowNum: number;
-  section?: string|WebElement;
-}
 
 export interface IColHeader {
   col: number|string;
@@ -420,23 +418,6 @@ export async function getVisibleDetailCells<T>(
     el.findContent('.g_record_detail_label', exactMatch(colName))
     .findClosest('.g_record_detail_el').find('.g_record_detail_value')
   )));
-}
-
-
-/**
- * Returns a visible GridView cell. Options may be given as arguments directly, or as an object.
- * - col: column name, or 0-based column index
- * - rowNum: 1-based row numbers, as visible in the row headers on the left of the grid.
- * - section: optional name of the section to use; will use active section if omitted.
- */
-export function getCell(col: number|string, rowNum: number, section?: string): WebElementPromise;
-export function getCell(options: ICellSelect): WebElementPromise;
-export function getCell(colOrOptions: number|string|ICellSelect, rowNum?: number, section?: string): WebElementPromise {
-  const mapper = async (el: WebElement) => el;
-  const options: IColSelect<WebElement> = (typeof colOrOptions === 'object' ?
-    {col: colOrOptions.col, rowNums: [colOrOptions.rowNum], section: colOrOptions.section, mapper} :
-    {col: colOrOptions, rowNums: [rowNum!], section, mapper});
-  return new WebElementPromise(driver, getVisibleGridCells(options).then((elems) => elems[0]));
 }
 
 

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -106,6 +106,7 @@ export const bigScreen = webdriverUtils.bigScreen.bind(webdriverUtils);
 export const narrowScreen = webdriverUtils.narrowScreen.bind(webdriverUtils);
 export const exactMatch = webdriverUtils.exactMatch.bind(webdriverUtils);
 export const getSection = webdriverUtils.getSection.bind(webdriverUtils);
+export const getVisibleGridCells = webdriverUtils.getVisibleGridCells.bind(webdriverUtils);
 
 export const fixturesRoot: string = testUtils.fixturesRoot;
 
@@ -310,54 +311,6 @@ export async function getSectionId() {
   const match = classList.match(/test-viewlayout-section-(\d+)/);
   if (!match) { throw new Error("Could not find section id"); }
   return parseInt(match[1]);
-}
-
-/**
- * Returns visible cells of the GridView from a single column and one or more rows. Options may be
- * given as arguments directly, or as an object.
- * - col: column name, or 0-based column index
- * - rowNums: array of 1-based row numbers, as visible in the row headers on the left of the grid.
- * - section: optional name of the section to use; will use active section if omitted.
- *
- * If given by an object, then an array of columns is also supported. In this case, the return
- * value is still a single array, listing all values from the first row, then the second, etc.
- *
- * Returns cell text by default. Mapper may be `identity` to return the cell objects.
- */
-export async function getVisibleGridCells(col: number|string, rows: number[], section?: string): Promise<string[]>;
-export async function getVisibleGridCells<T = string>(options: IColSelect<T>|IColsSelect<T>): Promise<T[]>;
-export async function getVisibleGridCells<T>(
-  colOrOptions: number|string|IColSelect<T>|IColsSelect<T>, _rowNums?: number[], _section?: string
-): Promise<T[]> {
-
-  if (typeof colOrOptions === 'object' && 'cols' in colOrOptions) {
-    const {rowNums, section, mapper} = colOrOptions;    // tslint:disable-line:no-shadowed-variable
-    const columns = await Promise.all(colOrOptions.cols.map((oneCol) =>
-      getVisibleGridCells({col: oneCol, rowNums, section, mapper})));
-    // This zips column-wise data into a flat row-wise array of values.
-    return ([] as T[]).concat(...rowNums.map((r, i) => columns.map((c) => c[i])));
-  }
-
-  const {col, rowNums, section, mapper = el => el.getText()}: IColSelect<any> = (
-    typeof colOrOptions === 'object' ? colOrOptions :
-    { col: colOrOptions, rowNums: _rowNums!, section: _section}
-  );
-
-  if (rowNums.includes(0)) {
-    // Row-numbers should be what the users sees: 0 is a mistake, so fail with a helpful message.
-    throw new Error('rowNum must not be 0');
-  }
-
-  const sectionElem = section ? await getSection(section) : await driver.findWait('.active_section', 4000);
-  const colIndex = (typeof col === 'number' ? col :
-    await sectionElem.findContent('.column_name', exactMatch(col)).index());
-
-  const visibleRowNums: number[] = await sectionElem.findAll('.gridview_data_row_num',
-    async (el) => parseInt(await el.getText(), 10));
-
-  const selector = `.gridview_data_scroll .record:not(.column_names) .field:nth-child(${colIndex + 1})`;
-  const fields = mapper ? await sectionElem.findAll(selector, mapper) : await sectionElem.findAll(selector);
-  return rowNums.map((n) => fields[visibleRowNums.indexOf(n)]);
 }
 
 /**

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -111,6 +111,7 @@ export const exactMatch = webdriverUtils.exactMatch.bind(webdriverUtils);
 export const getSection = webdriverUtils.getSection.bind(webdriverUtils);
 export const getVisibleGridCells = webdriverUtils.getVisibleGridCells.bind(webdriverUtils);
 export const getCell = webdriverUtils.getCell.bind(webdriverUtils);
+export const selectSectionByTitle = webdriverUtils.selectSectionByTitle.bind(webdriverUtils);
 
 export const fixturesRoot: string = testUtils.fixturesRoot;
 
@@ -278,22 +279,6 @@ export async function detachFromLayout(section?: string) {
       await waitForServer();
     }
   };
-}
-
-/**
- * Click into a section without disrupting cursor positions.
- */
-export async function selectSectionByTitle(title: string|RegExp) {
-  try {
-    if (typeof title === 'string') {
-      title = new RegExp("^" + escapeRegExp(title) + "$", 'i');
-    }
-    // .test-viewsection is a special 1px width element added for tests only.
-    await driver.findContent(`.test-viewsection-title`, title).find(".test-viewsection-blank").click();
-  } catch (e) {
-    // We might be in mobile view.
-    await driver.findContent(`.test-viewsection-title`, title).findClosest(".view_leaf").click();
-  }
 }
 
 export async function expandSection(title?: string) {

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -97,6 +97,7 @@ export const reloadDoc = webdriverUtils.reloadDoc.bind(webdriverUtils);
 export const sendActions = webdriverUtils.sendActions.bind(webdriverUtils);
 export const sendCommand = webdriverUtils.sendCommand.bind(webdriverUtils);
 export const openAccountMenu = webdriverUtils.openAccountMenu.bind(webdriverUtils);
+export const openProfileSettingsPage = webdriverUtils.openProfileSettingsPage.bind(webdriverUtils);
 
 export const fixturesRoot: string = testUtils.fixturesRoot;
 
@@ -2947,12 +2948,6 @@ export function addSamplesForSuite(includeTutorial = false) {
   after(async function() {
     await removeTemplatesOrg();
   });
-}
-
-export async function openProfileSettingsPage() {
-  await openAccountMenu();
-  await driver.find('.grist-floating-menu .test-dm-account-settings').click();
-  await driver.findWait('.test-account-page-login-method', 5000);
 }
 
 export async function openDocumentSettings() {

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -26,8 +26,8 @@ import { Product } from 'app/gen-server/entity/Product';
 import { create } from 'app/server/lib/create';
 import { getAppRoot } from 'app/server/lib/places';
 
-import { noCleanup as _noCleanup, GristWebDriverUtils, PageWidgetPickerOptions,
-         WindowDimensions as WindowDimensionsBase } from 'test/nbrowser/gristWebDriverUtils';
+import { noCleanup as _noCleanup, GristWebDriverUtils, IColsSelect, IColSelect,
+         PageWidgetPickerOptions, WindowDimensions as WindowDimensionsBase } from 'test/nbrowser/gristWebDriverUtils';
 import { APIConstructor, HomeUtil } from 'test/nbrowser/homeUtil';
 import { server } from 'test/nbrowser/testServer';
 import type { Cleanup } from 'test/nbrowser/testUtils';
@@ -114,13 +114,6 @@ export type WindowDimensions = WindowDimensionsBase;
 server.simulateLogin = simulateLogin;
 server.removeLogin = removeLogin;
 
-export interface IColSelect<T = WebElement> {
-  col: number|string;
-  rowNums: number[];
-  section?: string|WebElement;
-  mapper?: (e: WebElement) => Promise<T>;
-}
-
 export interface ICellSelect {
   col: number|string;
   rowNum: number;
@@ -130,13 +123,6 @@ export interface ICellSelect {
 export interface IColHeader {
   col: number|string;
   section?: string|WebElement;
-}
-
-export interface IColsSelect<T = WebElement> {
-  cols: Array<number|string>;
-  rowNums: number[];
-  section?: string|WebElement;
-  mapper?: (e: WebElement) => Promise<T>;
 }
 
 /**

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -19,7 +19,6 @@ import { AccessLevel } from 'app/common/CustomWidget';
 import { decodeUrl } from 'app/common/gristUrls';
 import { FullUser, UserProfile } from 'app/common/LoginSessionAPI';
 import { resetOrg } from 'app/common/resetOrg';
-import { DocAction, UserAction } from 'app/common/DocActions';
 import { TestState } from 'app/common/TestState';
 import { Organization as APIOrganization, DocStateComparison,
          UserAPI, UserAPIImpl, Workspace } from 'app/common/UserAPI';
@@ -96,6 +95,7 @@ export const acceptAlert = webdriverUtils.acceptAlert.bind(webdriverUtils);
 export const isAlertShown = webdriverUtils.isAlertShown.bind(webdriverUtils);
 export const waitForDocToLoad = webdriverUtils.waitForDocToLoad.bind(webdriverUtils);
 export const reloadDoc = webdriverUtils.reloadDoc.bind(webdriverUtils);
+export const sendActions = webdriverUtils.sendActions.bind(webdriverUtils);
 
 export const fixturesRoot: string = testUtils.fixturesRoot;
 
@@ -1211,32 +1211,6 @@ export async function waitAppFocus(yesNo: boolean = true): Promise<void> {
 
 export async function waitForLabelInput(): Promise<void> {
   await driver.wait(async () => (await driver.findWait('.test-column-title-label', 100).hasFocus()), 300);
-}
-
-/**
- * Sends UserActions using client api from the browser.
- */
-export async function sendActions(actions: (DocAction|UserAction)[]) {
-  await driver.manage().setTimeouts({
-    script: 1000 * 2, /* 2 seconds, default is 0.5s */
-  });
-
-  // Make quick test that we have a list of actions not just a single action, by checking
-  // if the first element is an array.
-  if (actions.length && !Array.isArray(actions[0])) {
-    throw new Error('actions argument should be a list of actions, not a single action');
-  }
-
-  const result = await driver.executeAsyncScript(`
-    const done = arguments[arguments.length - 1];
-    const prom = gristDocPageModel.gristDoc.get().docModel.docData.sendActions(${JSON.stringify(actions)});
-    prom.then(() => done(null));
-    prom.catch((err) => done(String(err?.message || err)));
-  `);
-  if (result) {
-    throw new Error(result as string);
-  }
-  await waitForServer();
 }
 
 export async function getDocId() {

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -104,6 +104,7 @@ export const openProfileSettingsPage = webdriverUtils.openProfileSettingsPage.bi
 export const undo = webdriverUtils.undo.bind(webdriverUtils);
 export const bigScreen = webdriverUtils.bigScreen.bind(webdriverUtils);
 export const narrowScreen = webdriverUtils.narrowScreen.bind(webdriverUtils);
+export const exactMatch = webdriverUtils.exactMatch.bind(webdriverUtils);
 
 export const fixturesRoot: string = testUtils.fixturesRoot;
 
@@ -123,17 +124,6 @@ export interface ICellSelect {
 export interface IColHeader {
   col: number|string;
   section?: string|WebElement;
-}
-
-/**
- * Helper for exact string matches using interfaces that expect a RegExp. E.g.
- *    driver.findContent('.selector', exactMatch("Foo"))
- *
- * TODO It would be nice if mocha-webdriver allowed exact string match in findContent() (it now
- * supports a substring match, but we still need a helper for an exact match).
- */
-export function exactMatch(value: string, flags?: string): RegExp {
-  return new RegExp(`^${escapeRegExp(value)}$`, flags);
 }
 
 /**

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -26,7 +26,7 @@ import { Product } from 'app/gen-server/entity/Product';
 import { create } from 'app/server/lib/create';
 import { getAppRoot } from 'app/server/lib/places';
 
-import { GristWebDriverUtils, PageWidgetPickerOptions,
+import { noCleanup as _noCleanup, GristWebDriverUtils, PageWidgetPickerOptions,
          WindowDimensions as WindowDimensionsBase } from 'test/nbrowser/gristWebDriverUtils';
 import { APIConstructor, HomeUtil } from 'test/nbrowser/homeUtil';
 import { server } from 'test/nbrowser/testServer';
@@ -40,6 +40,8 @@ import { lock } from 'proper-lockfile';
 // tslint:disable:no-namespace
 // Wrap in a namespace so that we can apply stackWrapOwnMethods to all the exports together.
 namespace gristUtils {
+
+export const noCleanup = _noCleanup;
 
 // Allow overriding the global 'driver' to use in gristUtil.
 let _driver: WebDriver|undefined;
@@ -84,6 +86,7 @@ export const waitForServer = webdriverUtils.waitForServer.bind(webdriverUtils);
 export const waitForSidePanel = webdriverUtils.waitForSidePanel.bind(webdriverUtils);
 export const toggleSidePanel = webdriverUtils.toggleSidePanel.bind(webdriverUtils);
 export const getWindowDimensions = webdriverUtils.getWindowDimensions.bind(webdriverUtils);
+export const setWindowDimensions = webdriverUtils.setWindowDimensions.bind(webdriverUtils);
 export const addNewSection = webdriverUtils.addNewSection.bind(webdriverUtils);
 export const selectWidget = webdriverUtils.selectWidget.bind(webdriverUtils);
 export const dismissBehavioralPrompts = webdriverUtils.dismissBehavioralPrompts.bind(webdriverUtils);
@@ -99,11 +102,10 @@ export const sendCommand = webdriverUtils.sendCommand.bind(webdriverUtils);
 export const openAccountMenu = webdriverUtils.openAccountMenu.bind(webdriverUtils);
 export const openProfileSettingsPage = webdriverUtils.openProfileSettingsPage.bind(webdriverUtils);
 export const undo = webdriverUtils.undo.bind(webdriverUtils);
+export const bigScreen = webdriverUtils.bigScreen.bind(webdriverUtils);
+export const narrowScreen = webdriverUtils.narrowScreen.bind(webdriverUtils);
 
 export const fixturesRoot: string = testUtils.fixturesRoot;
-
-// it is sometimes useful in debugging to turn off automatic cleanup of docs and workspaces.
-export const noCleanup = Boolean(process.env.NO_CLEANUP);
 
 export type WindowDimensions = WindowDimensionsBase;
 
@@ -2769,42 +2771,6 @@ export async function selectGrid() {
 
 export async function selectColumn(col: string|IColHeader) {
   await getColumnHeader(col).click();
-}
-
-/**
- * Sets browser window dimensions.
- */
-export function setWindowDimensions(width: number, height: number) {
-  return driver.manage().window().setRect({width, height});
-}
-
-/**
- * Changes browser window dimensions for the duration of a test suite.
- */
-export function resizeWindowForSuite(width: number, height: number) {
-  let oldDimensions: WindowDimensions;
-  before(async function () {
-    oldDimensions = await getWindowDimensions();
-    await setWindowDimensions(width, height);
-  });
-  after(async function () {
-    if (noCleanup) { return; }
-    await setWindowDimensions(oldDimensions.width, oldDimensions.height);
-  });
-}
-
-/**
- * Changes browser window dimensions to FullHd for a test suite.
- */
-export function bigScreen() {
-  resizeWindowForSuite(1920, 1080);
-}
-
-/**
- * Shrinks browser window dimensions to trigger mobile mode for a test suite.
- */
-export function narrowScreen() {
-  resizeWindowForSuite(400, 750);
 }
 
 export async function addSupportUserIfPossible() {

--- a/test/nbrowser/gristWebDriverUtils.ts
+++ b/test/nbrowser/gristWebDriverUtils.ts
@@ -309,6 +309,18 @@ export class GristWebDriverUtils {
     await this.driver.findWait('.test-site-switcher-org', 2000);
     await this.driver.sleep(250);  // There's still some jitter (scroll-bar? other user accounts?)
   }
+
+  public async openProfileSettingsPage(): Promise<ProfileSettingsPage> {
+    await this.openAccountMenu();
+    await this.driver.find('.grist-floating-menu .test-dm-account-settings').click();
+    //close alert if it is shown
+    if (await this.isAlertShown()) {
+      await this.acceptAlert();
+    }
+    await this.driver.findWait('.test-account-page-login-method', 5000);
+    await this.waitForServer();
+    return new ProfileSettingsPage(this);
+  }
 }
 
 export interface WindowDimensions {
@@ -328,4 +340,20 @@ export interface PageWidgetPickerOptions {
   dismissTips?: boolean;
   /** Optional pattern of custom widget name to select in the gallery. */
   customWidget?: RegExp|string;
+}
+
+export class ProfileSettingsPage {
+  private _driver: WebDriver;
+  private _gu: GristWebDriverUtils;
+
+  constructor(gu: GristWebDriverUtils) {
+    this._gu = gu;
+    this._driver = gu.driver;
+  }
+
+  public async setLanguage(language: string) {
+    await this._driver.findWait('.test-account-page-language .test-select-open', 100).click();
+    await this._driver.findContentWait('.test-select-menu li', language, 100).click();
+    await this._gu.waitForServer();
+  }
 }

--- a/test/nbrowser/gristWebDriverUtils.ts
+++ b/test/nbrowser/gristWebDriverUtils.ts
@@ -11,7 +11,7 @@
 import escapeRegExp = require('lodash/escapeRegExp');
 import { CommandName } from 'app/client/components/commandList';
 import { DocAction, UserAction } from 'app/common/DocActions';
-import { WebDriver, WebElement } from 'mocha-webdriver';
+import { WebDriver, WebElement, WebElementPromise } from 'mocha-webdriver';
 
 type SectionTypes = 'Table'|'Card'|'Card List'|'Chart'|'Custom'|'Form';
 
@@ -371,6 +371,17 @@ export class GristWebDriverUtils {
   public narrowScreen() {
     this.resizeWindowForSuite(400, 750);
   }
+
+  /**
+   * Returns a WebElementPromise for the .viewsection_content element for the section which contains
+   * the given text (case insensitive) content.
+   */
+  public getSection(sectionOrTitle: string | WebElement): WebElement | WebElementPromise {
+    if (typeof sectionOrTitle !== 'string') { return sectionOrTitle; }
+    return this.driver.findContent(`.test-viewsection-title`, new RegExp("^" + escapeRegExp(sectionOrTitle) + "$", 'i'))
+      .findClosest('.viewsection_content');
+  }
+
   /**
    * Helper for exact string matches using interfaces that expect a RegExp. E.g.
    *    driver.findContent('.selector', exactMatch("Foo"))

--- a/test/nbrowser/gristWebDriverUtils.ts
+++ b/test/nbrowser/gristWebDriverUtils.ts
@@ -421,6 +421,22 @@ export class GristWebDriverUtils {
   }
 
   /**
+   * Returns a visible GridView cell. Options may be given as arguments directly, or as an object.
+   * - col: column name, or 0-based column index
+   * - rowNum: 1-based row numbers, as visible in the row headers on the left of the grid.
+   * - section: optional name of the section to use; will use active section if omitted.
+   */
+  public getCell(col: number | string, rowNum: number, section?: string): WebElementPromise;
+  public getCell(options: ICellSelect): WebElementPromise;
+  public getCell(colOrOptions: number | string | ICellSelect, rowNum?: number, section?: string): WebElementPromise {
+    const mapper = async (el: WebElement) => el;
+    const options: IColSelect<WebElement> = (typeof colOrOptions === 'object' ?
+      { col: colOrOptions.col, rowNums: [colOrOptions.rowNum], section: colOrOptions.section, mapper } :
+      { col: colOrOptions, rowNums: [rowNum!], section, mapper });
+    return new WebElementPromise(this.driver, this.getVisibleGridCells(options).then((elems) => elems[0]));
+  }
+
+  /**
    * Returns a WebElementPromise for the .viewsection_content element for the section which contains
    * the given text (case insensitive) content.
    */
@@ -492,3 +508,8 @@ export interface IColSelect<T = WebElement> {
   mapper?: (e: WebElement) => Promise<T>;
 }
 
+export interface ICellSelect {
+  col: number|string;
+  rowNum: number;
+  section?: string|WebElement;
+}

--- a/test/nbrowser/gristWebDriverUtils.ts
+++ b/test/nbrowser/gristWebDriverUtils.ts
@@ -406,3 +406,18 @@ export class ProfileSettingsPage {
     await this._gu.waitForServer();
   }
 }
+
+export interface IColsSelect<T = WebElement> {
+  cols: Array<number|string>;
+  rowNums: number[];
+  section?: string|WebElement;
+  mapper?: (e: WebElement) => Promise<T>;
+}
+
+export interface IColSelect<T = WebElement> {
+  col: number|string;
+  rowNums: number[];
+  section?: string|WebElement;
+  mapper?: (e: WebElement) => Promise<T>;
+}
+

--- a/test/nbrowser/gristWebDriverUtils.ts
+++ b/test/nbrowser/gristWebDriverUtils.ts
@@ -457,6 +457,21 @@ export class GristWebDriverUtils {
     return new RegExp(`^${escapeRegExp(value)}$`, flags);
   }
 
+  /**
+   * Click into a section without disrupting cursor positions.
+   */
+  public async selectSectionByTitle(title: string | RegExp) {
+    try {
+      if (typeof title === 'string') {
+        title = new RegExp("^" + escapeRegExp(title) + "$", 'i');
+      }
+      // .test-viewsection is a special 1px width element added for tests only.
+      await this.driver.findContent(`.test-viewsection-title`, title).find(".test-viewsection-blank").click();
+    } catch (e) {
+      // We might be in mobile view.
+      await this.driver.findContent(`.test-viewsection-title`, title).findClosest(".view_leaf").click();
+    }
+  }
 }
 
 export interface WindowDimensions {

--- a/test/nbrowser/gristWebDriverUtils.ts
+++ b/test/nbrowser/gristWebDriverUtils.ts
@@ -8,6 +8,7 @@
  * easily.
  */
 
+import escapeRegExp = require('lodash/escapeRegExp');
 import { CommandName } from 'app/client/components/commandList';
 import { DocAction, UserAction } from 'app/common/DocActions';
 import { WebDriver, WebElement } from 'mocha-webdriver';
@@ -370,6 +371,17 @@ export class GristWebDriverUtils {
   public narrowScreen() {
     this.resizeWindowForSuite(400, 750);
   }
+  /**
+   * Helper for exact string matches using interfaces that expect a RegExp. E.g.
+   *    driver.findContent('.selector', exactMatch("Foo"))
+   *
+   * TODO It would be nice if mocha-webdriver allowed exact string match in findContent() (it now
+   * supports a substring match, but we still need a helper for an exact match).
+   */
+  public exactMatch(value: string, flags?: string): RegExp {
+    return new RegExp(`^${escapeRegExp(value)}$`, flags);
+  }
+
 }
 
 export interface WindowDimensions {

--- a/test/nbrowser/gristWebDriverUtils.ts
+++ b/test/nbrowser/gristWebDriverUtils.ts
@@ -8,6 +8,7 @@
  * easily.
  */
 
+import { CommandName } from 'app/client/components/commandList';
 import { DocAction, UserAction } from 'app/common/DocActions';
 import { WebDriver, WebElement } from 'mocha-webdriver';
 
@@ -282,6 +283,21 @@ export class GristWebDriverUtils {
     if (result) {
       throw new Error(result as string);
     }
+    await this.waitForServer();
+  }
+
+  /**
+   * Runs a Grist command in the browser window.
+   */
+  public async sendCommand(name: CommandName, argument: any = null) {
+    await this.driver.executeAsyncScript((name: any, argument: any, done: any) => {
+      const result = (window as any).gristApp.allCommands[name].run(argument);
+      if (result?.finally) {
+        result.finally(done);
+      } else {
+        done();
+      }
+    }, name, argument);
     await this.waitForServer();
   }
 }

--- a/test/nbrowser/gristWebDriverUtils.ts
+++ b/test/nbrowser/gristWebDriverUtils.ts
@@ -321,6 +321,17 @@ export class GristWebDriverUtils {
     await this.waitForServer();
     return new ProfileSettingsPage(this);
   }
+
+  /**
+   * Click the Undo button and wait for server. If optCount is given, click Undo that many times.
+   */
+  public async undo(optCount: number = 1, optTimeout?: number) {
+    await this.waitForServer(optTimeout);
+    for (let i = 0; i < optCount; ++i) {
+      await this.driver.find('.test-undo').doClick();
+      await this.waitForServer(optTimeout);
+    }
+  }
 }
 
 export interface WindowDimensions {

--- a/test/nbrowser/gristWebDriverUtils.ts
+++ b/test/nbrowser/gristWebDriverUtils.ts
@@ -300,6 +300,15 @@ export class GristWebDriverUtils {
     }, name, argument);
     await this.waitForServer();
   }
+
+  public async openAccountMenu() {
+    await this.driver.findWait('.test-dm-account', 2000).click();
+    // Since the AccountWidget loads orgs and the user data asynchronously, the menu
+    // can expand itself causing the click to land on a wrong button.
+    await this.waitForServer();
+    await this.driver.findWait('.test-site-switcher-org', 2000);
+    await this.driver.sleep(250);  // There's still some jitter (scroll-bar? other user accounts?)
+  }
 }
 
 export interface WindowDimensions {


### PR DESCRIPTION
## Context

We need to resynch our test harness between `grist-core` and `grist-widget`. This is a first step to move into `gristWebDriverUtils` the relevant tools (cf. [#154 1in `grist-widget`](https://github.com/gristlabs/grist-widget/pull/154)).

## Proposed solution

Move some needed functions into `gristWebDriverUtils` so it can be properly shared verbatim between `grist-core` and `grist-widget`.

## Related issues

* [#154 1in `grist-widget`](https://github.com/gristlabs/grist-widget/pull/154)

## Has this been tested?

- [x] 👍 yes, tests should still pass as if nothing changed
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->