### PR TITLE
Fix CSS regression in CustomView

### DIFF
--- a/app/client/components/CustomView.css
+++ b/app/client/components/CustomView.css
@@ -8,6 +8,10 @@
   flex-basis: 0px;
 }
 
+.custom_view_content {
+  height: 100%;
+}
+
 iframe.custom_view {
   border: none;
   flex: auto;

--- a/app/client/components/CustomView.ts
+++ b/app/client/components/CustomView.ts
@@ -261,7 +261,7 @@ export class CustomView extends Disposable {
         this._hasUnmappedColumns(), mode(), url(), access(), widgetId() || widgetDef()?.widgetId || '', pluginId()
       ], ([_hide, _mode, _url, _access, _widgetId, _pluginId]: string[]) =>
         _mode === "url" ?
-          dom("div.flexauto",
+          dom("div.flexauto.custom_view_content",
             kd.style("display", _hide ? "none" : "flex"),
             this._buildIFrame({
               baseUrl: _url,


### PR DESCRIPTION
## Context

A line of CSS that set an element's height to 100% was removed a few weeks ago. Removing it broke the styling of an existing custom widget (https://community.getgrist.com/t/help-with-custom-dropdown-widget-and-multi-page-dropdown-widget/10677/1).

## Proposed solution

Add the removed CSS back to the appropriate element.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
