### PR TITLE
fix(webhook): 2XX Status codes is not consided as valid

### DIFF
--- a/app/server/lib/Triggers.ts
+++ b/app/server/lib/Triggers.ts
@@ -826,8 +826,10 @@ export class DocTriggers {
           },
           signal,
         });
-        if (response.status === 200) {
-          await this._stats.logBatch(id, 'success', { size, httpStatus: 200, error: null, attempts: attempt + 1 });
+        if (response.ok) {
+          await this._stats.logBatch(id, 'success', {
+            size, httpStatus: response.status, error: null, attempts: attempt + 1
+          });
           return true;
         }
         await this._stats.logBatch(id, 'failure', {


### PR DESCRIPTION
## Context

Some APIs prefer return status code 201 in response instead of 200. So, users uses third party tool like N8N to bypass this limitation.

## Proposed solution

Add 2XX as valid status codes.

## Related issues

Internal issue

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
