### PR TITLE
Fix translation in ChoiceListEntry: "+{{count}} more"

### DIFF
--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -2209,8 +2209,8 @@
         "The main page of Grist should be available.": "The main page of Grist should be available."
     },
     "ChoiceListEntry": {
-        "+{{count}} more_one": "+{{count}} one",
-        "+{{count}} more_other": "+{{count}} many",
+        "+{{count}} more_one": "+{{count}} more",
+        "+{{count}} more_other": "+{{count}} more",
         "Edit": "Edit",
         "No choices configured": "No choices configured",
         "Reset": "Reset",


### PR DESCRIPTION
## Context

There is an inconsistent english translation

## Proposed solution

Fix that.

## Related issues


## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<img width="208" height="230" alt="image" src="https://github.com/user-attachments/assets/738f6e79-8f84-4b8d-8c58-17537a9a553a" />

