### PR TITLE
ask CLA assistant to not lock PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,3 +27,4 @@ jobs:
           path-to-document: 'https://github.com/gristlabs/grist-core/blob/main/.github/cla/individual-cla.md'
           branch: 'main'
           allowlist: github-actions[bot],dependabot[bot]
+          lock-pullrequest-aftermerge: false


### PR DESCRIPTION
It looks like the CLA assistant may be locking PRs by default once landed (and possibly even just abandoned).

See https://github.com/contributor-assistant/github-action?tab=readme-ov-file#configure-contributor-license-agreement-within-two-minutes