### PR TITLE
Enables snapshot external storage provider by default

### DIFF
--- a/app/server/lib/AttachmentStoreProvider.ts
+++ b/app/server/lib/AttachmentStoreProvider.ts
@@ -152,9 +152,9 @@ export async function makeTempFilesystemStoreSpec(
 }
 
 const settings = appSettings.section("attachmentStores");
-const GRIST_EXTERNAL_ATTACHMENTS_MODE = settings.flag("mode").readString({
+const GRIST_EXTERNAL_ATTACHMENTS_MODE = settings.flag("mode").requireString({
   envVar: "GRIST_EXTERNAL_ATTACHMENTS_MODE",
-  defaultValue: "none",
+  defaultValue: "snapshots",
 });
 
 export function getConfiguredStandardAttachmentStore(): string | undefined {
@@ -173,10 +173,10 @@ export async function getConfiguredAttachmentStoreConfigs(): Promise<IAttachment
     const snapshotProvider = create.getAttachmentStoreOptions().snapshots;
     // This shouldn't happen - it could only happen if a version of Grist removes the snapshot provider from ICreate.
     if (snapshotProvider === undefined) {
-      throw new Error("Snapshot provider is not available on this version of Grist");
+      return [];
     }
     if (!(await isAttachmentStoreOptionAvailable(snapshotProvider))) {
-      throw new Error("The currently configured external storage does not support attachments");
+      return [];
     }
     return [{
       label: 'snapshots',


### PR DESCRIPTION
## Context

Currently no external storage is enabled by default. This hinders both discovery of the feature, and getting it "put through its paces" by the wider Grist community.

## Proposed solution

This enables external attachments in 'snapshot' mode by default. If a Grist installation has an external storage configured (e.g. S3, MinIO) for snapshots, it will also enable that to be used for attachments. 

Two checks were changed from throwing startup errors to silent defaults. The checks made sense under the assumption that Grist has been misconfigured if 'snapshots' external storage was specified, and no storage configured / available.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
