### PR TITLE
User feedback on attachments/form long submission

### DIFF
--- a/app/client/components/FormRenderer.ts
+++ b/app/client/components/FormRenderer.ts
@@ -58,6 +58,8 @@ export interface FormRendererContext {
   rootLayoutNode: FormLayoutNode;
   /** Disables the Submit node if true. */
   disabled: Observable<boolean>;
+  /** Indicates the current form submission is taking longer than usual. */
+  slowSubmit: Observable<boolean>;
   /** Error to show above the Submit node. */
   error: Observable<string|null>;
 }
@@ -174,9 +176,12 @@ class SubmitRenderer extends FormRenderer {
       css.submitButtons(
         css.resetButton(
           t('Reset'),
-          dom.boolAttr('disabled', this.context.disabled),
+          dom.attr('aria-disabled', (use) => use(this.context.disabled) ? 'true' : 'false'),
           {type: 'button'},
-          dom.on('click', () => {
+          dom.on('click', (event) => {
+            if (this.context.disabled.get()) {
+              return event.preventDefault();
+            }
             return confirmModal(
               'Are you sure you want to reset your form?',
               'Reset',
@@ -186,13 +191,21 @@ class SubmitRenderer extends FormRenderer {
           testId('reset'),
         ),
         css.submitButton(
-          dom('input',
-            dom.boolAttr('disabled', this.context.disabled),
-            {
-              type: 'submit',
-              value: this.context.rootLayoutNode.submitText || t('Submit'),
-            },
-            dom.on('click', () => validateRequiredLists()),
+          dom('button',
+            dom.attr('aria-disabled', (use) => use(this.context.disabled) ? 'true' : 'false'),
+            {type: 'submit'},
+            dom.domComputed(use => {
+              const slowSubmit = use(this.context.slowSubmit);
+              return slowSubmit
+                ? [css.buttonLoadingSpinner(), t('Submitting…')]
+                : this.context.rootLayoutNode.submitText || t('Submit');
+            }),
+            dom.on('click', (event) => {
+              if (this.context.disabled.get()) {
+                return event.preventDefault();
+              }
+              return validateRequiredLists();
+            }),
           )
         ),
       ),

--- a/app/client/components/FormRenderer.ts
+++ b/app/client/components/FormRenderer.ts
@@ -58,8 +58,6 @@ export interface FormRendererContext {
   rootLayoutNode: FormLayoutNode;
   /** Disables the Submit node if true. */
   disabled: Observable<boolean>;
-  /** Indicates the current form submission is taking longer than usual. */
-  slowSubmit: Observable<boolean>;
   /** Error to show above the Submit node. */
   error: Observable<string|null>;
 }
@@ -195,8 +193,7 @@ class SubmitRenderer extends FormRenderer {
             dom.attr('aria-disabled', (use) => use(this.context.disabled) ? 'true' : 'false'),
             {type: 'submit'},
             dom.domComputed(use => {
-              const slowSubmit = use(this.context.slowSubmit);
-              return slowSubmit
+              return use(this.context.disabled)
                 ? [css.buttonLoadingSpinner(), t('Submitting…')]
                 : this.context.rootLayoutNode.submitText || t('Submit');
             }),

--- a/app/client/components/FormRendererCss.ts
+++ b/app/client/components/FormRendererCss.ts
@@ -69,7 +69,7 @@ export const resetButton = styled('button', `
     color: ${vars.primaryBgHover};
     border-color: ${vars.primaryBgHover};
   }
-  &:is(:disabled, [aria-disabled="true"]) {
+  &[aria-disabled="true"] {
     cursor: not-allowed;
     color: ${colors.light};
     background-color: ${colors.slate};
@@ -82,7 +82,7 @@ export const submitButton = styled('div', `
   justify-content: center;
   align-items: center;
 
-  & :is(input[type="submit"], button:not([type]), button[type="submit"]) {
+  & button[type="submit"] {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -97,11 +97,11 @@ export const submitButton = styled('div', `
     line-height: inherit;
     outline-color: ${vars.primaryBgHover};
   }
-  & :is(input[type="submit"], button:not([type]), button[type="submit"]):hover {
+  & button[type="submit"]):hover {
     border-color: ${vars.primaryBgHover};
     background-color: ${vars.primaryBgHover};
   }
-  & :is(input[type="submit"], button:not([type]), button[type="submit"]):is(:disabled, [aria-disabled="true"]) {
+  & button[type="submit"][aria-disabled="true"] {
     cursor: not-allowed;
     color: ${colors.light};
     background-color: ${colors.slate};

--- a/app/client/components/FormRendererCss.ts
+++ b/app/client/components/FormRendererCss.ts
@@ -97,7 +97,7 @@ export const submitButton = styled('div', `
     line-height: inherit;
     outline-color: ${vars.primaryBgHover};
   }
-  & button[type="submit"]):hover {
+  & button[type="submit"]:hover {
     border-color: ${vars.primaryBgHover};
     background-color: ${vars.primaryBgHover};
   }

--- a/app/client/components/FormRendererCss.ts
+++ b/app/client/components/FormRendererCss.ts
@@ -1,6 +1,7 @@
 import {colors, mediaXSmall, vars} from 'app/client/ui2018/cssVars';
 import {icon} from 'app/client/ui2018/icons';
 import {numericSpinner} from 'app/client/widgets/NumericSpinner';
+import {loadingSpinner} from 'app/client/ui2018/loaders';
 import {styled} from 'grainjs';
 
 export const label = styled('div', `
@@ -68,7 +69,7 @@ export const resetButton = styled('button', `
     color: ${vars.primaryBgHover};
     border-color: ${vars.primaryBgHover};
   }
-  &:disabled {
+  &:is(:disabled, [aria-disabled="true"]) {
     cursor: not-allowed;
     color: ${colors.light};
     background-color: ${colors.slate};
@@ -81,7 +82,11 @@ export const submitButton = styled('div', `
   justify-content: center;
   align-items: center;
 
-  & input[type="submit"] {
+  & :is(input[type="submit"], button:not([type]), button[type="submit"]) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
     background-color: ${vars.primaryBg};
     border: 1px solid ${vars.primaryBg};
     color: white;
@@ -92,11 +97,11 @@ export const submitButton = styled('div', `
     line-height: inherit;
     outline-color: ${vars.primaryBgHover};
   }
-  & input[type="submit"]:hover {
+  & :is(input[type="submit"], button:not([type]), button[type="submit"]):hover {
     border-color: ${vars.primaryBgHover};
     background-color: ${vars.primaryBgHover};
   }
-  & input[type="submit"]:disabled {
+  & :is(input[type="submit"], button:not([type]), button[type="submit"]):is(:disabled, [aria-disabled="true"]) {
     cursor: not-allowed;
     color: ${colors.light};
     background-color: ${colors.slate};
@@ -391,4 +396,14 @@ export const attachmentInput = styled('input', `
     background-color: ${colors.slate};
     border-color: ${colors.slate};
   }
+`);
+
+export const buttonLoadingSpinner = styled(loadingSpinner, `
+  width: 1em;
+  height: 1em;
+  line-height: inherit;
+  border-radius: 50%;
+  border-width: 1px;
+  margin-bottom: 1px;
+  --loader-fg: currentColor;
 `);

--- a/app/client/declarations.d.ts
+++ b/app/client/declarations.d.ts
@@ -73,6 +73,7 @@ declare module "app/client/components/BaseView" {
     public getLoadingDonePromise(): Promise<void>;
     public activateEditorAtCursor(options?: Options): void;
     public onResize(): void;
+    public onRowResize(rowModels: BaseRowModel[]): void;
     public prepareToPrint(onOff: boolean): void;
     public moveEditRowToCursor(): DataRowModel;
     public scrollToCursor(sync: boolean): Promise<void>;

--- a/app/client/lib/testState.ts
+++ b/app/client/lib/testState.ts
@@ -9,3 +9,10 @@ export function setTestState(state: Partial<TestState>) {
   }
   Object.assign(G.window.testGrist, state);
 }
+
+export function getTestState(): TestState {
+  if (!('testGrist' in G.window)) {
+    G.window.testGrist = {};
+  }
+  return G.window.testGrist as TestState;
+}

--- a/app/client/models/FormModel.ts
+++ b/app/client/models/FormModel.ts
@@ -92,7 +92,7 @@ export class FormModelImpl extends Disposable implements FormModel {
     const colValues = typedFormDataToJson(formData);
     try {
       this.submitting.set(true);
-      // we virtually wait for at a second to actually consider the form submitted;
+      // we virtually wait for at least a second to actually consider the form submitted;
       // this makes for a tiny bit of a delay allowing users to see the "submitting…" state of the FormRenderer
       await Promise.all([
         this._formAPI.createRecord({

--- a/app/client/models/FormModel.ts
+++ b/app/client/models/FormModel.ts
@@ -6,7 +6,7 @@ import {urlState} from 'app/client/models/gristUrlState';
 import {Form, FormAPI, FormAPIImpl} from 'app/client/ui/FormAPI';
 import {ApiError} from 'app/common/ApiError';
 import {safeJsonParse} from 'app/common/gutil';
-import {bundleChanges, Computed, Disposable, Observable, subscribe} from 'grainjs';
+import {bundleChanges, Computed, Disposable, Observable} from 'grainjs';
 
 const t = makeT('FormModel');
 
@@ -46,7 +46,7 @@ export class FormModelImpl extends Disposable implements FormModel {
     super();
 
     // we track in an observable when the submission is slow, allowing us to easily show user feedback in that case
-    this.autoDispose(subscribe(this.submitting, (use, submitting) => {
+    this.autoDispose(this.submitting.addListener((submitting) => {
       if (submitting) {
         this._submittingSlowTimeout = window.setTimeout(() => !this.isDisposed() && this.submittingSlow.set(true), 750);
       } else {

--- a/app/client/ui/FormPage.ts
+++ b/app/client/ui/FormPage.ts
@@ -56,6 +56,7 @@ export class FormPage extends Disposable {
         fields: form.formFieldsById,
         rootLayoutNode,
         disabled: this._model.submitting,
+        slowSubmit: this._model.submittingSlow,
         error: this._error,
       });
 

--- a/app/client/ui/FormPage.ts
+++ b/app/client/ui/FormPage.ts
@@ -56,7 +56,6 @@ export class FormPage extends Disposable {
         fields: form.formFieldsById,
         rootLayoutNode,
         disabled: this._model.submitting,
-        slowSubmit: this._model.submittingSlow,
         error: this._error,
       });
 

--- a/app/client/widgets/AttachmentsEditor.ts
+++ b/app/client/widgets/AttachmentsEditor.ts
@@ -99,7 +99,7 @@ export class AttachmentsEditor extends NewBaseEditor {
       const index = use(this._index);
       return index === null ? null : use(this._attachments)[index];
     }));
-    this._isUploading = Observable.create(null, false);
+    this._isUploading = Observable.create(this, false);
   }
 
   // This "attach" is not about "attachments", but about attaching this widget to the page DOM.
@@ -245,10 +245,11 @@ export class AttachmentsEditor extends NewBaseEditor {
         multiple: true,
         sizeLimit: 'attachment'
       }, (progress) => {
-      if (progress === 0) {
-        this._isUploading.set(true);
+        if (progress === 0) {
+          this._isUploading.set(true);
+          }
         }
-      });
+      );
       this._isUploading.set(false);
       return this._add(uploadResult);
     } catch (error) {

--- a/app/client/widgets/AttachmentsEditor.ts
+++ b/app/client/widgets/AttachmentsEditor.ts
@@ -146,7 +146,11 @@ export class AttachmentsEditor extends NewBaseEditor {
           }),
           testId('pw-counter'),
           dom.maybe(this._isUploading, () =>
-            cssLoading(loadingSpinner(), t('Uploading…'))
+            cssLoading(
+              loadingSpinner(),
+              t('Uploading…'),
+              testId('pw-spinner')
+            )
           ),
         ),
         dom.maybe(this._selected, selected =>

--- a/app/client/widgets/AttachmentsEditor.ts
+++ b/app/client/widgets/AttachmentsEditor.ts
@@ -9,6 +9,7 @@ import {selectFiles, uploadFiles} from 'app/client/lib/uploads';
 import {DocData} from 'app/client/models/DocData';
 import {MetaTableData} from 'app/client/models/TableData';
 import {basicButton, basicButtonLink, cssButtonGroup} from 'app/client/ui2018/buttons';
+import {makeT} from 'app/client/lib/localization';
 import {testId, theme, vars} from 'app/client/ui2018/cssVars';
 import {editableLabel} from 'app/client/ui2018/editableLabel';
 import {icon} from 'app/client/ui2018/icons';
@@ -20,6 +21,8 @@ import {SingleCell} from 'app/common/TableData';
 import {clamp, encodeQueryParams} from 'app/common/gutil';
 import {UploadResult} from 'app/common/uploads';
 import * as mimeTypes from 'mime-types';
+
+const t = makeT('AttachmentsEditor');
 
 interface Attachment {
   rowId: number;
@@ -135,7 +138,7 @@ export class AttachmentsEditor extends NewBaseEditor {
       cssHeader(
         cssFlexExpand(dom.text(use => {
             const len = use(this._attachments).length;
-            return len ? `${(use(this._index) || 0) + 1} of ${len}` : '';
+            return len ? t('{{index}} of {{total}}', {index: (use(this._index) || 0) + 1, total: len}) : '';
           }),
           testId('pw-counter')
         ),
@@ -150,7 +153,7 @@ export class AttachmentsEditor extends NewBaseEditor {
         cssFlexExpand(
           cssFileButtons(
             dom.maybe(this._selected, selected =>
-              basicButtonLink(cssButton.cls(''), cssButtonIcon('Download'), 'Download',
+              basicButtonLink(cssButton.cls(''), cssButtonIcon('Download'), t('Download'),
                 dom.attr('href', selected.url),
                 dom.attr('target', '_blank'),
                 dom.attr('download', selected.filename),
@@ -158,12 +161,12 @@ export class AttachmentsEditor extends NewBaseEditor {
               ),
             ),
             this.options.readonly ? null : [
-              cssButton(cssButtonIcon('FieldAttachment'), 'Add',
+              cssButton(cssButtonIcon('FieldAttachment'), t('Add'),
                 dom.on('click', () => this._select()),
                 testId('pw-add')
               ),
               dom.maybe(this._selected, () =>
-                cssButton(cssButtonIcon('Remove'), 'Delete',
+                cssButton(cssButtonIcon('Remove'), t('Delete'),
                   dom.on('click', () => this._remove()),
                   testId('pw-remove')
                 ),
@@ -186,7 +189,7 @@ export class AttachmentsEditor extends NewBaseEditor {
 
       // Drag-over logic
       (elem: HTMLElement) => dragOverClass(elem, cssDropping.className),
-      cssDragArea(this.options.readonly ? null : cssWarning('Drop files here to attach')),
+      cssDragArea(this.options.readonly ? null : cssWarning(t('Drop files here to attach'))),
       this.options.readonly ? null : dom.on('drop', ev => this._upload(ev.dataTransfer!.files)),
       testId('pw-modal')
     ];
@@ -255,7 +258,11 @@ function isInEditor(ev: KeyboardEvent): boolean {
 function renderContent(att: Attachment|null, readonly: boolean): HTMLElement {
   const commonArgs = [cssContent.cls(''), testId('pw-attachment-content')];
   if (!att) {
-    return cssWarning('No attachments', readonly ? null : cssDetails('Drop files here to attach.'), ...commonArgs);
+    return cssWarning(
+      t('No attachments'),
+      readonly ? null : cssDetails(t('Drop files here to attach.')),
+      ...commonArgs
+    );
   } else if (att.hasPreview) {
     return dom('img', dom.attr('src', att.url), ...commonArgs);
   } else if (att.fileType.startsWith('video/')) {
@@ -267,12 +274,12 @@ function renderContent(att: Attachment|null, readonly: boolean): HTMLElement {
     // but probably not using object tag (which needs work to look acceptable).
     return dom('div', ...commonArgs,
       cssWarning(cssContent.cls(''), renderFileType(att.filename.get(), att.fileIdent),
-        cssDetails('Preview not available.')));
+        cssDetails(t('Preview not available.'))));
   } else {
     // Setting 'type' attribute is important to avoid a download prompt from Chrome.
     return dom('object', {type: att.fileType}, dom.attr('data', att.inlineUrl), ...commonArgs,
       cssWarning(cssContent.cls(''), renderFileType(att.filename.get(), att.fileIdent),
-        cssDetails('Preview not available.'))
+        cssDetails(t('Preview not available.')))
     );
   }
 }

--- a/app/client/widgets/AttachmentsEditor.ts
+++ b/app/client/widgets/AttachmentsEditor.ts
@@ -10,7 +10,7 @@ import {DocData} from 'app/client/models/DocData';
 import {MetaTableData} from 'app/client/models/TableData';
 import {basicButton, basicButtonLink, cssButtonGroup} from 'app/client/ui2018/buttons';
 import {makeT} from 'app/client/lib/localization';
-import {testId, theme, vars} from 'app/client/ui2018/cssVars';
+import {mediaSmall, testId, theme, vars} from 'app/client/ui2018/cssVars';
 import {editableLabel} from 'app/client/ui2018/editableLabel';
 import {icon} from 'app/client/ui2018/icons';
 import {IModalControl, modal} from 'app/client/ui2018/modals';
@@ -342,11 +342,22 @@ const cssFullScreenModal = styled('div', `
 const cssHeader = styled('div', `
   padding: 16px 24px;
   position: fixed;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
   color: white;
+  @media ${mediaSmall} {
+    & {
+      align-items: flex-start;
+      flex-direction: column-reverse;
+      gap: 8px;
+      padding: 0 16px;
+    }
+  }
 `);
 
 const cssCloseButton = styled('div', `
@@ -359,6 +370,12 @@ const cssCloseButton = styled('div', `
   &:hover {
     background-color: ${theme.attachmentsEditorButtonHoverBg};
     --icon-color: ${theme.attachmentsEditorButtonHoverFg};
+  }
+
+  @media ${mediaSmall} {
+    & {
+      margin-left: auto;
+    }
   }
 `);
 
@@ -379,6 +396,12 @@ const cssTitle = styled('div', `
   &:focus-within {
     outline: 1px solid ${theme.controlFg};
   }
+
+  @media ${mediaSmall} {
+    & {
+      outline: 1px solid ${theme.lightText};
+    }
+  }
 `);
 
 const cssEditableLabel = styled(editableLabel, `
@@ -391,6 +414,11 @@ const cssFlexExpand = styled('div', `
   flex: 1;
   display: flex;
   align-items: center;
+  @media ${mediaSmall} {
+    & {
+      width: 100%;
+    }
+  }
 `);
 
 const cssLoading = styled('div', `
@@ -401,6 +429,13 @@ const cssLoading = styled('div', `
   & .${loadingSpinner.className} {
     --loader-fg: currentColor;
   }
+  @media ${mediaSmall} {
+    & .${loadingSpinner.className} {
+      width: 16px;
+      height: 16px;
+      border-width: 1px;
+    }
+  }
 `);
 
 const cssFileButtons = styled(cssButtonGroup, `
@@ -408,6 +443,13 @@ const cssFileButtons = styled(cssButtonGroup, `
   margin-right: 16px;
   height: 32px;
   flex: none;
+
+  @media ${mediaSmall} {
+    & {
+      margin-left: 0px;
+      margin-right: 0px;
+    }
+  }
 `);
 
 const cssButton = styled(basicButton, `
@@ -484,6 +526,12 @@ const cssContent = styled('div', `
   }
   .${cssDropping.className} > & {
     display: none;
+  }
+  @media ${mediaSmall} {
+    & {
+      margin-top: 102px;
+      height: calc(100% - 102px);
+    }
   }
 `);
 

--- a/app/client/widgets/AttachmentsWidget.ts
+++ b/app/client/widgets/AttachmentsWidget.ts
@@ -84,6 +84,7 @@ export class AttachmentsWidget extends NewAbstractWidget {
       dom.maybe(isUploadingObs, () =>
         cssSpinner(
           cssSpinner.cls('-has-attachments', (use) => use(values).length > 0),
+          testId('attachment-spinner'),
           {title: t('Uploading, please wait…')}
         )
       ),

--- a/app/client/widgets/AttachmentsWidget.ts
+++ b/app/client/widgets/AttachmentsWidget.ts
@@ -41,7 +41,7 @@ export class AttachmentsWidget extends NewAbstractWidget {
     this._attachmentsTable = this._getDocData().getMetaTable('_grist_Attachments');
 
     this._height = this.options.prop('height');
-    this._uploadingStatesObs = Observable.create(null, {});
+    this._uploadingStatesObs = Observable.create(this, {});
 
     this.autoDispose(this._height.subscribe(() => {
       this.field.viewSection().events.trigger('rowHeightChange');

--- a/app/client/widgets/AttachmentsWidget.ts
+++ b/app/client/widgets/AttachmentsWidget.ts
@@ -171,9 +171,10 @@ export class AttachmentsWidget extends NewAbstractWidget {
         states[rowId] = true;
         this._uploadingStatesObs.set({...states});
         // let the view know about the spinner so that it can expands the row height for it if needed
-        const rowModel = this.field.viewSection().viewInstance()?.viewData.getRowModel(rowId);
+        const viewInstance = this.field.viewSection().viewInstance();
+        const rowModel = viewInstance?.viewData.getRowModel(rowId);
         if (rowModel) {
-          this.field.viewSection().viewInstance()?.onRowResize([rowModel]);
+          viewInstance?.onRowResize([rowModel]);
         }
       }, 750);
     } else {

--- a/app/client/widgets/AttachmentsWidget.ts
+++ b/app/client/widgets/AttachmentsWidget.ts
@@ -46,6 +46,10 @@ export class AttachmentsWidget extends NewAbstractWidget {
     this.autoDispose(this._height.subscribe(() => {
       this.field.viewSection().events.trigger('rowHeightChange');
     }));
+
+    this.onDispose(() => {
+      Object.values(this._uploadingTimeouts).forEach(timeout => clearTimeout(timeout));
+    });
   }
 
   public buildDom(row: DataRowModel) {
@@ -64,6 +68,7 @@ export class AttachmentsWidget extends NewAbstractWidget {
 
     return cssAttachmentWidget(
       dom.autoDispose(values),
+      dom.autoDispose(isUploadingObs),
 
       dom.cls('field_clip'),
       dragOverClass('attachment_drag_over'),
@@ -168,6 +173,9 @@ export class AttachmentsWidget extends NewAbstractWidget {
     }
     if (uploading) {
       timeouts[rowId] = window.setTimeout(() => {
+        if (this.isDisposed()) {
+          return;
+        }
         states[rowId] = true;
         this._uploadingStatesObs.set({...states});
         // let the view know about the spinner so that it can expands the row height for it if needed

--- a/app/common/TestState.ts
+++ b/app/common/TestState.ts
@@ -1,4 +1,5 @@
 export interface TestState {
   clipboard?: string;
   anchorApplied?: boolean;
+  fakeSlowUploads?: boolean;
 }

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -2134,5 +2134,15 @@
     },
     "AttachmentsWidget": {
         "Uploading, please wait…": "Uploading, please wait…"
+    },
+    "AttachmentsEditor": {
+        "Add": "Add",
+        "Delete": "Delete",
+        "Download": "Download",
+        "Drop files here to attach": "Drop files here to attach",
+        "Drop files here to attach.": "Drop files here to attach.",
+        "No attachments": "No attachments",
+        "Preview not available.": "Preview not available.",
+        "{{index}} of {{total}}": "{{index}} of {{total}}"
     }
 }

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -1797,7 +1797,8 @@
         "Reset": "Reset",
         "Search": "Search",
         "Select...": "Select...",
-        "Submit": "Submit"
+        "Submit": "Submit",
+        "Submitting…": "Submitting…"
     },
     "widgetTypesMap": {
         "Calendar": "Calendar",

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -2131,5 +2131,8 @@
     "duplicateWidget": {
         "Duplicate widget": "Duplicate widget",
         "Duplicate widgets": "Duplicate widgets"
+    },
+    "AttachmentsWidget": {
+        "Uploading, please wait…": "Uploading, please wait…"
     }
 }

--- a/test/nbrowser/FormView1.ts
+++ b/test/nbrowser/FormView1.ts
@@ -201,7 +201,7 @@ describe('FormView1', function() {
       await gu.closeRawTable();
       await gu.onNewTab(async () => {
         await driver.get(formUrl);
-        await driver.findWait('input[type="submit"]', 2000).click();
+        await driver.findWait('button[type="submit"]', 2000).click();
         await waitForConfirm();
       });
       await expectSingle('Hello from trigger');
@@ -218,7 +218,7 @@ describe('FormView1', function() {
         assert.isTrue(await driver.findWait('[aria-label="Powered by Grist"]', 2000).isDisplayed());
 
         await gu.sendKeys('Hello');
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
 
       });
@@ -240,7 +240,7 @@ describe('FormView1', function() {
         await driver.find('input[name="D"]').click();
         await gu.sendKeys('Hello World');
         await assertSubmitOnEnterIsDisabled();
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       // Make sure we see the new record.
@@ -266,7 +266,7 @@ describe('FormView1', function() {
         assert.equal(await driver.find('textarea[name="D"]').value(), '');
         await driver.find('textarea[name="D"]').click();
         await gu.sendKeys('Hello,', Key.ENTER, 'World');
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       // Make sure we see the new record.
@@ -289,7 +289,7 @@ describe('FormView1', function() {
         await driver.find('input[name="D"]').click();
         await gu.sendKeys('1984');
         await assertSubmitOnEnterIsDisabled();
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       // Make sure we see the new record.
@@ -321,7 +321,7 @@ describe('FormView1', function() {
         await driver.find('.test-numeric-spinner-decrement').click();
         assert.equal(await driver.find('input[name="D"]').value(), '1984');
         await assertSubmitOnEnterIsDisabled();
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       // Make sure we see the new record.
@@ -344,7 +344,7 @@ describe('FormView1', function() {
         await driver.find('input[name="D"]').click();
         await gu.sendKeys('01012000');
         await assertSubmitOnEnterIsDisabled();
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       // Make sure we see the new record.
@@ -392,7 +392,7 @@ describe('FormView1', function() {
         assert.equal(await driver.find('.test-form-search-select').getText(), 'Select...');
         await gu.sendKeys(Key.ENTER);
         await driver.findContentWait('.test-sd-searchable-list-item', 'Bar', 2000).click();
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       await expectSingle('Bar');
@@ -433,7 +433,7 @@ describe('FormView1', function() {
         assert.equal(await driver.find('input[name="D"][value="Baz"]').getAttribute('checked'), null);
         await driver.find('input[name="D"][value="Bar"]').click();
         await assertSubmitOnEnterIsDisabled();
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       await expectSingle('Bar');
@@ -455,7 +455,7 @@ describe('FormView1', function() {
         await driver.find('input[name="D"]').click();
         await gu.sendKeys('1984');
         await assertSubmitOnEnterIsDisabled();
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       // Make sure we see the new record.
@@ -487,7 +487,7 @@ describe('FormView1', function() {
         await driver.find('.test-numeric-spinner-decrement').click();
         assert.equal(await driver.find('input[name="D"]').value(), '1984');
         await assertSubmitOnEnterIsDisabled();
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       // Make sure we see the new record.
@@ -507,13 +507,13 @@ describe('FormView1', function() {
         assert.equal(await driver.find('input[name="D"]').getAttribute('checked'), null);
         await driver.find('input[name="D"]').findClosest("label").click();
         await assertSubmitOnEnterIsDisabled();
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       await expectSingle(true);
       await gu.onNewTab(async () => {
         await driver.get(formUrl);
-        await driver.findWait('input[type="submit"]', 2000).click();
+        await driver.findWait('button[type="submit"]', 2000).click();
         await waitForConfirm();
       });
       await expectInD([true, false]);
@@ -539,13 +539,13 @@ describe('FormView1', function() {
         assert.equal(await driver.find('input[name="D"]').getAttribute('checked'), null);
         await driver.find('input[name="D"]').findClosest("label").click();
         await assertSubmitOnEnterIsDisabled();
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       await expectSingle(true);
       await gu.onNewTab(async () => {
         await driver.get(formUrl);
-        await driver.findWait('input[type="submit"]', 2000).click();
+        await driver.findWait('button[type="submit"]', 2000).click();
         await waitForConfirm();
       });
       await expectInD([true, false]);
@@ -587,7 +587,7 @@ describe('FormView1', function() {
         await driver.find('input[name="D[]"][value="Foo"]').click();
         await driver.find('input[name="D[]"][value="Baz"]').click();
         await assertSubmitOnEnterIsDisabled();
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       await expectSingle(['L', 'Foo', 'Baz']);
@@ -636,7 +636,7 @@ describe('FormView1', function() {
         assert.equal(await driver.find('.test-form-search-select').getText(), 'Select...');
         await gu.sendKeys(Key.ENTER);
         await driver.findContentWait('.test-sd-searchable-list-item', 'Bar', 2000 ).click();
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       await expectInD([0, 0, 0, 2]);
@@ -682,7 +682,7 @@ describe('FormView1', function() {
         assert.equal(await driver.find('label:has(input[name="D"][value="2"])').getText(), 'Bar');
         await driver.find('input[name="D"][value="2"]').click();
         await assertSubmitOnEnterIsDisabled();
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       await expectInD([0, 0, 0, 2]);
@@ -728,7 +728,7 @@ describe('FormView1', function() {
         await driver.find('input[name="D[]"][value="1"]').click();
         await driver.find('input[name="D[]"][value="2"]').click();
         await assertSubmitOnEnterIsDisabled();
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       await expectInD([null, null, null, ['L', 2, 1]]);
@@ -747,7 +747,7 @@ describe('FormView1', function() {
       });
       await gu.onNewTab(async () => {
         await driver.get(url);
-        await driver.findWait('input[type="submit"]', 2000).click();
+        await driver.findWait('button[type="submit"]', 2000).click();
         await gu.waitForUrl(/example\.com/);
       });
       await removeForm();
@@ -759,7 +759,7 @@ describe('FormView1', function() {
       });
       await gu.onNewTab(async () => {
         await driver.get(url);
-        await driver.findWait('input[type="submit"]', 2000).click();
+        await driver.findWait('button[type="submit"]', 2000).click();
         await waitForConfirm();
         assert.isFalse(await gu.isAlertShown());
       });
@@ -792,7 +792,7 @@ describe('FormView1', function() {
         await driver.findWait('input[name="D"]', 2000).click();
         await gu.sendKeys('Hello World');
         assert.isFalse(await driver.find('input[name="A"]').isPresent());
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
 
@@ -835,7 +835,7 @@ describe('FormView1', function() {
         await attachmentInput.sendKeys(paths);
 
         await assertSubmitOnEnterIsDisabled();
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
 
@@ -1721,7 +1721,7 @@ describe('FormView1', function() {
         await driver.get(formUrl);
         await driver.findWait('input[name="D"]', 2000).click();
         await gu.sendKeys('Hello World');
-        await driver.find('input[type="submit"]').click();
+        await driver.find('button[type="submit"]').click();
         await waitForConfirm();
       });
       // Make sure we see the new record.

--- a/test/nbrowser/FormView2.ts
+++ b/test/nbrowser/FormView2.ts
@@ -260,7 +260,7 @@ describe('FormView2', function() {
       // Submit a record
       await driver.findWait('input[name="A"]', 2000).click();
       await driver.findWait('input[name="A"]', 100).sendKeys('Hello');
-      await driver.findWait('input[type="submit"]', 1000).click();
+      await driver.findWait('button[type="submit"]', 1000).click();
       await driver.findWait('.test-form-success-page-text', 1000);
 
       // Check that the record was added to the table.


### PR DESCRIPTION
## Context

Attachments may take noticeable time to be uploaded because of antivirus scan. This can lead to user asking themselves if Grist works correctly as in those cases, no user feedback is given while uploading.

## Proposed solution

- in attachment cells, show a loading spinner if the attachment upload takes a little while
- in the attachment modal, when double-clicking on an attachment cell, show a "uploading…" status in the top left  corner when adding a file (+ bonus: add texts to the translation system, and fix the view when on mobile)
- in survey forms, change the submit button to show that it is still working if the submission takes a little while

Note: the spinner/text change doesn't happen right away to prevent some blinking UI when the upload/submission is fast. I set a 750ms delay.

### Help needed

For now, my implementation has limits:

- [x] in attachments cells, if the cell needs to expand its height in order to show the spinner, it currently doesn't. I didn't quite get how to update that correctly yet.  
**Update**: this has been fixed.

- [x] if I use a card view, upload an attachment through an input in the card, and change the current card, the loading state is still shown. And the upload ends up on the row matching the new card. Not sure this is a bug tied to the current one I talked you about @georgegevoian or if I messed up something.  
**Update**: this has been fixed, thanks George for your help.

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

https://github.com/user-attachments/assets/43374181-a232-4a31-813a-a0699ac986c5


https://github.com/user-attachments/assets/da478a3e-925a-4c7c-be06-62b037da55e7


