### PR TITLE
chore: remove outdated scripts from packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
     "start:debug": "NODE_INSPECT=--inspect sandbox/watch.sh",
     "start:debug-brk": "NODE_INSPECT=--inspect-brk sandbox/watch.sh",
     "install:python": "buildtools/prepare_python.sh",
-    "install:python2": "buildtools/prepare_python2.sh",
-    "install:python3": "buildtools/prepare_python3.sh",
     "build": "buildtools/build.sh",
     "build:prod": "buildtools/build.sh prod",
     "start:prod": "sandbox/run.sh",


### PR DESCRIPTION
## Context

The only prepare_python script still existanig after python2 removal is `prepare_python.sh`

```bash
$ ls buildtools/prepare_python*
buildtools/prepare_python.sh
```

## Proposed solution

`prepare_python2.sh` and `prepare_python3.sh` no longer exists. So this PR propose to remove the ability to try to invoke them from `npm run`.

## Related issues

#1525 