### PR TITLE
Fix pyodide installation when using yarn with corepack

### DIFF
--- a/sandbox/pyodide/setup.sh
+++ b/sandbox/pyodide/setup.sh
@@ -10,6 +10,7 @@ if [[ ! -e _build/worker ]]; then
   mkdir -p _build/worker
   cd _build/worker
   yarn init --yes
+  touch yarn.lock
   yarn add pyodide@0.23.4
   cd ../..
 fi


### PR DESCRIPTION
## Context

NB: this is a volunteer work, hence I do not commit with my professional email.

When When running `yarn init --yes` then `yarn add <whatever>`, yarn detects that the project root directory as a nodejs project. And then it fails with this error:
```
Usage Error: The nearest package directory (/var/www/grist/sandbox/pyodide/_build/worker) doesn't seem to be part of the project declared in /var/www/grist.

- If /var/www/grist isn't intended to be a project, remove any yarn.lock and/or package.json file there.
- If /var/www/grist is intended to be a project, it might be that you forgot to list sandbox/pyodide/_build/worker in its workspace configuration.
- Finally, if /var/www/grist is fine and you intend sandbox/pyodide/_build/worker to be treated as a completely separate project (not even a workspace), create an empty yarn.lock file in it.
```

Steps to reproduce:
1. Clone the grist-core repository
2. Remove yarn
3. Check that [corepack](https://www.npmjs.com/package/corepack) is installed otherwise install it globally
4. run `yarn install` at the root of the project
5. run `cd sandbox/pyodide` to go to the pyodide directory
6. run `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 make setup` to install pyodide
The `setup.sh` script fails with the error above

## Proposed solution

Fix the issue by creating an empty yarn.lock file

## Related issues

See this issue: https://github.com/YunoHost-Apps/grist_ynh/issues/86#issue-3201542965
And my analysis: https://github.com/YunoHost-Apps/grist_ynh/issues/86#issuecomment-3243317611

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->