### PR TITLE
Introduce extra truthy and falsy values at instance level

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,9 @@ Grist can be configured in many ways. Here are the main environment variables it
 | GRIST_OIDC_... | optional. Environment variables used to configure OpenID authentification. See [OpenID Connect](https://support.getgrist.com/install/oidc/) documentation for full related list of environment variables. |
 | GRIST_SAML_... | optional. Environment variables used to configure SAML authentification. See [SAML](https://support.getgrist.com/install/saml/) documentation for full related list of environment variables. |
 | GRIST_IDP_EXTRA_PROPS | optional. If set, defines which extra fields returned by your identity provider will be stored in the users table of the home database (in the `options.ssoExtraInfo` object). Usage: 'onekey,anotherkey'. |
-| GRIST_FEATURE_FORM_FRAMING | optional. Configures a border around around a rendered form that is added for security reasons; Can be set to: `border` or `minimal`. Defaults to `border`. |
+| GRIST_FEATURE_FORM_FRAMING | optional. Configures a border around a rendered form that is added for security reasons; Can be set to: `border` or `minimal`. Defaults to `border`. |
+| GRIST_TRUTHY_VALUES | optional. Comma-separated list of extra words that should be considered as truthy by the data engine beyond english defaults. Ex: "oui,ja,si" |
+| GRIST_FALSY_VALUES | optional. Comma-separated list of extra words that should be considered as falsy by the data engine beyond english defaults. Ex: "non,nein,no" |
 #### AI Formula Assistant related variables (all optional):
 
 Variable | Purpose

--- a/app/server/lib/NSandbox.ts
+++ b/app/server/lib/NSandbox.ts
@@ -927,11 +927,11 @@ export function getInsertedEnv(options: ISandboxOptions) {
     env.DETERMINISTIC_MODE = '1';
   }
 
-  if  (process.env.GRIST_TRUTHY_VALUES) {
+  if (process.env.GRIST_TRUTHY_VALUES) {
     env.GRIST_TRUTHY_VALUES = process.env.GRIST_TRUTHY_VALUES;
   }
 
-  if  (process.env.GRIST_FALSY_VALUES) {
+  if (process.env.GRIST_FALSY_VALUES) {
     env.GRIST_FALSY_VALUES = process.env.GRIST_FALSY_VALUES;
   }
 

--- a/app/server/lib/NSandbox.ts
+++ b/app/server/lib/NSandbox.ts
@@ -926,6 +926,15 @@ export function getInsertedEnv(options: ISandboxOptions) {
     // tells python to seed the random module
     env.DETERMINISTIC_MODE = '1';
   }
+
+  if  (process.env.GRIST_TRUTHY_VALUES) {
+    env.GRIST_TRUTHY_VALUES = process.env.GRIST_TRUTHY_VALUES;
+  }
+
+  if  (process.env.GRIST_FALSY_VALUES) {
+    env.GRIST_FALSY_VALUES = process.env.GRIST_FALSY_VALUES;
+  }
+
   return env;
 }
 


### PR DESCRIPTION
## Context

This PR tries to solve the issue described in #1702 through the introduction of 2 env variables :
`GRIST_TRUTHY_VALUES` and `GRIST_FALSY_VALUES`

## Proposed solution

I introduce 2 env variables **that are passed to the python sandbox**. ~~I know sandbox security is quite crucial, and so I'm looking for feedback as to whether that is safe.~~ it is :)

## Related issues

Closes #1702 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [x] 🙋 no, because I need help <!-- Detail how we can help you -->
