### PR TITLE
Add new attachment rows quicker

### DIFF
--- a/app/client/declarations.d.ts
+++ b/app/client/declarations.d.ts
@@ -79,6 +79,7 @@ declare module "app/client/components/BaseView" {
     public getAnchorLinkForSection(sectionId: number): IGristUrlState;
     public viewSelectedRecordAsCard(): void;
     public isRecordCardDisabled(): boolean;
+    public insertRow(): Promise<number>;
     public onNewRecordRequest?(): void;
   }
   export = BaseView;

--- a/app/client/widgets/AttachmentsEditor.ts
+++ b/app/client/widgets/AttachmentsEditor.ts
@@ -48,12 +48,6 @@ interface Attachment {
  * download, add or remove attachments in the edited cell.
  */
 export class AttachmentsEditor extends NewBaseEditor {
-  public static skipEditor(typedVal: CellValue|undefined, origVal: CellValue): CellValue|undefined {
-    if (Array.isArray(typedVal)) {
-      return typedVal;
-    }
-  }
-
   private _attachmentsTable: MetaTableData<'_grist_Attachments'>;
   private _docComm: DocComm;
 


### PR DESCRIPTION
## Context

Fixes #1666.

## Proposed solution

Splitting the operation of adding a new attachment row into two distinct steps:
 1. adding a blank row
 2. populating it with the uploaded attachment IDs.

This should help in scenarios where attachment uploads are the bottleneck.

More improvements can be made to the overall robustness of modifying a new row
while there are pending row adds. (There currently isn't a system in place to attribute all
pending edits to a single new row. Instead, each edit causes a distinct row to eventually get
added with the change. In the worst case, the client ends up in a badly broken state.)

## Related issues

#1666

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

Leaning on existing tests here, plus some manual testing in conditions that
simulated a slow network.