### PR TITLE
(themes) fix wrong theme set when using themeAppearance param

### DIFF
--- a/app/client/ui2018/theme.ts
+++ b/app/client/ui2018/theme.ts
@@ -133,9 +133,17 @@ function getThemeFromPrefs(themePrefs: ThemePrefs, userAgentPrefersDarkTheme: bo
     syncWithOS = urlParams?.themeSyncWithOs;
   }
 
-  let themeName = themePrefs.colors[appearance];
+  // The themeName is stored both in themePrefs.colors.light and themePrefs.colors.dark
+  // (see app/common/ThemePrefs.ts#getDefaultThemePrefs for more info).
+  // So, it doesn't matter if we take the theme name from colors.light or colors.dark
+  let themeName = themePrefs.colors['light'];
   if (urlParams?.themeName) {
     themeName = urlParams?.themeName;
+  }
+  // User might set up the theme appearance in the url params, but not the theme name:
+  // make sure the theme is correctly set in that case
+  if (urlParams?.themeAppearance && !urlParams?.themeName) {
+    themeName = appearance === 'dark' ? 'GristDark' : 'GristLight';
   }
 
   if (syncWithOS) {


### PR DESCRIPTION
Since changing how we store theme info [after adding the high contrast theme](https://github.com/gristlabs/grist-core/pull/1616), there was a bug where setting up the `themeAppearance` by itself in the URL, without theme name info, would not set theme correctly.

Now we detect that correctly: if only a theme appearance is passed, without a theme name, we set up the correct default theme for the given appearance.

ping @paulfitz @georgegevoian 