### PR TITLE
Rename fetchTableSchema in fetchPythonCode

### DIFF
--- a/app/client/components/DocComm.ts
+++ b/app/client/components/DocComm.ts
@@ -20,7 +20,7 @@ export class DocComm extends Disposable implements ActiveDocAPI {
   // that we haven't missed any.
   // closeDoc has a special implementation below.
   public fetchTable = this._wrapMethod("fetchTable");
-  public fetchTableSchema = this._wrapMethod("fetchTableSchema");
+  public fetchPythonCode = this._wrapMethod("fetchPythonCode");
   public useQuerySet = this._wrapMethod("useQuerySet");
   public disposeQuerySet = this._wrapMethod("disposeQuerySet");
   // applyUserActions has a special implementation below.

--- a/app/common/ActiveDocAPI.ts
+++ b/app/common/ActiveDocAPI.ts
@@ -353,9 +353,9 @@ export interface ActiveDocAPI {
   fetchTable(tableId: string): Promise<TableFetchResult>;
 
   /**
-   * Fetches the generated Python code for this document. (TODO rename this misnomer.)
+   * Fetches the generated Python code for this document.
    */
-  fetchTableSchema(): Promise<string>;
+  fetchPythonCode(): Promise<string>;
 
   /**
    * Makes a query (documented elsewhere) and subscribes to it, so that the client receives

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -1299,11 +1299,10 @@ export class ActiveDoc extends EventEmitter {
   }
 
   /**
-   * Fetches the generated schema for a given table.
-   * @param {String} tableId: The string identifier of the table.
-   * @returns {Promise} Promise for a string representing the generated table schema.
+   * Fetches the generated Python code.
+   * @returns {Promise} Promise for a string representing the generated Python code.
    */
-  public async fetchPythonCode(docSession: DocSession): Promise<string> {
+  public async fetchPythonCode(docSession: OptDocSession): Promise<string> {
     this._log.info(docSession, "fetchPythonCode(%s)", docSession);
     // Permit code view if user can read everything, or can download/copy (perhaps
     // via an exceptional permission for sample documents)

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -1303,8 +1303,8 @@ export class ActiveDoc extends EventEmitter {
    * @param {String} tableId: The string identifier of the table.
    * @returns {Promise} Promise for a string representing the generated table schema.
    */
-  public async fetchTableSchema(docSession: DocSession): Promise<string> {
-    this._log.info(docSession, "fetchTableSchema(%s)", docSession);
+  public async fetchPythonCode(docSession: DocSession): Promise<string> {
+    this._log.info(docSession, "fetchPythonCode(%s)", docSession);
     // Permit code view if user can read everything, or can download/copy (perhaps
     // via an exceptional permission for sample documents)
     if (!(await this._granularAccess.canReadEverything(docSession) ||

--- a/app/server/lib/DocWorker.ts
+++ b/app/server/lib/DocWorker.ts
@@ -108,7 +108,7 @@ export class DocWorker {
     comm.registerMethods({
       closeDoc:                 activeDocMethod.bind(null, null, 'closeDoc'),
       fetchTable:               activeDocMethod.bind(null, 'viewers', 'fetchTable'),
-      fetchTableSchema:         activeDocMethod.bind(null, 'viewers', 'fetchTableSchema'),
+      fetchPythonCode:         activeDocMethod.bind(null, 'viewers', 'fetchPythonCode'),
       useQuerySet:              activeDocMethod.bind(null, 'viewers', 'useQuerySet'),
       disposeQuerySet:          activeDocMethod.bind(null, 'viewers', 'disposeQuerySet'),
       applyUserActions:         activeDocMethod.bind(null, 'editors', 'applyUserActions'),

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -849,9 +849,9 @@ describe('GranularAccess', function() {
     await owner.getDocAPI(docId).addRows('PartialPrivate', {A: [99, 100]});
     assert.equal(rowSteps.called, true);
 
-    // Check editor cannot see private table schema via fetchTableSchema.
-    assert.match((await cliEditor.send('fetchTableSchema', 0)).error!, /Cannot view code/);
-    assert.equal((await cliOwner.send('fetchTableSchema', 0)).error, undefined);
+    // Check editor cannot see private table schema via fetchPythonCode.
+    assert.match((await cliEditor.send('fetchPythonCode', 0)).error!, /Cannot view code/);
+    assert.equal((await cliOwner.send('fetchPythonCode', 0)).error, undefined);
   });
 
   it('reports memos sensibly', async function() {


### PR DESCRIPTION
## Context

I would like to export document python code from the API.
A refactoring step seemed required given [a comment](https://github.com/gristlabs/grist-core/compare/main...betagouv:grist-core:reword-gencode?expand=1#diff-1bdd86910aa4377692ac9f3c2266ca1eaed399cd4a49f340f65749b9778fa5b6L356) in `app/common/ActiveDocAPI.ts`.




## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
