### PR TITLE
Enable comments announcement in grist-core

### DIFF
--- a/app/client/ui/GristTooltips.ts
+++ b/app/client/ui/GristTooltips.ts
@@ -464,6 +464,6 @@ data.")),
       ),
       ...args,
     ),
-    deploymentTypes: ['saas', 'enterprise'],
+    deploymentTypes: ['saas', 'core', 'enterprise', 'electron'],
   },
 };


### PR DESCRIPTION
## Context

A CI test for a new comments announcement popup began failing after a sync from the private Grist repo. On further investigation, the popup was not configured to appear in some deployment types, including grist-core.

## Proposed solution

Show the popup in all deployment types.

## Has this been tested?

CI tests should pass now
