### PR TITLE
Dialog for when the user is about to share a resource publicly

### DIFF
--- a/app/client/models/UserManagerModel.ts
+++ b/app/client/models/UserManagerModel.ts
@@ -53,6 +53,8 @@ export interface UserManagerModel {
   isActiveUser(member: IEditableMember): boolean;
   // Returns the PermissionDelta reflecting the current unsaved changes in the model.
   getDelta(): PermissionDelta;
+  // Returns whether we are enabling public sharing.
+  goingToSharePublicly(): boolean;
 }
 
 export type ResourceType = 'organization'|'workspace'|'document';
@@ -305,6 +307,12 @@ export class UserManagerModelImpl extends Disposable implements UserManagerModel
       }
     }
     return delta;
+  }
+
+  public goingToSharePublicly(): boolean {
+    // We want to detect when the original access for the public member did not exist
+    // and has just been defined.
+    return Boolean(this.publicMember?.access.get() && !this.publicMember?.origAccess);
   }
 
   private _buildAllMembers(): IEditableMember[] {

--- a/app/client/ui/UserManager.ts
+++ b/app/client/ui/UserManager.ts
@@ -17,6 +17,7 @@ import pick = require('lodash/pick');
 
 import {ACIndexImpl, normalizeText} from 'app/client/lib/ACIndex';
 import {copyToClipboard} from 'app/client/lib/clipboardUtils';
+import {markdown} from 'app/client/lib/markdown';
 import {setTestState} from 'app/client/lib/testState';
 import {buildMultiUserManagerModal} from 'app/client/lib/MultiUserManager';
 import {ACUserItem, buildACMemberEmail} from 'app/client/lib/ACUserManager';
@@ -44,6 +45,8 @@ import {confirmModal, cssAnimatedModal, cssModalBody, cssModalButtons, cssModalT
         IModalControl, modal} from 'app/client/ui2018/modals';
 
 const t = makeT('UserManager');
+
+type ACCEPTED_WARNINGS = "self-removal" | "public-sharing";
 
 export interface IUserManagerOptions {
   permissionData: Promise<PermissionData>;
@@ -80,7 +83,7 @@ async function getModel(options: IUserManagerOptions): Promise<UserManagerModelI
 export function showUserManagerModal(userApi: UserAPI, options: IUserManagerOptions) {
   const modelObs: Observable<UserManagerModel|null|"slow"> = observable(null);
 
-  async function onConfirm(ctl: IModalControl) {
+  async function onConfirm(ctl: IModalControl, acceptedWarnings = new Set<ACCEPTED_WARNINGS>()) {
     const model = modelObs.get();
     if (!model || model === "slow") {
       ctl.close();
@@ -104,11 +107,12 @@ export function showUserManagerModal(userApi: UserAPI, options: IUserManagerOpti
         reportError(err);
       }
     };
-    if (model.isSelfRemoved.get()) {
-      const resourceType = resourceName(model.resourceType);
+    const resourceType = resourceName(model.resourceType);
+    if (model.isSelfRemoved.get() && !acceptedWarnings.has("self-removal")) {
       confirmModal(
         t(`You are about to remove your own access to this {{resourceType}}`, { resourceType }),
-        t('Remove my access'), tryToSaveChanges,
+        t('Remove my access'),
+        () => onConfirm(ctl, new Set([...acceptedWarnings, "self-removal"])),
         {
           explanation: (
             t(`Once you have removed your own access, \
@@ -117,9 +121,25 @@ from someone else with sufficient access to the {{resourceType}}.`, { resourceTy
           ),
         }
       );
-    } else {
-      tryToSaveChanges().catch(reportError);
+      return;
     }
+    if (model.goingToSharePublicly() && !acceptedWarnings.has("public-sharing")) {
+      confirmModal(
+        t(`Verify your sensitive data before sharing publicly`),
+        t('Share it publicly'),
+        () => onConfirm(ctl, new Set([...acceptedWarnings, "public-sharing"])),
+        {
+          explanation: (
+            markdown(t(`Your {{resourceType}} will be accessible to anyone \
+with the link, including those who have found your document through a search engine. \
+\n\nCarefully check that your {{resourceType}} does not contain sensitive data.`,
+              { resourceType }))),
+        }
+      );
+      return;
+
+    }
+    tryToSaveChanges().catch(reportError);
   }
 
   // Get the model and assign it to the observable. Report errors to the app.


### PR DESCRIPTION
## Context

The user may not understand the consequences of sharing publicly a resource, especially a doc.

## Proposed solution

This confirmation dialog is meant to ask them to be sure the document does not contain sensitive data before sharing.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
