### PR TITLE
Fix bug that introduced unintended limit

### DIFF
--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -2757,6 +2757,40 @@ export class HomeDBManager {
     return this._org(scope, scope.includeSupport || false, org, options);
   }
 
+  public async getLimits(accountId: number): Promise<Limit[]> {
+    const result = this._connection.transaction(async manager => {
+      return await manager.createQueryBuilder()
+        .select('limit')
+        .from(Limit, 'limit')
+        .innerJoin('limit.billingAccount', 'account')
+        .where('account.id = :accountId', {accountId})
+        .getMany();
+    });
+    return result;
+  }
+
+  public async getLimit(accountId: number, limitType: LimitType): Promise<Limit|null> {
+    return await this._getOrCreateLimitAndReset(accountId, limitType, true);
+  }
+
+  public async peekLimit(accountId: number, limitType: LimitType): Promise<Limit|null> {
+    return await this._getOrCreateLimitAndReset(accountId, limitType, false);
+  }
+
+  public async removeLimit(scope: Scope, limitType: LimitType): Promise<void> {
+    await this._connection.transaction(async manager => {
+      const org = await this._org(scope, false, scope.org ?? null, {manager, needRealOrg: true})
+        .innerJoinAndSelect('orgs.billingAccount', 'billing_account')
+        .innerJoinAndSelect('billing_account.product', 'product')
+        .leftJoinAndSelect('billing_account.limits', 'limit', 'limit.type = :limitType', {limitType})
+        .getOne();
+      const existing = org?.billingAccount?.limits?.[0];
+      if (existing) {
+        await manager.remove(existing);
+      }
+    });
+  }
+
   /**
    * Increases the usage of a limit for a given org, and returns it.
    *
@@ -2789,7 +2823,13 @@ export class HomeDBManager {
         // track usage as it is basically unlimited.
         return null;
       }
-      const existing = await this._getOrCreateLimitAndReset(org.billingAccountId, limitType, manager);
+      const existing = await this._getOrCreateLimitAndReset(org.billingAccountId, limitType, true, manager);
+      if (!existing) {
+        throw new ApiError(
+          `Can't create a limit for non-existing organization`,
+          500,
+        );
+      }
       const limitLess = existing.limit === -1; // -1 means no limit, it is not possible to do in stripe.
       const projectedValue = existing.usage + options.delta;
       if (!limitLess && projectedValue > existing.limit) {
@@ -3306,8 +3346,9 @@ export class HomeDBManager {
   private async _getOrCreateLimitAndReset(
     accountId: number,
     limitType: LimitType,
+    force: boolean,
     transaction?: EntityManager
-  ): Promise<Limit> {
+  ): Promise<Limit|null> {
     if (accountId === 0) {
       throw new Error(`getLimit: called for not existing account`);
     }
@@ -3320,6 +3361,9 @@ export class HomeDBManager {
         .where('account.id = :accountId', {accountId})
           .andWhere('limit.type = :limitType', {limitType})
         .getOne();
+
+      // If we don't have a limit, and we can't create one, return null.
+      if (!existing && !force) { return null; }
 
       // If we have a limit, check if we don't need to reset it.
       if (existing) {


### PR DESCRIPTION
## Context

[A recent change](https://github.com/gristlabs/grist-core/commit/e5fa985bf66dd312f09340365c073d1cd8b11153) introduced an unintended limit on AI assistant usage on self-hosted Grist. Normally, limits are only enforced when the product associated with a billing account has them in its features. AI assistant limits (`baseMaxAssistantCalls`) are not defined in the default product used by self-hosted Grist.

## Proposed solution

Fix the regression so that limits are only enforced when the product has one defined.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

