### PR TITLE
Removing beta tag from document comparison feature

### DIFF
--- a/app/client/ui/DocHistory.ts
+++ b/app/client/ui/DocHistory.ts
@@ -8,7 +8,7 @@ import {buildConfigContainer} from 'app/client/ui/RightPanelUtils';
 import {buttonSelect} from 'app/client/ui2018/buttonSelect';
 import {testId, theme, vars} from 'app/client/ui2018/cssVars';
 import {icon} from 'app/client/ui2018/icons';
-import {menu, menuAnnotate, menuItemLink} from 'app/client/ui2018/menus';
+import {menu, menuItemLink} from 'app/client/ui2018/menus';
 import {buildUrlId, parseUrlId} from 'app/common/gristUrls';
 import {StringUnion} from 'app/common/StringUnion';
 import {DocSnapshot} from 'app/common/UserAPI';
@@ -111,10 +111,8 @@ export class DocHistory extends Disposable implements IDomComponent {
             cssMenuDots(icon('Dots'),
               menu(() => [
                   menuItemLink(setLink(snapshot), t("Open Snapshot")),
-                  menuItemLink(setLink(snapshot, origUrlId), t("Compare to Current"),
-                    menuAnnotate(t("Beta"))),
-                  prevSnapshot && menuItemLink(setLink(prevSnapshot, snapshot.docId), t("Compare to Previous"),
-                    menuAnnotate(t("Beta"))),
+                  menuItemLink(setLink(snapshot, origUrlId), t("Compare to Current")),
+                  prevSnapshot && menuItemLink(setLink(prevSnapshot, snapshot.docId), t("Compare to Previous")),
                 ],
                 {placement: 'bottom-end', parentSelectorToMark: '.' + cssSnapshotCard.className}
               ),

--- a/app/client/ui/ShareMenu.ts
+++ b/app/client/ui/ShareMenu.ts
@@ -19,7 +19,6 @@ import {mediaXSmall, testId, theme} from 'app/client/ui2018/cssVars';
 import {icon} from 'app/client/ui2018/icons';
 import {
   menu,
-  menuAnnotate,
   menuDivider,
   menuIcon,
   menuItem,
@@ -232,7 +231,6 @@ function menuOriginal(doc: Document, pageModel: DocPageModel, options: MenuOrigi
       testId('replace-original'),
     ),
     isTutorialFork ? null : menuItemLink(compareHref, {target: '_blank'}, t("Compare to {{termToUse}}", {termToUse}),
-      menuAnnotate('Beta'),
       dom.on('click', () => { pageModel.clearUnsavedChanges(); }),
       testId('compare-original'),
     ),


### PR DESCRIPTION
## Context
"Compare with Original" / "Compare with Current Version" is no longer marked as a beta feature.

## Has this been tested?
manual tests only