### PR TITLE
feature(webhook): Add remove event type

### DIFF
--- a/app/client/ui/WebhookPage.ts
+++ b/app/client/ui/WebhookPage.ts
@@ -58,7 +58,7 @@ const WEBHOOK_COLUMNS = [
     widgetOptions: JSON.stringify({
       widget: 'TextBox',
       alignment: 'left',
-      choices: ['add', 'update'],
+      choices: ['add', 'update', 'remove'],
       choiceOptions: {},
     }),
   },

--- a/app/common/Triggers-ti.ts
+++ b/app/common/Triggers-ti.ts
@@ -15,7 +15,7 @@ export const Webhook = t.iface([], {
 export const WebhookFields = t.iface([], {
   "url": "string",
   "authorization": t.opt("string"),
-  "eventTypes": t.array(t.union(t.lit("add"), t.lit("update"))),
+  "eventTypes": t.array(t.union(t.lit("add"), t.lit("update"), t.lit("remove"))),
   "tableId": "string",
   "watchedColIds": t.opt(t.array("string")),
   "enabled": t.opt("boolean"),
@@ -31,7 +31,7 @@ export const WebhookStatus = t.union(t.lit('idle'), t.lit('sending'), t.lit('ret
 export const WebhookSubscribe = t.iface([], {
   "url": "string",
   "authorization": t.opt("string"),
-  "eventTypes": t.array(t.union(t.lit("add"), t.lit("update"))),
+  "eventTypes": t.array(t.union(t.lit("add"), t.lit("update"), t.lit("remove"))),
   "watchedColIds": t.opt(t.array("string")),
   "enabled": t.opt("boolean"),
   "isReadyColumn": t.opt(t.union("string", "null")),
@@ -68,7 +68,7 @@ export const WebhookUpdate = t.iface([], {
 export const WebhookPatch = t.iface([], {
   "url": t.opt("string"),
   "authorization": t.opt("string"),
-  "eventTypes": t.opt(t.array(t.union(t.lit("add"), t.lit("update")))),
+  "eventTypes": t.opt(t.array(t.union(t.lit("add"), t.lit("update"), t.lit("remove")))),
   "tableId": t.opt("string"),
   "watchedColIds": t.opt(t.array("string")),
   "enabled": t.opt("boolean"),

--- a/app/common/Triggers.ts
+++ b/app/common/Triggers.ts
@@ -9,7 +9,7 @@ export interface Webhook {
 export interface WebhookFields {
   url: string;
   authorization?: string;
-  eventTypes: Array<"add"|"update">;
+  eventTypes: Array<"add"|"update"|"remove">;
   tableId: string;
   watchedColIds?: string[];
   enabled?: boolean;
@@ -28,7 +28,7 @@ export type WebhookStatus = 'idle'|'sending'|'retrying'|'postponed'|'error'|'inv
 export interface WebhookSubscribe {
   url: string;
   authorization?: string;
-  eventTypes: Array<"add"|"update">;
+  eventTypes: Array<"add"|"update"|"remove">;
   watchedColIds?: string[];
   enabled?: boolean;
   isReadyColumn?: string|null;
@@ -68,7 +68,7 @@ export interface WebhookUpdate {
 export interface WebhookPatch {
   url?: string;
   authorization?: string;
-  eventTypes?: Array<"add"|"update">;
+  eventTypes?: Array<"add"|"update"|"remove">;
   tableId?: string;
   watchedColIds?: string[];
   enabled?: boolean;

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -3914,7 +3914,7 @@ function testDocApi(settings: {
       await oldSubscribeCheck({eventTypes: 0}, 400, /url is missing/, /eventTypes is not an array/);
       await oldSubscribeCheck({eventTypes: []}, 400, /url is missing/);
       await oldSubscribeCheck({eventTypes: [], url: "https://example.com"}, 400, /eventTypes must be a non-empty array/);
-      await oldSubscribeCheck({eventTypes: ["foo"], url: "https://example.com"}, 400, /eventTypes\[0] is none of "add", "update"/);
+      await oldSubscribeCheck({eventTypes: ["foo"], url: "https://example.com"}, 400, /eventTypes\[0] is none of "add", "update", "remove"/);
       await oldSubscribeCheck({eventTypes: ["add"]}, 400, /url is missing/);
       await oldSubscribeCheck({eventTypes: ["add"], url: "https://evil.com"}, 403, /Provided url is forbidden/);
       await oldSubscribeCheck({eventTypes: ["add"], url: "http://example.com"}, 403, /Provided url is forbidden/);  // not https
@@ -3935,7 +3935,7 @@ function testDocApi(settings: {
         400, /eventTypes must be a non-empty array/);
       await postWebhookCheck({webhooks:[{fields: {tableId: "Table1", eventTypes: ["foo"],
               url: "https://example.com"}}]},
-        400, /eventTypes\[0] is none of "add", "update"/);
+        400, /eventTypes\[0] is none of "add", "update", "remove"/);
       await postWebhookCheck({webhooks:[{fields: {tableId: "Table1", eventTypes: ["add"]}}]},
         400, /url is missing/);
       await postWebhookCheck({webhooks:[{fields: {tableId: "Table1", eventTypes: ["add"],
@@ -4411,7 +4411,7 @@ function testDocApi(settings: {
       const {data, status} = await axios.post(
         `${serverUrl}/api/docs/${docId}/tables/${options?.tableId ?? 'Table1'}/_subscribe`,
         {
-          eventTypes: options?.eventTypes ?? ['add', 'update'],
+          eventTypes: options?.eventTypes ?? ['add', 'update', 'remove'],
           url: `${serving.url}/${endpoint}`,
           isReadyColumn: options?.isReadyColumn === undefined ? 'B' : options?.isReadyColumn,
           ...pick(options, 'name', 'memo', 'enabled', 'watchedColIds'),
@@ -4993,7 +4993,7 @@ function testDocApi(settings: {
 
         // Webhook with only one watchedColId.
         const webhook1 = await autoSubscribe('200', docId, {
-          watchedColIds: ['A'], eventTypes: ['add', 'update']
+          watchedColIds: ['A'], eventTypes: ['add', 'update', 'remove']
         });
         successCalled.reset();
         // Create record, that will call the webhook.
@@ -5046,7 +5046,7 @@ function testDocApi(settings: {
               url: `${serving.url}/200`,
               authorization: '',
               unsubscribeKey: first.unsubscribeKey,
-              eventTypes: ['add', 'update'],
+              eventTypes: ['add', 'update', 'remove'],
               enabled: true,
               isReadyColumn: 'B',
               tableId: 'Table1',
@@ -5065,7 +5065,7 @@ function testDocApi(settings: {
               url: `${serving.url}/404`,
               authorization: '',
               unsubscribeKey: second.unsubscribeKey,
-              eventTypes: ['add', 'update'],
+              eventTypes: ['add', 'update', 'remove'],
               enabled: true,
               isReadyColumn: 'B',
               tableId: 'Table1',
@@ -5511,9 +5511,9 @@ function testDocApi(settings: {
           await check({tableId: 'Santa'}, 404, `Table not found "Santa"`);
           await check({tableId: 'Table2', isReadyColumn: 'Foo', watchedColIds: []}, 200);
 
-          await check({eventTypes: ['add', 'update']}, 200);
+          await check({eventTypes: ['add', 'update', 'remove']}, 200);
           await check({eventTypes: []}, 400, "eventTypes must be a non-empty array");
-          await check({eventTypes: ["foo"]}, 400, /eventTypes\[0] is none of "add", "update"/);
+          await check({eventTypes: ["foo"]}, 400, /eventTypes\[0] is none of "add", "update", "remove"/);
 
           await check({isReadyColumn: null}, 200);
           await check({isReadyColumn: "bar"}, 404, `Column not found "bar"`);

--- a/test/server/lib/Webhooks-Proxy.ts
+++ b/test/server/lib/Webhooks-Proxy.ts
@@ -197,7 +197,7 @@ describe('Webhooks-Proxy', function () {
         const {data, status} = await axios.post(
           `${serverUrl}/api/docs/${docId}/tables/${options?.tableId ?? 'Table1'}/_subscribe`,
           {
-            eventTypes: options?.eventTypes ?? ['add', 'update'],
+            eventTypes: options?.eventTypes ?? ['add', 'update', 'remove'],
             url: `${serving.url}/${endpoint}`,
             isReadyColumn: options?.isReadyColumn === undefined ? 'B' : options?.isReadyColumn
           }, chimpy


### PR DESCRIPTION
## Context

It adds the possibility to register webhook for deleted rows.

## Proposed solution

I add the event type "removed", uncomment some existing work about it. 
I need to add "workaround" because TableColValues seems to be "created" from Database query.
But, it not works for delete rows because it no longer exists on database, so I need to append the data from TableDelta for each row id removed.

Feel free to purpose any other better solution for this.

## Related issues

- https://github.com/gristlabs/grist-core/issues/949

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
