### PR TITLE
testing: add some sandbox tests

### DIFF
--- a/sandbox/grist/main.py
+++ b/sandbox/grist/main.py
@@ -182,6 +182,31 @@ def run(sandbox):
   def test_fail(msg):
     raise Exception(msg)
 
+  # File read/write methods for testing
+  @export
+  def test_write_file(filename, contents):
+    with open(filename, "w") as f:
+      f.write(contents)
+
+  @export
+  def test_read_file(filename):
+    with open(filename) as f:
+      return f.read()
+
+  @export
+  def test_get_sandbox_root():
+    return os.path.realpath(os.path.join(__file__, '..'))
+
+  @export
+  def test_list_files(path, include_files=True):
+    paths = []
+    for root, _, fnames in os.walk(path):
+      paths.append(root)
+      if include_files:
+        for fname in sorted(fnames):
+          paths.append(fname)
+    return paths
+
   # Some sundry operations for tests only
   @export
   def test_operation(delay, operation, *inputs):

--- a/sandbox/gvisor/run.py
+++ b/sandbox/gvisor/run.py
@@ -238,6 +238,7 @@ def make_command(root_dir, action):
              "-network",
              "none"] + action + [
              root_dir.replace('/', '_')]  # Derive an arbitrary container name.
+  print(command)
   return command
 
 # Generate the OCI spec as config.json in a temporary directory, and either show

--- a/test/server/Sandbox.ts
+++ b/test/server/Sandbox.ts
@@ -1,5 +1,7 @@
 import { setGracefulCleanup } from 'tmp';
 import { assert } from 'chai';
+import * as path from 'path';
+import * as fs from "fs";
 
 import { NSandbox } from 'app/server/lib/NSandbox';
 import { timeoutReached } from 'app/server/lib/serverUtils';
@@ -7,17 +9,6 @@ import * as testUtils from 'test/server/testUtils';
 
 setGracefulCleanup();
 
-/**
- *
- * These tests were written for pynbox, a specific sandbox used
- * by Grist historically, but unfortunately using a technology
- * that became defunct (NaCl). We now have a variety of sandboxes,
- * but they don't all allow running python with arbitrary command
- * line options, so the tests have been narrowed. Also the file
- * system and permitted operations within the sandbox are now less
- * set in stone.
- *
- */
 describe('Sandbox', function () {
   this.timeout(12000);
 
@@ -157,146 +148,52 @@ describe('Sandbox', function () {
     });
   });
 
-  // pyodide can only do this in very specific narrow circumstances.
-  describe.skip("sandbox_py.call_external", function () {
-    it("should invoke exported JS functions", async function () {
-      let py_code = [
-        'import sandbox',
-        'results = {}',
-        // Simple call to the sandbox.
-        'results["quick"] = sandbox.call_external("quick", 1, 2, 3)',
-        // A slow call to the sandbox; the JS implementation returns a promise.
-        'results["slow"] = sandbox.call_external("slow")',
-        // A call to a function that throws an exception; we should see an exception.
-        'try:',
-        '  sandbox.call_external("bad")',
-        'except Exception, e:',
-        '  results["bad"] = e.message',
-        // Register our own function, and call a JS function which will call back to Python.
-        'sandbox.register("py_upper", lambda x: x.upper())',
-        'results["complicated"] = sandbox.call_external("complicated", "py_upper", "hello")',
-        // When all is done, report the results to the sandbox too.
-        'sandbox.call_external("report", results)',
-      ].join("\n") + "\n";
-
-      let results: { quick: string; slow: string; bad: string; complicated: string } | undefined;
-      const sandbox: NSandbox = new NSandbox({
-        args: [],
-        exports: {
-          quick: function (a, b, c) {
-            assert.equal(a, 1);
-            assert.equal(b, 2);
-            assert.equal(c, 3);
-            return "QUICK";
-          },
-          slow: function () {
-            return new Promise(resolve => setTimeout(() => resolve("SLOW"), 10));
-          },
-          bad: function () {
-            throw new Error("BAD WORKS");
-          },
-          complicated: function (py_func, arg) {
-            return sandbox.pyCall(py_func, arg);
-          },
-          report: function (_results) {
-            results = _results;
-          },
-        },
-      });
-      await sandbox.pyCall('test_exec', py_code);
-
-      assert.equal(results?.quick, "QUICK");
-      assert.equal(results?.slow, "SLOW");
-      assert.equal(results?.bad, "Error: BAD WORKS");
-      assert.equal(results?.complicated, "HELLO");
-      await sandbox.shutdown();
-    });
-  });
-
-  describe.skip("sandbox restrictions", function () {
+  describe("sandbox restrictions", function () {
     let sandbox: NSandbox;
     before(function () {
-      sandbox = new NSandbox({
-        args: ["-c", `
-import sys
-sys.path.insert(0, "/grist")
-import sandbox
-import os, stat, socket
-
-def test_listdir():
-  return sorted(os.listdir('/'))
-
-def test_write():
-  with open("/tmp_file", "w") as f:     # This should fail
-    f.write("hello\\n")
-  os.remove("/tmp_file")
-
-def test_chmod():
-  s = os.stat("/test")
-  os.chmod("/test", 0700)             # This should fail
-
-def test_socket():
-  socket.socket(socket.AF_INET, socket.SOCK_STREAM)   # This should fail
-
-def test_fork():
-  pid = os.fork()                       # This should fail
-  if pid == 0:    # If we do succeed, the child process shouldn't keep running.
-    sys.exit(0)
-
-sandbox.register('test_listdir', test_listdir)
-sandbox.register('test_write', test_write)
-sandbox.register('test_chmod', test_chmod)
-sandbox.register('test_socket', test_socket)
-sandbox.register('test_fork', test_fork)
-sandbox.run()
-`]
-      });
+      sandbox = new NSandbox({ args: []});
     });
 
     after(function () {
       return sandbox.shutdown();
     });
 
-    // This is different for every sandbox
-    it("should have no access to files outside sandbox root", async function () {
-      const value = await sandbox.pyCall("test_listdir")
-      assert.deepEqual(value, ['grist', 'python', 'slib', 'test', 'thirdparty']);
+    it("should only have access to directories inside the sandbox root", async function () {
+      const sandboxRoot = await sandbox.pyCall('test_get_sandbox_root');
+      const sandboxDirs = await sandbox.pyCall('test_list_files', sandboxRoot, false);
+      const expectedDirs = [
+        '', 'imports', 'functions',
+        '__pycache__', 'imports/__pycache__', 'functions/__pycache__',
+        'imports/fixtures'].map(
+        dir => path.join(sandboxRoot, dir)
+      );
+      assert.deepEqual(sandboxDirs.sort(), expectedDirs.sort());
+
+      const emptyTmp = await sandbox.pyCall('test_list_files', "/tmp", true);
+      assert.deepEqual(emptyTmp, ["/tmp"]);
     });
 
-    // May have write access in sandboxes, just not to "real" files
-    it("should have no write access to files", function () {
-      return sandbox.pyCall("test_write")
-        .then(
-          () => assert(false, "test_write should have failed"),
-          (err) => assert.match(err.message, /Permission denied:.*\/tmp_file/)
-        );
+    it("should have no write access to sandbox files", async function () {
+      // gvisor mounts the sandbox files as read-only
+      const sandboxRoot = await sandbox.pyCall('test_get_sandbox_root');
+      const mainFile = path.join(sandboxRoot, 'main.py');
+      await assert.isRejected(
+        sandbox.pyCall('test_write_file', mainFile, '# A rambunctious little edit')
+      );
+      const fileContents = await sandbox.pyCall('test_read_file', mainFile);
+      assert.match(fileContents, /defines what sandbox functions are made available to the Node controller/);
+      assert.notMatch(fileContents, /rambunctious/);
     });
 
-    // May be permitted, just within a sandbox scope
-    it("should not be able to chmod files", function () {
-      return sandbox.pyCall("test_chmod")
-        .then(
-          () => assert(false, "test_chmod should have failed"),
-          (err) => assert.match(err.message, /Permission denied:.*\/test/)
-        );
-    });
-
-    // May be permitted, just within a sandbox scope
-    it("should not be able to create sockets", function () {
-      return sandbox.pyCall("test_socket")
-        .then(
-          () => assert(false, "test_socket should have failed"),
-          (err) => assert.match(err.message, /Function not implemented/)
-        );
-    });
-
-    // May be permitted, just within a sandbox scope
-    it("should not be able to fork", function () {
-      return sandbox.pyCall("test_fork")
-        .then(
-          () => assert(false, "test_socket should have failed"),
-          (err) => assert.match(err.message, /Function not implemented/)
-        );
+    it("should have write access to some directories", async function () {
+      // gvisor mounts /tmp as a tmpfs, so it can be written to but is
+      // invisible to the host
+      const tmpFile = '/tmp/grist-fake-file-does-not-exist';
+      const testContents = 'chimpy + kiwi = <3';
+      await sandbox.pyCall('test_write_file', tmpFile, testContents);
+      const fileContents = await sandbox.pyCall('test_read_file', tmpFile);
+      assert.equal(fileContents, testContents, 'File should be writable in the sandbox');
+      assert.isFalse(fs.existsSync(tmpFile), 'File should not exist in the host OS');
     });
   });
 });


### PR DESCRIPTION
## Context

We have no sandbox tests.

## Proposed solution

This adds some basic sandbox tests. They're not very comprehensive, but they cover some basics such as file permissions. They're mostly geared towards gvisor but should work in any other sandbox.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

