### PR TITLE
Changes user presence to only show one icon per user

### DIFF
--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -139,6 +139,7 @@ import {shortDesc} from 'app/server/lib/shortDesc';
 import {TableMetadataLoader} from 'app/server/lib/TableMetadataLoader';
 import {DocTriggers} from 'app/server/lib/Triggers';
 import {fetchURL, FileUploadInfo, globalUploadSet, UploadInfo} from 'app/server/lib/uploads';
+import {UserPresence} from 'app/server/lib/UserPresence';
 import assert from 'assert';
 import {Mutex} from 'async-mutex';
 import * as bluebird from 'bluebird';
@@ -265,6 +266,7 @@ export class ActiveDoc extends EventEmitter {
 
   public isFork: boolean;
 
+  private _userPresence: UserPresence;
   protected _actionHistory: ActionHistory;
   protected _sharing: Sharing;
   // This lock is used to avoid reading sandbox state while it is being modified but before
@@ -423,6 +425,7 @@ export class ActiveDoc extends EventEmitter {
     }
     this.docStorage = new DocStorage(_docManager.storageManager, _docName);
     this.docClients = new DocClients(this);
+    this._userPresence = new UserPresence(this.docClients);
     this._triggers = new DocTriggers(this);
     this._requests = new DocRequests(this);
     this._actionHistory = new ActionHistoryImpl(this.docStorage);
@@ -620,7 +623,8 @@ export class ActiveDoc extends EventEmitter {
   /**
    * Adds a client of this doc to the list of connected clients.
    * @param client: The client object maintaining the websocket connection.
-   * @param docSessionPrecursor: The incomplete docSession, to be filled in and turned into real DocSession.
+   * @param docSessionPrecursor: The incomplete docSession, to be filled in and turned into real
+   *   DocSession.
    * @returns docSession
    */
   public addClient(client: Client, docSessionPrecursor: DocSessionPrecursor): DocSession {
@@ -635,7 +639,7 @@ export class ActiveDoc extends EventEmitter {
   }
 
   public async listActiveUserProfiles(docSession: DocSession): Promise<VisibleUserProfile[]> {
-    return this.docClients.listVisibleUserProfiles(docSession);
+    return this._userPresence.listVisibleUserProfiles(docSession);
   }
 
   /**
@@ -647,14 +651,16 @@ export class ActiveDoc extends EventEmitter {
    *
    * @param [options] Options to customize the shutdown process.
    * @param [options.beforeShutdown] A function to call before shutdown.
-   * NOTE: If a shutdown is already in progress, this callback will be ignored (it would be too late, obviously).
-   * In other words, the first call to this function determines the `beforeShutdown` callback to use
+   * NOTE: If a shutdown is already in progress, this callback will be ignored (it would be too
+   *   late, obviously). In other words, the first call to this function determines the
+   *   `beforeShutdown` callback to use
    * (or none if not provided).
    *
    * @param [options.afterShutdown] A function to call after shutdown.
    * NOTE: Unlike `beforeShutdown`, providing an `afterShutdown` callback will set or overwrite
    * the callback to be called after the shutdown, **even if** it is already in progress.
-   * In other words, the last call to this function determines the `afterShutdown` callback to use when provided.
+   * In other words, the last call to this function determines the `afterShutdown` callback to use
+   *   when provided.
    */
   public async shutdown(options: {
     beforeShutdown?: () => Promise<void>,
@@ -855,9 +861,9 @@ export class ActiveDoc extends EventEmitter {
   }
 
   /**
-   * Finishes import files, creates the new tables, and cleans up temporary hidden tables and uploads.
-   * Param `prevTableIds` is an array of hiddenTableIds as received from previous `importFiles`
-   * call, or empty if there was no previous call.
+   * Finishes import files, creates the new tables, and cleans up temporary hidden tables and
+   * uploads. Param `prevTableIds` is an array of hiddenTableIds as received from previous
+   * `importFiles` call, or empty if there was no previous call.
    */
   public finishImportFiles(docSession: DocSession, dataSource: DataSourceTransformed,
                            prevTableIds: string[], importOptions: ImportOptions): Promise<ImportResult> {
@@ -926,8 +932,8 @@ export class ActiveDoc extends EventEmitter {
   }
 
   /**
-   * This function saves attachments from a given upload and creates an entry for them in the database.
-   * It returns the list of rowIds for the rows created in the _grist_Attachments table.
+   * This function saves attachments from a given upload and creates an entry for them in the
+   * database. It returns the list of rowIds for the rows created in the _grist_Attachments table.
    */
   public async addAttachments(docSession: OptDocSession, uploadId: number): Promise<number[]> {
     const userId = docSession.userId;
@@ -1243,8 +1249,8 @@ export class ActiveDoc extends EventEmitter {
    * Fetches data according to the given query, which includes tableId and filters (see Query in
    * app/common/ActiveDocAPI.ts). The data is fetched from the data engine for regular tables, or
    * from the DocStorage directly for onDemand tables.
-   * @param {Boolean} waitForFormulas: If true, wait for all data to be loaded/calculated.  If false,
-   * special "pending" values may be returned.
+   * @param {Boolean} waitForFormulas: If true, wait for all data to be loaded/calculated.  If
+   *   false, special "pending" values may be returned.
    */
   public async fetchQuery(docSession: OptDocSession, query: ServerQuery,
                           waitForFormulas: boolean = false): Promise<TableFetchResult> {
@@ -1955,10 +1961,10 @@ export class ActiveDoc extends EventEmitter {
    * Check which attachments in the _grist_Attachments metadata are actually used,
    * i.e. referenced by some cell in an Attachments type column.
    * Set timeDeleted to the current time on newly unused attachments,
-   * 'soft deleting' them so that they get cleaned up automatically from _gristsys_Files after enough time has passed.
-   * Set timeDeleted to null on used attachments that were previously soft deleted,
-   * so that undo can 'undelete' attachments.
-   * Returns true if any changes were made, i.e. some row(s) of _grist_Attachments were updated.
+   * 'soft deleting' them so that they get cleaned up automatically from _gristsys_Files after
+   * enough time has passed. Set timeDeleted to null on used attachments that were previously soft
+   * deleted, so that undo can 'undelete' attachments. Returns true if any changes were made, i.e.
+   * some row(s) of _grist_Attachments were updated.
    */
   public async updateUsedAttachmentsIfNeeded() {
     const changes = await this.docStorage.scanAttachmentsForUsageChanges();
@@ -1976,10 +1982,12 @@ export class ActiveDoc extends EventEmitter {
 
   /**
    * Delete unused attachments from _grist_Attachments and gristsys_Files.
-   * @param expiredOnly: if true, only delete attachments that were soft-deleted sufficiently long ago.
-   * @param options.syncUsageToDatabase: if true, schedule an update to the usage column of the docs table, if
-   * any unused attachments were soft-deleted. defaults to true.
-   * @param options.broadcastUsageToClients: if true, broadcast updated doc usage to all clients, if
+   * @param expiredOnly: if true, only delete attachments that were soft-deleted sufficiently long
+   *   ago.
+   * @param options.syncUsageToDatabase: if true, schedule an update to the usage column of the
+   *   docs table, if any unused attachments were soft-deleted. defaults to true.
+   * @param options.broadcastUsageToClients: if true, broadcast updated doc usage to all clients,
+   *   if
    * any unused attachments were soft-deleted. defaults to true.
    */
   public async removeUnusedAttachments(expiredOnly: boolean, options?: UpdateUsageOptions) {
@@ -2122,8 +2130,9 @@ export class ActiveDoc extends EventEmitter {
   /**
    * Send a message to clients connected to the document that something
    * webhook-related has happened (a change in configuration, a delivery,
-   * or an error). It passes information about the type of event (currently data being updated in some way
-   * or an OverflowError, i.e., too many events waiting to be sent). More data may be added when necessary.
+   * or an error). It passes information about the type of event (currently data being updated in
+   * some way or an OverflowError, i.e., too many events waiting to be sent). More data may be
+   * added when necessary.
    */
   public async sendWebhookNotification(type: WebhookMessageType = WebhookMessageType.Update) {
     await this.docClients.broadcastDocMessage(null, 'docChatter', {
@@ -2327,8 +2336,8 @@ export class ActiveDoc extends EventEmitter {
    * @param {Array} actions - The user actions to apply.
    * @param {String} options.desc - Description of the action which overrides the default client
    *  description if provided. Should be used to describe bundled actions.
-   * @param {Int} options.otherId - Action number for the original useraction to which this undo/redo
-   *  action applies.
+   * @param {Int} options.otherId - Action number for the original useraction to which this
+   *   undo/redo action applies.
    * @param {Boolean} options.linkId - ActionNumber of the previous action in an undo/redo bundle.
    * @returns {Promise} Promise that's resolved when all actions are applied successfully to {
    *    actionNum: number of the action that got recorded
@@ -3224,7 +3233,8 @@ export class ActiveDoc extends EventEmitter {
   }
 
   /**
-   * Throw an error if the provided upload would exceed the total attachment filesize limit for this document.
+   * Throw an error if the provided upload would exceed the total attachment filesize limit for
+   * this document.
    */
   private async _assertUploadInfoSizeBelowLimit(upload: UploadInfo) {
     // Minor flaw: while we don't double-count existing duplicate files in the total size,

--- a/app/server/lib/DocClients.ts
+++ b/app/server/lib/DocClients.ts
@@ -49,14 +49,6 @@ export class DocClients extends EventEmitter {
   }
 
   /**
-   * Lists all active doc sessions
-   * @returns {DocSession[]}
-   */
-  public listClients(): DocSession[] {
-    return this._docSessions.slice();
-  }
-
-  /**
    * Adds a client's open file to the list of connected clients.
    */
   public addClient(client: Client, docSessionPrecursor: DocSessionPrecursor): DocSession {

--- a/app/server/lib/DocClients.ts
+++ b/app/server/lib/DocClients.ts
@@ -3,17 +3,14 @@
  * open, and what FD they are using.
  */
 
-import {VisibleUserProfile} from 'app/common/ActiveDocAPI';
-import {CommDocEventType, CommDocUserPresenceUpdate, CommMessage} from 'app/common/CommTypes';
+import {CommDocEventType, CommMessage} from 'app/common/CommTypes';
 import {arrayRemove} from 'app/common/gutil';
-import * as roles from 'app/common/roles';
-import {getRealAccess} from 'app/common/UserAPI';
 import {ActiveDoc} from 'app/server/lib/ActiveDoc';
 import {appSettings} from 'app/server/lib/AppSettings';
 import {Client} from 'app/server/lib/Client';
 import {DocSession, DocSessionPrecursor} from 'app/server/lib/DocSession';
 import {LogMethods} from "app/server/lib/LogMethods";
-import {fromPairs} from 'lodash';
+import EventEmitter from 'events';
 
 const isUserPresenceEnabledByDefault = false;
 export const SETTING_ENABLE_USER_PRESENCE = appSettings.section('userPresence').flag('enable');
@@ -31,19 +28,32 @@ export const Deps = {
   BROADCAST_ORDER: 'parallel' as 'parallel' | 'series',
 };
 
-export class DocClients {
+export type ClientAddedEventListener = (session: DocSession) => void;
+export type ClientRemovedEventListener = (session: DocSession) => void;
+
+export class DocClients extends EventEmitter {
   private _docSessions: DocSession[] = [];
   private _log = new LogMethods('DocClients ', (s: DocSession|null) => this.activeDoc.getLogMeta(s));
 
   constructor(
     public readonly activeDoc: ActiveDoc
-  ) {}
+  ) {
+    super();
+  }
 
   /**
    * Returns the number of connected clients.
    */
   public clientCount(): number {
     return this._docSessions.length;
+  }
+
+  /**
+   * Lists all active doc sessions
+   * @returns {DocSession[]}
+   */
+  public listClients(): DocSession[] {
+    return this._docSessions.slice();
   }
 
   /**
@@ -54,8 +64,12 @@ export class DocClients {
     this._docSessions.push(docSession);
     this._log.debug(docSession, "now %d clients; new client is %s (fd %s)",
       this._docSessions.length, client.clientId, docSession.fd);
-    this._broadcastUserPresenceSessionUpdate(docSession);
+    this._emitClientAdded(docSession);
     return docSession;
+  }
+
+  public addClientAddedListener(listener: ClientAddedEventListener) {
+    this.on('clientAdded', listener);
   }
 
   /**
@@ -70,7 +84,11 @@ export class DocClients {
       this._log.debug(docSession, "now %d clients", this._docSessions.length);
     }
 
-    this._broadcastUserPresenceSessionRemoval(docSession);
+    this._emitClientRemoved(docSession);
+  }
+
+  public addClientRemovedListener(listener: ClientRemovedEventListener) {
+    this.on('clientRemoved', listener);
   }
 
   /**
@@ -81,7 +99,7 @@ export class DocClients {
     const docSessions = this._docSessions.splice(0);
     for (const docSession of docSessions) {
       docSession.client.removeDocSession(docSession.fd);
-      this._broadcastUserPresenceSessionRemoval(docSession);
+      this._emitClientRemoved(docSession);
     }
   }
 
@@ -90,16 +108,6 @@ export class DocClients {
     for (const docSession of this._docSessions) {
       docSession.client.interruptConnection();
     }
-  }
-
-  public async listVisibleUserProfiles(viewingDocSession: DocSession): Promise<VisibleUserProfile[]> {
-    if (isUserPresenceDisabled()) { return []; }
-    const otherDocSessions = this._docSessions.filter(s => s.client.clientId !== viewingDocSession.client.clientId);
-    const docUserRoles = await this._getDocUserRoles();
-    const userProfiles = otherDocSessions.map(
-      s => getVisibleUserProfileFromDocSession(s, viewingDocSession, docUserRoles)
-    );
-    return userProfiles.filter((s?: VisibleUserProfile): s is VisibleUserProfile => s !== undefined);
   }
 
   /**
@@ -177,97 +185,12 @@ export class DocClients {
     }
   }
 
-  private _broadcastUserPresenceSessionUpdate(originSession: DocSession) {
-    if (isUserPresenceDisabled()) { return; }
-    // Loading the doc user roles first allows the callback to be quick + synchronous,
-    // avoiding a potentially linear series of async calls.
-    this._getDocUserRoles()
-      .then(docUserRoles => this.broadcastDocMessage(
-        originSession.client,
-        "docUserPresenceUpdate",
-        undefined,
-        async (destSession: DocSession, messageData: any): Promise<CommDocUserPresenceUpdate["data"] | undefined> => {
-          if (originSession === destSession) { return; }
-          const profile = getVisibleUserProfileFromDocSession(originSession, destSession, docUserRoles);
-          if (!profile) { return; }
-          return {
-            id: getVisibleUserProfileId(originSession),
-            profile
-          };
-        }
-      ))
-      .catch(err => {
-        this._log.error(originSession, "failed to broadcast user presence session update: %s", err);
-      });
+  private _emitClientAdded(session: DocSession) {
+    this.emit('clientAdded', session);
   }
 
-  private _broadcastUserPresenceSessionRemoval(originSession: DocSession) {
-    if (isUserPresenceDisabled()) { return; }
-    this.broadcastDocMessage(
-      originSession.client,
-      "docUserPresenceUpdate",
-      undefined,
-      async (destSession: DocSession, messageData: any): Promise<CommDocUserPresenceUpdate["data"] | undefined> => {
-        return {
-          id: getVisibleUserProfileId(originSession),
-          profile: null,
-        };
-      }
-    ).catch(err => {
-      this._log.error(originSession, "failed to broadcast user presence session removal: %s", err);
-    });
-  }
-
-  private async _getDocUserRoles(): Promise<UserIdRoleMap> {
-    const homeDb = this.activeDoc.getHomeDbManager();
-    const authCache = homeDb?.caches;
-    const docId = this.activeDoc.doc?.id;
-
-    // Not enough information - no useful data to be had here.
-    if (!homeDb || !docId || !authCache) {
-      return {};
-    }
-
-    const queryResult = await authCache.getDocAccess(docId);
-    const { users, maxInheritedRole } = homeDb.unwrapQueryResult(queryResult);
-
-    return fromPairs(users.map(user => [user.id, getRealAccess(user, { maxInheritedRole })]));
+  private _emitClientRemoved(session: DocSession) {
+    this.emit('clientRemoved', session);
   }
 }
 
-interface UserIdRoleMap {
-  [id: string]: roles.Role | null
-}
-
-function getVisibleUserProfileFromDocSession(
-  session: DocSession, viewingSession: DocSession, docUserRoles: UserIdRoleMap,
-): VisibleUserProfile | undefined {
-  // To see other users, you need to be a non-public user (i.e. added to the document), and have
-  // at least editor permissions.
-  if (!viewingSession.client.authSession.userId) {
-    return undefined;
-  }
-
-  const viewerRole = docUserRoles[viewingSession.client.authSession.userId];
-  if (!roles.canEdit(viewerRole)) {
-    return undefined;
-  }
-
-  const user = session.client.authSession.fullUser;
-  const userId = session.client.authSession.userId;
-  const explicitUserRole = userId ? docUserRoles[userId] : null;
-  // Only signed-in users that have explicit document access or are a member of the org / workspace
-  // have visible details by default.
-  const isAnonymous = !explicitUserRole;
-  return {
-    id: getVisibleUserProfileId(session),
-    name: (isAnonymous ? "Anonymous User" : user?.name) || "Unknown User",
-    email: isAnonymous ? undefined : user?.email,
-    picture: isAnonymous ? undefined : user?.picture,
-    isAnonymous,
-  };
-}
-
-function getVisibleUserProfileId(session: DocSession): string {
-  return session.client.publicClientId;
-}

--- a/app/server/lib/UserPresence.ts
+++ b/app/server/lib/UserPresence.ts
@@ -1,0 +1,127 @@
+import {VisibleUserProfile} from 'app/common/ActiveDocAPI';
+import {CommDocUserPresenceUpdate} from 'app/common/CommTypes';
+import * as roles from 'app/common/roles';
+import {getRealAccess} from 'app/common/UserAPI';
+import {DocClients, isUserPresenceDisabled} from 'app/server/lib/DocClients';
+import {DocSession} from 'app/server/lib/DocSession';
+import {LogMethods} from 'app/server/lib/LogMethods';
+
+import {fromPairs} from 'lodash';
+
+export class UserPresence {
+  private _log = new LogMethods('UserPresence ', (s: DocSession|null) => this._activeDoc.getLogMeta(s));
+
+  constructor(private _docClients: DocClients) {
+    this._docClients.addClientAddedListener(this._broadcastUserPresenceSessionUpdate.bind(this));
+    this._docClients.addClientRemovedListener(this._broadcastUserPresenceSessionRemoval.bind(this));
+  }
+
+  public async listVisibleUserProfiles(viewingDocSession: DocSession): Promise<VisibleUserProfile[]> {
+    if (isUserPresenceDisabled()) { return []; }
+    const otherDocSessions =
+      this._docClients.listClients().filter(s => s.client.clientId !== viewingDocSession.client.clientId);
+    const docUserRoles = await this._getDocUserRoles();
+    const userProfiles = otherDocSessions.map(
+      s => getVisibleUserProfileFromDocSession(s, viewingDocSession, docUserRoles)
+    );
+    return userProfiles.filter((s?: VisibleUserProfile): s is VisibleUserProfile => s !== undefined);
+  }
+
+  private _broadcastUserPresenceSessionUpdate(originSession: DocSession) {
+    if (isUserPresenceDisabled()) { return; }
+    // Loading the doc user roles first allows the callback to be quick + synchronous,
+    // avoiding a potentially linear series of async calls.
+    this._getDocUserRoles()
+      .then(docUserRoles => this._docClients.broadcastDocMessage(
+        originSession.client,
+        "docUserPresenceUpdate",
+        undefined,
+        async (destSession: DocSession): Promise<CommDocUserPresenceUpdate["data"] | undefined> => {
+          if (originSession === destSession) { return; }
+          const profile = getVisibleUserProfileFromDocSession(originSession, destSession, docUserRoles);
+          if (!profile) { return; }
+          return {
+            id: getVisibleUserProfileId(originSession),
+            profile
+          };
+        }
+      ))
+      .catch(err => {
+        this._log.error(originSession, "failed to broadcast user presence session update: %s", err);
+      });
+  }
+
+  private _broadcastUserPresenceSessionRemoval(originSession: DocSession) {
+    if (isUserPresenceDisabled()) { return; }
+    this._docClients.broadcastDocMessage(
+      originSession.client,
+      "docUserPresenceUpdate",
+      undefined,
+      async (): Promise<CommDocUserPresenceUpdate["data"] | undefined> => {
+        return {
+          id: getVisibleUserProfileId(originSession),
+          profile: null,
+        };
+      }
+    ).catch(err => {
+      this._log.error(originSession, "failed to broadcast user presence session removal: %s", err);
+    });
+  }
+
+  private async _getDocUserRoles(): Promise<UserIdRoleMap> {
+    const homeDb = this._activeDoc.getHomeDbManager();
+    const authCache = homeDb?.caches;
+    const docId = this._activeDoc.doc?.id;
+
+    // Not enough information - no useful data to be had here.
+    if (!homeDb || !docId || !authCache) {
+      return {};
+    }
+
+    const queryResult = await authCache.getDocAccess(docId);
+    const { users, maxInheritedRole } = homeDb.unwrapQueryResult(queryResult);
+
+    return fromPairs(users.map(user => [user.id, getRealAccess(user, { maxInheritedRole })]));
+  }
+
+  private get _activeDoc() {
+    return this._docClients.activeDoc;
+  }
+}
+
+
+interface UserIdRoleMap {
+  [id: string]: roles.Role | null
+}
+
+function getVisibleUserProfileFromDocSession(
+  session: DocSession, viewingSession: DocSession, docUserRoles: UserIdRoleMap,
+): VisibleUserProfile | undefined {
+  // To see other users, you need to be a non-public user (i.e. added to the document), and have
+  // at least editor permissions.
+  if (!viewingSession.client.authSession.userId) {
+    return undefined;
+  }
+
+  const viewerRole = docUserRoles[viewingSession.client.authSession.userId];
+  if (!roles.canEdit(viewerRole)) {
+    return undefined;
+  }
+
+  const user = session.client.authSession.fullUser;
+  const userId = session.client.authSession.userId;
+  const explicitUserRole = userId ? docUserRoles[userId] : null;
+  // Only signed-in users that have explicit document access or are a member of the org / workspace
+  // have visible details by default.
+  const isAnonymous = !explicitUserRole;
+  return {
+    id: getVisibleUserProfileId(session),
+    name: (isAnonymous ? "Anonymous User" : user?.name) || "Unknown User",
+    picture: isAnonymous ? undefined : user?.picture,
+    isAnonymous,
+  };
+}
+
+function getVisibleUserProfileId(session: DocSession): string {
+  return session.client.publicClientId;
+}

--- a/app/server/lib/UserPresence.ts
+++ b/app/server/lib/UserPresence.ts
@@ -2,6 +2,7 @@ import {VisibleUserProfile} from 'app/common/ActiveDocAPI';
 import {CommDocUserPresenceUpdate} from 'app/common/CommTypes';
 import * as roles from 'app/common/roles';
 import {FullUser, getRealAccess} from 'app/common/UserAPI';
+import {appSettings} from 'app/server/lib/AppSettings';
 import {DocClients, isUserPresenceDisabled} from 'app/server/lib/DocClients';
 import {DocSession} from 'app/server/lib/DocSession';
 import {LogMethods} from 'app/server/lib/LogMethods';
@@ -167,7 +168,16 @@ function getVisibleUserProfileFromDocSession(
   };
 }
 
+const GRIST_USER_PRESENCE_ICON_PER_TAB = Boolean(appSettings.section('userPresence').flag('iconPerTab').readBool({
+  envVar: 'GRIST_USER_PRESENCE_ICON_PER_TAB',
+  defaultValue: false,
+}));
+
 function getIdFromDocSession(session: DocSession): string {
+  // Forces every client to have a unique user presence session. Intended to ease frontend testing.
+  if (GRIST_USER_PRESENCE_ICON_PER_TAB) {
+    return session.client.publicClientId;
+  }
   const authSession = session.client.authSession;
   return (authSession.userIsAuthorized && authSession.userId?.toString()) || session.client.publicClientId;
 }

--- a/app/server/lib/UserPresence.ts
+++ b/app/server/lib/UserPresence.ts
@@ -34,21 +34,8 @@ export class UserPresence {
 
   private _onNewDocSession(docSession: DocSession) {
     const id = getIdFromDocSession(docSession);
-    this._log.debug(null, `Fetching session for ${id}`);
-    this._log.debug(null, `Fetching session for ${id}`);
-    this._log.debug(null, `Fetching session for ${id}`);
-    this._log.debug(null, `Fetching session for ${id}`);
-    this._log.debug(null, `Fetching session for ${id}`);
-    this._log.debug(null, `Fetching session for ${id}`);
-    this._log.debug(null, `Fetching session for ${id}`);
     const _existingPresenceSession = this._presenceSessionsById.get(id);
     if (!_existingPresenceSession) {
-      this._log.debug(null, `Creating session for ${id}`);
-      this._log.debug(null, `Creating session for ${id}`);
-      this._log.debug(null, `Creating session for ${id}`);
-      this._log.debug(null, `Creating session for ${id}`);
-      this._log.debug(null, `Creating session for ${id}`);
-      this._log.debug(null, `Creating session for ${id}`);
       const newPresenceSession = new UserPresenceSession(docSession);
       this._presenceSessionsById.set(id, newPresenceSession);
       this._broadcastUserPresenceSessionUpdate(newPresenceSession);

--- a/test/nbrowser/ActiveUserList.ts
+++ b/test/nbrowser/ActiveUserList.ts
@@ -42,6 +42,8 @@ describe('ActiveUserList', async function() {
     envSnapshot = new EnvironmentSnapshot();
     process.env.GRIST_ENABLE_USER_PRESENCE = 'true';
     process.env.GRIST_USER_PRESENCE_MAX_USERS = USER_PRESENCE_MAX_USERS.toFixed(0);
+    // Allows the same user to have many user presence sessions - needed to make enough icons show.
+    process.env.GRIST_USER_PRESENCE_ICON_PER_TAB = 'true';
     await server.restart();
 
     mainWindow = {


### PR DESCRIPTION
## Context

Currently, user presence shows each session (i.e. tab) as its own user. This means if a user has a doc open in several tabs, they'll show up several times for other users, including themselves.

This bloats the user list significantly, and isn't in line with the behaviour of other platforms.

## Proposed solution

This unifies user presence so that each user shows up as a single icon, regardless of how many times they've opened the document.

This also extracts the user presence logic from "DocClients" into its own class.

## Related issues

#1757 

## Has this been tested?

- [X] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

