### PR TITLE
Show ellipsis for long workspace names

### DIFF
--- a/app/client/ui/DocList.ts
+++ b/app/client/ui/DocList.ts
@@ -595,9 +595,6 @@ const cssDocName = styled(stretchedLink, `
   font-size: 14px;
   flex: 0 1 auto;
   padding: 5px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   color: ${theme.text};
   font-weight: 600;
 

--- a/app/client/ui2018/stretchedLink.ts
+++ b/app/client/ui2018/stretchedLink.ts
@@ -8,6 +8,10 @@
 import {styled} from 'grainjs';
 
 export const stretchedLink = styled('a', `
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
   &::after {
     position: absolute;
     inset: 0;


### PR DESCRIPTION
## Context

Long workspace names in the home left panel that overflow their container don't show an overflow ellipsis.

## Proposed solution

Set `overflow`, `text-overflow`, and `whitespace` CSS rules on all stretched links.

## Has this been tested?

Manually.
