### PR TITLE
add a test for pyodide

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: [3.11]
         node-version: [22.x]
         tests:
-          - ':lint:python:client:common:smoke:stubs:'
+          - ':lint:python:client:common:smoke:stubs:pyodide:'
           - ':server-1-of-2:'
           - ':server-2-of-2:'
           - ':gen-server:'
@@ -113,6 +113,17 @@ jobs:
           GRIST_DOCS_MINIO_ENDPOINT: localhost
           GRIST_DOCS_MINIO_PORT: 9000
           GRIST_DOCS_MINIO_BUCKET: grist-docs-test
+
+      - name: Run a test using pyodide
+        if: contains(matrix.test, ':pyodide:')
+        run:
+          cd sandbox/pyodide
+          make setup
+          cd ../..
+          yarn run test:gen-server -g ActiveDoc
+        env:
+          MOCHA_WEBDRIVER_HEADLESS: 1
+          GRIST_SANDBOX_FLAVOR: pyodide
 
       - name: Run gen-server tests with postgres, minio and redis
         if: contains(matrix.tests, ':gen-server:')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,12 +115,12 @@ jobs:
           GRIST_DOCS_MINIO_BUCKET: grist-docs-test
 
       - name: Run a test using pyodide
-        if: contains(matrix.test, ':pyodide:')
+        if: contains(matrix.tests, ':pyodide:')
         run:
           cd sandbox/pyodide
           make setup
           cd ../..
-          yarn run test:gen-server -g ActiveDoc
+          yarn run test:server -g ActiveDoc
         env:
           MOCHA_WEBDRIVER_HEADLESS: 1
           GRIST_SANDBOX_FLAVOR: pyodide

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
           cd sandbox/pyodide
           make setup
           cd ../..
-          yarn run test:server -g ActiveDoc
+          yarn run test:server -g ActiveDoc.useQuerySet
         env:
           MOCHA_WEBDRIVER_HEADLESS: 1
           GRIST_SANDBOX_FLAVOR: pyodide

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Run a test using pyodide
         if: contains(matrix.tests, ':pyodide:')
-        run:
+        run: |
           cd sandbox/pyodide
           make setup
           cd ../..

--- a/sandbox/pyodide/package_filenames.json
+++ b/sandbox/pyodide/package_filenames.json
@@ -12,6 +12,7 @@
   "pure_eval-0.2.2-cp311-none-any.whl",
   "python_dateutil-2.8.2-cp311-none-any.whl",
   "roman-3.3-cp311-none-any.whl",
+  "six-1.17.0-cp311-none-any.whl",
   "sortedcontainers-2.4.0-cp311-none-any.whl",
   "stack_data-0.5.1-cp311-none-any.whl",
   "typing_extensions-4.4.0-cp311-none-any.whl",


### PR DESCRIPTION
Pyodide sandboxing was broken recently when a package version changed during the removal of Python 2. This adds a small test to verify that pyodide sandboxing is still working. I have since built and added the needed package.

The packaged involved is `six`, which in principle may no longer be needed, but as long as it is listed in `sandbox/requirements.txt` then the Grist pyodide sandbox is going to need it too.