### PR TITLE
Add id substitution in form redirect URL

### DIFF
--- a/app/client/models/FormModel.ts
+++ b/app/client/models/FormModel.ts
@@ -18,7 +18,7 @@ export interface FormModel {
   readonly submitted: Observable<boolean>;
   readonly error: Observable<string | null>;
   fetchForm(): Promise<void>;
-  submitForm(formData: TypedFormData): Promise<void>;
+  submitForm(formData: TypedFormData): Promise<number>;
 }
 
 export class FormModelImpl extends Disposable implements FormModel {
@@ -76,7 +76,7 @@ export class FormModelImpl extends Disposable implements FormModel {
     }
   }
 
-  public async submitForm(formData: TypedFormData): Promise<void> {
+  public async submitForm(formData: TypedFormData): Promise<number> {
     const form = this.form.get();
     if (!form) { throw new Error("form is not defined"); }
 
@@ -96,7 +96,7 @@ export class FormModelImpl extends Disposable implements FormModel {
       this.submitting.set(true);
       // we virtually wait for at least a second to actually consider the form submitted;
       // this makes for a tiny bit of a delay allowing users to see the "submitting…" state of the FormRenderer
-      await Promise.all([
+      const results = await Promise.all([
         this._formAPI.createRecord({
           ...this._getDocIdOrShareKeyParam(),
           tableId: form.formTableId,
@@ -104,6 +104,7 @@ export class FormModelImpl extends Disposable implements FormModel {
         }),
         new Promise(resolve => setTimeout(resolve, 1000)),
       ]);
+      return results[0];
     } finally {
       this.submitting.set(false);
     }

--- a/app/client/ui/FormAPI.ts
+++ b/app/client/ui/FormAPI.ts
@@ -161,7 +161,7 @@ export class FormAPIImpl extends BaseAPI implements FormAPI {
         body: JSON.stringify({ records: [{ fields: colValues }] }),
       },
     );
-    return response?.records?.[0]?.id;
+    return response?.records?.[0]?.id || 0;
   }
 
   public async createAttachments(options: CreateAttachmentOptions): Promise<number[]> {

--- a/app/client/ui/FormAPI.ts
+++ b/app/client/ui/FormAPI.ts
@@ -107,7 +107,7 @@ export function getFormOptionsLimit(options: FormFieldOptions): number {
 
 export interface FormAPI {
   getForm(options: GetFormOptions): Promise<Form>;
-  createRecord(options: CreateRecordOptions): Promise<void>;
+  createRecord(options: CreateRecordOptions): Promise<number>;
   createAttachments(options: CreateAttachmentOptions): Promise<number[]>;
 }
 
@@ -152,15 +152,16 @@ export class FormAPIImpl extends BaseAPI implements FormAPI {
     });
   }
 
-  public async createRecord(options: CreateRecordOptions): Promise<void> {
+  public async createRecord(options: CreateRecordOptions): Promise<number> {
     const { tableId, colValues } = options;
-    return this.requestJson(
+    const response = await this.requestJson(
       this._docOrShareUrl(`/tables/${tableId}/records`, options),
       {
         method: "POST",
         body: JSON.stringify({ records: [{ fields: colValues }] }),
       },
     );
+    return response?.records?.[0]?.id;
   }
 
   public async createAttachments(options: CreateAttachmentOptions): Promise<number[]> {

--- a/app/client/ui/FormAPI.ts
+++ b/app/client/ui/FormAPI.ts
@@ -161,7 +161,12 @@ export class FormAPIImpl extends BaseAPI implements FormAPI {
         body: JSON.stringify({ records: [{ fields: colValues }] }),
       },
     );
-    return response?.records?.[0]?.id || 0;
+    // If we don't retrieve the record ID, we can reasonnably assume the creation has failed
+    // and throw an error.
+    if (!(response?.records?.[0]?.id)) {
+      throw new Error("Record creation failed");
+    }
+    return response.records[0].id;
   }
 
   public async createAttachments(options: CreateAttachmentOptions): Promise<number[]> {

--- a/app/client/ui/FormAPI.ts
+++ b/app/client/ui/FormAPI.ts
@@ -161,7 +161,7 @@ export class FormAPIImpl extends BaseAPI implements FormAPI {
         body: JSON.stringify({ records: [{ fields: colValues }] }),
       },
     );
-    // If we don't retrieve the record ID, we can reasonnably assume the creation has failed
+    // If we don't retrieve the record ID, we can reasonably assume the creation has failed
     // and throw an error.
     if (!(response?.records?.[0]?.id)) {
       throw new Error("Record creation failed");

--- a/app/client/ui/FormPage.ts
+++ b/app/client/ui/FormPage.ts
@@ -96,8 +96,8 @@ export class FormPage extends Disposable {
                 handleSubmit({
                   pending: this._model.submitting,
                   onSubmit: (_formData, formElement) => this._handleFormSubmit(formElement),
-                  onSuccess: () => this._handleFormSubmitSuccess(),
-                  onError: e => this._handleFormError(e),
+                  onSuccess: (recordId: number) => this._handleFormSubmitSuccess(recordId),
+                  onError: (e) => this._handleFormError(e),
                 }),
               ),
             ),
@@ -112,16 +112,16 @@ export class FormPage extends Disposable {
   }
 
   private async _handleFormSubmit(formElement: HTMLFormElement) {
-    await this._model.submitForm(new TypedFormData(formElement));
+    return await this._model.submitForm(new TypedFormData(formElement));
   }
 
-  private async _handleFormSubmitSuccess() {
+  private async _handleFormSubmitSuccess(recordId: number) {
     const formLayout = this._model.formLayout.get();
     if (!formLayout) { throw new Error("formLayout is not defined"); }
 
-    const { successURL } = formLayout;
+    const {successURL} = formLayout;
     if (successURL) {
-      const url = sanitizeHttpUrl(successURL);
+      const url = sanitizeHttpUrl(successURL)?.replace("{{ID}}", `${recordId}`);
       if (url) {
         window.location.href = url;
       }

--- a/app/client/ui/FormPage.ts
+++ b/app/client/ui/FormPage.ts
@@ -97,7 +97,7 @@ export class FormPage extends Disposable {
                   pending: this._model.submitting,
                   onSubmit: (_formData, formElement) => this._handleFormSubmit(formElement),
                   onSuccess: (recordId: number) => this._handleFormSubmitSuccess(recordId),
-                  onError: (e) => this._handleFormError(e),
+                  onError: e => this._handleFormError(e),
                 }),
               ),
             ),
@@ -119,7 +119,7 @@ export class FormPage extends Disposable {
     const formLayout = this._model.formLayout.get();
     if (!formLayout) { throw new Error("formLayout is not defined"); }
 
-    const {successURL} = formLayout;
+    const { successURL } = formLayout;
     if (successURL) {
       const url = sanitizeHttpUrl(successURL)?.replace("{{ID}}", `${recordId}`);
       if (url) {

--- a/app/client/ui/FormPage.ts
+++ b/app/client/ui/FormPage.ts
@@ -121,7 +121,7 @@ export class FormPage extends Disposable {
 
     const { successURL } = formLayout;
     if (successURL) {
-      const url = sanitizeHttpUrl(successURL)?.replace("{{ID}}", `${recordId}`);
+      const url = sanitizeHttpUrl(successURL)?.replace(/\{\{ID\}\}/g, `${recordId}`);
       if (url) {
         window.location.href = url;
       }

--- a/app/client/ui/RightPanel.ts
+++ b/app/client/ui/RightPanel.ts
@@ -1016,6 +1016,10 @@ export class RightPanel extends Disposable {
         ),
         dom.show(redirection),
       ),
+      cssHintRow(
+        t("You may use {{ID}} placeholder for the ID of the added record."),
+        dom.show(redirection)
+      ),
     ];
   }
 
@@ -1202,6 +1206,11 @@ const cssRow = styled("div", `
   & .${cssCheckboxLabel.className} {
     flex-shrink: revert;  /* allow checkbox labels to wrap in right-panel rows */
   }
+`);
+
+const cssHintRow = styled('div', `
+  margin: -4px 16px 8px 16px;
+  color: ${theme.lightText};
 `);
 
 const cssButtonRow = styled(cssRow, `

--- a/app/client/ui/RightPanel.ts
+++ b/app/client/ui/RightPanel.ts
@@ -1018,7 +1018,7 @@ export class RightPanel extends Disposable {
       ),
       cssHintRow(
         t("You may use {{ID}} placeholder for the ID of the added record."),
-        dom.show(redirection)
+        dom.show(redirection),
       ),
     ];
   }
@@ -1208,7 +1208,7 @@ const cssRow = styled("div", `
   }
 `);
 
-const cssHintRow = styled('div', `
+const cssHintRow = styled("div", `
   margin: -4px 16px 8px 16px;
   color: ${theme.lightText};
 `);

--- a/app/client/ui/RightPanel.ts
+++ b/app/client/ui/RightPanel.ts
@@ -1017,7 +1017,7 @@ export class RightPanel extends Disposable {
         dom.show(redirection),
       ),
       cssHintRow(
-        t("You may use {{ID}} placeholder for the ID of the added record."),
+        t("You may use {{placeholder}} placeholder for the ID of the added record.", { placeholder: "{{ID}}" }),
         dom.show(redirection),
       ),
     ];

--- a/test/nbrowser/FormView1.ts
+++ b/test/nbrowser/FormView1.ts
@@ -1099,6 +1099,18 @@ describe("FormView1", function() {
       await removeForm();
     });
 
+    it("redirects to valid URLs on submission with id substitution", async function() {
+      const url = await createFormWith("Text", {
+        redirectUrl: externalSite.getUrl().href + "?id={{ID}}",
+      });
+      await gu.onNewTab(async () => {
+        await driver.get(url);
+        await driver.findWait("button[type="submit"]", 2000).click();
+        await gu.waitForUrl(/localtest\.datagrist\.com.*\?id=\d+/);
+      });
+      await removeForm();
+    });
+
     it("excludes formula fields from forms", async function() {
       const formUrl = await createFormWith("Text");
 

--- a/test/nbrowser/FormView1.ts
+++ b/test/nbrowser/FormView1.ts
@@ -1105,7 +1105,7 @@ describe("FormView1", function() {
       });
       await gu.onNewTab(async () => {
         await driver.get(url);
-        await driver.findWait("button[type="submit"]", 2000).click();
+        await driver.findWait('button[type="submit"]', 2000).click();
         await gu.waitForUrl(/localtest\.datagrist\.com.*\?id=\d+/);
       });
       await removeForm();

--- a/test/nbrowser/FormView1.ts
+++ b/test/nbrowser/FormView1.ts
@@ -1101,12 +1101,12 @@ describe("FormView1", function() {
 
     it("redirects to valid URLs on submission with id substitution", async function() {
       const url = await createFormWith("Text", {
-        redirectUrl: externalSite.getUrl().href + "?id={{ID}}",
+        redirectUrl: externalSite.getUrl().href + "?id={{ID}}&title=untitled-{{ID}}",
       });
       await gu.onNewTab(async () => {
         await driver.get(url);
         await driver.findWait('button[type="submit"]', 2000).click();
-        await gu.waitForUrl(/localtest\.datagrist\.com.*\?id=\d+/);
+        await gu.waitForUrl(/localtest\.datagrist\.com.*\?id=(\d+)&title=untitled-\1/);
       });
       await removeForm();
     });


### PR DESCRIPTION
## Context

Forms are great but redirecting to a submission related page would be great.

So far, a trick is possible (based on the latest submission) but it is not guaranteed (in case of concurrent submissions) to show the relevant data.

We have a document with input columns and output columns computed with formulas.
We relied on a card view but is a very constrained in term of UI.

This PR allows to redirect to a fully custom UI or to a grist page with a specific anchor such as
https://docs.getgrist.com/o/docs/bS42RAoQBs1W/test#a1.s5.r__ID__.c2
Describe the solution you would like

Allow id substitution in the redirection URL with `{{ID}}` (edited) (but that's a proposal).

## Related issues

fixes #1823

## Has this been tested?


- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
