### PR TITLE
Fixes python3 sandbox test failure when GVisor not installed

### DIFF
--- a/test/server/lib/ActiveDoc.ts
+++ b/test/server/lib/ActiveDoc.ts
@@ -973,8 +973,8 @@ describe('ActiveDoc', async function() {
     });
   });
 
-  describe('python3', async function() {
-    let oldEnv: EnvironmentSnapshot;
+  describe('sandboxed python3', async function() {
+    let oldEnv: EnvironmentSnapshot | undefined;
 
     before(async function() {
       // Skip this test if sandbox is not present.
@@ -987,7 +987,7 @@ describe('ActiveDoc', async function() {
     });
 
     after(async function() {
-      oldEnv.restore();
+      oldEnv?.restore();
     });
 
     // Adds an Info table containing `sys.version`, and checks python


### PR DESCRIPTION
## Context

When GVisor isn't installed, the Python 3 sandbox tests should be skipped.

Due to a bug, if the tests are skipped, they'll instead fail due to an issue in the 'after' hook.

## Proposed solution

This fixes the issue in the after hook, and renames the test suite to make it clearer they're focused on testing the sandbox.
