### PR TITLE
Make the enterprise toggle more resilient

### DIFF
--- a/app/client/models/ToggleEnterpriseModel.ts
+++ b/app/client/models/ToggleEnterpriseModel.ts
@@ -74,7 +74,9 @@ export class ToggleEnterpriseModel extends Disposable {
     let maxTries = 30;
     while(maxTries-- > 0) {
       try {
-        await this._configAPI.getValue('edition');
+        await this._configAPI.healthcheck();
+        // We're done, last step is to reload the page.
+        this.busy.set(false);
         window.location.reload();
         return;
       } catch (err) {

--- a/app/client/models/ToggleEnterpriseModel.ts
+++ b/app/client/models/ToggleEnterpriseModel.ts
@@ -69,8 +69,9 @@ export class ToggleEnterpriseModel extends Disposable {
   }
 
   private async _reloadWhenReady() {
-    // Now wait for the server to come back up, and refresh the page.
-    let maxTries = 10;
+    // Now wait about 30 seconds for the server to come back up, and
+    // refresh the page.
+    let maxTries = 30;
     while(maxTries-- > 0) {
       try {
         await this._configAPI.getValue('edition');

--- a/app/client/models/ToggleEnterpriseModel.ts
+++ b/app/client/models/ToggleEnterpriseModel.ts
@@ -1,3 +1,4 @@
+import {makeT} from 'app/client/lib/localization';
 import {getHomeUrl} from 'app/client/models/AppModel';
 import {Disposable, Observable} from "grainjs";
 import {ConfigAPI} from 'app/common/ConfigAPI';
@@ -6,6 +7,8 @@ import {delay} from 'app/common/delay';
 import {getGristConfig} from 'app/common/urlUtils';
 import {GristDeploymentType} from 'app/common/gristUrls';
 import {Notifier} from 'app/client/models/NotifyModel';
+
+const t = makeT('ToggleEnterprise');
 
 export class ToggleEnterpriseModel extends Disposable {
   public readonly edition: Observable<GristDeploymentType | null> = Observable.create(this, null);
@@ -55,7 +58,7 @@ export class ToggleEnterpriseModel extends Disposable {
 
   private async _doWork(func: () => Promise<void>) {
     if (this.busy.get()) {
-      throw new Error("Please wait for the previous operation to complete.");
+      throw new Error(t("Please wait for the previous operation to complete."));
     }
     try {
       this.busy.set(true);

--- a/app/common/ConfigAPI.ts
+++ b/app/common/ConfigAPI.ts
@@ -25,6 +25,13 @@ export class ConfigAPI extends BaseAPI {
     await this.request(`${this._url}/api/admin/restart`, {method: 'POST'});
   }
 
+  public async healthcheck(): Promise<void> {
+    const resp = await this.request(`${this._homeUrl}/status?ready=1`);
+    if (!resp.ok) {
+      throw new Error(await resp.text());
+    }
+  }
+
   private get _url(): string {
     return addCurrentOrgToPath(this._homeUrl);
   }

--- a/app/server/MergedServer.ts
+++ b/app/server/MergedServer.ts
@@ -204,7 +204,7 @@ export class MergedServer {
       await this.flexServer.finalizePlugins(this.hasComponent("home") ? checkUserContentPort() : null);
       this.flexServer.checkOptionCombinations();
       this.flexServer.summary();
-      this.flexServer.ready();
+      this.flexServer.setReady(true);
 
       if (this._options.extraWorkers) {
         if (!process.env.REDIS_URL) {

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1877,9 +1877,13 @@ export class FlexServer implements GristServer {
     }
   }
 
-  public ready() {
-    log.debug('FlexServer is ready');
-    this._isReady = true;
+  public setReady(value: boolean) {
+    if(value) {
+      log.debug('FlexServer is ready');
+    } else {
+      log.debug('FlexServer is no longer ready');
+    }
+    this._isReady = value;
   }
 
   public checkOptionCombinations() {

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -549,6 +549,11 @@ export class FlexServer implements GristServer {
     // If docWorkerRegistered=1 query parameter is included, status will include the status of the
     // doc worker registration in Redis.
     this.app.get('/status(/hooks)?', async (req, res) => {
+      log.rawDebug(`Healthcheck[${req.method}]:`, {
+        host: req.get('host'),
+        path: req.path,
+        query: req.query,
+      });
       const checks = new Map<string, Promise<boolean>|boolean>();
       const timeout = optIntegerParam(req.query.timeout, 'timeout') || 10_000;
 
@@ -1873,6 +1878,7 @@ export class FlexServer implements GristServer {
   }
 
   public ready() {
+    log.debug('FlexServer is ready');
     this._isReady = true;
   }
 

--- a/app/server/lib/GristServer.ts
+++ b/app/server/lib/GristServer.ts
@@ -99,6 +99,7 @@ export interface GristServer extends StorageCoordinator {
   isRestrictedMode(): boolean;
   onUserChange(callback: (change: UserChange) => Promise<void>): void;
   onStreamingDestinationsChange(callback: (orgId?: number) => Promise<void>): void;
+  setReady(value: boolean): void;
 }
 
 export interface GristLoginSystem {
@@ -207,6 +208,7 @@ export function createDummyGristServer(): GristServer {
     onUserChange() { /* do nothing */ },
     onStreamingDestinationsChange() { /* do nothing */ },
     hardDeleteDoc() { return Promise.resolve(); },
+    setReady() { /* do nothing */ },
   };
 }
 

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -99,12 +99,11 @@ export function attachEarlyEndpoints(options: AttachOptions) {
         // Docker) tell the parent that we have a new environment so it
         // can restart us.
         log.rawDebug(`Restart[${mreq.method}] finishing:`, meta);
-        if (process.send) {
+        if (process.send && process.env.GRIST_RUNNING_UNDER_SUPERVISOR) {
           log.rawDebug(`Restart[${mreq.method}] requesting supervisor to restart home server:`, meta);
           process.send({ action: "restart" });
         }
       });
-
       if (!process.env.GRIST_RUNNING_UNDER_SUPERVISOR) {
         // On the topic of http response codes, thus spake MDN:
         // "409: This response is sent when a request conflicts with the current state of the server."

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -86,12 +86,21 @@ export function attachEarlyEndpoints(options: AttachOptions) {
 
   app.post(
     "/api/admin/restart",
-    expressWrap(async (_, res) => {
+    expressWrap(async (req, res) => {
+      const mreq = req as RequestWithLogin;
+      const meta = {
+        host: mreq.get('host'),
+        path: mreq.path,
+        email: mreq.user?.loginEmail,
+      };
+      log.rawDebug(`Restart[${mreq.method}] starting:`, meta);
       res.on("finish", () => {
         // If we have IPC with parent process (e.g. when running under
         // Docker) tell the parent that we have a new environment so it
         // can restart us.
+        log.rawDebug(`Restart[${mreq.method}] finishing:`, meta);
         if (process.send) {
+          log.rawDebug(`Restart[${mreq.method}] requesting supervisor to restart home server:`, meta);
           process.send({ action: "restart" });
         }
       });

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -112,6 +112,8 @@ export function attachEarlyEndpoints(options: AttachOptions) {
             "Cannot automatically restart the Grist server to enact changes. Please restart server manually.",
         });
       }
+      // We're going down, so we're no longer ready to serve requests.
+      gristServer.setReady(false);
       return res.status(200).send({ msg: "ok" });
     })
   );

--- a/test/server/lib/Authorizer.ts
+++ b/test/server/lib/Authorizer.ts
@@ -42,7 +42,7 @@ async function activateServer(home: FlexServer, docManager: DocManager) {
   home.addApiErrorHandlers();
   home.finalizeEndpoints();
   await home.finalizePlugins(null);
-  home.ready();
+  home.setReady(true);
   serverUrl = home.getOwnUrl();
 }
 


### PR DESCRIPTION
## Context

The enterprise toggle was a bit flaky and didn't always work as expected.

## Proposed solution

I slightly enhanced the ability of the `FlexServer` to also be able to report when it is no longer ready, and use the health check endpoint with an explicit "ready" flag to see if the server really is ready or not. This is better than the `configAPI` endpoint that mostly worked sort of accidentally because it was just slow enough to mostly work.

Original commit messages:

* fc6fc4dd742f FlexServer: add a few more debug logging statements

  I found it helpful to have these debugging logs when I was trying to
  figure out the order in which things were being checked and restarted
  or not.

* 24fc3495a649 FlexServer: add a `notReady` method

  It's helpful to say that the server is going to switch into a "not
  ready" state in certain situations. For example, if we're about to
  reboot the server.

* cce82d13c46e FlexServer: mark the server as not ready when initiating a restart

  This way if the frontend tries to query the health endpoint of the
  server during the restart, we'll know that the server isn't ready yet,
  because it's in the process of shutting down and rebooting.

* 5a06d4e26c95 FlexServer: don't attempt to restart unless there's a supervisor

  Checking for `process.send` isn't enough in general, because for
  example, nodemon which we use in development also has IPC between
  nodemon and the main Grist process.. We really need a supervisor here,
  so let's explicitly check for it.

* 7b13dec32de8 ToggleEnterpriseModel: be more patient in waiting for the server to restart

  Approximately 10 seconds is a little impatient, especially if we have
  more than one home server to restart. Let's wait a little bit longer,
  about 30 seconds.

* df21eb06e9d0 ToggleEnterpriseModel: use healthcheck endpoint instead fo configAPI endpoint

  The config API endpoint was working but sort of accidentally. It was
  slow enough to work in most cases.

  Instead, we'll use the healthcheck endpoint with the "ready=1" query
  param that explicitly checks that the FlexServer has gotten to the end
  of its initialisation routine, or, if the server is in the process is
  being restarted, is no longer in a ready state.

* 59d2ebbd24e1 ToggleEnterpriseModel: don't try to set the busy observable after a page reload

  Before this change, in the happy path we'd reload the page but then
  attempt to set the busy observable to false. That produced a stack
  trace deep in the GrainJS library to the effect of

    TypeError: can't access property "callback", t is null

  Instead, make sure that the page reload is done last, right before the
  page is reloaded. If for some reason the page wasn't reloaded, set the
  busy observable to false too.


## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

