### PR TITLE
Allow custom CSS in forms

### DIFF
--- a/app/client/formMain.ts
+++ b/app/client/formMain.ts
@@ -2,4 +2,7 @@ import {createPage} from 'app/client/ui/createPage';
 import {FormPage} from 'app/client/ui/FormPage';
 import {dom} from 'grainjs';
 
-createPage(() => dom.create(FormPage), {disableTheme: true});
+createPage(() => {
+  document.documentElement.setAttribute('data-grist-form', '');
+  return dom.create(FormPage);
+}, {disableTheme: true});

--- a/static/form.html
+++ b/static/form.html
@@ -8,6 +8,7 @@
   <!-- INSERT BASE -->
   <link rel="icon" type="image/x-icon" href="icons/favicon.png" />
   <link rel="stylesheet" href="icons/icons.css">
+  <!-- INSERT CUSTOM -->
   <title>Grist Form<!-- INSERT TITLE SUFFIX --></title>
 </head>
 <body>


### PR DESCRIPTION
## Context

Form pages do not support custom CSS because they lack the placeholder comment that is
replaced with a link to a custom stylesheet (when `APP_STATIC_INCLUDE_CUSTOM_CSS` is set).

## Proposed solution

Add the missing placeholder comment to `form.html`, and a `data-grist-form` CSS data attribute
to form pages.

## Has this been tested?

Tested manually.
