### PR TITLE
fix: wrong fs type

### DIFF
--- a/sandbox/gvisor/run.py
+++ b/sandbox/gvisor/run.py
@@ -56,12 +56,12 @@ mounts = [             # These will be filled in more fully programmatically bel
   {
     "destination": "/proc",  # gvisor virtualizes /proc
     "source": "/proc",
-    "type": "/procfs"
+    "type": "proc"
   },
   {
     "destination": "/sys",  # gvisor virtualizes /sys
     "source": "/sys",
-    "type": "/sysfs",
+    "type": "sysfs",
     "options": [
       "nosuid",
       "noexec",


### PR DESCRIPTION
## Context

When upgrading gvisor and building runsc with a more recent go stdlib it fails.
After some investigation with @jonathanperret we discover that the culprit is the OCI configuration generated
by `sandbox/gvisor/run.py`.
The mount points seems to no be listable by upgraded runsc.
So `/usr/bin/python3.x` is reported as  `no such file or directory` when a command is sent to the gvisor sandbox.

## Proposed solution

Change the OCI config so the `python3.xx` can be listed and executed by upgraded gvisor.
And also that the config can be backward compatible with current version of gvisor used in docker community images and in gristlabs SaaS ones.
At least the time of migrating to a newer version.

A consensus found in discussion with @paulfitz is to expose entirely `/usr/bin`.

Some more fixes to be complient withOCI documentation will be add and documented as long as this PR evolved

## Related issues

None till this day

## Has this been tested?

If everything works CI should still pass without more tests.
Gvisor old or new should be spawned and run a command.

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
