### PR TITLE
Fix mismatched chromedriver warning

### DIFF
--- a/buildtools/install_chrome_for_tests.sh
+++ b/buildtools/install_chrome_for_tests.sh
@@ -20,5 +20,6 @@ fi
 
 curl -sS -o /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
   && sudo apt-get install --allow-downgrades -y /tmp/chrome.deb \
-  && rm /tmp/chrome.deb /usr/bin/chromedriver \
+  && rm /tmp/chrome.deb \
+  && sudo rm /usr/bin/chromedriver \
   && node_modules/selenium-webdriver/bin/linux/selenium-manager --driver chromedriver

--- a/buildtools/install_chrome_for_tests.sh
+++ b/buildtools/install_chrome_for_tests.sh
@@ -20,5 +20,5 @@ fi
 
 curl -sS -o /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
   && sudo apt-get install --allow-downgrades -y /tmp/chrome.deb \
-  && rm /tmp/chrome.deb \
+  && rm /tmp/chrome.deb /usr/bin/chromedriver \
   && node_modules/selenium-webdriver/bin/linux/selenium-manager --driver chromedriver


### PR DESCRIPTION
## Context

CI tests began failing again. On closer inspection, it appears the cause was Chrome and chromedriver versions falling too far apart. They should normally be in sync, but there was a bug in the script that installs Chrome that was preventing the matching version of chromedriver to be installed (a warning was printed in logs with remediation steps).

## Proposed solution

Update the script that installs Chrome to make sure the old version of chromedriver is removed, so that the correct version can then be installed.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

