### PR TITLE
Fix install gvisor step in main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,8 +57,10 @@ jobs:
         run: yarn install
 
       - name: Install gvisor
-        run: sudo apt install runsc
-
+        run: |
+          sudo apt update
+          sudo apt install runsc
+ 
       - name: Run eslint
         if: contains(matrix.tests, ':lint:')
         run: yarn run lint:ci


### PR DESCRIPTION
## Context

The main workflow started failing on the install gVisor step due to a missing file.

## Proposed solution

Refresh the package list with `sudo apt update` before installing gVisor.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

