### PR TITLE
Rollback MinIO version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,7 +184,7 @@ jobs:
     services:
       # https://github.com/bitnami/bitnami-docker-minio/issues/16
       minio:
-        image: bitnami/minio:latest
+        image: bitnami/minio:2025.4.8
         env:
           MINIO_DEFAULT_BUCKETS: "grist-docs-test:public"
           MINIO_ROOT_USER: administrator


### PR DESCRIPTION
## Context

CI is currently failing due to the latest MinIO release

## Proposed solution

This pins the container at 2025.04.08, which allows CI to pass.
