### PR TITLE
Improve keyboard and screen reader navigation on homepage

### DIFF
--- a/app/client/components/RegionFocusSwitcher.ts
+++ b/app/client/components/RegionFocusSwitcher.ts
@@ -662,7 +662,7 @@ const isSpecialPage = (doc: GristDoc | null) => {
   return false;
 };
 
-const cssFocusedPanel = styled('div', `
+export const cssFocusedPanel = styled('div', `
   &-focused:focus {
     outline: 3px solid ${components.kbFocusHighlight} !important;
     outline-offset: -3px !important;

--- a/app/client/ui/AccountWidget.ts
+++ b/app/client/ui/AccountWidget.ts
@@ -286,6 +286,7 @@ export const cssUserIcon = styled(unstyledButton, `
   width: 48px;
   padding: 8px;
   cursor: pointer;
+  outline-offset: -3px;
 `);
 
 const cssUserInfo = styled('div', `

--- a/app/client/ui/AccountWidget.ts
+++ b/app/client/ui/AccountWidget.ts
@@ -7,6 +7,7 @@ import {createUserImage} from 'app/client/ui/UserImage';
 import * as viewport from 'app/client/ui/viewport';
 import {bigPrimaryButtonLink, primaryButtonLink} from 'app/client/ui2018/buttons';
 import {mediaDeviceNotSmall, testId, theme, vars} from 'app/client/ui2018/cssVars';
+import {unstyledButton} from 'app/client/ui2018/unstyled';
 import {icon} from 'app/client/ui2018/icons';
 import {
   menu,
@@ -280,7 +281,7 @@ const cssAccountWidget = styled('div', `
   white-space: nowrap;
 `);
 
-export const cssUserIcon = styled('div', `
+export const cssUserIcon = styled(unstyledButton, `
   height: 48px;
   width: 48px;
   padding: 8px;

--- a/app/client/ui/AddNewButton.ts
+++ b/app/client/ui/AddNewButton.ts
@@ -1,6 +1,7 @@
 import {theme, vars} from 'app/client/ui2018/cssVars';
 import {makeT} from 'app/client/lib/localization';
 import {icon} from 'app/client/ui2018/icons';
+import {unstyledButton} from 'app/client/ui2018/buttons';
 import {dom, DomElementArg, Observable, styled} from "grainjs";
 
 const t = makeT(`AddNewButton`);
@@ -31,7 +32,7 @@ export function addNewButton(
   );
 }
 
-export const cssAddNewButton = styled('div', `
+export const cssAddNewButton = styled(unstyledButton, `
   display: flex;
   align-items: center;
   margin: 22px 0px 22px 0px;
@@ -45,6 +46,10 @@ export const cssAddNewButton = styled('div', `
   font-size: ${vars.bigControlFontSize};
   font-weight: bold;
   overflow: hidden;
+
+  /* make sure keyboard highlight is not glued to the button,
+  as it is the same color as the button background */
+  outline-offset: 2px;
 
   --circle-color: ${theme.addNewCircleSmallBg};
 

--- a/app/client/ui/AddNewButton.ts
+++ b/app/client/ui/AddNewButton.ts
@@ -1,7 +1,7 @@
 import {theme, vars} from 'app/client/ui2018/cssVars';
 import {makeT} from 'app/client/lib/localization';
 import {icon} from 'app/client/ui2018/icons';
-import {unstyledButton} from 'app/client/ui2018/buttons';
+import {unstyledButton} from 'app/client/ui2018/unstyled';
 import {dom, DomElementArg, Observable, styled} from "grainjs";
 
 const t = makeT(`AddNewButton`);

--- a/app/client/ui/AppHeader.ts
+++ b/app/client/ui/AppHeader.ts
@@ -7,6 +7,7 @@ import {commonUrls} from 'app/common/gristUrls';
 import {getOrgName, isTemplatesOrg, Organization} from 'app/common/UserAPI';
 import {AppModel} from 'app/client/models/AppModel';
 import {icon} from 'app/client/ui2018/icons';
+import {unstyledButton} from 'app/client/ui2018/buttons';
 import {DocPageModel} from 'app/client/models/DocPageModel';
 import * as roles from 'app/common/roles';
 import {manageTeamUsersApp} from 'app/client/ui/OpenUserManager';
@@ -80,7 +81,7 @@ export class AppHeader extends Disposable {
     // Check if we have a custom image.
     const customImage = this._appModel.currentOrg?.orgPrefs?.customLogoUrl;
 
-    const variant = () => [cssUserImage.cls('-border'), cssUserImage.cls('-square')];
+    const variant = () => [cssUserImage.cls('-border'), cssUserImage.cls('-square'), cssUserImage.cls('-inAppLogo')];
 
     // Personal avatar is shown only for logged in users.
     const personalAvatar = () => !this._appModel.currentValidUser
@@ -135,6 +136,7 @@ export class AppHeader extends Disposable {
       );
     } else {
       return cssOrg(
+        dom.cls('_cssOrg'),
         cssOrgName(dom.text(this._appLogoOrgName), testId('orgname')),
         productPill(this._currentOrg),
         dom.maybe(this._appLogoOrgName, () => [
@@ -324,7 +326,11 @@ const cssAppLogo = styled('a._cssAppLogo', `
   overflow: hidden;
   border-right-color: var(--middle-border-color, ${theme.appHeaderBorder});
 
-  outline-offset: -1px;
+  /* make sure keyboard highlight is visible
+  (it wouldn't be without the offset because of the overflow: hidden) */
+  outline-offset: -3px;
+  position: relative;
+  z-index: 1;
 
   &-grist-logo {
     background-image: var(--icon-GristLogo);
@@ -355,7 +361,7 @@ const cssAppLogo = styled('a._cssAppLogo', `
   }
 `);
 
-const cssOrg = styled('div._cssOrg', `
+const cssOrg = styled(unstyledButton, `
   display: none;
   flex-grow: 1;
   flex-basis: 0px;
@@ -370,6 +376,10 @@ const cssOrg = styled('div._cssOrg', `
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
   border-left: 0px;
+
+  /* make sure keyboard highlight is visible
+  (it wouldn't be without the offset because of the overflow: hidden) */
+  outline-offset: -3px;
 
   &:hover {
     border-color: ${theme.appHeaderBorderHover};

--- a/app/client/ui/AppHeader.ts
+++ b/app/client/ui/AppHeader.ts
@@ -273,7 +273,7 @@ export function productPill(org: Organization|null, options: {large?: boolean} =
 }
 
 
-const cssAppHeader = styled('div._cssAppHeader', `
+const cssAppHeader = styled('header._cssAppHeader', `
   width: 100%;
   height: 100%;
   background-color: ${theme.leftPanelBg};

--- a/app/client/ui/AppHeader.ts
+++ b/app/client/ui/AppHeader.ts
@@ -2,7 +2,6 @@ import {getWelcomeHomeUrl, urlState} from 'app/client/models/gristUrlState';
 import {getTheme} from 'app/client/ui/CustomThemes';
 import {cssLeftPane} from 'app/client/ui/PagePanels';
 import {colors, theme, vars} from 'app/client/ui2018/cssVars';
-import * as version from 'app/common/version';
 import {menu, menuItem, menuItemLink, menuSubHeader} from 'app/client/ui2018/menus';
 import {commonUrls} from 'app/common/gristUrls';
 import {getOrgName, isTemplatesOrg, Organization} from 'app/common/UserAPI';
@@ -108,18 +107,13 @@ export class AppHeader extends Disposable {
                           ? null
                           : image();
 
-    const title = `Version ${version.version}` +
-          ((version.gitcommit as string) !== 'unknown' ? ` (${version.gitcommit})` : '');
+    const altText = t('{{ organizationName }} - Back to home', { organizationName: this._appLogoOrg.get().name });
 
     return cssAppHeader(
       cssAppHeader.cls('-widelogo', productFlavor.wideLogo || false),
       cssAppHeaderBox(
         dom.domComputed(this._appLogoOrgLink, orgLink => cssAppLogo(
-          // Show version when hovering over the application icon.
-          // Include gitcommit when known. Cast version.gitcommit since, depending
-          // on how Grist is compiled, tsc may believe it to be a constant and
-          // believe that testing it is unnecessary.
-          {title},
+          {'aria-label': altText},
           this._setHomePageUrl(orgLink),
           content(),
           testId('logo'),

--- a/app/client/ui/AppHeader.ts
+++ b/app/client/ui/AppHeader.ts
@@ -7,7 +7,7 @@ import {commonUrls} from 'app/common/gristUrls';
 import {getOrgName, isTemplatesOrg, Organization} from 'app/common/UserAPI';
 import {AppModel} from 'app/client/models/AppModel';
 import {icon} from 'app/client/ui2018/icons';
-import {unstyledButton} from 'app/client/ui2018/buttons';
+import {unstyledButton} from 'app/client/ui2018/unstyled';
 import {DocPageModel} from 'app/client/models/DocPageModel';
 import * as roles from 'app/common/roles';
 import {manageTeamUsersApp} from 'app/client/ui/OpenUserManager';

--- a/app/client/ui/DocList.ts
+++ b/app/client/ui/DocList.ts
@@ -223,7 +223,7 @@ export class DocList extends Disposable {
                         parentSelectorToMark: "." + cssDocRow.className,
                       }),
                       dom.on("click", (ev) => stopEvent(ev)),
-                      {'aria-label': t("Document options - {{- documentName }}", {documentName: `"${doc.name}"`})},
+                      {'aria-label': t("context menu - {{- documentName }}", {documentName: `"${doc.name}"`})},
                       testId("doc-options")
                     ),
                     contextMenu(() => makeDocOptionsMenu(this._home, doc), {

--- a/app/client/ui/DocList.ts
+++ b/app/client/ui/DocList.ts
@@ -20,7 +20,8 @@ import {
 } from "app/client/ui2018/cssVars";
 import { IconName } from "app/client/ui2018/IconList";
 import { icon as cssIcon } from "app/client/ui2018/icons";
-import { unstyledH2, unstyledUl } from "app/client/ui2018/unstyled";
+import { unstyledButton, unstyledH2, unstyledUl } from "app/client/ui2018/unstyled";
+import { stretchedLink } from "app/client/ui2018/stretchedLink";
 import { visuallyHidden } from "app/client/ui2018/visuallyHidden";
 import { menu, menuItem, select } from "app/client/ui2018/menus";
 import { confirmModal, saveModal } from "app/client/ui2018/modals";
@@ -159,7 +160,6 @@ export class DocList extends Disposable {
               dom.forEach(docs, (doc) => {
                 return cssDocRow(
                   cssDoc(
-                    urlState().setLinkUrl(docUrl(doc)),
                     cssDoc.cls("-no-access", !roles.canView(doc.access)),
                     cssDocIconAndName(
                       buildDocIcon(
@@ -168,10 +168,12 @@ export class DocList extends Disposable {
                           docName: doc.name,
                           icon: doc.options?.appearance?.icon,
                         },
-                        testId("doc-icon")
+                        testId("doc-icon"),
+                        {'aria-hidden': 'true'},
                       ),
                       cssDocNameAndBadges(
                         cssDocName(
+                          urlState().setLinkUrl(docUrl(doc)),
                           stripIconFromName(doc.name, Boolean(doc.options?.appearance?.icon?.emoji)),
                           testId("doc-name")
                         ),
@@ -187,7 +189,10 @@ export class DocList extends Disposable {
                     ),
                     cssDocWorkspace(
                       dom.show(this._showWorkspace),
-                      workspaceName(this._home.app, doc.workspace),
+                      dom('span',
+                        visuallyHidden(t("Workspace")),
+                        workspaceName(this._home.app, doc.workspace)
+                      ),
                       testId("doc-workspace")
                     ),
                     cssDocEditedAt(
@@ -218,6 +223,7 @@ export class DocList extends Disposable {
                         parentSelectorToMark: "." + cssDocRow.className,
                       }),
                       dom.on("click", (ev) => stopEvent(ev)),
+                      {'aria-label': t("Document options - {{- documentName }}", {documentName: `"${doc.name}"`})},
                       testId("doc-options")
                     ),
                     contextMenu(() => makeDocOptionsMenu(this._home, doc), {
@@ -508,18 +514,13 @@ const cssDocRow = styled("li", `
   }
 `);
 
-const cssDoc = styled("a", `
+const cssDoc = styled("div", `
   display: flex;
+  position: relative;
   align-items: center;
   border-radius: 3px;
   outline: none;
   padding: 8px;
-
-  &, &:hover, &:focus {
-    text-decoration: none;
-    outline: none;
-    color: inherit;
-  }
 
   &-no-access, &-no-access:hover, &-no-access:focus {
     color: ${theme.disabledText};
@@ -587,7 +588,7 @@ const noAccessStyles = `
   }
 `;
 
-const cssDocName = styled("div", `
+const cssDocName = styled(stretchedLink, `
   font-size: 14px;
   flex: 0 1 auto;
   white-space: nowrap;
@@ -595,6 +596,17 @@ const cssDocName = styled("div", `
   text-overflow: ellipsis;
   color: ${theme.text};
   font-weight: 600;
+
+  &, &:hover, &:focus {
+    text-decoration: none;
+    outline: none;
+    color: inherit;
+  }
+
+  &:focus-visible {
+    outline-offset: -3px;
+    padding: 5px;
+  }
 
   ${noAccessStyles}
 
@@ -660,7 +672,9 @@ const cssDocEditedAt = styled(cssEditedAtColumn, `
   }
 `);
 
-const cssDocOptions = styled("div", `
+const cssDocOptions = styled(unstyledButton, `
+  position: relative;
+  z-index: 2; /* make sure this is above the stretched link row */
   flex: none;
   display: flex;
   justify-content: center;

--- a/app/client/ui/DocList.ts
+++ b/app/client/ui/DocList.ts
@@ -200,7 +200,10 @@ export class DocList extends Disposable {
                       testId("doc-edited-at")
                     ),
                     cssDocDetailsCompact(
-                      cssDocName(stripIconFromName(doc.name, Boolean(doc.options?.appearance?.icon?.emoji))),
+                      cssDocName(
+                        urlState().setLinkUrl(docUrl(doc)),
+                        stripIconFromName(doc.name, Boolean(doc.options?.appearance?.icon?.emoji))
+                      ),
                       cssDocEditedAt(
                         t("Edited {{at}}", {
                           at: getTimeFromNow(doc.updatedAt),

--- a/app/client/ui/DocList.ts
+++ b/app/client/ui/DocList.ts
@@ -557,7 +557,7 @@ const cssDocDetailsCompact = styled("div", `
 const cssDocIconAndName = styled(cssNameColumn, `
   display: flex;
   align-items: center;
-  column-gap: 16px;
+  column-gap: 11px;
   overflow: hidden;
 
   @media ${mediaMedium} {
@@ -573,7 +573,7 @@ const cssDocNameAndBadges = styled("div", `
   align-items: center;
   gap: 8px;
   width: 100%;
-  margin-right: 40px;
+  margin-right: 35px;
   overflow: hidden;
 
   @media ${mediaMedium} {
@@ -594,6 +594,7 @@ const noAccessStyles = `
 const cssDocName = styled(stretchedLink, `
   font-size: 14px;
   flex: 0 1 auto;
+  padding: 5px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -608,10 +609,17 @@ const cssDocName = styled(stretchedLink, `
 
   &:focus-visible {
     outline-offset: -3px;
-    padding: 5px;
   }
 
   ${noAccessStyles}
+
+  .${cssDocDetailsCompact.className} & {
+    padding: 0;
+  }
+
+  .${cssDocDetailsCompact.className} &:focus-visible {
+    outline-offset: 3px;
+  }
 
   @media ${mediaMedium} {
     & {

--- a/app/client/ui/DocMenuCss.ts
+++ b/app/client/ui/DocMenuCss.ts
@@ -1,3 +1,5 @@
+import {components} from 'app/common/ThemePrefs';
+import {cssFocusedPanel} from 'app/client/components/RegionFocusSwitcher';
 import {transientInput} from 'app/client/ui/transientInput';
 import {mediaSmall, theme, vars} from 'app/client/ui2018/cssVars';
 import {icon} from 'app/client/ui2018/icons';
@@ -107,6 +109,12 @@ export const otherSitesHeader = templatesHeader;
 
 export const STICKY_HEADER_HEIGHT_PX = 76;
 
+// The main panel may have a focus ring, but it is hidden by the header that is sticky positioned
+// at `top: 0px`. In theory we'd want to say that the sticky header is at `top: 3px` to compensate for
+// potential focus ring; but in that case other issues arise (like we see 3px of content below the sticky
+// header when scrolling).
+// The trick here is to set a top border that is transparent by default, and colored when the main
+// panel has focus. We basically replicate the top-side of the focus ring on the header.
 export const stickyHeader = styled(headerWrap, `
   height: ${STICKY_HEADER_HEIGHT_PX}px;
   position: sticky;
@@ -114,7 +122,11 @@ export const stickyHeader = styled(headerWrap, `
   background-color: ${theme.mainPanelBg};
   z-index: ${vars.stickyHeaderZIndex};
   margin-bottom: 0px;
-  padding: 16px 0px 24px 0px;
+  padding: 13px 0px 24px 0px;
+  border-top: 3px solid transparent;
+  .${cssFocusedPanel.className}-focused:focus & {
+    border-top-color: ${components.kbFocusHighlight};
+  }
 `);
 
 export const allDocsTemplates = styled('div', `

--- a/app/client/ui/HomeIntro.ts
+++ b/app/client/ui/HomeIntro.ts
@@ -50,6 +50,9 @@ function makePersonalIntro(homeModel: HomeModel, user: FullUser) {
   return [
     css.stickyHeader(
       cssHeader(
+        // this is like using a `<h1>` element, but in our case it's easier to use aria attributes than changing
+        // some common `styled` components in order to use a specific h1 here
+        {role: 'heading', 'aria-level': '1'},
         dom.text((use) =>
           use(isNarrowScreenObs())
             ? t("Welcome to Grist!")

--- a/app/client/ui/HomeIntroCards.ts
+++ b/app/client/ui/HomeIntroCards.ts
@@ -134,6 +134,7 @@ const mediaSmall = `(max-width: ${828 - 0.02}px)`;
 const cssHomeIntroCards = styled('div', `
   display: grid;
   gap: 24px;
+  margin-top: 4px;
   margin-bottom: 24px;
   display: grid;
   grid-template-columns: 239px minmax(0, 437px) minmax(196px, 1fr) minmax(196px, 1fr);

--- a/app/client/ui/HomeIntroCards.ts
+++ b/app/client/ui/HomeIntroCards.ts
@@ -103,8 +103,7 @@ export function buildHomeIntroCards(
     cssWebinars(
       dom.show(isFeatureEnabled('helpCenter')),
       cssWebinarsImage({src: 'img/webinars.svg'}),
-      // the now unused `webinarsLinks` is kept to prevent breaking existing translation strings
-      unstyledH2(t('Learn more {{webinarsLinks}}', {webinarsLinks: ''})),
+      unstyledH2(t('Learn more')),
       cssWebinarsButton(
         t('Webinars'),
         {href: commonUrls.webinars, target: '_blank'},
@@ -114,8 +113,7 @@ export function buildHomeIntroCards(
     cssHelpCenter(
       dom.show(isFeatureEnabled('helpCenter')),
       cssHelpCenterImage({src: 'img/help-center.svg'}),
-      // the now unused `helpCenterLink` is kept to prevent breaking existing translation strings
-      unstyledH2(t('Find solutions and explore more resources {{helpCenterLink}}', {helpCenterLink: ''})),
+      unstyledH2(t('Find solutions and explore more resources')),
       cssHelpCenterButton(
         t('Help center'),
         {href: commonUrls.help, target: '_blank'},

--- a/app/client/ui/HomeIntroCards.ts
+++ b/app/client/ui/HomeIntroCards.ts
@@ -6,6 +6,7 @@ import {openVideoTour} from 'app/client/ui/OpenVideoTour';
 import {basicButtonLink, bigPrimaryButton, primaryButtonLink} from 'app/client/ui2018/buttons';
 import {colors, theme, vars} from 'app/client/ui2018/cssVars';
 import {icon} from 'app/client/ui2018/icons';
+import {unstyledButton, unstyledH2} from 'app/client/ui2018/unstyled';
 import {commonUrls, isFeatureEnabled} from 'app/common/gristUrls';
 import {getGristConfig} from 'app/common/urlUtils';
 import {Computed, dom, IDisposableOwner, makeTestId, styled, subscribeElem} from 'grainjs';
@@ -102,24 +103,24 @@ export function buildHomeIntroCards(
     cssWebinars(
       dom.show(isFeatureEnabled('helpCenter')),
       cssWebinarsImage({src: 'img/webinars.svg'}),
-      t('Learn more {{webinarsLinks}}', {
-        webinarsLinks: cssWebinarsButton(
-          t('Webinars'),
-          {href: commonUrls.webinars, target: '_blank'},
-          testId('webinars'),
-        ),
-      }),
+      // the now unused `webinarsLinks` is kept to prevent breaking existing translation strings
+      unstyledH2(t('Learn more {{webinarsLinks}}', {webinarsLinks: ''})),
+      cssWebinarsButton(
+        t('Webinars'),
+        {href: commonUrls.webinars, target: '_blank'},
+        testId('webinars'),
+      )
     ),
     cssHelpCenter(
       dom.show(isFeatureEnabled('helpCenter')),
       cssHelpCenterImage({src: 'img/help-center.svg'}),
-      t('Find solutions and explore more resources {{helpCenterLink}}', {
-        helpCenterLink: cssHelpCenterButton(
-          t('Help center'),
-          {href: commonUrls.help, target: '_blank'},
-          testId('help-center'),
-        ),
-      }),
+      // the now unused `helpCenterLink` is kept to prevent breaking existing translation strings
+      unstyledH2(t('Find solutions and explore more resources {{helpCenterLink}}', {helpCenterLink: ''})),
+      cssHelpCenterButton(
+        t('Help center'),
+        {href: commonUrls.help, target: '_blank'},
+        testId('help-center'),
+      ),
     ),
     testId('cards'),
   ));
@@ -158,7 +159,7 @@ const cssHomeIntroCards = styled('div', `
   }
 `);
 
-const cssVideoTour = styled('div', `
+const cssVideoTour = styled(unstyledButton, `
   grid-area: 1 / 1 / 2 / 2;
   flex-shrink: 0;
   width: 239px;
@@ -166,6 +167,8 @@ const cssVideoTour = styled('div', `
   cursor: pointer;
   border-radius: 4px;
   aspect-ratio: 16 / 9;
+
+  outline-offset: 1px;
 
   @media ${mediaSmall} {
     & {
@@ -293,7 +296,8 @@ const cssNewDocument = styled('div', `
   min-height: 140px;
 `);
 
-const cssNewDocumentHeader = styled('div', `
+const cssNewDocumentHeader = styled('h2', `
+  margin: 0;
   font-weight: 500;
   font-size: ${vars.xxlargeFontSize};
 `);

--- a/app/client/ui/HomeLeftPane.ts
+++ b/app/client/ui/HomeLeftPane.ts
@@ -26,6 +26,7 @@ import {
 import {newDocMethods} from 'app/client/ui/NewDocMethods';
 import {menu, menuIcon, menuItem, upgradableMenuItem, upgradeText} from 'app/client/ui2018/menus';
 import {confirmModal} from 'app/client/ui2018/modals';
+import * as version from 'app/common/version';
 import {commonUrls, isFeatureEnabled} from 'app/common/gristUrls';
 import * as roles from 'app/common/roles';
 import {getGristConfig} from 'app/common/urlUtils';
@@ -40,6 +41,13 @@ export function createHomeLeftPane(leftPanelOpen: Observable<boolean>, home: Hom
   const isAnonymous = !home.app.currentValidUser;
   const {enableAnonPlayground, templateOrg, onboardingTutorialDocId} = getGristConfig();
   const canCreate = !isAnonymous || enableAnonPlayground;
+
+  // Show version when hovering over the application icon.
+  // Include gitcommit when known. Cast version.gitcommit since, depending
+  // on how Grist is compiled, tsc may believe it to be a constant and
+  // believe that testing it is unnecessary.
+  const appVersion = `Version ${version.version}` +
+    ((version.gitcommit as string) !== 'unknown' ? ` (${version.gitcommit})` : '');
 
   return cssContent(
     dom.autoDispose(creating),
@@ -122,7 +130,7 @@ export function createHomeLeftPane(leftPanelOpen: Observable<boolean>, home: Hom
       )),
       cssHomeTools(
         cssSectionHeader(
-          cssPageColorIcon('GristLogo'),
+          cssPageColorIcon('GristLogo', {title: appVersion}),
           cssSectionHeaderText(t("Grist Resources"))
         ),
         cssPageEntry(

--- a/app/client/ui/HomeLeftPane.ts
+++ b/app/client/ui/HomeLeftPane.ts
@@ -102,6 +102,7 @@ export function createHomeLeftPane(leftPanelOpen: Observable<boolean>, home: Hom
 
               // Clicks on the menu trigger shouldn't follow the link that it's contained in.
               dom.on('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); }),
+              {'aria-label': t("{{ workspaceName }} - workspace options", {workspaceName: ws.name})},
               testId('dm-workspace-options'),
             ),
             testId('dm-workspace'),

--- a/app/client/ui/HomeLeftPane.ts
+++ b/app/client/ui/HomeLeftPane.ts
@@ -110,7 +110,7 @@ export function createHomeLeftPane(leftPanelOpen: Observable<boolean>, home: Hom
 
                 // Clicks on the menu trigger shouldn't follow the link that it's contained in.
                 dom.on('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); }),
-                {'aria-label': t("Workspace options - {{- workspaceName }}", {workspaceName: `"${ws.name}"`})},
+                {'aria-label': t("context menu - {{- workspaceName }}", {workspaceName: `"${ws.name}"`})},
                 testId('dm-workspace-options'),
               ),
               testId('dm-workspace'),

--- a/app/client/ui/HomeLeftPane.ts
+++ b/app/client/ui/HomeLeftPane.ts
@@ -74,52 +74,56 @@ export function createHomeLeftPane(leftPanelOpen: Observable<boolean>, home: Hom
         cssSectionHeader(
           cssSectionHeaderText(t("Workspaces")),
           // Give it a testId, because it's a good element to simulate "click-away" in tests.
-          testId('dm-ws-label')
+          testId('dm-ws-label'),
+          {id: 'grist-workspaces-heading'}
         ),
       ),
-      dom.forEach(home.workspaces, (ws) => {
-        if (ws.isSupportWorkspace) { return null; }
-        const info = getWorkspaceInfo(home.app, ws);
-        const isTrivial = computed((use) => Boolean(getWorkspaceInfo(home.app, ws).isDefault &&
-                                                    use(home.singleWorkspace)));
-        // TODO: Introduce a "SwitchSelector" pattern to avoid the need for N computeds (and N
-        // recalculations) to select one of N items.
-        const isRenaming = computed((use) => use(renaming) === ws);
-        return cssPageEntry(
-          dom.autoDispose(isRenaming),
-          dom.autoDispose(isTrivial),
-          dom.hide(isTrivial),
-          cssPageEntry.cls('-selected', (use) => use(home.currentWSId) === ws.id),
-          cssPageLink(cssPageIcon('Folder'), cssLinkText(workspaceName(home.app, ws)),
-            dom.hide(isRenaming),
-            urlState().setLinkUrl({ws: ws.id}),
-            // Don't show menu if workspace is personal and shared by another user; we could
-            // be a bit more nuanced here, but as of today the menu isn't particularly useful
-            // as all the menu options are disabled.
-            !info.self && info.owner ? null : cssMenuTrigger(icon('Dots'),
-              menu(() => workspaceMenu(home, ws, renaming),
-                {placement: 'bottom-start', parentSelectorToMark: '.' + cssPageEntry.className}),
+      dom('nav',
+        {'aria-labelledby': 'grist-workspaces-heading'},
+        dom.forEach(home.workspaces, (ws) => {
+          if (ws.isSupportWorkspace) { return null; }
+          const info = getWorkspaceInfo(home.app, ws);
+          const isTrivial = computed((use) => Boolean(getWorkspaceInfo(home.app, ws).isDefault &&
+                                                      use(home.singleWorkspace)));
+          // TODO: Introduce a "SwitchSelector" pattern to avoid the need for N computeds (and N
+          // recalculations) to select one of N items.
+          const isRenaming = computed((use) => use(renaming) === ws);
+          return cssPageEntry(
+            dom.autoDispose(isRenaming),
+            dom.autoDispose(isTrivial),
+            dom.hide(isTrivial),
+            cssPageEntry.cls('-selected', (use) => use(home.currentWSId) === ws.id),
+            cssPageLink(cssPageIcon('Folder'), cssLinkText(workspaceName(home.app, ws)),
+              dom.hide(isRenaming),
+              urlState().setLinkUrl({ws: ws.id}),
+              // Don't show menu if workspace is personal and shared by another user; we could
+              // be a bit more nuanced here, but as of today the menu isn't particularly useful
+              // as all the menu options are disabled.
+              !info.self && info.owner ? null : cssMenuTrigger(icon('Dots'),
+                menu(() => workspaceMenu(home, ws, renaming),
+                  {placement: 'bottom-start', parentSelectorToMark: '.' + cssPageEntry.className}),
 
-              // Clicks on the menu trigger shouldn't follow the link that it's contained in.
-              dom.on('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); }),
-              {'aria-label': t("{{ workspaceName }} - workspace options", {workspaceName: ws.name})},
-              testId('dm-workspace-options'),
+                // Clicks on the menu trigger shouldn't follow the link that it's contained in.
+                dom.on('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); }),
+                {'aria-label': t("{{ workspaceName }} - workspace options", {workspaceName: ws.name})},
+                testId('dm-workspace-options'),
+              ),
+              testId('dm-workspace'),
+              dom.cls('test-dm-workspace-selected', (use) => use(home.currentWSId) === ws.id),
             ),
-            testId('dm-workspace'),
-            dom.cls('test-dm-workspace-selected', (use) => use(home.currentWSId) === ws.id),
-          ),
-          cssPageEntry.cls('-renaming', isRenaming),
-          dom.maybe(isRenaming, () =>
-            cssPageLink(cssPageIcon('Folder'),
-              cssEditorInput({
-                initialValue: ws.name || '',
-                save: async (val) => (val !== ws.name) ? home.renameWorkspace(ws.id, val) : undefined,
-                close: () => renaming.set(null),
-              }, testId('dm-ws-name-editor'))
-            )
-          ),
-        );
-      }),
+            cssPageEntry.cls('-renaming', isRenaming),
+            dom.maybe(isRenaming, () =>
+              cssPageLink(cssPageIcon('Folder'),
+                cssEditorInput({
+                  initialValue: ws.name || '',
+                  save: async (val) => (val !== ws.name) ? home.renameWorkspace(ws.id, val) : undefined,
+                  close: () => renaming.set(null),
+                }, testId('dm-ws-name-editor'))
+              )
+            ),
+          );
+        }),
+      ),
       dom.maybe(creating, () => cssPageEntry(
         cssPageLink(cssPageIcon('Folder'),
           cssEditorInput({
@@ -130,9 +134,10 @@ export function createHomeLeftPane(leftPanelOpen: Observable<boolean>, home: Hom
         )
       )),
       cssHomeTools(
+        {'aria-labelledby': 'grist-resources-heading'},
         cssSectionHeader(
           cssPageColorIcon('GristLogo', {title: appVersion}),
-          cssSectionHeaderText(t("Grist Resources"))
+          cssSectionHeaderText(t("Grist Resources"), {id: 'grist-resources-heading'})
         ),
         cssPageEntry(
           dom.show(isFeatureEnabled("templates") && Boolean(templateOrg)),

--- a/app/client/ui/HomeLeftPane.ts
+++ b/app/client/ui/HomeLeftPane.ts
@@ -9,6 +9,7 @@ import {createVideoTourToolsButton} from 'app/client/ui/OpenVideoTour';
 import {transientInput} from 'app/client/ui/transientInput';
 import {testId, theme} from 'app/client/ui2018/cssVars';
 import {icon} from 'app/client/ui2018/icons';
+import {stretchedLink} from 'app/client/ui2018/stretchedLink';
 import {
   createHelpTools,
   cssHomeTools,
@@ -19,6 +20,7 @@ import {
   cssPageEntry,
   cssPageIcon,
   cssPageLink,
+  cssPageLinkContainer,
   cssScrollPane,
   cssSectionHeader,
   cssSectionHeaderText
@@ -93,9 +95,12 @@ export function createHomeLeftPane(leftPanelOpen: Observable<boolean>, home: Hom
             dom.autoDispose(isTrivial),
             dom.hide(isTrivial),
             cssPageEntry.cls('-selected', (use) => use(home.currentWSId) === ws.id),
-            cssPageLink(cssPageIcon('Folder'), cssLinkText(workspaceName(home.app, ws)),
+            cssPageLinkContainer(cssPageIcon('Folder'),
+              stretchedLink(
+                cssLinkText(workspaceName(home.app, ws)),
+                urlState().setLinkUrl({ws: ws.id}),
+              ),
               dom.hide(isRenaming),
-              urlState().setLinkUrl({ws: ws.id}),
               // Don't show menu if workspace is personal and shared by another user; we could
               // be a bit more nuanced here, but as of today the menu isn't particularly useful
               // as all the menu options are disabled.
@@ -105,7 +110,7 @@ export function createHomeLeftPane(leftPanelOpen: Observable<boolean>, home: Hom
 
                 // Clicks on the menu trigger shouldn't follow the link that it's contained in.
                 dom.on('click', (ev) => { ev.stopPropagation(); ev.preventDefault(); }),
-                {'aria-label': t("{{ workspaceName }} - workspace options", {workspaceName: ws.name})},
+                {'aria-label': t("Workspace options - {{- workspaceName }}", {workspaceName: `"${ws.name}"`})},
                 testId('dm-workspace-options'),
               ),
               testId('dm-workspace'),

--- a/app/client/ui/LeftPanelCommon.ts
+++ b/app/client/ui/LeftPanelCommon.ts
@@ -147,6 +147,8 @@ export const cssPageEntry = styled('div', `
 `);
 
 const cssPageAction = `
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
   height: 32px;
@@ -156,7 +158,7 @@ const cssPageAction = `
   cursor: pointer;
   outline-offset: -3px;
   width: 100%;
-  &, &:hover, &:focus {
+  &, &:hover, &:focus, & a, & a:hover, & a:focus {
     text-decoration: none;
     outline: none;
     color: inherit;
@@ -170,6 +172,8 @@ const cssPageAction = `
 `;
 
 export const cssPageLink = styled('a', cssPageAction);
+
+export const cssPageLinkContainer = styled('div', cssPageAction);
 
 export const cssPageButton = styled(unstyledButton, cssPageAction);
 
@@ -239,6 +243,8 @@ export const cssPageEntrySmall = styled(cssPageEntry, `
 `);
 
 export const cssMenuTrigger = styled(unstyledButton, `
+  position: relative;
+  z-index: 2;
   margin: 0 4px 0 auto;
   height: 24px;
   width: 24px;
@@ -247,7 +253,11 @@ export const cssMenuTrigger = styled(unstyledButton, `
   border-radius: 3px;
   cursor: default;
   display: none;
-  .${cssPageLink.className}:hover > &, .${cssPageLink.className}:focus-within > &, &.weasel-popup-open {
+  .${cssPageLinkContainer.className}:hover > &,
+  .${cssPageLinkContainer.className}:focus-within > &,
+  .${cssPageLink.className}:hover > &,
+  .${cssPageLink.className}:focus-within > &,
+  &.weasel-popup-open {
     display: block;
   }
   &:hover, &.weasel-popup-open {

--- a/app/client/ui/LeftPanelCommon.ts
+++ b/app/client/ui/LeftPanelCommon.ts
@@ -18,6 +18,7 @@ import {makeT} from 'app/client/lib/localization';
 import {AppModel} from 'app/client/models/AppModel';
 import {testId, theme, vars} from 'app/client/ui2018/cssVars';
 import {colorIcon, icon} from 'app/client/ui2018/icons';
+import {unstyledButton} from 'app/client/ui2018/buttons';
 import {commonUrls, isFeatureEnabled} from 'app/common/gristUrls';
 import {getGristConfig} from 'app/common/urlUtils';
 import {dom, DomContents, Observable, styled} from 'grainjs';
@@ -231,7 +232,7 @@ export const cssPageEntrySmall = styled(cssPageEntry, `
   }
 `);
 
-export const cssMenuTrigger = styled('div', `
+export const cssMenuTrigger = styled(unstyledButton, `
   margin: 0 4px 0 auto;
   height: 24px;
   width: 24px;
@@ -240,7 +241,7 @@ export const cssMenuTrigger = styled('div', `
   border-radius: 3px;
   cursor: default;
   display: none;
-  .${cssPageLink.className}:hover > &, &.weasel-popup-open {
+  .${cssPageLink.className}:hover > &, .${cssPageLink.className}:focus-within > &, &.weasel-popup-open {
     display: block;
   }
   &:hover, &.weasel-popup-open {

--- a/app/client/ui/LeftPanelCommon.ts
+++ b/app/client/ui/LeftPanelCommon.ts
@@ -146,7 +146,7 @@ export const cssPageEntry = styled('div', `
   }
 `);
 
-export const cssPageLink = styled('a', `
+const cssPageAction = `
   display: flex;
   align-items: center;
   height: 32px;
@@ -155,6 +155,7 @@ export const cssPageLink = styled('a', `
   outline: none;
   cursor: pointer;
   outline-offset: -3px;
+  width: 100%;
   &, &:hover, &:focus {
     text-decoration: none;
     outline: none;
@@ -166,7 +167,11 @@ export const cssPageLink = styled('a', `
   .${cssTools.className}-collapsed & {
     padding-left: 16px;
   }
-`);
+`;
+
+export const cssPageLink = styled('a', cssPageAction);
+
+export const cssPageButton = styled(unstyledButton, cssPageAction);
 
 export const cssLinkText = styled('span', `
   white-space: nowrap;

--- a/app/client/ui/LeftPanelCommon.ts
+++ b/app/client/ui/LeftPanelCommon.ts
@@ -47,7 +47,7 @@ export function createHelpTools(appModel: AppModel): DomContents {
     ),
     cssPageEntrySmall(
       cssPageLink(cssPageIcon('FieldLink'),
-        {href: commonUrls.help, target: '_blank'},
+        {href: commonUrls.help, 'aria-label': t("Help Center"), target: '_blank'},
       ),
     ),
   );

--- a/app/client/ui/LeftPanelCommon.ts
+++ b/app/client/ui/LeftPanelCommon.ts
@@ -18,7 +18,7 @@ import {makeT} from 'app/client/lib/localization';
 import {AppModel} from 'app/client/models/AppModel';
 import {testId, theme, vars} from 'app/client/ui2018/cssVars';
 import {colorIcon, icon} from 'app/client/ui2018/icons';
-import {unstyledButton} from 'app/client/ui2018/buttons';
+import {unstyledButton} from 'app/client/ui2018/unstyled';
 import {commonUrls, isFeatureEnabled} from 'app/common/gristUrls';
 import {getGristConfig} from 'app/common/urlUtils';
 import {dom, DomContents, Observable, styled} from 'grainjs';

--- a/app/client/ui/LeftPanelCommon.ts
+++ b/app/client/ui/LeftPanelCommon.ts
@@ -85,7 +85,8 @@ export const cssScrollPane = styled('div', `
   flex-direction: column;
 `);
 
-export const cssTools = styled('div', `
+
+export const cssTools = styled('nav', `
   flex: none;
   margin-top: auto;
   padding: 16px 0 16px 0;

--- a/app/client/ui/OpenVideoTour.ts
+++ b/app/client/ui/OpenVideoTour.ts
@@ -1,7 +1,7 @@
 import {makeT} from 'app/client/lib/localization';
 import {logTelemetryEvent} from 'app/client/lib/telemetry';
 import {getMainOrgUrl} from 'app/client/models/gristUrlState';
-import {cssLinkText, cssPageEntryMain, cssPageIcon, cssPageLink} from 'app/client/ui/LeftPanelCommon';
+import {cssLinkText, cssPageButton, cssPageEntry, cssPageIcon} from 'app/client/ui/LeftPanelCommon';
 import {YouTubePlayer} from 'app/client/ui/YouTubePlayer';
 import {theme} from 'app/client/ui2018/cssVars';
 import {icon} from 'app/client/ui2018/icons';
@@ -83,8 +83,8 @@ export function createVideoTourToolsButton(): HTMLDivElement | null {
 
   let iconElement: HTMLElement;
 
-  return cssPageEntryMain(
-    cssPageLink(
+  return cssPageEntry(
+    cssPageButton(
       iconElement = cssPageIcon('Video'),
       cssLinkText(t("Video Tour")),
       dom.cls('tour-help-center'),

--- a/app/client/ui/PagePanels.ts
+++ b/app/client/ui/PagePanels.ts
@@ -7,6 +7,7 @@ import {hoverTooltip} from 'app/client/ui/tooltips';
 import {transition, TransitionWatcher} from 'app/client/ui/transitions';
 import {cssHideForNarrowScreen, isScreenResizing, mediaNotSmall, mediaSmall, theme} from 'app/client/ui2018/cssVars';
 import {isNarrowScreenObs} from 'app/client/ui2018/cssVars';
+import {unstyledButton} from 'app/client/ui2018/unstyled';
 import {icon} from 'app/client/ui2018/icons';
 import {
   dom, DomElementArg, DomElementMethod, MultiHolder, noTestId, Observable, styled, subscribe, TestId
@@ -292,22 +293,38 @@ export function pagePanels(page: PageContents) {
           testId('top-header'),
           regionFocusSwitcher?.panelAttrs('top', t('Document header')),
           (left.hideOpener ? null :
-            cssPanelOpener('PanelRight', cssPanelOpener.cls('-open', left.panelOpen),
-              testId('left-opener'),
+            unstyledButton(
+              {'aria-label': left.panelOpen.get()
+                ? t('Close navigation panel (left panel)')
+                : t('Open navigation panel (left panel)')},
               dom.on('click', () => toggleObs(left.panelOpen)),
-              cssHideForNarrowScreen.cls(''))
+              cssPanelOpener(
+                'PanelRight',
+                cssPanelOpener.cls('-open', left.panelOpen),
+                testId('left-opener'),
+                cssHideForNarrowScreen.cls('')
+              ),
+            )
           ),
 
           page.headerMain,
 
           (!right || right.hideOpener ? null :
-            cssPanelOpener('PanelLeft', cssPanelOpener.cls('-open', right.panelOpen),
-              testId('right-opener'),
-              dom.cls('tour-creator-panel'),
-              hoverTooltip(() => (right.panelOpen.get() ? t('Close Creator Panel') : t('Open Creator Panel')),
-                {key: 'topBarBtnTooltip'}),
+            unstyledButton(
+              {'aria-label': right.panelOpen.get() ? t('Close Creator Panel') : t('Open Creator Panel')},
               dom.on('click', () => toggleObs(right.panelOpen)),
-              cssHideForNarrowScreen.cls(''))
+              cssPanelOpener(
+                'PanelLeft',
+                cssPanelOpener.cls('-open', right.panelOpen),
+                testId('right-opener'),
+                dom.cls('tour-creator-panel'),
+                hoverTooltip(
+                  () => (right.panelOpen.get() ? t('Close Creator Panel') : t('Open Creator Panel')),
+                  {key: 'topBarBtnTooltip'}
+                ),
+                cssHideForNarrowScreen.cls('')
+              ),
+            )
           ),
           dom.style('margin-bottom', use => use(bannerHeight) + 'px'),
         ),

--- a/app/client/ui/Pages.ts
+++ b/app/client/ui/Pages.ts
@@ -56,7 +56,10 @@ export function buildPagesDom(owner: Disposable, activeDoc: GristDoc, isOpen: Ob
   }, null, true));
 
   // dom
-  return dom('div', dom.create(TreeViewComponent, model, {isOpen, selected, isReadonly: activeDoc.isReadonly}));
+  return dom('nav',
+    {'aria-label': t("Document pages")},
+    dom.create(TreeViewComponent, model, {isOpen, selected, isReadonly: activeDoc.isReadonly})
+  );
 }
 
 const testId = makeTestId('test-removepage-');

--- a/app/client/ui/Tools.ts
+++ b/app/client/ui/Tools.ts
@@ -43,8 +43,9 @@ export function tools(owner: Disposable, gristDoc: GristDoc, leftPanelOpen: Obse
   owner.autoDispose(gristDoc.docModel.rules.tableData.tableActionEmitter.addListener(updateCanViewAccessRules));
   updateCanViewAccessRules();
   return cssTools(
+    {'aria-labelledby': 'grist-tools-heading'},
     cssTools.cls('-collapsed', (use) => !use(leftPanelOpen)),
-    cssSectionHeader(cssSectionHeaderText(t("TOOLS"))),
+    cssSectionHeader(cssSectionHeaderText(t("TOOLS"), {id: 'grist-tools-heading'})),
     buildOpenAssistantButton(gristDoc, testId('assistant')),
     cssPageEntry(
       cssPageEntry.cls('-selected', (use) => use(gristDoc.activeViewId) === 'acl'),

--- a/app/client/ui/TopBarCss.ts
+++ b/app/client/ui/TopBarCss.ts
@@ -1,8 +1,9 @@
 import {theme} from 'app/client/ui2018/cssVars';
 import {icon} from 'app/client/ui2018/icons';
+import {unstyledButton} from 'app/client/ui2018/unstyled';
 import {styled} from 'grainjs';
 
-export const cssHoverCircle = styled('div', `
+export const cssHoverCircle = styled(unstyledButton, `
   width: 32px;
   height: 32px;
   background: none;

--- a/app/client/ui/UserImage.ts
+++ b/app/client/ui/UserImage.ts
@@ -125,6 +125,10 @@ export const cssUserImage = styled('div', `
     background-color: ${colors.slate};
     border: 1px solid ${colors.slate};
   }
+  /* make sure the kb highlight is on top of the image when used in app logo */
+  &-inAppLogo {
+    z-index: -1;
+  }
 `);
 
 const cssUserPicture = styled('img', `

--- a/app/client/ui2018/buttons.ts
+++ b/app/client/ui2018/buttons.ts
@@ -144,20 +144,6 @@ export const textButton = styled(cssButton, `
   }
 `);
 
-// Button without any style, used as a base for building specific buttons
-export const unstyledButton = styled('button', `
-  margin: 0;
-  padding: 0;
-  border: 0 solid;
-  font: inherit;
-  letter-spacing: inherit;
-  color: inherit;
-  border-radius: 0;
-  background-color: transparent;
-  opacity: 1;
-  appearance: button;
-`);
-
 const cssButtonLink = styled('a', `
   display: inline-block;
   &, &:hover, &:focus {

--- a/app/client/ui2018/buttons.ts
+++ b/app/client/ui2018/buttons.ts
@@ -144,6 +144,20 @@ export const textButton = styled(cssButton, `
   }
 `);
 
+// Button without any style, used as a base for building specific buttons
+export const unstyledButton = styled('button', `
+  margin: 0;
+  padding: 0;
+  border: 0 solid;
+  font: inherit;
+  letter-spacing: inherit;
+  color: inherit;
+  border-radius: 0;
+  background-color: transparent;
+  opacity: 1;
+  appearance: button;
+`);
+
 const cssButtonLink = styled('a', `
   display: inline-block;
   &, &:hover, &:focus {

--- a/app/client/ui2018/stretchedLink.ts
+++ b/app/client/ui2018/stretchedLink.ts
@@ -1,0 +1,17 @@
+/**
+ * A link that has a clickable area that spans the entire containing block.
+ *
+ * Don't forget to apply the `position: relative` CSS property to the parent block you want the link to cover.
+ *
+ * @see https://getbootstrap.com/docs/5.3/helpers/stretched-link
+ */
+import {styled} from 'grainjs';
+
+export const stretchedLink = styled('a', `
+  &::after {
+    position: absolute;
+    inset: 0;
+    content: '';
+    z-index: 1;
+  }
+`);

--- a/app/client/ui2018/unstyled.ts
+++ b/app/client/ui2018/unstyled.ts
@@ -1,0 +1,19 @@
+/**
+ * Helpers to create unstyled variants of various HTML elements that have default styles.
+ *
+ * Useful to easily build semantic content without having to deal with removing styles all the time.
+ */
+import {styled} from "grainjs";
+
+export const unstyledButton = styled('button', `
+  margin: 0;
+  padding: 0;
+  border: 0 solid;
+  font: inherit;
+  letter-spacing: inherit;
+  color: inherit;
+  border-radius: 0;
+  background-color: transparent;
+  opacity: 1;
+  appearance: button;
+`);

--- a/app/client/ui2018/unstyled.ts
+++ b/app/client/ui2018/unstyled.ts
@@ -22,6 +22,11 @@ export const unstyledButton = styled('button', `
   appearance: button;
 `);
 
+export const unstyledUl = styled('ul', `
+  ${base}
+  list-style: none;
+`);
+
 const unstyledHeadings = `
   ${base}
   font-size: inherit;

--- a/app/client/ui2018/unstyled.ts
+++ b/app/client/ui2018/unstyled.ts
@@ -5,10 +5,14 @@
  */
 import {styled} from "grainjs";
 
-export const unstyledButton = styled('button', `
+const base = `
   margin: 0;
   padding: 0;
   border: 0 solid;
+`;
+
+export const unstyledButton = styled('button', `
+  ${base}
   font: inherit;
   letter-spacing: inherit;
   color: inherit;
@@ -17,3 +21,11 @@ export const unstyledButton = styled('button', `
   opacity: 1;
   appearance: button;
 `);
+
+const unstyledHeadings = `
+  ${base}
+  font-size: inherit;
+  font-weight: inherit;
+`;
+
+export const unstyledH2 = styled('h2', unstyledHeadings);

--- a/app/client/ui2018/visuallyHidden.ts
+++ b/app/client/ui2018/visuallyHidden.ts
@@ -1,0 +1,65 @@
+/**
+ * "Visually hidden" helpers.
+ *
+ * Allows to add things in the DOM that are not shown on screen but are still announced by screen readers.
+ *
+ * The code is taken from Bootstrap which has a pretty battle-tested implementation (thanks to them!)
+ * @see https://github.com/twbs/bootstrap/blob/c5bec4ea7bd74b679fc2ecc53c141bff3750915b/scss/mixins/_visually-hidden.scss
+ * @see https://getbootstrap.com/docs/5.3/helpers/visually-hidden/
+ * @see https://www.ffoodd.fr/masquage-accessible-de-pointe/index.html
+ */
+import {styled} from "grainjs";
+
+const commonStyles = `
+  border: 0 !important;
+  clip-path: inset(50%) !important;
+  height: 1px !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  width: 1px !important;
+  white-space: nowrap !important;
+`;
+
+/**
+ * Visually hides an element.
+ *
+ * You should use this with div, span, p, headings. Certainly not much else.
+ */
+export const visuallyHidden = styled('div', `
+  ${commonStyles}
+
+  &:not(caption) {
+    position: absolute !important;
+  }
+
+  & * {
+    overflow: hidden !important;
+  }
+`);
+
+
+/**
+ * Visually hides an element but show it when it gets keyboard focus.
+ * Useful for things like skip links.
+ *
+ * You should use this on interactive html elements like <a> or <button>.
+ *
+ * Note: you can also use this on a div containing interactive elements, that you want
+ * to show as a whole only when one of its interactive elements is focused.
+ *
+ * See bootstrap docs linked above for more details.
+ */
+export const visuallyHiddenFocusable = styled(visuallyHidden, `
+  &:not(:focus, :focus-within) {
+    ${commonStyles}
+  }
+
+  &:not(caption):not(:focus, :focus-within){
+    position: absolute !important;
+  }
+
+  &:not(:focus, :focus-within) * {
+    overflow: hidden !important;
+  }
+`);

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -729,7 +729,8 @@
         "The following tables will no longer be visible_one": "The following table will no longer be visible",
         "The following tables will no longer be visible_other": "The following tables will no longer be visible",
         "Keep data and delete page. Table will remain available in {{rawDataLink}}": "Keep data and delete page. Table will remain available in {{rawDataLink}}",
-        "raw data page": "raw data page"
+        "raw data page": "raw data page",
+        "Document pages": "Document pages"
     },
     "PermissionsWidget": {
         "Allow All": "Allow All",

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -2040,6 +2040,7 @@
         "Sort by name": "Sort by name",
         "Unpin": "Unpin",
         "Workspace": "Workspace",
+        "Document options - {{- documentName }}": "Document options - {{- documentName }}",
         "Documents list": "Documents list"
     },
     "RenameDocModal": {

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -1352,7 +1352,9 @@
         "Creator panel (right panel)": "Creator panel (right panel)",
         "Document header": "Document header",
         "Main content": "Main content",
-        "Main navigation and document settings (left panel)": "Main navigation and document settings (left panel)"
+        "Main navigation and document settings (left panel)": "Main navigation and document settings (left panel)",
+        "Close navigation panel (left panel)": "Close navigation panel (left panel)",
+        "Open navigation panel (left panel)": "Open navigation panel (left panel)"
     },
     "ColumnTitle": {
         "Add description": "Add description",

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -629,7 +629,8 @@
         "Workspaces": "Workspaces",
         "Tutorial": "Tutorial",
         "Terms of service": "Terms of service",
-        "Grist Resources": "Grist Resources"
+        "Grist Resources": "Grist Resources",
+        "{{ workspaceName }} - workspace options": "{{ workspaceName }} - workspace options"
     },
     "Importer": {
         "Merge rows that match these fields:": "Merge rows that match these fields:",

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -1941,11 +1941,11 @@
     "HomeIntroCards": {
         "3 minute video tour": "3 minute video tour",
         "Blank document": "Blank document",
-        "Find solutions and explore more resources {{helpCenterLink}}": "Find solutions and explore more resources {{helpCenterLink}}",
+        "Find solutions and explore more resources": "Find solutions and explore more resources",
         "Finish our basics tutorial": "Finish our basics tutorial",
         "Help center": "Help center",
         "Import file": "Import file",
-        "Learn more {{webinarsLinks}}": "Learn more {{webinarsLinks}}",
+        "Learn more": "Learn more",
         "Start a new document": "Start a new document",
         "Templates": "Templates",
         "Tutorial": "Tutorial",

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -120,7 +120,8 @@
         "Team Site": "Team Site",
         "Grist Templates": "Grist Templates",
         "Billing Account": "Billing Account",
-        "Manage Team": "Manage Team"
+        "Manage Team": "Manage Team",
+        "{{ organizationName }} - Back to home": "{{ organizationName }} - Back to home"
     },
     "AppModel": {
         "This team site is suspended. Documents can be read, but not modified.": "This team site is suspended. Documents can be read, but not modified."

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -630,7 +630,7 @@
         "Tutorial": "Tutorial",
         "Terms of service": "Terms of service",
         "Grist Resources": "Grist Resources",
-        "Workspace options - {{- workspaceName }}": "Workspace options - {{- workspaceName }}"
+        "context menu - {{- workspaceName }}": "context menu - {{- workspaceName }}"
     },
     "Importer": {
         "Merge rows that match these fields:": "Merge rows that match these fields:",
@@ -2040,7 +2040,7 @@
         "Sort by name": "Sort by name",
         "Unpin": "Unpin",
         "Workspace": "Workspace",
-        "Document options - {{- documentName }}": "Document options - {{- documentName }}",
+        "context menu - {{- documentName }}": "context menu - {{- documentName }}",
         "Documents list": "Documents list"
     },
     "RenameDocModal": {

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -630,7 +630,7 @@
         "Tutorial": "Tutorial",
         "Terms of service": "Terms of service",
         "Grist Resources": "Grist Resources",
-        "{{ workspaceName }} - workspace options": "{{ workspaceName }} - workspace options"
+        "Workspace options - {{- workspaceName }}": "Workspace options - {{- workspaceName }}"
     },
     "Importer": {
         "Merge rows that match these fields:": "Merge rows that match these fields:",

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -2039,7 +2039,8 @@
         "Sort by date": "Sort by date",
         "Sort by name": "Sort by name",
         "Unpin": "Unpin",
-        "Workspace": "Workspace"
+        "Workspace": "Workspace",
+        "Documents list": "Documents list"
     },
     "RenameDocModal": {
         "Choose color": "Choose color",


### PR DESCRIPTION
## Context

When [full keyboard navigation](https://github.com/gristlabs/grist-core/pull/1440) will be possible, we'll want to target every link and button with keyboard only. Also, we'll want to understand everything if using a screen reader.

As for now, even when working on a grist version with the keyboard navigation PR code applied, some interactive elements here and there can't be targeted with keyboard. And some elements also don't have any text tied to them (some icon buttons, for example), making it pretty hard to understand things with a screen reader.

edit: the full keyboard navigation PR has been merged, so you can already see on the main branch the issues I talk about.

## Proposed solution

This is a first pass to handle most cases I stumbled upon when **on the grist homepage**, listing our documents.

The whole idea is to:

- make all necessary elements keyboard focusable
- make sure all focusable elements have visible focus rings when focused
- add text alternative to elements missing them, so that focusing the elements with a screen reader correctly announces what we focus
- when necessary, add hidden text, like headings, to help screen reader users understand where they are 

Some things are not perfect (yet), but it's a good first pass. Every change should be pretty understandable, on its own commit.

~note that, if you want to test the behavior right now, you should rebase this on my [keyboard branch](https://github.com/manuhabitela/grist-core/tree/issue-1251-keyboard-nav), as it is not merged yet and it's the code allowing normal browser tab navigation on the homepage.~

## Has this been tested?

I didn't add any tests and wonder if I should right now ; those are lots of small technical changes. Maybe the best way to move forward would be to move along (updating current tests if they break). I'd like to, in parallel, try to include https://github.com/IBMa/equal-access in the tests suite to handle accessibility tests in a more global way.

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here (maybe?)
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

Before this PR, (rebased on the [keyboard PR](https://github.com/gristlabs/grist-core/pull/1440) branch):

https://github.com/user-attachments/assets/8c958d53-a0a5-4fd8-ba34-639e5f32bb1f

After this PR, (rebased on the [keyboard PR](https://github.com/gristlabs/grist-core/pull/1440) branch):

https://github.com/user-attachments/assets/441412e9-35e8-4bb2-a611-a274ddd438d1



