### PR TITLE
GranularAccess: add `_grist_Pages` to STRUCTURAL_TABLES

### DIFF
--- a/app/server/lib/GranularAccess.ts
+++ b/app/server/lib/GranularAccess.ts
@@ -88,7 +88,7 @@ function isAddOrUpdateRecordAction([actionName]: UserAction): boolean {
 const STRUCTURAL_TABLES = new Set(['_grist_Tables', '_grist_Tables_column', '_grist_Views',
                                    '_grist_Views_section', '_grist_Views_section_field',
                                    '_grist_ACLResources', '_grist_ACLRules',
-                                   '_grist_Shares']);
+                                   '_grist_Shares', '_grist_Pages']);
 
 // Actions that won't be allowed (yet) for a user with nuanced access to a document.
 // A few may be innocuous, but that hasn't been figured out yet.

--- a/app/server/lib/GranularAccess.ts
+++ b/app/server/lib/GranularAccess.ts
@@ -1156,7 +1156,7 @@ export class GranularAccess implements GranularAccessForBundle {
     }
 
     for (const tableId of STRUCTURAL_TABLES) {
-      censor.apply(tables[tableId]);
+      censor.filter(tables[tableId]);
     }
     if (await this.needAttachmentControl(docSession)) {
       // Attachments? No attachments here (whistles innocently).
@@ -2423,7 +2423,7 @@ export class GranularAccess implements GranularAccessForBundle {
                                       ruler.ruleCollection,
                                       step.metaAfter,
                                       await this.hasAccessRulesPermission(cursor.docSession));
-    if (censor.apply(act)) {
+    if (censor.filter(act)) {
       results.push(act);
     }
 
@@ -3172,21 +3172,17 @@ export class CensorshipInfo {
     }
   }
 
-  public apply(a: DataAction) {
-    const tableId = getTableId(a);
-    if (!STRUCTURAL_TABLES.has(tableId)) { return true; }
-    return this.filter(a);
-  }
-
   public filter(a: DataAction) {
     const tableId = getTableId(a);
-    if (!(tableId in this.censored)) {
+    if (['_grist_ACLResources', '_grist_ACLRules', '_grist_Shares'].includes(tableId)) {
       if (!this._canViewACLs && a[0] === 'TableData') {
         a[2] = [];
         a[3] = {};
       }
       return this._canViewACLs;
     }
+    if (!(tableId in this.censored)) { return true; }
+
     const rec = new RecordEditor(a, undefined, true);
     const method = getCensorMethod(getTableId(a));
     const censoredRows = (this.censored as any)[tableId] as Set<number>;
@@ -3214,12 +3210,6 @@ function getCensorMethod(tableId: string): (rec: RecordEditor) => void {
         .set('formula', '').set('type', 'Any').set('parentId', 0);
     case '_grist_Views_section_field':
       return rec => rec.set('widgetOptions', '').set('filter', '').set('parentId', 0);
-    case '_grist_ACLResources':
-      return rec => rec;
-    case '_grist_ACLRules':
-      return rec => rec;
-    case '_grist_Shares':
-      return rec => rec;
     case '_grist_Cells':
         return rec => rec.set('content', [GristObjCode.Censored]).set('userRef', '');
     default:


### PR DESCRIPTION
When we have a published form, new rules need to be evaluated for it. In particular, for users that are not owners of a document, the code eventually lands [here](https://github.com/gristlabs/grist-core/blob/bd27dcfaa16cec8b541baf30ca9848692a8fb255/app/common/ACLRulesReader.ts#L218):

```typescript
    const pages = this.docData.getMetaTable('_grist_Pages').filterRecords({
      shareRef: share.id,
    });
```

Here `this.docData` gets populated up higher in the call stack right [here](https://github.com/gristlabs/grist-core/blob/bd27dcfaa16cec8b541baf30ca9848692a8fb255/app/server/lib/GranularAccess.ts#L2251-L2260):

```typescript
    const metaDocData = new DocData(
      async (tableId) => {
        const result = this._docData.getTable(tableId)?.getTableDataAction();
        if (!result) { throw new Error('surprising load'); }
        return {tableData: result};
      },
      null,
    );
    // Read the structural tables.
    await Promise.all([...STRUCTURAL_TABLES].map(tableId => metaDocData.syncTable(tableId)));
```

During this permission for an editor trying to remove conditional rules, therefore, if there is a published form, we end up going through the codepath above.

Before this change, however, there was no `_grist_Pages` defined, so we end up throwing an exception in the first code block above when trying to evaluate this rule.

This exception gets swallowed [here](https://github.com/gristlabs/grist-core/blob/bd27dcfaa16cec8b541baf30ca9848692a8fb255/app/common/ACLRuleCollection.ts#L190-L201):

```typescript
  public async update(docData: DocData, options: ReadAclOptions) {
    this.ruleError = undefined;
    try {
      await this.updateWithExceptions(docData, options);
    } catch (e) {
      this.ruleError = e;  // Report the error indirectly.
      await this.updateWithExceptions(docData, {
        ...options,
        emergency: true,
      });
    }
  }
```

which ends up updating the current rule evaluation with [the emergency rules](https://github.com/gristlabs/grist-core/blob/bd27dcfaa16cec8b541baf30ca9848692a8fb255/app/common/ACLRuleCollection.ts#L101): only the document owner has any permissions for this user action.

A test is included which failed before adding this change and passes now.