### PR TITLE
Add some sandbox tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,12 +11,13 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     strategy:
       # it is helpful to know which sets of tests would have succeeded,
       # even when there is a failure.
       fail-fast: false
       matrix:
+        os: ['ubuntu-24.04']
         python-version: [3.11]
         node-version: [22.x]
         tests:
@@ -33,6 +34,11 @@ jobs:
           - tests: ':lint:python:client:common:smoke:'
             node-version: 22.x
             python-version: '3.10'
+            os: ubuntu-24.04
+          - tests: ':pyodide:macsandbox:'
+            node-version: 22.x
+            python-version: '3.11'
+            os: macos-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -57,6 +63,7 @@ jobs:
         run: yarn install
 
       - name: Install gvisor
+        if: contains(matrix.os, 'ubuntu')
         run: |
           docker create --name temp-runsc gristlabs/gvisor-unprivileged:buster /bin/true
           sudo docker cp temp-runsc:/runsc /usr/bin/runsc
@@ -67,7 +74,7 @@ jobs:
         run: yarn run lint:ci
 
       - name: Make sure bucket is versioned
-        if: contains(matrix.tests, ':server-') || contains(matrix.tests, ':gen-server:')
+        if: contains(matrix.os, 'ubuntu') && contains(matrix.tests, ':server-') || contains(matrix.os, 'ubuntu') && contains(matrix.tests, ':gen-server:')
         env:
           AWS_ACCESS_KEY_ID: administrator
           AWS_SECRET_ACCESS_KEY: administrator
@@ -127,6 +134,14 @@ jobs:
         env:
           MOCHA_WEBDRIVER_HEADLESS: 1
           GRIST_SANDBOX_FLAVOR: pyodide
+
+      - name: Run a couple of tests using macSandboxExec
+        if: contains(matrix.tests, ':macsandbox:')
+        run: |
+          yarn run test:server -g Sandbox
+        env:
+          MOCHA_WEBDRIVER_HEADLESS: 1
+          GRIST_SANDBOX_FLAVOR: macSandboxExec
 
       - name: Run gen-server tests with postgres, minio and redis
         if: contains(matrix.tests, ':gen-server:')
@@ -202,7 +217,7 @@ jobs:
     services:
       # https://github.com/bitnami/bitnami-docker-minio/issues/16
       minio:
-        image: bitnami/minio:2025.4.22
+        image: ${{ matrix.os == 'ubuntu-24.04' && 'bitnami/minio:2025.4.22' || '' }} 
         env:
           MINIO_DEFAULT_BUCKETS: "grist-docs-test:public"
           MINIO_ROOT_USER: administrator
@@ -216,7 +231,7 @@ jobs:
           --health-retries 5
 
       redis:
-        image: redis
+        image: ${{ matrix.os == 'ubuntu-24.04' && 'redis' || '' }}
         ports:
           - 6379:6379
         options: >-
@@ -226,7 +241,7 @@ jobs:
           --health-retries 5
 
       postgresql:
-        image: postgres:latest
+        image: ${{ matrix.os == 'ubuntu-24.04' && 'postgres:latest' || '' }}
         env:
           POSTGRES_USER: db_user
           POSTGRES_PASSWORD: db_password

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,13 @@ jobs:
 
       - name: Install Node.js packages
         run: yarn install
- 
+
+      - name: Install gvisor
+        run: |
+          docker create --name temp-runsc gristlabs/gvisor-unprivileged:buster /bin/true
+          sudo docker cp temp-runsc:/runsc /usr/bin/runsc
+          docker rm temp-runsc
+
       - name: Run eslint
         if: contains(matrix.tests, ':lint:')
         run: yarn run lint:ci
@@ -154,6 +160,8 @@ jobs:
           GRIST_DOCS_MINIO_ACCESS_KEY: administrator
           GRIST_DOCS_MINIO_SECRET_KEY: administrator
           TEST_REDIS_URL: "redis://localhost/11"
+          GVISOR_FLAGS: "-unprivileged -ignore-cgroups"
+          GVISOR_EXTRA_DIRS: /opt
           GRIST_DOCS_MINIO_USE_SSL: 0
           GRIST_DOCS_MINIO_ENDPOINT: localhost
           GRIST_DOCS_MINIO_PORT: 9000
@@ -168,6 +176,8 @@ jobs:
         env:
           TESTS: ${{ matrix.tests }}
           MOCHA_WEBDRIVER_LOGDIR: ${{ runner.temp }}/test-logs/webdriver
+          GVISOR_FLAGS: "-unprivileged -ignore-cgroups"
+          GVISOR_EXTRA_DIRS: /opt
           TESTDIR: ${{ runner.temp }}/test-logs
 
       - name: Prepare for saving artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,13 +117,13 @@ jobs:
           GRIST_DOCS_MINIO_PORT: 9000
           GRIST_DOCS_MINIO_BUCKET: grist-docs-test
 
-      - name: Run a test using pyodide
+      - name: Run a couple of tests using pyodide
         if: contains(matrix.tests, ':pyodide:')
         run: |
           cd sandbox/pyodide
           make setup
           cd ../..
-          yarn run test:server -g ActiveDoc.useQuerySet
+          yarn run test:server -g 'ActiveDoc.useQuerySet|Sandbox'
         env:
           MOCHA_WEBDRIVER_HEADLESS: 1
           GRIST_SANDBOX_FLAVOR: pyodide

--- a/app/server/lib/NSandbox.ts
+++ b/app/server/lib/NSandbox.ts
@@ -886,6 +886,7 @@ function macSandboxExec(options: ISandboxOptions): SandboxProcess {
   // Sundry extra permissions that proved necessary. These work at the time of writing for
   // python versions installed by brew. Other arrangements could need tweaking.
   profile.push(`(allow file-read* (subpath "/usr/local/"))`);
+  profile.push(`(allow file-read* (subpath "/opt/homebrew/"))`);
   profile.push('(allow sysctl-read)');  // needed for os.uname()
   // From another python installation variant.
   profile.push(`(allow file-read* (subpath "/usr/lib/"))`);

--- a/sandbox/grist/main.py
+++ b/sandbox/grist/main.py
@@ -182,6 +182,31 @@ def run(sandbox):
   def test_fail(msg):
     raise Exception(msg)
 
+  # File read/write methods for testing
+  @export
+  def test_write_file(filename, contents):
+    with open(filename, "a") as f:
+      f.write(contents)
+
+  @export
+  def test_read_file(filename):
+    with open(filename) as f:
+      return f.read()
+
+  @export
+  def test_get_sandbox_root():
+    return os.path.realpath(os.path.join(__file__, '..'))
+
+  @export
+  def test_list_files(path, include_files=True):
+    paths = []
+    for root, _, fnames in os.walk(path):
+      paths.append(root)
+      if include_files:
+        for fname in sorted(fnames):
+          paths.append(fname)
+    return paths
+
   # Some sundry operations for tests only
   @export
   def test_operation(delay, operation, *inputs):

--- a/test/server/Sandbox.ts
+++ b/test/server/Sandbox.ts
@@ -1,20 +1,11 @@
 import { assert } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
 
-import { NSandbox } from 'app/server/lib/NSandbox';
+import { createSandbox, NSandbox } from 'app/server/lib/NSandbox';
 import { timeoutReached } from 'app/server/lib/serverUtils';
 import * as testUtils from 'test/server/testUtils';
 
-/**
- *
- * These tests were written for pynbox, a specific sandbox used
- * by Grist historically, but unfortunately using a technology
- * that became defunct (NaCl). We now have a variety of sandboxes,
- * but they don't all allow running python with arbitrary command
- * line options, so the tests have been narrowed. Also the file
- * system and permitted operations within the sandbox are now less
- * set in stone.
- *
- */
 describe('Sandbox', function () {
   this.timeout(12000);
 
@@ -44,7 +35,7 @@ describe('Sandbox', function () {
 
   describe("Basic operation", function () {
     it("should echo hello world", async function () {
-      const sandbox = new NSandbox({ args: [] });
+      const sandbox = createSandbox('sandboxed', {});
       try {
         const result = await sandbox.pyCall(
           'test_echo', 'Hello world'
@@ -56,7 +47,7 @@ describe('Sandbox', function () {
     });
 
     it("should handle exceptions", async function () {
-      const sandbox = new NSandbox({ args: [] });
+      const sandbox = createSandbox('sandboxed', {});
       try {
         await assert.isRejected(sandbox.pyCall(
           'test_fail', 'Hello world'
@@ -73,7 +64,7 @@ describe('Sandbox', function () {
 
   describe("sandbox.pyCall", function () {
     it("should invoke python functions", async function () {
-      const sandbox = new NSandbox({ args: [] });
+      const sandbox = createSandbox('sandboxed', {});
       // Startup can be noisy in logs, wait for it to be done
       // and for the sandbox to be available, then clear the logs.
       await sandbox.pyCall('test_echo', '1');
@@ -91,7 +82,7 @@ describe('Sandbox', function () {
     });
 
     it("should fail when sandbox has exited", async function () {
-      const sandbox = new NSandbox({ args: [] });
+      const sandbox = createSandbox('sandboxed', {});
       try {
         // Normally pyCall should succeed.
         const value = await sandbox.pyCall("test_operation", 1.5, "uppercase", "hello");
@@ -118,7 +109,7 @@ describe('Sandbox', function () {
     });
 
     it("should get killed if sandbox refuses to exit", async function () {
-      const sandbox = new NSandbox({ args: [] });
+      const sandbox = createSandbox('sandboxed', {});
       const expectedRejection = assert.isRejected(
         sandbox.pyCall("test_operation", 100, "uppercase", "hello"),
         /PipeFromSandbox is closed/
@@ -128,7 +119,7 @@ describe('Sandbox', function () {
     });
 
     it("should be reasonably quick with big data", async function () {
-      const sandbox = new NSandbox({ args: [] });
+      const sandbox = createSandbox('sandboxed', {});
       const bigString = new Array(1000001).join("*");
       assert.equal(bigString.length, 1000000);
 
@@ -154,146 +145,78 @@ describe('Sandbox', function () {
     });
   });
 
-  // pyodide can only do this in very specific narrow circumstances.
-  describe.skip("sandbox_py.call_external", function () {
-    it("should invoke exported JS functions", async function () {
-      let py_code = [
-        'import sandbox',
-        'results = {}',
-        // Simple call to the sandbox.
-        'results["quick"] = sandbox.call_external("quick", 1, 2, 3)',
-        // A slow call to the sandbox; the JS implementation returns a promise.
-        'results["slow"] = sandbox.call_external("slow")',
-        // A call to a function that throws an exception; we should see an exception.
-        'try:',
-        '  sandbox.call_external("bad")',
-        'except Exception, e:',
-        '  results["bad"] = e.message',
-        // Register our own function, and call a JS function which will call back to Python.
-        'sandbox.register("py_upper", lambda x: x.upper())',
-        'results["complicated"] = sandbox.call_external("complicated", "py_upper", "hello")',
-        // When all is done, report the results to the sandbox too.
-        'sandbox.call_external("report", results)',
-      ].join("\n") + "\n";
-
-      let results: { quick: string; slow: string; bad: string; complicated: string } | undefined;
-      const sandbox: NSandbox = new NSandbox({
-        args: [],
-        exports: {
-          quick: function (a, b, c) {
-            assert.equal(a, 1);
-            assert.equal(b, 2);
-            assert.equal(c, 3);
-            return "QUICK";
-          },
-          slow: function () {
-            return new Promise(resolve => setTimeout(() => resolve("SLOW"), 10));
-          },
-          bad: function () {
-            throw new Error("BAD WORKS");
-          },
-          complicated: function (py_func, arg) {
-            return sandbox.pyCall(py_func, arg);
-          },
-          report: function (_results) {
-            results = _results;
-          },
-        },
-      });
-      await sandbox.pyCall('test_exec', py_code);
-
-      assert.equal(results?.quick, "QUICK");
-      assert.equal(results?.slow, "SLOW");
-      assert.equal(results?.bad, "Error: BAD WORKS");
-      assert.equal(results?.complicated, "HELLO");
-      await sandbox.shutdown();
-    });
-  });
-
-  describe.skip("sandbox restrictions", function () {
+  describe("sandbox restrictions", function () {
     let sandbox: NSandbox;
     before(function () {
-      sandbox = new NSandbox({
-        args: ["-c", `
-import sys
-sys.path.insert(0, "/grist")
-import sandbox
-import os, stat, socket
-
-def test_listdir():
-  return sorted(os.listdir('/'))
-
-def test_write():
-  with open("/tmp_file", "w") as f:     # This should fail
-    f.write("hello\\n")
-  os.remove("/tmp_file")
-
-def test_chmod():
-  s = os.stat("/test")
-  os.chmod("/test", 0700)             # This should fail
-
-def test_socket():
-  socket.socket(socket.AF_INET, socket.SOCK_STREAM)   # This should fail
-
-def test_fork():
-  pid = os.fork()                       # This should fail
-  if pid == 0:    # If we do succeed, the child process shouldn't keep running.
-    sys.exit(0)
-
-sandbox.register('test_listdir', test_listdir)
-sandbox.register('test_write', test_write)
-sandbox.register('test_chmod', test_chmod)
-sandbox.register('test_socket', test_socket)
-sandbox.register('test_fork', test_fork)
-sandbox.run()
-`]
-      });
+      sandbox = createSandbox('sandboxed', {}) as NSandbox;
     });
 
     after(function () {
       return sandbox.shutdown();
     });
 
-    // This is different for every sandbox
-    it("should have no access to files outside sandbox root", async function () {
-      const value = await sandbox.pyCall("test_listdir")
-      assert.deepEqual(value, ['grist', 'python', 'slib', 'test', 'thirdparty']);
+    it("should only have access to directories inside the sandbox root", async function () {
+      const sandboxRoot = await sandbox.pyCall('test_get_sandbox_root');
+      const sandboxDirs = await sandbox.pyCall('test_list_files', sandboxRoot, false);
+      const hostDirs = getSubDirs(`${testUtils.appRoot}/sandbox/grist`, sandboxRoot);
+      assert.deepEqual(sandboxDirs.sort(), hostDirs.sort());
+
+      if (sandbox.getFlavor() === 'macSandboxExec') {
+        // Mac sandbox doesn't allow this kind of tmpfs overlay. End
+        // this test early.
+        return;
+      }
+      const emptyTmp = await sandbox.pyCall('test_list_files', "/tmp", true);
+      assert.deepEqual(emptyTmp, ["/tmp"]);
     });
 
-    // May have write access in sandboxes, just not to "real" files
-    it("should have no write access to files", function () {
-      return sandbox.pyCall("test_write")
-        .then(
-          () => assert(false, "test_write should have failed"),
-          (err) => assert.match(err.message, /Permission denied:.*\/tmp_file/)
-        );
+    it("gvisor and macSandboxExec should have no write access to sandbox files", async function () {
+      if (!['gvisor', 'macSandboxExec'].includes(sandbox.getFlavor())) {
+        this.skip();
+      }
+      const sandboxRoot = await sandbox.pyCall('test_get_sandbox_root');
+      const mainFile = path.join(sandboxRoot, 'main.py');
+
+      // gvisor mounts the sandbox files as read-only
+      await assert.isRejected(
+        sandbox.pyCall('test_write_file', mainFile, '# A rambunctious little edit')
+      );
+      const fileContents = await sandbox.pyCall('test_read_file', mainFile);
+      assert.match(fileContents, /defines what sandbox functions are made available to the Node controller/);
+      assert.notMatch(fileContents, /rambunctious/);
     });
 
-    // May be permitted, just within a sandbox scope
-    it("should not be able to chmod files", function () {
-      return sandbox.pyCall("test_chmod")
-        .then(
-          () => assert(false, "test_chmod should have failed"),
-          (err) => assert.match(err.message, /Permission denied:.*\/test/)
-        );
+    it("pyodide writes to sandbox files should not survive outside the sandbox", async function () {
+      if (sandbox.getFlavor() !== 'pyodide') {
+        this.skip();
+      }
+      const sandboxRoot = await sandbox.pyCall('test_get_sandbox_root');
+      const mainFile = path.join(sandboxRoot, 'main.py');
+
+      // pyodide works on a copy of the original files
+      await sandbox.pyCall('test_write_file', mainFile, '# A rambunctious little edit');
+      const fileContentsInSandbox = await sandbox.pyCall('test_read_file', mainFile);
+      assert.match(fileContentsInSandbox, /defines what sandbox functions are made available to the Node controller/);
+      assert.match(fileContentsInSandbox, /rambunctious/, );
+
+      const fileContents = fs.readFileSync(`./sandbox/${mainFile}`).toString();
+      assert.match(fileContents, /defines what sandbox functions are made available to the Node controller/);
+      assert.notMatch(fileContents, /rambunctious/);
     });
 
-    // May be permitted, just within a sandbox scope
-    it("should not be able to create sockets", function () {
-      return sandbox.pyCall("test_socket")
-        .then(
-          () => assert(false, "test_socket should have failed"),
-          (err) => assert.match(err.message, /Function not implemented/)
-        );
-    });
-
-    // May be permitted, just within a sandbox scope
-    it("should not be able to fork", function () {
-      return sandbox.pyCall("test_fork")
-        .then(
-          () => assert(false, "test_socket should have failed"),
-          (err) => assert.match(err.message, /Function not implemented/)
-        );
+    it("should have write access to some directories", async function () {
+      if (sandbox.getFlavor() === 'macSandboxExec') {
+        // Mac sandbox doesn't allow this kind of tmpfs overlay.
+        this.skip();
+      }
+      // gvisor mounts /tmp as a tmpfs, so it can be written to but is
+      // invisible to the host
+      const tmpFile = '/tmp/grist-fake-file-does-not-exist';
+      const testContents = 'chimpy + kiwi = <3';
+      await sandbox.pyCall('test_write_file', tmpFile, testContents);
+      const fileContents = await sandbox.pyCall('test_read_file', tmpFile);
+      assert.equal(fileContents, testContents, 'File should be writable in the sandbox');
+      assert.isFalse(fs.existsSync(tmpFile), 'File should not exist in the host OS');
     });
   });
 });

--- a/test/server/Sandbox.ts
+++ b/test/server/Sandbox.ts
@@ -1,0 +1,311 @@
+import { assert } from 'chai';
+
+import { NSandbox } from 'app/server/lib/NSandbox';
+import { timeoutReached } from 'app/server/lib/serverUtils';
+import * as testUtils from 'test/server/testUtils';
+
+/**
+ *
+ * These tests were written for pynbox, a specific sandbox used
+ * by Grist historically, but unfortunately using a technology
+ * that became defunct (NaCl). We now have a variety of sandboxes,
+ * but they don't all allow running python with arbitrary command
+ * line options, so the tests have been narrowed. Also the file
+ * system and permitted operations within the sandbox are now less
+ * set in stone.
+ *
+ */
+describe('Sandbox', function () {
+  this.timeout(12000);
+
+  const output: { stdout: string[], stderr: string[] } = {
+    stdout: [],
+    stderr: []
+  };
+
+  function capture(level: string, msg: string) {
+    const match = /^Sandbox.*(stdout|stderr): (.*)$/s.exec(msg);
+    if (match && level === 'info') {
+      const stream = match[1] as 'stdout' | 'stderr';
+      output[stream].push(match[2]);
+    }
+  }
+
+  function clear() {
+    output.stdout.length = 0;
+    output.stderr.length = 0;
+  }
+
+  testUtils.setTmpLogLevel('warn', capture);
+
+  beforeEach(function () {
+    clear();
+  });
+
+  describe("Basic operation", function () {
+    it("should echo hello world", async function () {
+      const sandbox = new NSandbox({ args: [] });
+      try {
+        const result = await sandbox.pyCall(
+          'test_echo', 'Hello world'
+        );
+        assert.equal(result, 'Hello world');
+      } finally {
+        await sandbox.shutdown();
+      }
+    });
+
+    it("should handle exceptions", async function () {
+      const sandbox = new NSandbox({ args: [] });
+      try {
+        await assert.isRejected(sandbox.pyCall(
+          'test_fail', 'Hello world'
+        ), /Hello world/);
+        assert.deepEqual(output.stdout, []);
+        const stderr = output.stderr.join('\n');
+        assert.match(stderr, /Traceback \(most recent call last\):/);
+        assert.match(stderr, /Exception: Hello world/);
+      } finally {
+        await sandbox.shutdown();
+      }
+    });
+  });
+
+  describe("sandbox.pyCall", function () {
+    it("should invoke python functions", async function () {
+      const sandbox = new NSandbox({ args: [] });
+      // Startup can be noisy in logs, wait for it to be done
+      // and for the sandbox to be available, then clear the logs.
+      await sandbox.pyCall('test_echo', '1');
+      clear();
+      try {
+        let value = await sandbox.pyCall("test_operation", 0, "uppercase", "hello");
+        assert.equal(value, "HELLO");
+        value = await sandbox.pyCall("test_operation", 0, "triple", 2.5);
+        assert.equal(value, 7.5);
+        assert.deepEqual(output.stdout, []);
+        assert.deepEqual(output.stderr, []);
+      } finally {
+        await sandbox.shutdown();
+      }
+    });
+
+    it("should fail when sandbox has exited", async function () {
+      const sandbox = new NSandbox({ args: [] });
+      try {
+        // Normally pyCall should succeed.
+        const value = await sandbox.pyCall("test_operation", 1.5, "uppercase", "hello");
+        assert.equal(value, "HELLO");
+
+        // Now kill the sandbox, and call again. In this case pyCall doesn't know yet that the
+        // sandbox has exited, so it should fail on reading the response.
+        const assertPromise = assert.isRejected(sandbox.pyCall("test_operation", 1.5, "uppercase", "shouldfail1"),
+          /PipeFromSandbox is closed/,
+          "When sandbox exits, pyCall should not succeed");
+
+        await sandbox.shutdown();
+        assert.equal(await timeoutReached(1000, Promise.resolve(assertPromise)), false,
+          "When sandbox exits, pyCall should not hang");
+        await assertPromise;
+
+        // Now try to make another pyCall; it should fail too, but this time immediately.
+        await assert.isRejected(sandbox.pyCall("test_operation", 1.5, "uppercase", "shouldfail2"),
+          /PipeToSandbox is closed/,
+          "When sandbox has exited, pyCall should not succeed");
+      } finally {
+        await sandbox.shutdown();
+      }
+    });
+
+    it("should get killed if sandbox refuses to exit", async function () {
+      const sandbox = new NSandbox({ args: [] });
+      const expectedRejection = assert.isRejected(
+        sandbox.pyCall("test_operation", 100, "uppercase", "hello"),
+        /PipeFromSandbox is closed/
+      );
+      await sandbox.shutdown();
+      await expectedRejection;
+    });
+
+    it("should be reasonably quick with big data", async function () {
+      const sandbox = new NSandbox({ args: [] });
+      const bigString = new Array(1000001).join("*");
+      assert.equal(bigString.length, 1000000);
+
+      try {
+        let start: number;
+        // Make a small call to the sandbox, to ensure if finished startup, before we start timing.
+        let count = await sandbox.pyCall("test_operation", 0, "bigToSmall", "test");
+        assert.equal(count, 4);
+        start = Date.now();
+        count = await sandbox.pyCall("test_operation", 0, "bigToSmall", bigString);
+        let delta = Date.now() - start;
+        assert.equal(count, 1000000);
+        assert(delta < 100, "Should really be around 20ms, but took " + delta);
+
+        start = Date.now();
+        const value = await sandbox.pyCall("test_operation", 0, "smallToBig", 1000000);
+        delta = Date.now() - start;
+        assert(delta < 100, "Should really be around 20ms, but took " + delta);
+        assert.equal(value, bigString);
+      } finally {
+        await sandbox.shutdown();
+      }
+    });
+  });
+
+  // pyodide can only do this in very specific narrow circumstances.
+  describe.skip("sandbox_py.call_external", function () {
+    it("should invoke exported JS functions", async function () {
+      let py_code = [
+        'import sandbox',
+        'results = {}',
+        // Simple call to the sandbox.
+        'results["quick"] = sandbox.call_external("quick", 1, 2, 3)',
+        // A slow call to the sandbox; the JS implementation returns a promise.
+        'results["slow"] = sandbox.call_external("slow")',
+        // A call to a function that throws an exception; we should see an exception.
+        'try:',
+        '  sandbox.call_external("bad")',
+        'except Exception, e:',
+        '  results["bad"] = e.message',
+        // Register our own function, and call a JS function which will call back to Python.
+        'sandbox.register("py_upper", lambda x: x.upper())',
+        'results["complicated"] = sandbox.call_external("complicated", "py_upper", "hello")',
+        // When all is done, report the results to the sandbox too.
+        'sandbox.call_external("report", results)',
+      ].join("\n") + "\n";
+
+      let results: { quick: string; slow: string; bad: string; complicated: string } | undefined;
+      const sandbox: NSandbox = new NSandbox({
+        args: [],
+        exports: {
+          quick: function (a, b, c) {
+            assert.equal(a, 1);
+            assert.equal(b, 2);
+            assert.equal(c, 3);
+            return "QUICK";
+          },
+          slow: function () {
+            return new Promise(resolve => setTimeout(() => resolve("SLOW"), 10));
+          },
+          bad: function () {
+            throw new Error("BAD WORKS");
+          },
+          complicated: function (py_func, arg) {
+            return sandbox.pyCall(py_func, arg);
+          },
+          report: function (_results) {
+            results = _results;
+          },
+        },
+      });
+      await sandbox.pyCall('test_exec', py_code);
+
+      assert.equal(results?.quick, "QUICK");
+      assert.equal(results?.slow, "SLOW");
+      assert.equal(results?.bad, "Error: BAD WORKS");
+      assert.equal(results?.complicated, "HELLO");
+      await sandbox.shutdown();
+    });
+  });
+
+  describe.skip("sandbox restrictions", function () {
+    let sandbox: NSandbox;
+    before(function () {
+      sandbox = new NSandbox({
+        args: ["-c", `
+import sys
+sys.path.insert(0, "/grist")
+import sandbox
+import os, stat, socket
+
+def test_listdir():
+  return sorted(os.listdir('/'))
+
+def test_write():
+  with open("/tmp_file", "w") as f:     # This should fail
+    f.write("hello\\n")
+  os.remove("/tmp_file")
+
+def test_chmod():
+  s = os.stat("/test")
+  os.chmod("/test", 0700)             # This should fail
+
+def test_socket():
+  socket.socket(socket.AF_INET, socket.SOCK_STREAM)   # This should fail
+
+def test_fork():
+  pid = os.fork()                       # This should fail
+  if pid == 0:    # If we do succeed, the child process shouldn't keep running.
+    sys.exit(0)
+
+sandbox.register('test_listdir', test_listdir)
+sandbox.register('test_write', test_write)
+sandbox.register('test_chmod', test_chmod)
+sandbox.register('test_socket', test_socket)
+sandbox.register('test_fork', test_fork)
+sandbox.run()
+`]
+      });
+    });
+
+    after(function () {
+      return sandbox.shutdown();
+    });
+
+    // This is different for every sandbox
+    it("should have no access to files outside sandbox root", async function () {
+      const value = await sandbox.pyCall("test_listdir")
+      assert.deepEqual(value, ['grist', 'python', 'slib', 'test', 'thirdparty']);
+    });
+
+    // May have write access in sandboxes, just not to "real" files
+    it("should have no write access to files", function () {
+      return sandbox.pyCall("test_write")
+        .then(
+          () => assert(false, "test_write should have failed"),
+          (err) => assert.match(err.message, /Permission denied:.*\/tmp_file/)
+        );
+    });
+
+    // May be permitted, just within a sandbox scope
+    it("should not be able to chmod files", function () {
+      return sandbox.pyCall("test_chmod")
+        .then(
+          () => assert(false, "test_chmod should have failed"),
+          (err) => assert.match(err.message, /Permission denied:.*\/test/)
+        );
+    });
+
+    // May be permitted, just within a sandbox scope
+    it("should not be able to create sockets", function () {
+      return sandbox.pyCall("test_socket")
+        .then(
+          () => assert(false, "test_socket should have failed"),
+          (err) => assert.match(err.message, /Function not implemented/)
+        );
+    });
+
+    // May be permitted, just within a sandbox scope
+    it("should not be able to fork", function () {
+      return sandbox.pyCall("test_fork")
+        .then(
+          () => assert(false, "test_socket should have failed"),
+          (err) => assert.match(err.message, /Function not implemented/)
+        );
+    });
+  });
+});
+
+function getSubDirs(dir: string, root: string): string[] {
+  // Walk directories but replace the root with the given root
+  return [root, ...fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    if (!entry.isDirectory()) {
+      return [];
+    }
+    const full = path.join(dir, entry.name);
+    const mapped = path.join(root, entry.name);
+    return getSubDirs(full, mapped);
+  })];
+}

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -96,10 +96,6 @@ function makeUserApi(
 }
 
 describe('DocApi', function () {
-  // The XLS test fails on Jenkins without this. Mysterious? Maybe a real problem or
-  // a problem in test setup related to plugins? TODO: investigate and fix.
-  testUtils.withoutSandboxing();
-
   const webhooksTestPort = Number(process.env.WEBHOOK_TEST_PORT || 34365);
 
   this.timeout(30000);
@@ -110,6 +106,9 @@ describe('DocApi', function () {
   before(async function () {
     sandbox.stub(Deps, 'ACTIVEDOC_TIMEOUT').value(30);
     oldEnv = new testUtils.EnvironmentSnapshot();
+    // The XLS test fails on Jenkins without this. Mysterious? Maybe a real problem or
+    // a problem in test setup related to plugins? TODO: investigate and fix.
+    process.env.GRIST_SANDBOX_FLAVOR = 'unsandboxed';
 
     await flushAllRedis();
 

--- a/test/server/testUtils.ts
+++ b/test/server/testUtils.ts
@@ -356,6 +356,12 @@ export async function getBuildFile(relativePath: string): Promise<string> {
   return path.join('_build', 'core', relativePath);
 }
 
+/**
+ * Setup a new environment in which sandboxing is disabled. Do not use
+ * this function if you also need to modify the environment in your
+ * own tests, because the environments will not be restored in the
+ * right order.
+ */
 export function withoutSandboxing() {
   let env: EnvironmentSnapshot;
   before(() => {


### PR DESCRIPTION
## Context

We had no public sandboxing tests, so this adds a few. They're small in scope and mostly tailored for gVisor, although macOS and pyodide also get exercised. It is difficult to write tests for all sandboxing methods, but a little testing is better than no testing.

## Has this been tested?

Working on it!

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
