### PR TITLE
(small) Fix fiddle mode documentation link

### DIFF
--- a/app/client/ui/DocumentSettings.ts
+++ b/app/client/ui/DocumentSettings.ts
@@ -589,7 +589,7 @@ export class DocSettingsPage extends Disposable {
             description:  t('Document automatically opens in {{fiddleModeDocUrl}}. ' +
               'Anyone may edit, which will create a new unsaved copy.',
               {
-                fiddleModeDocUrl: cssLink({href: commonUrls.helpAPI, target: '_blank'}, t('fiddle mode'))
+                fiddleModeDocUrl: cssLink({href: commonUrls.helpFiddleMode, target: '_blank'}, t('fiddle mode'))
               }
             ),
             itemTestId: testId('doctype-modal-option-template'),

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -106,6 +106,7 @@ export const commonUrls = {
   helpAPI: 'https://support.getgrist.com/api',
   helpSummaryFormulas: 'https://support.getgrist.com/summary-tables/#summary-formulas',
   helpAdminControls: "https://support.getgrist.com/admin-controls",
+  helpFiddleMode: 'https://support.getgrist.com/glossary/#fiddle-mode',
   freeCoachingCall: getFreeCoachingCallUrl(),
   contactSupport: getContactSupportUrl(),
   termsOfService: getTermsOfServiceUrl(),


### PR DESCRIPTION
Wrong link was shown when switching between document mode 🫡 