### PR TITLE
Add emails to active user list

### DIFF
--- a/app/client/ui/ActiveUserList.ts
+++ b/app/client/ui/ActiveUserList.ts
@@ -67,7 +67,7 @@ function createRemainingUsersIndicator(users: VisibleUserProfile[], userCount?: 
     menu(
       () => users.map(user => remainingUsersMenuItem(
         createUserImage(user, 'medium'),
-        dom('div', testId('user-list-user-name'), user.name),
+        dom('div', createUsername(user.name), createEmail(user.email)),
         testId('user-list-user')
       )),
       {
@@ -82,11 +82,19 @@ function createRemainingUsersIndicator(users: VisibleUserProfile[], userCount?: 
 }
 
 const createTooltipContent = (user: VisibleUserProfile) => {
-  return [
-    cssUsername(visuallyHidden('Name: '), user.name),
-    cssEmail(visuallyHidden('Email: '), user.email)
-  ];
+  return [createUsername(user.name), createEmail(user.email)];
 };
+
+function createUsername(name: string) {
+  return cssUsername(visuallyHidden('Name: '), dom('span', testId('user-name'), name));
+}
+
+function createEmail(email?: string) {
+  if (!email) {
+    return null;
+  }
+  return cssEmail(visuallyHidden('Email: '), dom('span', testId('user-email'), email));
+}
 
 const cssUsername = styled('div', `
   font-weight: ${tokens.headerControlTextWeight};

--- a/app/client/ui/ActiveUserList.ts
+++ b/app/client/ui/ActiveUserList.ts
@@ -4,10 +4,10 @@ import {hoverTooltip} from 'app/client/ui/tooltips';
 import {createUserImage, cssUserImage} from 'app/client/ui/UserImage';
 import {isXSmallScreenObs, theme} from 'app/client/ui2018/cssVars';
 import {menu} from 'app/client/ui2018/menus';
+import {visuallyHidden} from 'app/client/ui2018/visuallyHidden';
 import {VisibleUserProfile} from 'app/common/ActiveDocAPI';
 import {nativeCompare} from 'app/common/gutil';
-import {FullUser} from 'app/common/LoginSessionAPI';
-import {components} from 'app/common/ThemePrefs';
+import {components, tokens} from 'app/common/ThemePrefs';
 import {getGristConfig} from 'app/common/urlUtils';
 
 import {dom, domComputed, DomElementArg, makeTestId, styled} from 'grainjs';
@@ -22,8 +22,6 @@ export function buildActiveUserList(userPresenceModel: UserPresenceModel) {
     const users = userProfiles
       .slice()
       .sort(compareUserProfiles)
-      // Need to delete id as it's incompatible with createUserImage's parameters.
-      .map(userProfile => ({...userProfile, id: undefined }))
       // Limits the display to avoid overly long lists on public documents.
       .slice(0, maxUsers);
 
@@ -48,17 +46,17 @@ export function buildActiveUserList(userPresenceModel: UserPresenceModel) {
   });
 }
 
-function createUserIndicator(user: Partial<FullUser>, options = { overlapLeft: false }) {
+function createUserIndicator(user: VisibleUserProfile, options = { overlapLeft: false }) {
   return createUserListImage(
     user,
-    hoverTooltip(user.name, { key: "topBarBtnTooltip" }),
+    hoverTooltip(createTooltipContent(user), { key: "topBarBtnTooltip" }),
     options.overlapLeft ? createStyledUserImage.cls("-overlapping") : undefined,
     { 'aria-label': `${t('active user')}: ${user.name}`},
     testId('user-icon')
   );
 }
 
-function createRemainingUsersIndicator(users: Partial<FullUser>[], userCount?: number) {
+function createRemainingUsersIndicator(users: VisibleUserProfile[], userCount?: number) {
   const count = userCount ?? users.length;
   return cssRemainingUsersButton(
     cssRemainingUsersImage(
@@ -82,6 +80,21 @@ function createRemainingUsersIndicator(users: Partial<FullUser>[], userCount?: n
     testId('all-users-button')
   );
 }
+
+const createTooltipContent = (user: VisibleUserProfile) => {
+  return [
+    cssUsername(visuallyHidden('Name: '), user.name),
+    cssEmail(visuallyHidden('Email: '), user.email)
+  ];
+};
+
+const cssUsername = styled('div', `
+  font-weight: ${tokens.headerControlTextWeight};
+`);
+
+const cssEmail = styled('div', `
+  font-size: ${tokens.smallFontSize};
+`);
 
 // Flex-direction is reversed to give us the correct overlaps without messing with z-indexes.
 const cssActiveUserList = styled('ul', `

--- a/app/common/ActiveDocAPI.ts
+++ b/app/common/ActiveDocAPI.ts
@@ -355,6 +355,7 @@ export interface AssistantState {
 export interface VisibleUserProfile {
   id: string; // An identifier that uniquely identifies this profile / the other user's session.
   name: string; // Name associated with the user. May be different from their user name, e.g. due to permissions.
+  email?: string;
   picture?: string | null; // URL of the user's picture with unspecified dimensions.
   isAnonymous: boolean; // True if the user isn't logged into an account.
 }

--- a/app/server/lib/DocClients.ts
+++ b/app/server/lib/DocClients.ts
@@ -262,6 +262,7 @@ function getVisibleUserProfileFromDocSession(
   return {
     id: getVisibleUserProfileId(session),
     name: (isAnonymous ? "Anonymous User" : user?.name) || "Unknown User",
+    email: isAnonymous ? undefined : user?.email,
     picture: isAnonymous ? undefined : user?.picture,
     isAnonymous,
   };

--- a/test/nbrowser/ActiveUserList.ts
+++ b/test/nbrowser/ActiveUserList.ts
@@ -72,13 +72,12 @@ describe('ActiveUserList', async function() {
     }, 5000);
   });
 
-  it('shows name on hover', async function() {
+  it('shows name and email on hover', async function() {
     await driver.find('.test-aul-container .test-aul-user-icon').mouseMove();
-    assert.equal(
-      await driver.findWait('.test-tooltip', 1000).getText(),
-      gu.translateUser(User3).name,
-      'name tooltip not opened'
-    );
+    const tooltipText = await driver.findWait('.test-tooltip', 1000).getText();
+    const user = gu.translateUser(User3);
+    assert.include(tooltipText, user.name, 'name not in tooltip');
+    assert.include(tooltipText, user.email, 'email not in tooltip');
   });
 
   it('shows a remaining users icon with many users', async function() {

--- a/test/nbrowser/ActiveUserList.ts
+++ b/test/nbrowser/ActiveUserList.ts
@@ -92,7 +92,7 @@ describe('ActiveUserList', async function() {
   it('shows a list of all users when button is clicked', async function() {
     await driver.find('.test-aul-all-users-button').click();
     const menuItemTexts = await gu.findOpenMenuAllItems(
-      '.test-aul-user-list-user-name', async (item) => item.getText()
+      '.test-aul-user-name', async (item) => item.getText()
     );
     assert.isFalse(menuItemTexts.length < USER_PRESENCE_MAX_USERS, 'not all users in user list');
     assert.isFalse(menuItemTexts.length > USER_PRESENCE_MAX_USERS, 'max users not enforced');

--- a/test/server/lib/UserPresence.ts
+++ b/test/server/lib/UserPresence.ts
@@ -110,6 +110,7 @@ describe('UserPresence', function() {
       makeJoinerClient: () => getWebsocket(owner),
       expectedProfile: {
         name: Users.owner.name,
+        email: Users.owner.email,
         picture: null,
         isAnonymous: false,
       }
@@ -142,7 +143,8 @@ describe('UserPresence', function() {
       await joiningClient.openDocOnConnect(docId);
 
       const joinMessage = await waitForDocUserPresenceUpdateMessage(observerClient);
-      assert.deepInclude(joinMessage.data.profile, testCase.expectedProfile);
+      const expectedProfile = {...testCase.expectedProfile, id: joinMessage.data.profile.id};
+      assert.deepStrictEqual(joinMessage.data.profile, expectedProfile);
 
       await closeClient(joiningClient);
 


### PR DESCRIPTION
## Context

It's impossible to tell users apart in the active user list if they have the same name. 

## Proposed solution

This adds emails to the tooltip for the active user list, and to the dropdown user list.

## Related issues

#1757 

## Has this been tested?

- [X] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<img width="326" height="178" alt="2025-09-02_14-29 - User Presence Email" src="https://github.com/user-attachments/assets/03976a98-510e-4770-b122-ae165cefd566" />
<img width="435" height="401" alt="2025-09-02_14-29 - User Presence Email Menu" src="https://github.com/user-attachments/assets/4e6be98a-5508-4ebb-aa95-f881509d6bea" />


