### PR TITLE
fix: override layoutSpec when changing widget to form

### DIFF
--- a/app/client/components/Forms/FormView.ts
+++ b/app/client/components/Forms/FormView.ts
@@ -146,7 +146,15 @@ export class FormView extends Disposable {
     });
 
     this._layoutSpec = jsonObservable(this.viewSection.layoutSpec, (layoutSpec: FormLayoutNode|null) => {
-      return layoutSpec ?? buildDefaultFormLayout(this._formFields.get());
+      // Sometimes the layout spec is not a form layout, but a layout from another type of widget
+      // This used to cause the document to crash (see: https://github.com/gristlabs/grist-core/issues/1677)
+      if (layoutSpec?.type === "Layout") {
+        // This is already a form layout. Let's keep it.
+        return layoutSpec;
+      } else {
+        // Overwrite old layout with a clean form layout
+        return buildDefaultFormLayout(this._formFields.get());
+      }
     });
 
     this._layout = Computed.create(this, use => {


### PR DESCRIPTION
## Context

This fixes the bug described in #1677 which caused a document to irreversibly crash

## Proposed solution

As discussed with @georgegevoian and @anaisconce on Slack, we override layoutSpec on widget change and build a clean one.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

I don't think adding a test is needed here, but I can try if you really want to, lmk.
