### PR TITLE
Tiny: contributor-assistant: Change allowlist to add members of grist.gouv

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,4 +26,4 @@ jobs:
           path-to-signatures: '.github/cla/signatures.json'
           path-to-document: 'https://github.com/gristlabs/grist-core/blob/main/.github/cla/individual-cla.md'
           branch: 'main'
-          allowlist: github-actions[bot],dependabot[bot]
+          allowlist: github-actions[bot],dependabot[bot],fflorent,vviers,audez,hexaltation,manuhabitela,ohemelaar,jonathanperret


### PR DESCRIPTION
## Context

As per the license agreement:

> Contributions entirely composed of commits with authorship at *.gouv.fr domains fall outside the scope of this agreement.

But the contributor assistant requires a signature anyway.

## Proposed solution

Add members of grist.gouv in the `allowlist`.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

