### PR TITLE
i18n: document how to generate the translation keys

### DIFF
--- a/documentation/translations.md
+++ b/documentation/translations.md
@@ -151,6 +151,15 @@ function getPageTitle(req: express.Request, config: GristLoadConfig): string {
 }
 ```
 
+## Translation generation
+
+In order to collect the keys, so they are added to the `en.client.json` file, you may run the following steps:
+1. Call the `t()` function as stated above
+2. Build the project using `yarn build` (or `yarn start`)
+3. Call the command `yarn generate:translation`, which scans the source in javascript (hence the `yarn build` above), and add the missing keys in `en.client.json`
+
+You may change locally the translations to check whether the localized strings are taken into account and revert afterwards.
+
 ### Next steps
 
 - Annotate all client code and create all resource files in `en.client.json` and `en.server.json` files.


### PR DESCRIPTION
## Context

The local generation is not documented.

## Proposed solution

Add a section to the translation doc,

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
