### PR TITLE
Updates migration docs with details on specific files, _gristsys_ tables.

### DIFF
--- a/documentation/database.md
+++ b/documentation/database.md
@@ -50,11 +50,13 @@ _grist_Shares                     _gristsys_PluginData
 
 :warning: If you want to ensure that you will not alter a document's contents, make a backup copy beforehand.
 
+`_grist_*` tables are managed by the data engine. Their schema is defined in [`sandbox/grist/schema.py`](/sandbox/grist/schema.py).
+
+`_gristsys_*` tables are managed by the Node.js process. Their schema is defined in [`app/server/lib/DocStorage.ts`](/app/server/lib/DocStorage.ts).
+
 ### The migrations
 
-The migrations are handled in the Python sandbox in [`sandbox/grist/migrations.py`](../sandbox/grist/migrations.py).
-
-For more information, please consult [the documentation for migrations](./migrations.md).
+For information on document database migrations, please consult [the documentation for migrations](./migrations.md#document-database).
 
 ## The Home Database
 
@@ -292,4 +294,5 @@ Stores information related to the identification.
 
 ### The migrations
 
-The database migrations are handled by TypeORM ([documentation](https://typeorm.io/migrations)). The migration files are located at [`app/gen-server/migration`](../app/gen-server/migration) and are run at startup (so you don't have to worry about running them yourself).
+For information on home database migrations, please consult [the documentation for migrations](./migrations.md#home-database).
+

--- a/documentation/migrations.md
+++ b/documentation/migrations.md
@@ -1,8 +1,25 @@
-# Migrations
+# Migrations and schema changes
+
+Grist uses [two types of database](database.md):
+* The home database, which stores data for the entire Grist instance
+* Document databases, which each store data for an individual document
+
+In code, these are governed by three database schemas, each responsible for different areas:
+* [/app/gen-server](/app/gen-server) - A TypeORM schema for the home database
+* [schema.py](/sandbox/grist/schema.py) - A python schema for `_grist` tables in the document database
+* [DocStorage.ts](/app/server/lib/DocStorage.ts) - A typescript schema for `_gristsys` tables in the document database
+
+Each of these has their own approach to changes and migrations, detailed below:
+
+## Document database
+### `_grist_*` tables
 
 If you change Grist schema, i.e. the schema of the Grist metadata tables (in [`sandbox/grist/schema.py`](../sandbox/grist/schema.py)), you'll have to increment the `SCHEMA_VERSION` (on top of that file) and create a migration. A migration is a set of actions that would get applied to a document at the previous version, to make it satisfy the new schema.
 
-To add a migration, add a function to [`sandbox/grist/migrations.py`](../sandbox/grist/migrations.py), of this form (using the new version number):
+Typescript has its own copy of the schema at [schema.ts](/app/common/schema.ts), which needs updating whenever the python schema changes.
+The process for this is described in [schema.ts](/app/common/schema.ts).
+
+To add a migration, add a function to [`sandbox/grist/migrations.py`](/sandbox/grist/migrations.py), of this form (using the new version number):
 
 ```python
 @migration(schema_version=11)
@@ -16,13 +33,21 @@ Some migrations need to actually add or modify the data in a document. You can l
 
 If you are doing anything other than adding a column or a table, you must read this document to the end.
 
-## Philosophy of migrations
+### `_gristsys_*` tables
+
+The schema and migrations for `_gristsys_*` tables are defined in [DocStorage.ts](/app/server/lib/DocStorage.ts).
+
+These tables are managed by the Node.js server and not by the data engine.
+
+Migrations are implemented as functions which run raw SQLite queries against the database.
+
+### Philosophy of migrations
 
 Migrations are tricky. Normally, we think about the software we are writing, but migrations work with documents that were created by an older version of the software, which may not have the logic you think our software has, and MAY have logic that the current version knows nothing about.
 
 This is why migrations code uses its own "dumb" implementation for loading and examining data (see [`sandbox/grist/table_data_set.py`](../sandbox/grist/table_data_set.py)), because trying to load an older document using our primary code base will usually fail, since the document will not satisfy our current assumptions.
 
-## Restrictions
+### Restrictions
 
 The rules below should make it at least barely possible to share documents by people who are not all on the same Grist version (even so, it will require more work). It should also make it somewhat safe to upgrade and then open the document with a previous version.
 
@@ -41,3 +66,8 @@ Similar justification applies to renaming columns, or modifying them (e.g. chang
 WARNING: If you change the meaning or type of a column, you have to create a new column with a new name.
 
 You'll also need to write a migration to fill it from the old column, and would mark the old column as deprecated.
+
+## Home database
+
+Home database migrations are handled by TypeORM ([documentation](https://typeorm.io/migrations)). 
+The migration files are located at [`app/gen-server/migration`](/app/gen-server/migration) and are run at startup (so you don't have to worry about running them yourself).

--- a/documentation/migrations.md
+++ b/documentation/migrations.md
@@ -1,6 +1,6 @@
 # Migrations and schema changes
 
-Grist uses [two types of database](database.md):
+Grist uses [two types of databases](database.md):
 * The home database, which stores data for the entire Grist instance
 * Document databases, which each store data for an individual document
 


### PR DESCRIPTION
## Context

The existing migration.md documentation focuses on `_grist` tables, and doesn't cover `_gristsys` tables or the home database.

## Proposed solution

This PR adds information on `_gristsys` tables, and moves the home database migration documentation into `migration.md` from `database.md`.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
