### PR TITLE
add instructions on how to build with grist-ee

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,23 @@ These sandboxing methods have been written for our own use at Grist Labs and
 may need tweaking to work in your own environment - pull requests
 very welcome here!
 
+If you wish to include Grist Labs enterprise extensions in your build,
+the steps are as follows. Note that this will add non-OSS code to your
+build. It will also place a directory called `node_modules` one level
+up, at the same level as the Grist repo. If that is a problem for you,
+just move everything into a subdirectory first.
+
+    yarn install
+    ./buildtools/checkout-ext-directory.sh grist-ee
+    yarn install --cwd ext --modules-folder ../../node_modules/
+    WEBPACK_EXTRA_MODULE_PATHS=../node_modules yarn build
+    yarn run install:python
+    WEBPACK_EXTRA_MODULE_PATHS=../node_modules yarn start
+    # Grist will be available at http://localhost:8484/
+
+The enterprise code will by default not be used. You need to explicitly enable
+it in the [Admin Panel](https://support.getgrist.com/self-managed/#how-do-i-enable-grist-enterprise).
+
 ## Logins
 
 Like git, Grist has features to track document revision history. So for full operation,


### PR DESCRIPTION
There is demand for Grist Enterprise among people building from source. This adds instructions for how to do so.

The `WEBPACK_EXTRA_MODULE_PATHS` bit wasn't necessary in the past, I think there was a little extra logic in the webpack config file, but maybe I messed it up when working on grist-desktop?
