### PR TITLE
Auto-revert setAndSave on failure

### DIFF
--- a/app/client/models/modelUtil.js
+++ b/app/client/models/modelUtil.js
@@ -24,8 +24,14 @@ function addSaveInterface(observable, saveFunc) {
     return this.saveOnly(this.peek());
   };
   observable.setAndSave = function(value) {
+    const previousValue = this.peek();
     this(value);
-    return this.saveOnly(value);
+    return this.saveOnly(value).catch((e) => {
+      if (this.peek() === value) {
+        this(previousValue);
+      }
+      throw e;
+    });
   };
   return observable;
 }

--- a/app/client/ui/ColumnTitle.ts
+++ b/app/client/ui/ColumnTitle.ts
@@ -118,7 +118,7 @@ function buildColumnRenamePopup(ctrl: IOpenController, options: IColumnTitleOpti
   const saveColumnDesc = async () => {
     const newDesc = editedDesc.get()?.trim() ?? '';
     if (newDesc !== field.description.peek()) {
-      await field.description.saveOnly(newDesc);
+      await field.description.setAndSave(newDesc);
     }
   };
 

--- a/app/client/ui/DescriptionConfig.ts
+++ b/app/client/ui/DescriptionConfig.ts
@@ -34,11 +34,13 @@ export function buildDescriptionConfig(
     cssLabel(t("DESCRIPTION")),
     cssRow(
       editor = cssTextArea(fromKo(description),
-        { onInput: false },
+        {
+          onInput: false,
+          save: async (value) => {
+            await description.setAndSave(value);
+          },
+        },
         { rows: '3' },
-        dom.on('blur', async (e, elem) => {
-          await description.saveOnly(elem.value);
-        }),
         testId(`${options.testPrefix}-description`),
         autoGrow(fromKo(description))
       )

--- a/app/client/ui/FieldConfig.ts
+++ b/app/client/ui/FieldConfig.ts
@@ -34,7 +34,7 @@ export function buildNameConfig(
   const editedLabel = Observable.create(owner, '');
   const editableColId = Computed.create(owner, editedLabel, (use, edited) =>
     '$' + (edited ? sanitizeIdent(edited) : use(origColumn.colId)));
-  const saveColId = (val: string) => origColumn.colId.saveOnly(val.startsWith('$') ? val.slice(1) : val);
+  const saveColId = (val: string) => origColumn.colId.setAndSave(val.startsWith('$') ? val.slice(1) : val);
 
   const isSummaryTable = Computed.create(owner, use => Boolean(use(use(origColumn.table).summarySourceTable)));
   // We will listen to cursor position and force a blur event on both the id and
@@ -52,7 +52,7 @@ export function buildNameConfig(
 
   const toggleUntieColId = () => {
     if (!origColumn.disableModify.peek() && !disabled.peek()) {
-      untieColId.saveOnly(!untieColId.peek()).catch(reportError);
+      untieColId.setAndSave(!untieColId.peek()).catch(reportError);
     }
   };
 
@@ -62,7 +62,9 @@ export function buildNameConfig(
       dom.cls(cssBlockedCursor.className, origColumn.disableModify),
       cssColLabelBlock(
         cssInput(fromKo(origColumn.label),
-          async val => { await origColumn.label.saveOnly(val); editedLabel.set(''); },
+          val => origColumn.label.setAndSave(val)
+            .catch(reportError)
+            .finally(() => editedLabel.set('')),
           dom.on('input', (ev, elem) => { if (!untieColId.peek()) { editedLabel.set(elem.value); } }),
           dom.boolAttr('readonly', use => use(origColumn.disableModify) || use(disabled)),
           testId('field-label'),


### PR DESCRIPTION
## Context

`setAndSave` in `modelUtil.js` was not automatically reverting to the previous value if a save failed. This would lead to inconsistent UI state if a save failed for any reason (e.g. blocked by access rules).

The UI for setting column ID, label, and description was also using a mix of `saveOnly` and `setAndSave`. It now always uses `setAndSave`.

## Proposed solution

Revert to the previous value if the save call in `setAndSave` fails.

## Related issues

#1794

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
