### PR TITLE
Tiny: Fix translations misc #2

### DIFF
--- a/app/client/ui/Pages.ts
+++ b/app/client/ui/Pages.ts
@@ -146,12 +146,16 @@ function buildPrompt(tableNames: string[], onSave: (option: RemoveOption) => Pro
         cssRadioCheckboxOptions(
           radioCheckboxOption(selected, 'data', t("Delete data and this page.")),
           radioCheckboxOption(selected, 'page',
-            [ // TODO i18n
-              `Keep data and delete page. `,
-              `Table will remain available in `,
-              cssLink(urlState().setHref({docPage: 'data'}), 'raw data page', { target: '_blank'}),
-              `.`
-            ]),
+            t("Keep data and delete page. Table will remain available in {{rawDataLink}}",
+              {
+                rawDataLink: cssLink(
+                  t('raw data page'),
+                  urlState().setHref({docPage: 'data'}),
+                  {target: '_blank'},
+                )
+              }
+            )
+          )
         )
       ),
       saveDisabled,

--- a/app/server/lib/AppEndpoint.ts
+++ b/app/server/lib/AppEndpoint.ts
@@ -132,7 +132,7 @@ export function attachAppEndpoint(options: AttachOptions): void {
             return forceLogin(req, res, next);
           }
         }
-        throw new ApiError('You do not have access to this document.', 403);
+        throw new ApiError(req.t("access.docNoAccess"), 403);
       }
       throw err;
     }

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -722,7 +722,9 @@
         "Delete": "Delete",
         "Delete data and this page.": "Delete data and this page.",
         "The following tables will no longer be visible_one": "The following table will no longer be visible",
-        "The following tables will no longer be visible_other": "The following tables will no longer be visible"
+        "The following tables will no longer be visible_other": "The following tables will no longer be visible",
+        "Keep data and delete page. Table will remain available in {{rawDataLink}}": "Keep data and delete page. Table will remain available in {{rawDataLink}}",
+        "raw data page": "raw data page"
     },
     "PermissionsWidget": {
         "Allow All": "Allow All",

--- a/static/locales/en.server.json
+++ b/static/locales/en.server.json
@@ -6,5 +6,8 @@
   },
   "oidc": {
     "emailNotVerifiedError": "Please verify your email with the identity provider, and log in again."
+  },
+  "access": {
+    "docNoAccess": "You do not have access to this document."
   }
 }


### PR DESCRIPTION
## Context

2 simple fixes:
 - Fix untranslated string `Keep data and delete page. Table will remain available in {{rawDataLink}}`;
 - Translate server-side error: `You do not have access to this document.`

## Proposed solution

1. Just translate it using the `t()` function
2. Add a translation the server-side way

## Related issues

Probably no related issue.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

When prefixing English translation with ✅, which means that the localization works:

!["Keep data and delete page" is translated](https://github.com/user-attachments/assets/59a5d89e-0c9e-40f8-9d71-acf349b3b037)

!["You do not have access to this document" is translated](https://github.com/user-attachments/assets/0e7e9467-5342-4c4a-accb-728c481bf69f)
