### PR TITLE
update endpoints for deleting sites and workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ Grist can be configured in many ways. Here are the main environment variables it
 | GRIST_ACTION_HISTORY_MAX_BYTES | Maximum number of rows allowed in ActionHistory before pruning (up to a 1.25 grace factor). Defaults to 1Gb. ⚠️ A too low value may make the "[Work on a copy](https://support.getgrist.com/newsletters/2021-06/#work-on-a-copy)" feature [malfunction](https://github.com/gristlabs/grist-core/issues/1121#issuecomment-2248112023) |
 | GRIST_ADAPT_DOMAIN | set to "true" to support multiple base domains (careful, host header should be trustworthy) |
 | GRIST_ALLOW_AUTOMATIC_VERSION_CHECKING | Whether Grist is allowed to automatically check if a newer Grist version is available. Defaults to "true" on the default `grist` and `grist-ee` Docker images. Defaults false in `grist-oss` and everywhere else. |
+| GRIST_ALLOW_DEPRECATED_BARE_ORG_DELETE | If set, the deprecated DELETE /api/orgs/:orgId endpoint is available. |
 | GRIST_APP_ROOT | directory containing Grist sandbox and assets (specifically the sandbox and static subdirectories). |
 | GRIST_ATTACHMENT_THRESHOLD_MB | attachment storage limit per document beyond which Grist will recommend external storage (if available). Defaults to 50MB. |
 | GRIST_BACKUP_DELAY_SECS | wait this long after a doc change before making a backup |

--- a/app/common/UserAPI.ts
+++ b/app/common/UserAPI.ts
@@ -762,7 +762,7 @@ export class UserAPIImpl extends BaseAPI implements UserAPI {
   }
 
   public async deleteOrg(orgId: number|string): Promise<void> {
-    await this.request(`${this._url}/api/orgs/${orgId}`, { method: 'DELETE' });
+    await this.request(`${this._url}/api/orgs/${orgId}/force-delete`, { method: 'DELETE' });
   }
 
   public async deleteWorkspace(workspaceId: number): Promise<void> {

--- a/app/gen-server/ApiServer.ts
+++ b/app/gen-server/ApiServer.ts
@@ -656,8 +656,15 @@ export class ApiServer {
 
   private async _hardDeleteWorkspace(req: Request, wsId: number) {
     const ws = this._dbManager.unwrapQueryResult(
-      await this._dbManager.getWorkspace(getScope(req), wsId, undefined,
-                                         { requirePermissions: Permissions.REMOVE })
+      await this._dbManager.getWorkspace(
+        {
+          ...getScope(req),
+          showAll: true,  // fine to hard-delete a soft-deleted workspace
+        },
+        wsId, undefined,
+        {
+          requirePermissions: Permissions.REMOVE
+        })
     );
     try {
       const doom = await this._gristServer.getDoomTool();

--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -759,10 +759,21 @@ export class HomeDBManager {
     },
   ): Promise<QueryResult<Workspace>> {
     const {userId} = scope;
+    if (scope.specialPermit && scope.specialPermit.workspaceId === wsId) {
+      const effectiveUserId = this._usersManager.getPreviewerUserId();
+      scope = {...scope};
+      scope.userId = effectiveUserId;
+      delete scope.users;
+      options = {
+        ...options,
+        requirePermissions: Permissions.VIEW,
+      };
+    }
     let queryBuilder = this._workspace(scope, wsId, {
       manager: transaction,
       ...(options?.requirePermissions ? {
         markPermissions: options.requirePermissions,
+        allowSpecialPermit: true,
       } : undefined),
     })
       // Nest the docs within the workspace object

--- a/app/server/lib/AuditEvent.ts
+++ b/app/server/lib/AuditEvent.ts
@@ -269,6 +269,7 @@ export interface AuditEventDetails {
   };
   "site.delete": {
     site: Pick<Organization, "id" | "name" | "domain">;
+    error?: string;
   };
   "site.rename": PreviousAndCurrent<{
     site: Pick<Organization, "id" | "name" | "domain">;
@@ -309,6 +310,7 @@ export interface AuditEventDetails {
   };
   "workspace.delete": {
     workspace: Pick<Workspace, "id" | "name">;
+    error?: string;
   };
   "workspace.move_to_trash": {
     workspace: Pick<Workspace, "id" | "name">;

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1601,6 +1601,15 @@ export class FlexServer implements GristServer {
     this._disableExternalStorage = true;
   }
 
+  public async getDoomTool() {
+    const dbManager = this.getHomeDBManager();
+    const permitStore = this.getPermitStore();
+    const notifier = this.getNotifier();
+    const loginSystem = await this.resolveLoginSystem();
+    const homeUrl = this.getHomeInternalUrl().replace(/\/$/, '');
+    return new Doom(dbManager, permitStore, notifier, loginSystem, homeUrl);
+  }
+
   public addAccountPage() {
     const middleware = [
       this._redirectToHostMiddleware,
@@ -1611,15 +1620,6 @@ export class FlexServer implements GristServer {
     this.app.get('/account', ...middleware, expressWrap(async (req, resp) => {
       return this._sendAppPage(req, resp, {path: 'app.html', status: 200, config: {}});
     }));
-
-    const createDoom = async () => {
-      const dbManager = this.getHomeDBManager();
-      const permitStore = this.getPermitStore();
-      const notifier = this.getNotifier();
-      const loginSystem = await this.resolveLoginSystem();
-      const homeUrl = this.getHomeInternalUrl().replace(/\/$/, '');
-      return new Doom(dbManager, permitStore, notifier, loginSystem, homeUrl);
-    };
 
     if (isAffirmative(process.env.GRIST_ACCOUNT_CLOSE)) {
       this.app.delete('/api/doom/account', expressWrap(async (req, resp) => {
@@ -1641,7 +1641,7 @@ export class FlexServer implements GristServer {
 
         // Reuse Doom cli tool for account deletion. It won't allow to delete account if it has access
         // to other (not public) team sites.
-        const doom = await createDoom();
+        const doom = await this.getDoomTool();
         const {data} = await doom.deleteUser(userId);
         if (data) { this._logDeleteUserEvents(req as RequestWithLogin, data); }
         return resp.status(200).json(true);
@@ -1675,7 +1675,7 @@ export class FlexServer implements GristServer {
 
         // Reuse Doom cli tool for org deletion. Note, this removes everything as a super user.
         const deletedOrg = structuredClone(org);
-        const doom = await createDoom();
+        const doom = await this.getDoomTool();
         await doom.deleteOrg(org.id);
         this._logDeleteSiteEvents(mreq, deletedOrg);
         return resp.status(200).send();

--- a/app/server/lib/GristServer.ts
+++ b/app/server/lib/GristServer.ts
@@ -8,6 +8,7 @@ import { Organization } from 'app/gen-server/entity/Organization';
 import { User } from 'app/gen-server/entity/User';
 import { Workspace } from 'app/gen-server/entity/Workspace';
 import { ActivationsManager } from 'app/gen-server/lib/ActivationsManager';
+import { Doom } from 'app/gen-server/lib/Doom';
 import { HomeDBManager, UserChange } from 'app/gen-server/lib/homedb/HomeDBManager';
 import { IAccessTokens } from 'app/server/lib/AccessTokens';
 import { RequestWithLogin } from 'app/server/lib/Authorizer';
@@ -95,6 +96,7 @@ export interface GristServer extends StorageCoordinator {
   getInfo(key: string): any;
   getJobs(): GristJobs;
   getBilling(): IBilling;
+  getDoomTool(): Promise<Doom>;
   getLatestVersionAvailable(): LatestVersionAvailable|undefined;
   setLatestVersionAvailable(latestVersionAvailable: LatestVersionAvailable): void
   publishLatestVersionAvailable(latestVersionAvailable: LatestVersionAvailable): Promise<void>;
@@ -210,6 +212,7 @@ export function createDummyGristServer(): GristServer {
     getInfo(key: string) { return undefined; },
     getJobs(): GristJobs { throw new Error('no job system'); },
     getBilling() { throw new Error('no billing'); },
+    getDoomTool() { throw new Error('no doom tool'); },
     getLatestVersionAvailable() { throw new Error('no version checking'); },
     setLatestVersionAvailable() { /* do nothing */ },
     publishLatestVersionAvailable() { return Promise.resolve(); },

--- a/app/server/lib/Permit.ts
+++ b/app/server/lib/Permit.ts
@@ -15,7 +15,8 @@
  *
  *   - It the operation you care about involves the database, check
  *     that "allowSpecialPermit" is enabled for it in HomeDBManager
- *     (currently only deletion of docs/workspaces has this enabled).
+ *     (currently only deletion of docs, and deleting/viewing workspaces
+ *     has this enabled).
  *
  *   - Save the permit in the permit store, with setPermit, noting its
  *     generated key.

--- a/test/gen-server/ApiServer.ts
+++ b/test/gen-server/ApiServer.ts
@@ -1040,27 +1040,14 @@ describe('ApiServer', function() {
       return fetchResp.data;
     }
 
-    // Check use of org name
-    oid = await createTestDomain();
-    resp = await axios.delete(`${homeUrl}/api/orgs/${oid}/The Nam`, chimpy);
-    assert.equal(resp.status, 400);
-    resp = await axios.delete(`${homeUrl}/api/orgs/${oid}/The Name`, chimpy);
-    assert.equal(resp.status, 200);
-
-    // Check use of org domain
-    oid = await createTestDomain();
-    resp = await axios.delete(`${homeUrl}/api/orgs/${oid}/the-domai`, chimpy);
-    assert.equal(resp.status, 400);
-    resp = await axios.delete(`${homeUrl}/api/orgs/${oid}/the-domain`, chimpy);
-    assert.equal(resp.status, 200);
-
-    // Check use of force-delete
-    oid = await createTestDomain();
-    resp = await axios.delete(`${homeUrl}/api/orgs/${oid}/force-delet`, chimpy);
-    assert.equal(resp.status, 400);
-    resp = await axios.delete(`${homeUrl}/api/orgs/${oid}/force-delete`, chimpy);
-    assert.equal(resp.status, 200);
-
+    // Check use of org name, domain, and force-delete
+    for (const name of ["The Name", "the-domain", "force-delete"]) {
+      oid = await createTestDomain();
+      resp = await axios.delete(`${homeUrl}/api/orgs/${oid}/${name.slice(0, -1)}`, chimpy);
+      assert.equal(resp.status, 400);
+      resp = await axios.delete(`${homeUrl}/api/orgs/${oid}/${name}`, chimpy);
+      assert.equal(resp.status, 200);
+    }
   });
 
   it('DELETE /api/orgs/{oid}/{name} returns 404 appropriately', async function() {

--- a/test/gen-server/lib/DocPrefs.ts
+++ b/test/gen-server/lib/DocPrefs.ts
@@ -29,7 +29,7 @@ describe('DocPrefs', function() {
 
   before(async function setUp(this: Mocha.Context) {
     server = new TestServer(this);
-    await server.start();
+    await server.start(['home', 'docs']);
     dbManager = server.dbManager;
 
     // Fill in user info, to use throughout the test.

--- a/test/gen-server/lib/everyone.ts
+++ b/test/gen-server/lib/everyone.ts
@@ -9,7 +9,7 @@ describe('everyone', function() {
 
   before(async function() {
     home = new TestServer(this);
-    await home.start();
+    await home.start(['home', 'docs']);
   });
 
   after(async function() {

--- a/test/gen-server/lib/previewer.ts
+++ b/test/gen-server/lib/previewer.ts
@@ -125,11 +125,11 @@ describe('previewer', function() {
     resp = await axios.delete(`${homeUrl}/api/workspaces/${wsId}`, permit(goodDocPermit));
     assert.equal(resp.status, 403);
     resp = await axios.get(`${homeUrl}/api/workspaces/${wsId}`, permit(goodWsPermit));
-    assert.equal(resp.status, 403);
+    assert.equal(resp.status, 200);  // workspace read respects permit
     resp = await axios.patch(`${homeUrl}/api/workspaces/${wsId}`, {name: 'diff'}, permit(goodWsPermit));
     assert.equal(resp.status, 403);
     resp = await axios.delete(`${homeUrl}/api/workspaces/${wsId}`, permit(goodWsPermit));
-    assert.equal(resp.status, 200);
+    assert.equal(resp.status, 200);  // workspace delete respects permit
 
   });
 });


### PR DESCRIPTION
The easiest-to-find endpoints for deleting sites and workspaces were old, from an early Grist prototype. The correct method for deleting sites in particular was hard to find, hidden in a `Doom` class. This updates the endpoints to use the preferred implementation.

Note that these endpoints are very unforgiving. Call them to delete a resource, and it ends up deleted, with no soft-delete step. There is a `/remove` endpoint for workspaces (and documents) that does soft-deletes.

For the org delete endpoint, there is now an extra `/{name}` path segment added at the end of the URL, which must match either `org.name` or `org.domain` or `force-delete`. This is a breaking change. To continue using the endpoint without this new path segment, set `GRIST_ALLOW_DEPRECATED_BARE_ORG_DELETE=1` in the environment.