### PR TITLE
(tiny) set DEFAULT_MAX_ROWS according to deploymentType

### DIFF
--- a/app/client/components/DocumentUsage.ts
+++ b/app/client/components/DocumentUsage.ts
@@ -13,6 +13,7 @@ import {Features, isFreePlan} from 'app/common/Features';
 import {capitalizeFirstWord} from 'app/common/gutil';
 import {APPROACHING_LIMIT_RATIO} from 'app/common/Limits';
 import {canUpgradeOrg} from 'app/common/roles';
+import {getGristConfig} from 'app/common/urlUtils';
 import {Computed, Disposable, dom, DomContents, DomElementArg, makeTestId, styled} from 'grainjs';
 import {makeT} from 'app/client/lib/localization';
 
@@ -20,11 +21,16 @@ const t = makeT('DocumentUsage');
 
 const testId = makeTestId('test-doc-usage-');
 
+const {deploymentType} = getGristConfig();
+
 // Default used by the progress bar to visually indicate row usage.
-const DEFAULT_MAX_ROWS = 20000;
+// For self-hosters, the 20,000 rows limit is not actually the limit
+// So we use a larger default value to avoid confusion.
+const DEFAULT_MAX_ROWS = deploymentType == "saas" ? 20000 : 150000;
 
 // Default used by the progress bar to visually indicate data size usage.
-const DEFAULT_MAX_DATA_SIZE = DEFAULT_MAX_ROWS * 2 * 1024; // 40MB (2KiB per row)
+// 40MB on SaaS, 300MB for self-hosters (2KiB per row)
+const DEFAULT_MAX_DATA_SIZE = DEFAULT_MAX_ROWS * 2 * 1024;
 
 // Default used by the progress bar to visually indicate attachments size usage.
 const DEFAULT_MAX_ATTACHMENTS_SIZE = 1 * 1024 * 1024 * 1024; // 1GiB


### PR DESCRIPTION
## Context

For self-hosters, the 20,000 row limit shown in Raw Data is both false and confusing. A default of 150,000 seems to be more sensible on a configuration that's aligned with [what the documentation suggests](https://support.getgrist.com/self-managed/#what-are-the-hardware-requirements-for-hosting-grist).

## Proposed solution

Check the `deploymentType` variable in the Grist config, set DEFAULT_MAX_ROWS to 20,000 when on the SaaS and to 150,000 otherwise.

I know that in theory you'd just need to rewrite the default plan in the Features table of the home db in order to set this value, but a sensible default goes a long way imo.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

Tested locally and it works.

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
