### PR TITLE
Trigger rowHeightChange after Marked loads

### DIFF
--- a/app/client/widgets/MarkdownTextBox.ts
+++ b/app/client/widgets/MarkdownTextBox.ts
@@ -29,7 +29,11 @@ export class MarkdownTextBox extends NTextBox {
           }
         }),
         dom.onMatch('a', 'click', (ev, el) => handleGristLinkClick(ev as MouseEvent, el as HTMLAnchorElement)),
-        dom.domComputed(valueObs, value => renderCellMarkdown(String(value))),
+        dom.domComputed(valueObs, value => renderCellMarkdown(String(value), {
+          onMarkedResolved: () => {
+            this.field.viewSection().events.trigger('rowHeightChange');
+          },
+        })),
       )
     );
   }


### PR DESCRIPTION
## Context

This fixes a rendering bug in Markdown cells where the row height is not correctly initialized, causing each cell's content to potentially appear cutoff.

The reason for this is that `Marked` is loaded asynchronously on the first call to render Markdown, meaning rendering itself is an asynchronous operation. Since loading `Marked` takes some time, we need to trigger a row height change event after so that the row height reflects the rendered Markdown in the cell.

## Proposed solution

Adding an optional `onMarkedResolved` callback to `renderCellMarkdown` that's called when `Marked` is first loaded and triggers a row height change.

## Has this been tested?

Tested manually by reloading a page containing Markdown cells and confirming row heights are updated to fit the rendered Markdown values.
