### PR TITLE
Multi-server pubsub healthcheck endpoint

### DIFF
--- a/app/common/ConfigAPI.ts
+++ b/app/common/ConfigAPI.ts
@@ -26,7 +26,7 @@ export class ConfigAPI extends BaseAPI {
   }
 
   public async healthcheck(): Promise<void> {
-    const resp = await this.request(`${this._homeUrl}/status?ready=1`);
+    const resp = await this.request(`${this._homeUrl}/status?allInstancesReady=1`);
     if (!resp.ok) {
       throw new Error(await resp.text());
     }

--- a/app/server/MergedServer.ts
+++ b/app/server/MergedServer.ts
@@ -206,7 +206,7 @@ export class MergedServer {
       await this.flexServer.finalizePlugins(this.hasComponent("home") ? checkUserContentPort() : null);
       this.flexServer.checkOptionCombinations();
       this.flexServer.summary();
-      this.flexServer.setReady(true);
+      this.flexServer.ready = true;
 
       if (this._options.extraWorkers) {
         if (!process.env.REDIS_URL) {

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1890,13 +1890,17 @@ export class FlexServer implements GristServer {
     }
   }
 
-  public setReady(value: boolean) {
+  public set ready(value: boolean) {
     if(value) {
       log.debug('FlexServer is ready');
     } else {
       log.debug('FlexServer is no longer ready');
     }
     this._isReady = value;
+  }
+
+  public get ready() {
+    return this._isReady;
   }
 
   public checkOptionCombinations() {

--- a/app/server/lib/GristServer.ts
+++ b/app/server/lib/GristServer.ts
@@ -52,6 +52,7 @@ export interface StorageCoordinator {
 export interface GristServer extends StorageCoordinator {
   readonly create: ICreate;
   readonly testPending: boolean;
+  ready: boolean;
   settings?: IGristCoreConfig;
   getHost(): string;
   getHomeUrl(req: express.Request, relPath?: string): string;
@@ -103,7 +104,6 @@ export interface GristServer extends StorageCoordinator {
   isRestrictedMode(): boolean;
   onUserChange(callback: (change: UserChange) => Promise<void>): void;
   onStreamingDestinationsChange(callback: (orgId?: number) => Promise<void>): void;
-  setReady(value: boolean): void;
 }
 
 export interface GristLoginSystem {
@@ -163,6 +163,7 @@ export function createDummyGristServer(): GristServer {
   return {
     create,
     testPending: false,
+    ready: true,
     settings: loadGristCoreConfig(),
     getHost() { return 'localhost:4242'; },
     getHomeUrl() { return 'http://localhost:4242'; },
@@ -214,7 +215,6 @@ export function createDummyGristServer(): GristServer {
     onUserChange() { /* do nothing */ },
     onStreamingDestinationsChange() { /* do nothing */ },
     hardDeleteDoc() { return Promise.resolve(); },
-    setReady() { /* do nothing */ },
   };
 }
 

--- a/app/server/lib/HealthChecker.ts
+++ b/app/server/lib/HealthChecker.ts
@@ -1,0 +1,140 @@
+import {GristServer} from 'app/server/lib/GristServer';
+import log from 'app/server/lib/log';
+import {createPubSubManager, IPubSubManager} from 'app/server/lib/PubSubManager';
+import * as shutdown from 'app/server/lib/shutdown';
+
+import {v4 as uuidv4} from 'uuid';
+
+// Not to be confused with health checks from the frontend, these
+// request/response pairs are internal checks between Grist instances
+// in multi-server environments
+interface ServerHealthcheckRequest {
+  id: string;
+  instanceId: string;
+  checkReady: boolean;
+}
+interface ServerHealthcheckResponse {
+  instanceId: string;
+  requestId: string;
+  healthy: boolean;
+}
+
+// For keeping track of pending health checks for all other servers
+// for each request that was broadcast to all of them.
+interface PendingServerHealthCheck {
+  expectedCount: number;
+  responses: Record<string, boolean>;
+  resolve: (res: boolean) => void;
+  reject: (err: Error) => void;
+  timeout: NodeJS.Timeout;
+}
+
+/** This class uses pubsub via Redis, if available, to register this
+ *  Grist instance and check that all other instances are healthy.
+ *
+ *  In single-server instances, it also works without Redis, leveraging
+ *  the dummy defaults of `PubSubManager`.
+ */
+export class HealthChecker {
+  private _pendingServerHealthChecks: Map<string, PendingServerHealthCheck>;
+  private _serverInstanceID: string;
+  private _pubSubManager: IPubSubManager;
+
+  constructor(
+    private _server: GristServer
+  ) {
+    this._pubSubManager = createPubSubManager(process.env.REDIS_URL);
+    this._pendingServerHealthChecks = new Map<string, PendingServerHealthCheck>();
+    this._serverInstanceID = process.env.GRIST_INSTANCE_ID || `testInsanceId_${this._server.getHost()}`;
+    this._pubSubManager.getClient()?.sadd('grist-instances', this._serverInstanceID).catch((err) => {
+      log.error('Failed to contact redis', err);
+    });
+    this._subscribeToChannels();
+
+    // Make sure we clean up our Redis mess, if any, even if we exit
+    // by signal.
+    shutdown.addCleanupHandler(null, () => this.close());
+  }
+
+
+  /** This returns a promise that resolves to `true` when all other
+   *  registered instances must respond as healthy within the given
+   *  timeout.
+   *
+   *  @param {number} timeout - number of milliseconds to wait for
+   *                            responses from all servers before timeout
+   *
+   *  @param {boolean} checkReady - whether to insist on `ready` status
+   *                                or just a simple health check
+   */
+  public async allServersOkay(timeout: number, checkReady: boolean): Promise<boolean> {
+    const requestId = uuidv4();
+    const client = this._pubSubManager.getClient();
+
+    // If there is no Redis, then our current instance is the only instance
+    const allInstances = await client?.smembers('grist-instances') || [this._serverInstanceID];
+
+    const allInstancesPromise: Promise<boolean> = new Promise((resolve: (res: boolean) => void, reject) => {
+      const allInstancesTimeout = setTimeout(() => {
+        log.warn('allServersOkay: timeout waiting for responses');
+        reject(new Error('Timeout waiting for health responses'));
+        this._pendingServerHealthChecks.delete(requestId);
+      }, timeout);
+
+      this._pendingServerHealthChecks.set(requestId, {
+        responses: {},
+        expectedCount: allInstances.length,
+        resolve,
+        reject,
+        timeout: allInstancesTimeout,
+      });
+    }).catch(() => false);
+    const request: ServerHealthcheckRequest = {
+      id: requestId,
+      instanceId: this._serverInstanceID,
+      checkReady,
+    };
+    await this._pubSubManager.publish('healthcheck:requests', JSON.stringify(request));
+    return allInstancesPromise;
+  }
+
+  public async close() {
+    await this._pubSubManager.getClient()?.srem('grist-instances', [this._serverInstanceID]);
+    await this._pubSubManager.close();
+  }
+
+  private _subscribeToChannels() {
+    this._pubSubManager.subscribe('healthcheck:requests', async (message) => {
+      const request: ServerHealthcheckRequest = JSON.parse(message);
+      const response: ServerHealthcheckResponse = {
+        instanceId: this._serverInstanceID|| '',
+        requestId: request.id,
+        healthy: !request.checkReady || this._server.ready,
+      };
+      log.debug('allServersOkay request', response);
+      await this._pubSubManager.publish(`healthcheck:responses-${request.instanceId}`, JSON.stringify(response));
+    });
+
+    this._pubSubManager.subscribe(`healthcheck:responses-${this._serverInstanceID}`, (message) => {
+      const response: ServerHealthcheckResponse = JSON.parse(message);
+      const pending = this._pendingServerHealthChecks.get(response.requestId);
+      if (!pending) {
+        // This instance didn't broadcast a health check request with
+        // this requestId, so nothing to do.
+        return;
+      }
+
+      pending.responses[response.instanceId] = response.healthy;
+      log.debug(
+        `allServersOkay cleared pending response on ${this._serverInstanceID} for ${response.instanceId}`
+      );
+
+      if (Object.keys(pending.responses).length === pending.expectedCount) {
+        // All servers have replied. Make it known and clean up.
+        clearTimeout(pending.timeout);
+        pending.resolve(Object.values(pending.responses).every(e => e));
+        this._pendingServerHealthChecks.delete(response.requestId);
+      }
+    });
+  }
+}

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -113,7 +113,7 @@ export function attachEarlyEndpoints(options: AttachOptions) {
         });
       }
       // We're going down, so we're no longer ready to serve requests.
-      gristServer.setReady(false);
+      gristServer.ready = false;
       return res.status(200).send({ msg: "ok" });
     })
   );

--- a/test/server/lib/Authorizer.ts
+++ b/test/server/lib/Authorizer.ts
@@ -43,7 +43,7 @@ async function activateServer(home: FlexServer, docManager: DocManager) {
   home.addApiErrorHandlers();
   home.finalizeEndpoints();
   await home.finalizePlugins(null);
-  home.setReady(true);
+  home.ready = true;
   serverUrl = home.getOwnUrl();
 }
 

--- a/test/server/lib/HealthChecker.ts
+++ b/test/server/lib/HealthChecker.ts
@@ -1,0 +1,137 @@
+import {TestServer} from 'test/server/lib/helpers/TestServer';
+import {RedisForwarder} from 'test/server/tcpForwarder';
+import * as testUtils from 'test/server/testUtils';
+import {prepareFilesystemDirectoryForTests} from 'test/server/lib/helpers/PrepareFilesystemDirectoryForTests';
+import {prepareDatabase} from 'test/server/lib/helpers/PrepareDatabase';
+
+import fetch from 'node-fetch';
+import {assert} from 'chai';
+import IORedis from "ioredis";
+
+import * as path from 'path';
+import {tmpdir} from 'os';
+
+const username = process.env.USER || "nobody";
+const tmpDir = path.join(tmpdir(), `grist_test_${username}_health_checker`);
+
+describe('HealthChecker', function() {
+  testUtils.setTmpLogLevel('error');
+  this.timeout(10_000);
+
+  let servers: {server: TestServer, forwarder?: RedisForwarder}[] = [];
+  let client: IORedis;
+
+  before(async function() {
+    await prepareFilesystemDirectoryForTests(tmpDir);
+    await prepareDatabase(tmpDir);
+
+    if(process.env.TEST_REDIS_URL) {
+      client = new IORedis(process.env.TEST_REDIS_URL);
+      await client.flushall();
+
+      for(let i = 0; i < 3; i++) {
+        // Use a forwarder for each server so we can simulate
+        // disconnects
+        const forwarder = await RedisForwarder.create();
+
+        const server = await TestServer.startServer('home', tmpDir, `with-redis-${i}`, {
+          REDIS_URL: forwarder.redisUrl,
+          GRIST_INSTANCE_ID: `test-instance-${i}`,
+        });
+        servers.push({server, forwarder});
+      }
+    }
+    else {
+      servers = [{server: await TestServer.startServer('home', tmpDir, 'without-redis')}];
+    }
+  });
+
+  after(async function () {
+    await Promise.all(servers.map(async (pair) => {
+      await pair.server.stop();
+      await pair.forwarder?.disconnect();
+    }));
+    client?.disconnect();
+  });
+
+  it('registers all servers', async function () {
+    if(!process.env.TEST_REDIS_URL) {
+      this.skip();
+    }
+
+    const instances = await client.smembers('grist-instances');
+    instances.sort();
+    assert.deepEqual(instances, ['test-instance-0', 'test-instance-1', 'test-instance-2']);
+  });
+
+  it('reports healthy when all servers are healthy', async function () {
+    const server = servers[process.env.TEST_REDIS_URL ? 2 : 0].server;
+    const resp = await fetch(`${server.serverUrl}/status?allInstancesReady=1`);
+    assert.equal(resp.status, 200);
+    assert.match(await resp.text(), /allInstancesReady ok/);
+  });
+
+  it('reports not healthy when one server is not healthy', async function () {
+    if(!process.env.TEST_REDIS_URL) {
+      this.skip();
+    }
+
+    const downServer = servers[2];
+    await downServer.forwarder?.disconnect();
+
+    const server = servers[0].server;
+    const resp = await fetch(`${server.serverUrl}/status?allInstancesReady=1&timeout=500`);
+    const text = await resp.text();
+    assert.equal(resp.status, 500);
+    assert.match(text, /allInstancesReady not ok/);
+
+    await downServer.forwarder?.connect();
+  });
+
+  it('reports healthy when one server is cleanly disconnected', async function () {
+    if(!process.env.TEST_REDIS_URL) {
+      this.skip();
+    }
+
+    const downServer = servers[2];
+    await downServer.server.stop();
+    await downServer.forwarder?.disconnect();
+    servers.pop();
+
+    const server = servers[0].server;
+    const resp = await fetch(`${server.serverUrl}/status?allInstancesReady=1`);
+    const text = await resp.text();
+    assert.equal(resp.status, 200);
+    assert.match(text, /allInstancesReady ok/);
+  });
+
+  it('checks when a new server comes back', async function() {
+    if(!process.env.TEST_REDIS_URL) {
+      this.skip();
+    }
+
+    let instances = await client.smembers('grist-instances');
+    instances.sort();
+    assert.deepEqual(instances, ['test-instance-0', 'test-instance-1']);
+
+    const newForwarder = await RedisForwarder.create();
+    await newForwarder.connect();
+    const newServer = await TestServer.startServer('home', tmpDir, `with-redis-3`, {
+      REDIS_URL: newForwarder.redisUrl,
+      GRIST_INSTANCE_ID: `test-instance-3`,
+    });
+
+    instances = await client.smembers('grist-instances');
+    instances.sort();
+    assert.deepEqual(instances, ['test-instance-0', 'test-instance-1', 'test-instance-3']);
+
+    const server = servers[0].server;
+    const resp = await fetch(`${server.serverUrl}/status?allInstancesReady=1`);
+    const text = await resp.text();
+    assert.equal(resp.status, 200);
+    assert.match(text, /allInstancesReady ok/);
+
+    await newServer.stop();
+    await newForwarder.disconnect();
+  });
+});

--- a/test/server/tcpForwarder.ts
+++ b/test/server/tcpForwarder.ts
@@ -59,3 +59,21 @@ async function destroySock(sock: Socket): Promise<void> {
       sock.on('close', resolve).destroy());
   }
 }
+
+export class RedisForwarder extends TcpForwarder {
+  public static async create() {
+    if (!process.env.TEST_REDIS_URL) {
+      throw new Error("TEST_REDIS_URL is expected");
+    }
+
+    const url = new URL(process.env.TEST_REDIS_URL);
+    const port = parseInt(url.port, 10) || 6379;
+    const forwarder = new RedisForwarder(port, url.hostname);
+    await forwarder.pickForwarderPort();
+    await forwarder.connect();
+    forwarder.redisUrl = `redis://localhost:${forwarder.port}${url.pathname}`;
+    return forwarder;
+  }
+
+  public redisUrl: string;
+}


### PR DESCRIPTION
## Context

In order to properly restart multi-instance Grist installs, I need to know when all of the instances (home servers, doc workers) are up and ready and restarted with the new Grist parameters.

This adds a new option to the `/status` health check endpoint called `allServersReady` to make sure that all the servers are up and ready to serve requests.

In the absence of Redis, the same endpoint also works with in-memory dummy pubsub provided by the `PubSubManager`.

## Proposed solution

This adds to `FlexServer` a new option handled by a `HealthChecker` class that uses Redis pubsub to broadcast and handle requests to check each instances `ready` status. Each server registers and de-registers itself on Redis during startup and shutdown respectively. During a request to check if all servers are okay, the server handling the request from the web browser will report back when all registered servers respond one way or another, with a default timeout of 10 seconds.

This also adds a new optional `GRIST_INSTANCE_ID` parameter, which defaults to a combination of instance's host and port. This is ID is used to identify registered instances as well as to supply the listening channels unique to each instance for pubsub.

## Related issues

Follow-up to #1697 

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
