### PR TITLE
make HomeDBManager.getDocAccess do something reasonable for unsaved docs

### DIFF
--- a/app/server/lib/DocClients.ts
+++ b/app/server/lib/DocClients.ts
@@ -5,7 +5,6 @@
 
 import {VisibleUserProfile} from 'app/common/ActiveDocAPI';
 import {CommDocEventType, CommDocUserPresenceUpdate, CommMessage} from 'app/common/CommTypes';
-import {parseUrlId} from 'app/common/gristUrls';
 import {arrayRemove} from 'app/common/gutil';
 import * as roles from 'app/common/roles';
 import {getRealAccess} from 'app/common/UserAPI';
@@ -226,14 +225,6 @@ export class DocClients {
 
     // Not enough information - no useful data to be had here.
     if (!homeDb || !docId || !authCache) {
-      return {};
-    }
-
-    // TODO - This prevents an error in tests + any installation where anonymous users can create docs.
-    //        HomeDBManager.getDocAccess can't (as of 2025-08-22) handle ids in the format
-    //        'new~12345', and throws an error.
-    const parsedId = parseUrlId(docId);
-    if (parsedId.trunkId === 'new' || parsedId.forkId) {
       return {};
     }
 


### PR DESCRIPTION
Unsaved documents created by the anonymous user don't have the usual mechanism of access control, and if you look them up in the database, you won't find anything. Anyone with the URL can access them, they are protected only by a hard to guess ID in the URL. This commit updates getDocAccess() to return something moderately sensible for this case, since the user presence work now exercises the bulk access call more broadly. The getDoc() method for checking the access of an individual user already has special logic for this case.
