### PR TITLE
(tiny) use python3 in bundle_as_wheel.sh

### DIFF
--- a/sandbox/bundle_as_wheel.sh
+++ b/sandbox/bundle_as_wheel.sh
@@ -10,7 +10,7 @@ set -e
 rm -rf dist foo.egg-info grist.egg-info build
 
 # Go ahead and run packaging again.
-python setup.py bdist_wheel
+python3 setup.py bdist_wheel
 
 echo ""
 echo "Result is in the dist directory:"


### PR DESCRIPTION
This script is only used for grist-static builds
Hopefully fixes https://github.com/gristlabs/grist-static/pull/42#pullrequestreview-3072216190