### PR TITLE
an optimization for querying docs with postgres

### DIFF
--- a/app/gen-server/entity/Document.ts
+++ b/app/gen-server/entity/Document.ts
@@ -170,6 +170,17 @@ export class Document extends Resource {
   }
 }
 
+/**
+ * In a query optimization, we filter docs in a CTE. There's no
+ * direct way to tell TypeORM that this filtered version of docs
+ * has the same structure as the table. So we create a entity
+ * with a distinct name for this purpose. Does not exist in the
+ * database.
+ */
+@Entity({name: 'filtered_docs'})
+export class FilteredDocument extends Document {
+}
+
 // Check that icon points to an expected location.  This will definitely
 // need changing, it is just a placeholder as the icon feature is developed.
 function sanitizeIcon(icon: string|null) {


### PR DESCRIPTION
In the Grist Labs SaaS, we are seeing the postgres planner having trouble with the docs query in a large db. There is an X OR Y where clause that is fast with just X or just Y but combined is much much slower. Replacing the query with a UNION of two would work but make an already long query twice as long. Instead this commit adds a prefiltering CTE that greatly cuts down the number of rows considered, and makes the query much snappier.

The planning time for these queries has become significant, which could also be addressed e.g. with prepared statements, but that's left as a separate issue.
