### PR TITLE
Add missing lru-cache package in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "knockout": "3.5.0",
     "locale-currency": "0.0.2",
     "lodash": "4.17.21",
+    "lru-cache": "5.1.1",
     "marked": "14.0.0",
     "marked-highlight": "2.1.4",
     "marked-linkify-it": "3.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6228,17 +6228,17 @@ loupe@^2.3.6:
   dependencies:
     get-func-name "^2.0.1"
 
-lru-cache@^10.2.0, lru-cache@^10.4.3:
-  version "10.4.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
-  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
-
-lru-cache@^5.1.1:
+lru-cache@5.1.1, lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@^10.2.0, lru-cache@^10.4.3:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
 lru-cache@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
## Context

Grist package for Yunohost cannot be installed in version 1.7.1: https://ci-apps-dev.yunohost.org/ci/logs/11633.log

The error is the following:
```
Aug 01 07:41:33 run.sh[4453]: 2025-08-01 07:41:33.565 - warn: DocWorkerMap: redisClient connection closed
Aug 01 07:41:33 run.sh[4453]: TypeError: lru_cache_1.default is not a constructor
Aug 01 07:41:33 run.sh[4453]:     at new CachedWidgetRepository (/var/www/grist/_build/app/server/lib/WidgetRepository.js:215:23)
Aug 01 07:41:33 run.sh[4453]:     at buildWidgetRepository (/var/www/grist/_build/app/server/lib/WidgetRepository.js:242:12)
Aug 01 07:41:33 run.sh[4453]:     at FlexServer.addWidgetRepository (/var/www/grist/_build/app/server/lib/FlexServer.js:868:79)
Aug 01 07:41:33 run.sh[4453]:     at MergedServer.run (/var/www/grist/_build/app/server/MergedServer.js:138:33)
Aug 01 07:41:33 run.sh[4453]:     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
Aug 01 07:41:33 run.sh[4453]:     at async main (/var/www/grist/_build/stubs/app/server/server.js:140:5)
Aug 01 07:41:33 systemd[1]: grist.service: Deactivated successfully.
Aug 01 07:41:33 systemd[1]: grist.service: Consumed 3.287s CPU time.
```

The steps for installing grist in Yunohost is the following:
```bash
  yarn install --frozen-lockfile --network-timeout 600000
  yarn install:python
  yarn run build:prod
  rm -rf ./node_modules/
  yarn add --network-timeout 600000 node-gyp node-pre-gyp node-gyp-build node-gyp-build-optional-packages
  yarn install --prod --frozen-lockfile --network-timeout 600000
```

lru-cache could be used because it has been required by other packages fetched by devDependencies. But if you remove the devDependencies it does not work anymore.


## Proposed solution

Add lru-cache explicitly in dependencies list of package.json so it can be installed properly.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->