### PR TITLE
When serving forms, use a better temporary title and include social-preview metatags

### DIFF
--- a/static/form.html
+++ b/static/form.html
@@ -3,10 +3,11 @@
 <head>
   <meta charset="utf8">
   <meta name="robots" content="noindex">
+  <!-- INSERT META -->
   <!-- INSERT BASE -->
   <link rel="icon" type="image/x-icon" href="icons/favicon.png" />
   <link rel="stylesheet" href="icons/icons.css">
-  <title>Loading...<!-- INSERT TITLE SUFFIX --></title>
+  <title>Grist Form<!-- INSERT TITLE SUFFIX --></title>
 </head>
 <body>
   <!-- INSERT CONFIG -->


### PR DESCRIPTION
## Context

Public forms pages were served with a title of "Loading..." (to be replaced by form title asynchronously), which was picked up by social media preview and looked broken. They also didn't include meta tags such as 'og:image'.

## Proposed solution

- Include a better title: "Grist Form" instead of "Loading...".
- Include metatags (the same basic ones included for other Grist app pages).

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

The change is too small to warrant the effort of a new test case, and I didn't find an existing test case to tweak.
