### PR TITLE
fix: use setuptools instead of deprecated distutils

### DIFF
--- a/sandbox/setup.py
+++ b/sandbox/setup.py
@@ -1,6 +1,6 @@
 # see bundle_as_wheel.sh
 
-from distutils.core import setup
+from setuptools import setup
 import glob
 
 files = glob.glob('grist/*.py') + glob.glob('grist/**/*.py')


### PR DESCRIPTION
## Context

Trying to make grist-static install work when using python > 3.12 where `distutils` was removed from the standard library. `setuptools` is the replacement (but needs to be pip installed)

Rest of the work will happen in grist-static :)