### PR TITLE
Add support of Attachments

### DIFF
--- a/app/client/components/FormRenderer.ts
+++ b/app/client/components/FormRenderer.ts
@@ -898,6 +898,29 @@ class RefRenderer extends BaseFieldRenderer {
   }
 }
 
+class AttachmentsRenderer extends BaseFieldRenderer {
+  protected inputType = 'file';
+  private _value = Observable.create<File[]>(this, []);
+
+  public input() {
+    return css.attachmentInput(
+      dom.cls('field_clip'),
+      {
+        type: this.inputType,
+        name: this.name(),
+        id: this.id(),
+        required: this.field.options.formRequired,
+      },
+      dom.prop('value', this._value),
+      testId('attachment-input')
+    );
+  }
+
+  public resetInput(): void {
+    this._value.set([]);
+  }
+}
+
 const FieldRenderers = {
   'Text': TextRenderer,
   'Numeric': NumericRenderer,
@@ -909,6 +932,7 @@ const FieldRenderers = {
   'DateTime': DateTimeRenderer,
   'Ref': RefRenderer,
   'RefList': RefListRenderer,
+  'Attachments': AttachmentsRenderer,
 };
 
 const FormRenderers = {

--- a/app/client/components/FormRenderer.ts
+++ b/app/client/components/FormRenderer.ts
@@ -912,6 +912,7 @@ class AttachmentsRenderer extends BaseFieldRenderer {
         required: this.field.options.formRequired,
       },
       dom.prop('value', this._value),
+      dom.prop('multiple', true),
       testId('attachment-input')
     );
   }

--- a/app/client/components/FormRendererCss.ts
+++ b/app/client/components/FormRendererCss.ts
@@ -354,3 +354,39 @@ export const searchSelect = styled('div', `
 export const searchSelectIcon = styled(icon, `
   flex-shrink: 0;
 `);
+
+export const attachmentInput = styled('input', `
+  display: flex;
+  flex-wrap: wrap;
+  white-space: pre-wrap;
+  position: relative;
+  width: 100%;
+
+  &:focus {
+    outline-color: ${vars.primaryBgHover};
+  }
+
+  &::file-selector-button, &::-webkit-file-upload-button {
+    background-color: ${vars.primaryBg};
+    border: 1px solid ${vars.primaryBg};
+    color: white;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 13px;
+    cursor: pointer;
+    line-height: inherit;
+    outline-color: ${vars.primaryBgHover};
+  }
+
+  &::file-selector-button:hover, &::-webkit-file-upload-button:hover {
+    border-color: ${vars.primaryBgHover};
+    background-color: ${vars.primaryBgHover};
+  }
+
+  &::file-selector-button:disabled, &::-webkit-file-upload-button:disabled {
+    cursor: not-allowed;
+    color: ${colors.light};
+    background-color: ${colors.slate};
+    border-color: ${colors.slate};
+  }
+`);

--- a/app/client/components/Forms/Field.ts
+++ b/app/client/components/Forms/Field.ts
@@ -683,6 +683,7 @@ class AttachmentsModel extends Question {
       css.cssAttachmentInput(
         dom.prop('name', u => u(u(this.field).colId)),
         dom.prop('type', 'file'),
+        dom.prop('multiple', true),
       ),
     );
   }

--- a/app/client/components/Forms/Field.ts
+++ b/app/client/components/Forms/Field.ts
@@ -677,8 +677,16 @@ class RefModel extends RefListModel {
 
 const AnyModel = TextModel;
 
-// Attachments are not currently supported.
-const AttachmentsModel = TextModel;
+class AttachmentsModel extends Question {
+  public renderInput() {
+    return dom('div',
+      css.cssAttachmentInput(
+        dom.prop('name', u => u(u(this.field).colId)),
+        dom.prop('type', 'file'),
+      ),
+    );
+  }
+}
 
 function fieldConstructor(type: string): Constructor<Question> {
   switch (type) {

--- a/app/client/components/Forms/Field.ts
+++ b/app/client/components/Forms/Field.ts
@@ -681,7 +681,7 @@ class AttachmentsModel extends Question {
   public renderInput() {
     return dom('div',
       css.cssAttachmentInput(
-        dom.prop('name', u => u(u(this.field).colId)),
+        dom.prop('name', use => use(use(this.field).colId)),
         dom.prop('type', 'file'),
         dom.prop('multiple', true),
       ),

--- a/app/client/components/Forms/FormView.ts
+++ b/app/client/components/Forms/FormView.ts
@@ -139,7 +139,6 @@ export class FormView extends Disposable {
       return fields.filter(f => {
         const column = use(f.column);
         return (
-          use(column.pureType) !== 'Attachments' &&
           !(use(column.isRealFormula) && !use(column.colId).startsWith('gristHelper_Transform'))
         );
       });

--- a/app/client/components/Forms/Menu.ts
+++ b/app/client/components/Forms/Menu.ts
@@ -97,7 +97,7 @@ export function buildMenu(props: Props, ...args: IDomArgs<HTMLElement>): IDomArg
 
       // Field menus.
       const quick = ['Text', 'Numeric', 'Choice', 'Date'];
-      const disabled = ['Attachments'];
+      const disabled: string[] = [];
       const commonTypes = () => getNewColumnTypes(gristDoc, viewSection.tableId());
       const isQuick = ({colType}: {colType: string}) => quick.includes(colType);
       const notQuick = ({colType}: {colType: string}) => !quick.includes(colType);

--- a/app/client/components/Forms/styles.ts
+++ b/app/client/components/Forms/styles.ts
@@ -736,6 +736,38 @@ export const cssFormDisabledOverlay = styled('div', `
   z-index: 100;
 `);
 
+export const cssAttachmentInput = styled('input', `
+  display: flex;
+  flex-wrap: wrap;
+  white-space: pre-wrap;
+  position: relative;
+  width: 100%;
+
+  &::file-selector-button, &::-webkit-file-upload-button {
+    background-color: ${theme.controlPrimaryBg};
+    border: 1px solid ${theme.controlPrimaryBg};
+    color: white;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 13px;
+    cursor: pointer;
+    line-height: inherit;
+    outline-color: ${theme.controlPrimaryBg};
+  }
+
+  &::file-selector-button:hover, &::-webkit-file-upload-button:hover {
+    border-color: ${theme.controlPrimaryBg};
+    background-color: ${theme.controlPrimaryBg};
+  }
+
+  &::file-selector-button:disabled, &::-webkit-file-upload-button:disabled {
+    cursor: not-allowed;
+    color: ${colors.light};
+    background-color: ${colors.slate};
+    border-color: ${colors.slate};
+  }
+`);
+
 export function saveControls(editMode: Observable<boolean>, save: (ok: boolean) => void) {
   return [
     dom.onKeyDown({

--- a/app/client/lib/formUtils.ts
+++ b/app/client/lib/formUtils.ts
@@ -126,8 +126,8 @@ export class TypedFormData {
     return type === 'Ref' || type === 'RefList' ? Number(value) : value;
   }
 
-  public setAttachmentId(key: string, value: number) {
-    this._formData.set(key, String(value));
+  public setAttachmentIds(key: string, value: number[]) {
+    this._formData.set(key, JSON.stringify(value));
   }
 
   public getAll(key: string) {

--- a/app/client/lib/formUtils.ts
+++ b/app/client/lib/formUtils.ts
@@ -126,7 +126,7 @@ export class TypedFormData {
     return type === 'Ref' || type === 'RefList' ? Number(value) : value;
   }
 
-  public setAttachmentIds(key: string, value: number[]) {
+  public set(key: string, value: any) {
     this._formData.set(key, JSON.stringify(value));
   }
 

--- a/app/client/lib/formUtils.ts
+++ b/app/client/lib/formUtils.ts
@@ -126,6 +126,10 @@ export class TypedFormData {
     return type === 'Ref' || type === 'RefList' ? Number(value) : value;
   }
 
+  public setAttachmentId(key: string, value: number) {
+    this._formData.set(key, String(value));
+  }
+
   public getAll(key: string) {
     const values = Array.from(this._formData.getAll(key));
     if (['Ref', 'RefList'].includes(String(this.type(key)))) {

--- a/app/client/models/FormModel.ts
+++ b/app/client/models/FormModel.ts
@@ -85,7 +85,7 @@ export class FormModelImpl extends Disposable implements FormModel {
           ...this._getDocIdOrShareKeyParam(),
           upload: value as File[],
         });
-        formData.setAttachmentIds(key, uploadResult);
+        formData.set(key, uploadResult);
       }
     }
 

--- a/app/client/models/FormModel.ts
+++ b/app/client/models/FormModel.ts
@@ -79,13 +79,13 @@ export class FormModelImpl extends Disposable implements FormModel {
     if (!form) { throw new Error('form is not defined'); }
 
     for (const key of formData.keys()) {
-      const value = formData.get(key);
-      if (value instanceof File) {
-        const uploadResult = await this._formAPI.createAttachment({
+      const value = formData.getAll(key);
+      if (value.length > 0 && value[0] instanceof File) {
+        const uploadResult = await this._formAPI.createAttachments({
           ...this._getDocIdOrShareKeyParam(),
-          upload: value,
+          upload: value as File[],
         });
-        formData.setAttachmentId(key, uploadResult);
+        formData.setAttachmentIds(key, uploadResult);
       }
     }
 

--- a/app/client/models/FormModel.ts
+++ b/app/client/models/FormModel.ts
@@ -78,6 +78,17 @@ export class FormModelImpl extends Disposable implements FormModel {
     const form = this.form.get();
     if (!form) { throw new Error('form is not defined'); }
 
+    for (const key of formData.keys()) {
+      const value = formData.get(key);
+      if (value instanceof File) {
+        const uploadResult = await this._formAPI.createAttachment({
+          ...this._getDocIdOrShareKeyParam(),
+          upload: value,
+        });
+        formData.setAttachmentId(key, uploadResult);
+      }
+    }
+
     const colValues = typedFormDataToJson(formData);
     try {
       this.submitting.set(true);

--- a/app/client/models/entities/ColumnRec.ts
+++ b/app/client/models/entities/ColumnRec.ts
@@ -162,7 +162,6 @@ export function createColumnRec(this: ColumnRec, docModel: DocModel): void {
   this.isHiddenCol = ko.pureComputed(() => gristTypes.isHiddenCol(this.colId()));
   this.isFormCol = ko.pureComputed(() => (
     !this.isHiddenCol() &&
-    this.pureType() !== 'Attachments' &&
     !this.isRealFormula()
   ));
 

--- a/app/client/ui/FormAPI.ts
+++ b/app/client/ui/FormAPI.ts
@@ -135,6 +135,9 @@ export class FormAPIImpl extends BaseAPI implements FormAPI {
   public async createRecord(options: CreateRecordOptions): Promise<void> {
     const urlPrefix = this._getUrlPrefix(options);
     const {tableId, colValues} = options;
+    if ('shareKey' in options) {
+      url.searchParams.set('utm_source', 'grist-forms');
+    }
 
     return this.requestJson(`${urlPrefix}/tables/${tableId}/records`, {
       method: 'POST',

--- a/app/client/ui/FormAPI.ts
+++ b/app/client/ui/FormAPI.ts
@@ -145,8 +145,13 @@ export class FormAPIImpl extends BaseAPI implements FormAPI {
   public async createAttachments(options: CreateAttachmentOptions): Promise<number[]> {
     const url = this._getUrl(options, 'attachments');
 
+    const upload = options.upload.filter(f => f.size > 0);
+    if (upload.length === 0) {
+      return [];
+    }
+
     const formData = new FormData();
-    for (const file of options.upload) {
+    for (const file of upload) {
       formData.append('upload', file);
     }
 

--- a/app/client/widgets/AttachmentsWidget.ts
+++ b/app/client/widgets/AttachmentsWidget.ts
@@ -16,6 +16,7 @@ import {UploadResult} from 'app/common/uploads';
 import { GristObjCode } from 'app/plugin/GristData';
 import {Computed, dom, DomContents, fromKo, input, onElem, styled} from 'grainjs';
 import {extname} from 'path';
+import {FormFieldRulesConfig} from "app/client/components/Forms/FormConfig";
 
 
 /**
@@ -98,6 +99,12 @@ export class AttachmentsWidget extends NewAbstractWidget {
       cssSizeLabel('Size'),
       inputRange
     );
+  }
+
+  public buildFormConfigDom(): DomContents {
+    return [
+      dom.create(FormFieldRulesConfig, this.field),
+    ];
   }
 
   protected _buildAttachment(value: number, allValues: Computed<number[]>, cell: SingleCell): Element {

--- a/app/client/widgets/FieldBuilder.ts
+++ b/app/client/widgets/FieldBuilder.ts
@@ -133,15 +133,9 @@ export class FieldBuilder extends Disposable {
 
     // Observable with a list of available types.
     this._availableTypes = Computed.create(this, (use) => {
-      const isForm = use(this._isForm);
       const isFormula = use(this.origColumn.isFormula);
       const types: Array<IOptionFull<string>> = [];
       _.each(UserType.typeDefs, (def: any, key: string|number) => {
-        if (isForm && key === 'Attachments') {
-          // Attachments in forms are currently unsupported.
-          return;
-        }
-
         const o: IOptionFull<string> = {
           value: key as string,
           label: def.label,

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -1654,8 +1654,8 @@ export class DocWorkerApi {
           .filterRecords({parentId: sectionId})
           .filter(f => {
             const col = Tables_column.getRecord(f.colRef);
-            // Formulas and attachments are currently unsupported.
-            return col && !(col.isFormula && col.formula) && col.type !== 'Attachments';
+            // Formulas are currently unsupported.
+            return col && !(col.isFormula && col.formula);
           });
 
         let {layoutSpec: formLayoutSpec} = section;

--- a/test/nbrowser/FormView1.ts
+++ b/test/nbrowser/FormView1.ts
@@ -825,7 +825,6 @@ describe('FormView1', function() {
       await gu.onNewTab(async () => {
         await driver.get(formUrl);
 
-        // items should be wrapped in a labelled group for better screen reader support
         const attachmentInput = await driver.findWait('input[name="D"]', 2000);
         await driver.findWait('label[for="D"]', 2000);
 
@@ -840,7 +839,9 @@ describe('FormView1', function() {
         await waitForConfirm();
       });
 
-      await expectInD([['L', 1, 2]]);
+      // Expects the 2 attachments have been uploaded and have been associated
+      const expectedUploadIds = [1, 2];
+      await expectInD([['L', ...expectedUploadIds]]);
 
       const docApi = api.getDocAPI(docId);
       const url = `${docApi.getBaseUrl()}/attachments`;

--- a/test/nbrowser/FormView1.ts
+++ b/test/nbrowser/FormView1.ts
@@ -816,59 +816,6 @@ describe('FormView1', function() {
       await removeForm();
     });
 
-    it('excludes attachment fields from forms', async function() {
-      const formUrl = await createFormWith('Text');
-
-      // Temporarily make A an attachments column.
-      await gu.sendActions([
-        ['ModifyColumn', 'Table1', 'A', {type: 'Attachments'}],
-      ]);
-
-      // Check that A is hidden in the form editor.
-      await gu.waitToPass(async () => assert.deepEqual(await labels(), ['B', 'C', 'D']));
-      await gu.openWidgetPanel('widget');
-      assert.deepEqual(
-        await driver.findAll('.test-vfc-visible-field', (e) => e.getText()),
-        ['B', 'C', 'D']
-      );
-      assert.deepEqual(
-        await driver.findAll('.test-vfc-hidden-field', (e) => e.getText()),
-        []
-      );
-
-      // Check that A is excluded from the published form.
-      await gu.onNewTab(async () => {
-        await driver.get(formUrl);
-        await driver.findWait('input[name="D"]', 2000).click();
-        await gu.sendKeys('Hello World');
-        assert.isFalse(await driver.find('input[name="A"]').isPresent());
-        await driver.find('input[type="submit"]').click();
-        await waitForConfirm();
-      });
-
-      // Make sure we see the new record.
-      await expectInD(['Hello World']);
-
-      // And check that A was not modified.
-      assert.deepEqual(await api.getTable(docId, 'Table1').then(t => t.A), [null]);
-
-      // Revert A and check that it's visible again in the editor.
-      await gu.sendActions([
-        ['ModifyColumn', 'Table1', 'A', {type: 'Text'}],
-      ]);
-      await gu.waitToPass(async () => assert.deepEqual(await labels(), ['A', 'B', 'C', 'D']));
-      assert.deepEqual(
-        await driver.findAll('.test-vfc-visible-field', (e) => e.getText()),
-        ['A', 'B', 'C', 'D']
-      );
-      assert.deepEqual(
-        await driver.findAll('.test-vfc-hidden-field', (e) => e.getText()),
-        []
-      );
-
-      await removeForm();
-    });
-
     it('can unpublish forms', async function() {
       const formUrl = await createFormWith('Text');
       await driver.find('.test-forms-unpublish').click();


### PR DESCRIPTION
## Context

Allow add Attachment type in public form view.

## Proposed solution

Remove blacklist of Attachment. Add "default" button in form view.

this PR https://github.com/gristlabs/grist-core/pull/1654 or similar must be added to avoid malicious file upload

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

Idea for style of button, the default icon is very small and can be not ergonomic for some people

## Screenshots / Screencasts

![step1](https://github.com/user-attachments/assets/c0f447e8-99c3-47d0-bab8-a57ecb8ae358)
![step2](https://github.com/user-attachments/assets/6963802f-8c13-47e1-bbe3-2df9963a4265)
![step3](https://github.com/user-attachments/assets/1b7284cf-a01d-4074-8b49-0121df6d0e2c)
![step4](https://github.com/user-attachments/assets/984fa0b6-ff5d-43ad-82bb-746d8bf99229)
![step5](https://github.com/user-attachments/assets/a18cb4fc-88da-4c7c-bf24-b280d60defd0)

