### PR TITLE
Make "text buttons" more pronounced with the high contrast theme

### DIFF
--- a/app/client/ui/ApiKey.ts
+++ b/app/client/ui/ApiKey.ts
@@ -67,6 +67,7 @@ export class ApiKey extends Disposable {
             this._inputArgs
           ),
           cssTextBtn(
+            textButton.cls('-hover-bg-padding-none'),
             cssTextBtnIcon('Remove'), t("Remove"),
             dom.on('click', () => this._showRemoveKeyModal()),
             testId('delete'),

--- a/app/client/ui/ColumnFilterMenu.ts
+++ b/app/client/ui/ColumnFilterMenu.ts
@@ -942,7 +942,7 @@ const cssSelectAll = styled(textButton, `
 `);
 const cssDotSeparator = styled('span', `
   color: ${theme.controlFg};
-  margin: 0 4px;
+  margin: 0 8px;
   user-select: none;
 `);
 const cssMenuDivider = styled(menuDivider, `

--- a/app/client/ui/FilterConfig.ts
+++ b/app/client/ui/FilterConfig.ts
@@ -5,6 +5,7 @@ import {addFilterMenu} from 'app/client/ui/FilterBar';
 import {cssIcon, cssPinButton, cssRow, cssSortFilterColumn} from 'app/client/ui/RightPanelStyles';
 import {theme} from 'app/client/ui2018/cssVars';
 import {icon} from 'app/client/ui2018/icons';
+import {textButton} from 'app/client/ui2018/buttons';
 import {Computed, Disposable, dom, makeTestId, styled} from 'grainjs';
 import {IMenuOptions} from 'popweasel';
 
@@ -86,7 +87,7 @@ export class FilterConfig extends Disposable {
       cssRow(
         dom.domComputed((use) => {
           const filters = use(this._section.filters);
-          return cssTextBtn(
+          return textButton(
             t("Add Column"),
             addFilterMenu(filters, this._popupControls, {
               menuOptions: {
@@ -112,15 +113,6 @@ const cssLabel = styled('div', `
   text-overflow: ellipsis;
   overflow: hidden;
   flex-grow: 1;
-`);
-
-const cssTextBtn = styled('div', `
-  color: ${theme.controlFg};
-  cursor: pointer;
-
-  &:hover {
-    color: ${theme.controlHoverFg};
-  }
 `);
 
 const cssFilterIcon = styled(cssIcon, `

--- a/app/client/ui/SortConfig.ts
+++ b/app/client/ui/SortConfig.ts
@@ -8,6 +8,7 @@ import {ObjObservable} from 'app/client/models/modelUtil';
 import {dropdownWithSearch} from 'app/client/ui/searchDropdown';
 import {cssIcon, cssRow, cssSortFilterColumn} from 'app/client/ui/RightPanelStyles';
 import {labeledLeftSquareCheckbox} from 'app/client/ui2018/checkbox';
+import {textButton} from 'app/client/ui2018/buttons';
 import {theme} from 'app/client/ui2018/cssVars';
 import {cssDragger} from 'app/client/ui2018/draggableList';
 import {menu} from 'app/client/ui2018/menus';
@@ -222,7 +223,7 @@ export class SortConfig extends Disposable {
       dom.autoDispose(available),
       dom.domComputed(use => {
         const cols = use(available);
-        return cssTextBtn(
+        return textButton(
           t("Add Column"),
           dropdownWithSearch({
             popupOptions: menuOptions,
@@ -241,7 +242,7 @@ export class SortConfig extends Disposable {
   private _buildUpdateDataButton() {
     return dom.maybe(this._section.isSorted, () =>
       cssButtonRow(
-        cssTextBtn(t("Update Data"),
+        textButton(t("Update Data"),
           dom.on('click', () => updatePositions(this._gristDoc, this._section)),
           testId('update'),
           dom.show((use) => (
@@ -291,15 +292,6 @@ const cssSortRow = styled('div', `
   display: flex;
   align-items: center;
   width: 100%;
-`);
-
-const cssTextBtn = styled('div', `
-  color: ${theme.controlFg};
-  cursor: pointer;
-
-  &:hover {
-    color: ${theme.controlHoverFg};
-  }
 `);
 
 const cssSortIconBtn = styled(cssIcon, `

--- a/app/client/ui/VisibleFieldsConfig.ts
+++ b/app/client/ui/VisibleFieldsConfig.ts
@@ -520,7 +520,6 @@ const cssFieldListHeader = styled('span', `
 const cssRow = styled('div', `
   display: flex;
   margin: 16px;
-  overflow: hidden;
   gap: 8px;
   --icon-color: ${theme.lightText};
 `);

--- a/app/client/ui2018/buttons.ts
+++ b/app/client/ui2018/buttons.ts
@@ -14,6 +14,7 @@
 
 import { theme, vars } from 'app/client/ui2018/cssVars';
 import { tbind } from 'app/common/tbind';
+import { components, tokens } from 'app/common/ThemePrefs';
 import { BindableValue, dom, DomElementArg, styled } from 'grainjs';
 
 export const cssButton = styled('button', `
@@ -103,7 +104,11 @@ export const primaryButtonLink = tbind(button, null, {link: true, primary: true}
 export const bigPrimaryButtonLink = tbind(button, null, {link: true, large: true, primary: true});
 
 // Button that looks like a link (have no background and no border).
+// On text button hover, allow theme to show a background and/or border.
+// It's done with a pseudo-element to add some "padding" to the background without moving the content.
 export const textButton = styled(cssButton, `
+  position: relative;
+  z-index: 1;
   border: none;
   padding: 0px;
   text-align: left;
@@ -111,6 +116,30 @@ export const textButton = styled(cssButton, `
   &:disabled {
     color: ${theme.controlPrimaryBg};
     opacity: 0.4;
+  }
+  &:hover::after {
+    z-index: -1;
+    content: '';
+    position: absolute;
+    inset: -3px;
+    left: -6px;
+    right: -6px;
+    border-radius: ${tokens.controlBorderRadius};
+    background-color: ${components.textButtonHoverBg};
+    border: 1px solid ${components.textButtonHoverBorder};
+  }
+  &-hover-bg-padding-none:hover::after {
+    top: 0px;
+    bottom: 0px;
+  }
+  &-hover-bg-padding-sm:hover::after {
+    inset: -1px;
+    left: -3px;
+    right: -3px;
+  }
+  &:active::after {
+    border-color: transparent;
+    background-color: transparent;
   }
 `);
 

--- a/app/client/ui2018/menus.ts
+++ b/app/client/ui2018/menus.ts
@@ -453,7 +453,11 @@ export function upgradableMenuItem(needUpgrade: boolean, action: () => void, ...
 export function upgradeText(needUpgrade: boolean, onClick: () => void) {
   if (!needUpgrade) { return null; }
   return menuText(dom('span', t("* Workspaces are available on team plans. "),
-    cssUpgradeTextButton(t("Upgrade now"), dom.on('click', () => onClick()))));
+    cssUpgradeTextButton(
+      t("Upgrade now"),
+      textButton.cls('-hover-bg-padding-sm'),
+      dom.on('click', () => onClick())
+    )));
 }
 
 /**

--- a/app/common/ThemePrefs.ts
+++ b/app/common/ThemePrefs.ts
@@ -578,6 +578,8 @@ export const componentsCssMapping = {
   cardButtonBorderSelected: 'card-button-border-selected',
   cardButtonShadow: 'card-button-shadow',
   formulaIcon: 'formula-icon',
+  textButtonHoverBg: 'text-button-hover-bg',
+  textButtonHoverBorder: 'text-button-hover-border',
 } as const;
 
 export const tokens = Object.fromEntries(
@@ -1300,6 +1302,8 @@ export interface BaseThemeTokens {
     cardButtonBorderSelected: Token;
     cardButtonShadow: Token;
     formulaIcon: Token;
+    textButtonHoverBg: Token;
+    textButtonHoverBorder: Token;
   };
 }
 

--- a/app/common/themes/Base.ts
+++ b/app/common/themes/Base.ts
@@ -490,5 +490,9 @@ export const Base: BaseThemeTokens = {
     cardButtonShadow: 'rgba(0,0,0,0.1)',
 
     formulaIcon: '#D0D0D0',
+
+    /* Text Button */
+    textButtonHoverBg: 'transparent',
+    textButtonHoverBorder: 'transparent',
   }
 };

--- a/app/common/themes/HighContrastLight.ts
+++ b/app/common/themes/HighContrastLight.ts
@@ -35,5 +35,6 @@ export const HighContrastLight: ThemeTokens = {
     rightPanelTabBorder: tokens.decoration,
     rightPanelSubtabFg: tokens.secondary,
     formulaIcon: tokens.decoration,
+    textButtonHoverBorder: 'currentColor',
   }
 };


### PR DESCRIPTION
## Context

Linked issue: https://github.com/gristlabs/grist-core/issues/1245

The idea is to make the "text buttons" have a little more user feedback so that they better tell that they are interactive. Not _that_ necessary but a welcome change. 

[Link to figma design by @lusebille](https://www.figma.com/design/wcpetFt6aOKzTszcvPPWLQ/-05-24--Grist-Design?node-id=2438-130148&t=FVXjF8zPA2UXCZdt-4).


## Proposed solution

This added feedback is added in the high contrast theme only (for now?).

The implementation is a bit different than the figma design in the end. Since we ended up not changing the colors of the default theme, if I added the gray background on the default theme it would make the text less readable, so I'd rather not change anything. Or I'd rather set the border on hover for all themes, but this was already decided a few months ago we'd rather not :)

:warning: There a few places where `textButton` is used that I didn't manage to verify the rendering myself. I didn't find where they were in the UI or how to setup a local install to make them appear:

- `LoginPageCSS` uses `textButton` but I can't find it used anywhere in the codebase,
- `DocTutorial` uses `textButton` but I didn't manage to correctly set up a tutorial workflow locally,
- `buildReassignModal` uses `textButton` (_"Configure reference"_) but I couldn't find where that was in the UI,
- `Assistant` uses `textButton` but again I couldn't find how to render it.

Otherwise I manually checked every spot where `textButton` was used.


## Related issues

Fixes https://github.com/gristlabs/grist-core/issues/1245.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

https://github.com/user-attachments/assets/e402b426-873a-461d-bde8-9c9653c02d7c


