### PR TITLE
add limit on API request body size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ Grist can be configured in many ways. Here are the main environment variables it
 | GRIST_MAX_PARALLEL_REQUESTS_PER_DOC| max number of concurrent API requests allowed per document (default is 10, set to 0 for unlimited) |
 | GRIST_MAX_UPLOAD_ATTACHMENT_MB | max allowed size for attachments (0 or empty for unlimited). |
 | GRIST_MAX_UPLOAD_IMPORT_MB | max allowed size for imports (except .grist files) (0 or empty for unlimited). |
+| GRIST_MAX_API_REQUEST_BODY_MB | max allowed size for API request bodies in MB (0 or empty for unlimited, defaults to 1). |
 | GRIST_OFFER_ALL_LANGUAGES | if set, all translated langauages are offered to the user (by default, only languages with a special 'good enough' key set are offered to user). |
 | GRIST_ORG_IN_PATH | if true, encode org in path rather than domain |
 | GRIST_PAGE_TITLE_SUFFIX | a string to append to the end of the `<title>` in HTML documents. Defaults to `" - Grist"`. Set to `_blank` for no suffix at all. |

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -864,6 +864,9 @@ export interface GristLoadConfig {
   // Max upload allowed for attachments, in bytes; 0 or omitted for unlimited.
   maxUploadSizeAttachment?: number;
 
+  // Max allowed size for API request bodies, in bytes; 0 or omitted for unlimited.
+  maxApiRequestBodySize?: number;
+
   // Pre-fetched call to getDoc for the doc being loaded.
   getDoc?: {[id: string]: Document};
 

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1078,7 +1078,8 @@ export class FlexServer implements GristServer {
 
   public addJsonSupport() {
     if (this._check('json')) { return; }
-    this.app.use(express.json({limit: '1mb'}));  // Increase from the default 100kb
+    const limit = process.env.GRIST_MAX_API_REQUEST_BODY_MB ? `${process.env.GRIST_MAX_API_REQUEST_BODY_MB}mb` : '1mb';
+    this.app.use(express.json({limit}));  // Configurable limit, defaulting to 1mb
   }
 
   public addSessions() {

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -35,6 +35,11 @@ import {
 } from "express";
 import pick from "lodash/pick";
 
+function getApiRequestBodyLimit(): string {
+  const limitMB = Number(process.env.GRIST_MAX_API_REQUEST_BODY_MB);
+  return limitMB > 0 ? `${limitMB}mb` : '1mb';  // Default to 1mb if not set or invalid
+}
+
 export interface AttachOptions {
   app: Application;
   gristServer: GristServer;
@@ -136,7 +141,7 @@ export function attachEarlyEndpoints(options: AttachOptions) {
 
   app.patch(
     "/api/install/prefs",
-    json({ limit: "1mb" }),
+    json({ limit: getApiRequestBodyLimit() }),
     expressWrap(async (req, res) => {
       const props = { prefs: req.body };
       const activation = await gristServer.getActivations().current();
@@ -188,7 +193,7 @@ export function attachEarlyEndpoints(options: AttachOptions) {
 
   app.put(
     "/api/install/configs/:key",
-    json({ limit: "1mb", strict: false }),
+    json({ limit: getApiRequestBodyLimit(), strict: false }),
     hasValidConfig,
     expressWrap(async (req, res) => {
       const key = stringParam(req.params.key, "key") as ConfigKey;
@@ -235,7 +240,7 @@ export function attachEarlyEndpoints(options: AttachOptions) {
 
   app.put(
     "/api/orgs/:oid/configs/:key",
-    json({ limit: "1mb", strict: false }),
+    json({ limit: getApiRequestBodyLimit(), strict: false }),
     hasValidConfig,
     expressWrap(async (req, res) => {
       const key = stringParam(req.params.key, "key") as ConfigKey;

--- a/app/server/lib/sendAppPage.ts
+++ b/app/server/lib/sendAppPage.ts
@@ -112,6 +112,7 @@ export function makeGristConfig(options: MakeGristConfigOptions): GristLoadConfi
     helpScoutBeaconId: process.env.HELP_SCOUT_BEACON_ID_V2,
     maxUploadSizeImport: (Number(process.env.GRIST_MAX_UPLOAD_IMPORT_MB) * 1024 * 1024) || undefined,
     maxUploadSizeAttachment: (Number(process.env.GRIST_MAX_UPLOAD_ATTACHMENT_MB) * 1024 * 1024) || undefined,
+    maxApiRequestBodySize: (Number(process.env.GRIST_MAX_API_REQUEST_BODY_MB) * 1024 * 1024) || undefined,
     timestampMs: Date.now(),
     enableWidgetRepository: Boolean(process.env.GRIST_WIDGET_LIST_URL) ||
         ((server?.getBundledWidgets().length || 0) > 0),

--- a/test/nbrowser/testServer.ts
+++ b/test/nbrowser/testServer.ts
@@ -119,6 +119,7 @@ export class TestServerMerged extends EventEmitter implements IMochaServer {
       // Set low limits for uploads, for testing.
       GRIST_MAX_UPLOAD_IMPORT_MB: '1',
       GRIST_MAX_UPLOAD_ATTACHMENT_MB: '2',
+      GRIST_MAX_API_REQUEST_BODY_MB: '1',
       // The following line only matters for testing with non-localhost URLs, which some tests do.
       GRIST_SERVE_SAME_ORIGIN: 'true',
       // Run with HOME_PORT, STATIC_PORT, DOC_PORT, DOC_WORKER_COUNT in the environment to override.


### PR DESCRIPTION
## Context
There is a limit set on the maximum API request body size. That limit is currently hardcoded to 1mb.

<!-- Please include a summary of the change, with motivation and context -->
<!-- Bonus: if you are comfortable writing one, please insert a user-story https://en.wikipedia.org/wiki/User_story#Common_templates -->

## Proposed solution
Added configurable maximum API request body size

<!-- Describe here how you address the issue -->

## Related issues
#916 

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

## Has this been tested?
Yes

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
