### PR TITLE
(tiny) fix: takes GRIST_WEBINARS_URL into account

### DIFF
--- a/app/server/lib/sendAppPage.ts
+++ b/app/server/lib/sendAppPage.ts
@@ -8,6 +8,7 @@ import {
   getOnboardingVideoId,
   getPageTitleSuffix,
   getTermsOfServiceUrl,
+  getWebinarsUrl,
   GristLoadConfig,
   IFeature
 } from 'app/common/gristUrls';
@@ -81,6 +82,7 @@ export function makeGristConfig(options: MakeGristConfigOptions): GristLoadConfi
     termsOfServiceUrl: getTermsOfServiceUrl(),
     freeCoachingCallUrl: getFreeCoachingCallUrl(),
     onboardingTutorialVideoId: getOnboardingVideoId(),
+    webinarsUrl: getWebinarsUrl(),
     contactSupportUrl: getContactSupportUrl(),
     pathOnly,
     supportAnon: shouldSupportAnon(),


### PR DESCRIPTION
There was a missing piece that made grist ignore the GRIST_WEBINARS_URL env variable even though it was set.