### PR TITLE
Fix page name CSS on mobile

### DIFF
--- a/app/client/ui/BottomBar.ts
+++ b/app/client/ui/BottomBar.ts
@@ -1,5 +1,6 @@
 import {DocPageModel} from 'app/client/models/DocPageModel';
 import {testId} from 'app/client/ui2018/cssVars';
+import {tokens} from 'app/common/ThemePrefs';
 import {dom, MultiHolder, Observable, styled} from 'grainjs';
 
 
@@ -15,6 +16,7 @@ export function createBottomBarDoc(owner: MultiHolder, pageModel: DocPageModel, 
 }
 
 const cssPageName = styled('div', `
+  color: ${tokens.body};
   margin: 0 10px;
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
## Context

The page name in the bottom bar on narrow screens is unreadable in dark mode.

## Proposed solution

Give the page name element a suitable color.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

