### PR TITLE
add a placeholder for "Proposed Changes" UI

### DIFF
--- a/app/client/components/ActionLog.ts
+++ b/app/client/components/ActionLog.ts
@@ -16,11 +16,9 @@ import {ActionSummary, asTabularDiffs, defunctTableName, getAffectedTables,
         LabelDelta} from 'app/common/ActionSummary';
 import {CellDelta, TabularDiff} from 'app/common/TabularDiff';
 import {timeFormat} from 'app/common/timeFormat';
-import { ResultRow, TimeCursor, TimeQuery} from 'app/common/TimeQuery';
-import {dom, DomContents, fromKo, IDomComponent, makeTestId, styled} from 'grainjs';
+import {ResultRow, TimeCursor, TimeQuery} from 'app/common/TimeQuery';
+import {dom, DomContents, fromKo, IDomComponent, styled} from 'grainjs';
 import * as ko from 'knockout';
-
-const testId = makeTestId('ActionLog_');
 
 /**
  *
@@ -205,7 +203,6 @@ export class ActionLog extends dispose.Disposable implements IDomComponent {
         dom('div',
           labeledSquareCheckbox(fromKo(this.showAllTables),
             t('All tables'),
-            testId('allTables'),
           ),
         ),
         dom('div.action_log_load',
@@ -640,9 +637,9 @@ export async function computeContext(gristDoc: GristDoc, base: ActionSummary, in
 }
 
 const cssBasicButton = styled(basicButton, `
-padding: 0;
-margin-left: 5px;
-border: none;
+  padding: 0;
+  margin-left: 5px;
+  border: none;
 `);
 
 function reportDeletedObject(obj: DeletedObject, actionNum: number) {

--- a/app/client/components/ActionLog.ts
+++ b/app/client/components/ActionLog.ts
@@ -2,23 +2,25 @@
  * ActionLog manages the list of actions from server and displays them in the side bar.
  */
 
+import {GristDoc} from 'app/client/components/GristDoc';
 import * as dispose from 'app/client/lib/dispose';
-import dom from 'app/client/lib/dom';
-import {timeFormat} from 'app/common/timeFormat';
-import * as ko from 'knockout';
-
 import koArray from 'app/client/lib/koArray';
 import {KoArray} from 'app/client/lib/koArray';
 import * as koDom from 'app/client/lib/koDom';
-
-import {GristDoc} from 'app/client/components/GristDoc';
+import {makeT} from 'app/client/lib/localization';
+import {ClientTimeData} from 'app/client/models/TimeQuery';
+import {basicButton} from 'app/client/ui2018/buttons';
+import {labeledSquareCheckbox} from 'app/client/ui2018/checkbox';
 import {ActionGroup} from 'app/common/ActionGroup';
 import {ActionSummary, asTabularDiffs, defunctTableName, getAffectedTables,
         LabelDelta} from 'app/common/ActionSummary';
 import {CellDelta, TabularDiff} from 'app/common/TabularDiff';
-import {DomContents, fromKo, IDomComponent} from 'grainjs';
-import {makeT} from 'app/client/lib/localization';
-import {labeledSquareCheckbox} from 'app/client/ui2018/checkbox';
+import {timeFormat} from 'app/common/timeFormat';
+import { ResultRow, TimeCursor, TimeQuery} from 'app/common/TimeQuery';
+import {dom, DomContents, fromKo, IDomComponent, makeTestId, styled} from 'grainjs';
+import * as ko from 'knockout';
+
+const testId = makeTestId('ActionLog_');
 
 /**
  *
@@ -35,7 +37,10 @@ export interface ActionGroupWithState extends ActionGroup {
   state?: ko.Observable<string>;  // is action undone/buried
   tableFilters?: {[tableId: string]: ko.Observable<string>};  // current names of tables
   affectedTableIds?: Array<ko.Observable<string>>; // names of tables affecting this ActionGroup
+  context?: ko.Observable<ActionContext>;  // extra cell information, computed on demand
 }
+
+export type ActionContext = Record<string, ResultRow[]>;
 
 const gristNotify = (window as any).gristNotify;
 
@@ -49,11 +54,11 @@ const state = {
 const t = makeT('ActionLog');
 
 export class ActionLog extends dispose.Disposable implements IDomComponent {
+  public displayStack: KoArray<ActionGroupWithState>;
+  public selectedTableId: ko.Computed<string>;
+  public showAllTables: ko.Observable<boolean>;      // should all tables be visible?
 
-  private _displayStack: KoArray<ActionGroupWithState>;
   private _gristDoc: GristDoc|null;
-  private _selectedTableId: ko.Computed<string>;
-  private _showAllTables: ko.Observable<boolean>;      // should all tables be visible?
 
   private _pending: ActionGroupWithState[] = [];  // cache for actions that arrive while loading log
   private _loaded: boolean = false;               // flag set once log is loaded
@@ -67,18 +72,18 @@ export class ActionLog extends dispose.Disposable implements IDomComponent {
    */
   public create(options: {gristDoc: GristDoc|null}) {
     // By default, just show actions for the currently viewed table.
-    this._showAllTables = ko.observable(false);
+    this.showAllTables = ko.observable(false);
     // We load the ActionLog lazily now, when it is first viewed.
     this._loading = ko.observable(false);
 
     this._gristDoc = options.gristDoc;
 
-    // TODO: _displayStack grows without bound within a single session.
+    // TODO: displayStack grows without bound within a single session.
     // Stack of actions as they should be displayed to the user.
-    this._displayStack = koArray<ActionGroupWithState>();
+    this.displayStack = koArray<ActionGroupWithState>();
 
     // Computed for the tableId of the table currently being viewed.
-    this._selectedTableId = this.autoDispose(ko.computed(() => {
+    this.selectedTableId = this.autoDispose(ko.computed(() => {
       if (!this._gristDoc || this._gristDoc.viewModel.isDisposed()) { return ""; }
       const section = this._gristDoc.viewModel.activeSection();
       if (!section || section.isDisposed()) { return ""; }
@@ -101,8 +106,9 @@ export class ActionLog extends dispose.Disposable implements IDomComponent {
       return;
     }
 
-    this._setupFilters(ag, this._displayStack.at(0) || undefined);
-    const otherAg = ag.otherId ? this._displayStack.all().find(a => a.actionNum === ag.otherId) : null;
+    ag.context = ko.observable({});
+    this._setupFilters(ag, this.displayStack.at(0) || undefined);
+    const otherAg = ag.otherId ? this.displayStack.all().find(a => a.actionNum === ag.otherId) : null;
 
     if (otherAg) {
       // Undo/redo action.
@@ -115,8 +121,8 @@ export class ActionLog extends dispose.Disposable implements IDomComponent {
         // Bury all undos immediately preceding this action since they can no longer
         // be redone. This is triggered by normal actions and undo/redo actions whose
         // targets are not recent (not in the stack).
-        for (let i = 0; i < this._displayStack.peekLength; i++) {
-          const prevAction = this._displayStack.at(i)!;
+        for (let i = 0; i < this.displayStack.peekLength; i++) {
+          const prevAction = this.displayStack.at(i)!;
           if (!prevAction.state) { continue; }
           const prevState = prevAction.state();
           if (prevAction.fromSelf && prevState === state.DEFAULT) {
@@ -130,7 +136,7 @@ export class ActionLog extends dispose.Disposable implements IDomComponent {
       }
       if (!ag.otherId) {
         ag.state = ko.observable(state.DEFAULT);
-        this._displayStack.unshift(ag);
+        this.displayStack.unshift(ag);
       }
     }
   }
@@ -142,36 +148,12 @@ export class ActionLog extends dispose.Disposable implements IDomComponent {
    * @param {ActionGroupWithState} ag - the full action information we have
    */
   public renderTabularDiffs(sum: ActionSummary, txt: string, ag?: ActionGroupWithState): HTMLElement {
-    const act = asTabularDiffs(sum);
-    const editDom = dom('div',
-      this._renderTableSchemaChanges(sum, ag),
-      this._renderColumnSchemaChanges(sum, ag),
-      Object.entries(act).map(([table, tdiff]: [string, TabularDiff]) => {
-        if (tdiff.cells.length === 0) { return dom('div'); }
-        return dom('table.action_log_table',
-          koDom.show(() => this._showForTable(table, ag)),
-          dom('caption',
-            this._renderTableName(table)),
-          dom('tr',
-            dom('th'),
-            tdiff.header.map(diff => {
-              return dom('th', this._renderCell(diff));
-            })),
-            tdiff.cells.map(row => {
-            return dom('tr',
-              dom('td', this._renderCell(row[0])),
-                row[2].map((diff, idx: number) => {
-                return dom('td',
-                           this._renderCell(diff),
-                           dom.on('click', () => {
-                             return this._selectCell(row[1], act[table].header[idx], table,
-                                              ag ? ag.actionNum : 0);
-                           }));
-              }));
-            }));
-      }),
-      dom('span.action_comment', txt));
-    return editDom;
+    const part = new ActionLogPartInList(
+      this._gristDoc,
+      ag,
+      this
+    );
+    return part.renderTabularDiffs(sum, txt, ag?.context);
   }
 
   /**
@@ -213,17 +195,7 @@ export class ActionLog extends dispose.Disposable implements IDomComponent {
    */
   private _hasSelectedTable(ag: ActionGroupWithState): boolean {
     if (!this._gristDoc) { return true; }
-    return ag.affectedTableIds!.some(tableId => tableId() === this._selectedTableId());
-  }
-
-  /**
-   * Return a koDom.show clause that activates when the named table is not
-   * filtered out.
-   */
-  private _showForTable(tableName: string, ag?: ActionGroupWithState): boolean {
-    if (!ag) { return true; }
-    const obs = ag.tableFilters![tableName];
-    return this._showAllTables() || !obs || obs() === this._selectedTableId();
+    return ag.affectedTableIds!.some(tableId => tableId() === this.selectedTableId());
   }
 
   private _buildLogDom() {
@@ -231,15 +203,15 @@ export class ActionLog extends dispose.Disposable implements IDomComponent {
     return dom('div.action_log',
         {tabIndex: '-1'},
         dom('div',
-          labeledSquareCheckbox(fromKo(this._showAllTables),
+          labeledSquareCheckbox(fromKo(this.showAllTables),
             t('All tables'),
-            dom.testId('ActionLog_allTables'),
+            testId('allTables'),
           ),
         ),
         dom('div.action_log_load',
           koDom.show(() => this._loading()),
           'Loading...'),
-        koDom.foreach(this._displayStack, (ag: ActionGroupWithState) => {
+        koDom.foreach(this.displayStack, (ag: ActionGroupWithState) => {
         const timestamp = ag.time ? timeFormat("D T", new Date(ag.time)) : "";
         let desc: DomContents = ag.desc || "";
         if (ag.actionSummary) {
@@ -247,7 +219,7 @@ export class ActionLog extends dispose.Disposable implements IDomComponent {
         }
         return dom('div.action_log_item',
           koDom.cssClass(ag.state),
-          koDom.show(() => this._showAllTables() || this._hasSelectedTable(ag)),
+          koDom.show(() => this.showAllTables() || this._hasSelectedTable(ag)),
           dom('div.action_info',
             dom('span.action_info_action_num', `#${ag.actionNum}`),
             ag.user ? dom('span.action_info_user',
@@ -281,7 +253,98 @@ export class ActionLog extends dispose.Disposable implements IDomComponent {
     }
     this._pending.length = 0;
   }
+}
 
+
+/**
+ * Factor out the display of a single action group, since that
+ * is useful elsewhere in the UI now. This is an abstract class,
+ * we will connect it with ActionLog in ActionLogPartInList.
+ */
+export abstract class ActionLogPart {
+  public constructor(
+    _gristDoc: GristDoc|null,
+  ) {}
+
+  /**
+   * This is used in the ActionLog to selectively show entries in the
+   * log that are relevant to a particular table. This could simply
+   * return true if everything should be shown.
+   */
+  public abstract showForTable(tableName: string): boolean;
+
+  /**
+   * When the user clicks on the specified cell within this entry,
+   * this should bring the user to that cell elsewhere in the UI,
+   * so they can see its full current context.
+   */
+  public abstract selectCell(rowId: number, colId: string, tableId: string): Promise<void>;
+
+  /**
+   * Should return completions for the rows mentioned in this entry.
+   */
+  public abstract getContext(): Promise<ActionContext|undefined>;
+
+  /**
+   * Render a description of an action prepared on the server.
+   * @param {TabularDiffs} act - a collection of table changes
+   * @param {string} txt - a textual description of the action
+   * @param {Observable} context - extra information about the action
+   */
+  public renderTabularDiffs(sum: ActionSummary, txt?: string, contextObs?: ko.Observable<ActionContext>): HTMLElement {
+    const editDom = koDom.scope(contextObs, (context: ActionContext) => {
+      const act = asTabularDiffs(sum, context);
+      return dom(
+        'div',
+        this._renderTableSchemaChanges(sum),
+        this._renderColumnSchemaChanges(sum),
+        Object.entries(act).map(([table, tdiff]: [string, TabularDiff]) => {
+          if (tdiff.cells.length === 0) { return dom('div'); }
+          return dom(
+            'table.action_log_table',
+            koDom.show(() => this.showForTable(table)),
+            dom('caption',
+                this._renderTableName(table),
+                // Add a little button to show or hide extra context.
+                // This is a baby step, there's a lot more that could
+                // and should be done here.
+                contextObs ? cssBasicButton(
+                  context[table] ? ' <' : ' >',
+                  dom.on('click', async () => {
+                    if (context[table]) {
+                      await this._resetContext(contextObs, table, context);
+                    } else {
+                      await this._setContext(contextObs, table, context);
+                    }
+                  })) : null,
+                dom.style('text-align', 'left'),
+               ),
+            dom(
+              'tr',
+              dom('th'),
+              tdiff.header.map(diff => {
+                return dom('th', this._renderCell(diff));
+              })),
+            tdiff.cells.map(
+              row => {
+                return dom(
+                  'tr',
+                  dom('td', this._renderCell(row.type)),
+                  row.cellDeltas.map((diff, idx: number) => {
+                    return dom('td',
+                               this._renderCell(diff),
+                               dom.on('click', () => {
+                                 return this.selectCell(row.rowId, act[table].header[idx], table);
+                               }));
+                  }));
+              }));
+        }),
+        txt ? dom('span.action_comment', txt) : null,
+      );
+    });
+    return dom('div',
+               editDom);
+  }
   /**
    * Prepare dom element(s) for a cell that has been created, destroyed,
    * or modified.
@@ -297,6 +360,9 @@ export class ActionLog extends dispose.Disposable implements IDomComponent {
     }
     // strings are shown as themselves
     if (typeof(cell) === 'string') {
+      return cell;
+    }
+    if (!Array.isArray(cell)) {
       return cell;
     }
     // by elimination, we have a TabularDiff.CellDelta with before and after values.
@@ -345,12 +411,12 @@ export class ActionLog extends dispose.Disposable implements IDomComponent {
    * for a rename of name1 to name2.
    * @return a filtered dom element.
    */
-  private _renderSchemaChange(scope: string, pair: LabelDelta, ag?: ActionGroupWithState) {
+  private _renderSchemaChange(scope: string, pair: LabelDelta) {
     const [pre, post] = pair;
     // ignore addition/removal of manualSort column
     if ((pre || post) === 'manualSort') { return dom('div'); }
     return dom('div.action_log_rename',
-      koDom.show(() => this._showForTable(post || defunctTableName(pre!), ag)),
+      koDom.show(() => this.showForTable(post || defunctTableName(pre!))),
       (!post ? ["Remove ", scope, dom("span.action_log_rename_pre", pre)] :
        (!pre ? ["Add ", scope, dom("span.action_log_rename_post", post)] :
         ["Rename ", scope, dom("span.action_log_rename_pre", pre),
@@ -360,99 +426,246 @@ export class ActionLog extends dispose.Disposable implements IDomComponent {
   /**
    * Show any table additions/removals/renames.
    */
-  private _renderTableSchemaChanges(sum: ActionSummary, ag?: ActionGroupWithState) {
+  private _renderTableSchemaChanges(sum: ActionSummary) {
     return dom('div',
-               sum.tableRenames.map(pair => this._renderSchemaChange("", pair, ag)));
+               sum.tableRenames.map(pair => this._renderSchemaChange("", pair)));
   }
 
   /**
    * Show any column additions/removals/renames.
    */
-  private _renderColumnSchemaChanges(sum: ActionSummary, ag?: ActionGroupWithState) {
+  private _renderColumnSchemaChanges(sum: ActionSummary) {
     return dom('div',
                Object.keys(sum.tableDeltas).filter(key => !key.startsWith('-')).map(key =>
                  dom('div',
-                     koDom.show(() => this._showForTable(key, ag)),
+                     koDom.show(() => this.showForTable(key)),
                      sum.tableDeltas[key].columnRenames.map(pair =>
                         this._renderSchemaChange(key + ".", pair)))));
   }
 
-  /**
-   * Move cursor to show a given cell of a given table. Uses primary view of table.
-   */
-  private async _selectCell(rowId: number, colId: string, tableId: string, actionNum: number) {
+  private async _resetContext(contextObs: ko.Observable<ActionContext>, tableId: string, context: ActionContext) {
+    delete context[tableId];
+    contextObs(context);
+  }
+
+  private async _setContext(contextObs: ko.Observable<ActionContext>, tableId: string, context: ActionContext) {
+    const result = await this.getContext();
+    if (result) {
+      contextObs({...context, [tableId]: result[tableId]});
+    }
+  }
+}
+
+/**
+ * Connect ActionLogPart back to ActionLog. The only non-trivial
+ * work is relating cells within it to current state, via the
+ * action stack.
+ */
+class ActionLogPartInList extends ActionLogPart {
+  public constructor(
+    private _gristDoc: GristDoc|null,
+    private _actionGroup: ActionGroupWithState|undefined,
+    private _actionLog: ActionLog,
+  ) {
+    super(_gristDoc);
+  }
+
+  public showForTable(tableName: string): boolean {
+    return this._showForTable(tableName, this._actionGroup);
+  }
+
+  public async selectCell(rowId: number, colId: string, tableId: string): Promise<void> {
     if (!this._gristDoc) { return; }
+    if (!this._actionGroup) { return; }
+    const actionNum = this._actionGroup.actionNum;
 
     // Find action in the stack.
-    const index = this._displayStack.peek().findIndex(a => a.actionNum === actionNum);
+    const index = this._actionLog.displayStack.peek().findIndex(a => a.actionNum === actionNum);
     if (index < 0) { throw new Error(`Cannot find action ${actionNum} in the action log.`); }
 
     // Found the action. Now trace forward to find current tableId, colId, rowId.
     for (let i = index; i >= 0; i--) {
-      const action = this._displayStack.at(i)!;
+      const action = this._actionLog.displayStack.at(i)!;
       const sum = action.actionSummary;
-
-      // Check if this table was renamed / removed.
-      const tableRename: LabelDelta|undefined = sum.tableRenames.find(r => r[0] === tableId);
-      if (tableRename) {
-        const newName = tableRename[1];
-        if (!newName) {
-          // TODO - find a better way to send informative notifications.
-          gristNotify(t(
-            "Table {{tableId}} was subsequently removed in action #{{actionNum}}",
-            {tableId:tableId, actionNum: action.actionNum}
-          ));
-          return;
-        }
-        tableId = newName;
-      }
-      const td = sum.tableDeltas[tableId];
-      if (!td) { continue; }
-
-      // Check is this row was removed - if so there's no reason to go on.
-      if (td.removeRows.indexOf(rowId) >= 0) {
-          // TODO - find a better way to send informative notifications.
-        gristNotify(t("This row was subsequently removed in action {{action.actionNum}}", {actionNum}));
-        return;
-      }
-
-      // Check if this column was renamed / added.
-      const columnRename: LabelDelta|undefined = td.columnRenames.find(r => r[0] === colId);
-      if (columnRename) {
-        const newName = columnRename[1];
-        if (!newName) {
-          // TODO - find a better way to send informative notifications.
-          gristNotify(t(
-            "Column {{colId}} was subsequently removed in action #{{action.actionNum}}",
-            {colId, actionNum: action.actionNum}
-          ));
-          return;
-        }
-        colId = newName;
+      const cell = traceCell({rowId, colId, tableId}, sum, (deletedObj: DeletedObject) => {
+        reportDeletedObject(deletedObj, action.actionNum);
+      });
+      if (cell) {
+        tableId = cell.tableId;
+        colId = cell.colId;
+        rowId = cell.rowId;
       }
     }
-
-    // Find the table model of interest.
-    const tableModel = this._gristDoc.getTableModel(tableId);
-    if (!tableModel) { return; }
-
-    // Get its "primary" view.
-    const viewRow = tableModel.tableMetaRow.primaryView();
-    const viewId = viewRow.getRowId();
-
-    // Switch to that view.
-    await this._gristDoc.openDocPage(viewId);
-
-    // Now let's pick a reasonable section in that view.
-    const viewSection = viewRow.viewSections().peek().find((s: any) => s.table().tableId() === tableId);
-    if (!viewSection) { return; }
-    const sectionId = viewSection.getRowId();
-
-    // Within that section, find the column of interest if possible.
-    const fieldIndex = viewSection.viewFields().peek().findIndex((f: any) => f.colId.peek() === colId);
-
-    // Finally, move cursor position to the section, column (if we found it), and row.
-    this._gristDoc.moveToCursorPos({rowId, sectionId, fieldIndex}).catch(() => { /* do nothing */ });
+    await showCell(this._gristDoc, {tableId, colId, rowId});
   }
 
+  public async getContext(): Promise<ActionContext|undefined> {
+    if (!this._gristDoc) { return; }
+    if (!this._actionGroup) { return; }
+    const base = this._actionGroup.actionSummary;
+    const actionNum = this._actionGroup.actionNum;
+    return await computeContext(this._gristDoc, base, (cursor) => {
+      // Find action in the stack.
+      const index = this._actionLog.displayStack.peek().findIndex(a => a.actionNum === actionNum);
+      if (index < 0) { throw new Error(`Cannot find action ${actionNum} in the action log.`); }
+      // Found the action. Now find mapping to current doc, just
+      // after this action.
+      for (let i = index - 1; i >= 0; i--) {
+        const action = this._actionLog.displayStack.at(i)!;
+        cursor.append(action.actionSummary);
+      }
+    });
+  }
+
+  /**
+   * Return a koDom.show clause that activates when the named table is not
+   * filtered out.
+   */
+  private _showForTable(tableName: string, ag?: ActionGroupWithState): boolean {
+    if (!ag) { return true; }
+    const obs = ag.tableFilters![tableName];
+    return this._actionLog.showAllTables() || !obs || obs() === this._actionLog.selectedTableId();
+  }
+}
+
+/**
+ * Trace a cell through a change. The row, column, or table may be
+ * deleted, in which case reportDeletion is called and null is returned.
+ * Column and table renames are tracked, with updated names returned.
+ */
+export function traceCell(cell: {rowId: number, colId: string, tableId: string},
+                          summary: ActionSummary,
+                          reportDeletion: (deletedObj: DeletedObject) => void) {
+  let {tableId, colId} = cell;
+  const {rowId} = cell;
+  // Check if this table was renamed / removed.
+  const tableRename: LabelDelta|undefined = summary.tableRenames.find(r => r[0] === tableId);
+  if (tableRename) {
+    const newName = tableRename[1];
+    if (!newName) {
+      reportDeletion({tableId});
+      return null;
+    }
+    tableId = newName;
+  }
+  const td = summary.tableDeltas[tableId];
+  if (!td) {
+    return {tableId, rowId, colId};
+  }
+
+  // Check is this row was removed - if so there's no reason to go on.
+  if (td.removeRows.indexOf(rowId) >= 0) {
+    reportDeletion({thisRow: true});
+    return null;
+  }
+
+  // Check if this column was renamed / added.
+  const columnRename: LabelDelta|undefined = td.columnRenames.find(r => r[0] === colId);
+  if (columnRename) {
+    const newName = columnRename[1];
+    if (!newName) {
+      reportDeletion({colId});
+      return null;
+    }
+    colId = newName;
+  }
+  return {tableId, rowId, colId};
+}
+
+/**
+ * Show a cell in the UI. That is pretty ambiguous! The same
+ * rowId/colId/tableId cell might be shown in many places.  The logic
+ * here is ancient, written before the Raw Data page existed for
+ * example, but for simple cases where the cell appears just once on a
+ * user-created page, it works okay. A lot that could be done here.
+ */
+export async function showCell(gristDoc: GristDoc, cell: {
+  tableId: string,
+  colId: string,
+  rowId: number,
+}) {
+  const {tableId, colId, rowId} = cell;
+
+  // Find the table model of interest.
+  const tableModel = gristDoc.getTableModel(tableId);
+  if (!tableModel) { return; }
+
+  // Get its "primary" view.
+  const viewRow = tableModel.tableMetaRow.primaryView();
+  const viewId = viewRow.getRowId();
+
+  // Switch to that view.
+  await gristDoc.openDocPage(viewId);
+
+  // Now let's pick a reasonable section in that view.
+  const viewSection = viewRow.viewSections().peek().find((s: any) => s.table().tableId() === tableId);
+  if (!viewSection) { return; }
+  const sectionId = viewSection.getRowId();
+
+  // Within that section, find the column of interest if possible.
+  const fieldIndex = viewSection.viewFields().peek().findIndex((f: any) => f.colId.peek() === colId);
+
+  // Finally, move cursor position to the section, column (if we found it), and row.
+  gristDoc.moveToCursorPos({rowId, sectionId, fieldIndex}).catch(() => { /* do nothing */ });
+}
+
+/**
+ * Look up the information in other cells on the same row as changed
+ * cells. This is useful to help the user understand what row it is.
+ * This is not robust code, or much tested, and should be seen as a
+ * placeholder for some systematic work.
+ */
+export async function computeContext(gristDoc: GristDoc, base: ActionSummary, init?: (cursor: TimeCursor) => void) {
+  if (!gristDoc) { return; }
+
+  const data = new ClientTimeData(gristDoc.docData);
+  const cursor = new TimeCursor(data);
+
+  init?.(cursor);
+
+  async function getTable(tableId: string, rowIds: number[]) {
+    const query = new TimeQuery(cursor, tableId, '*', rowIds);
+    await query.update();
+    return query.all();
+  }
+
+  const result: ActionContext = {};
+  for (const [tableId, tableDelta] of Object.entries(base.tableDeltas)) {
+    const rowIds = new Set([...tableDelta.addRows,
+                            ...tableDelta.updateRows]);
+    const rows = await getTable(tableId, [...rowIds]);
+    result[tableId] = rows;
+  }
+  return result;
+}
+
+const cssBasicButton = styled(basicButton, `
+padding: 0;
+margin-left: 5px;
+border: none;
+`);
+
+function reportDeletedObject(obj: DeletedObject, actionNum: number) {
+  // This is written to avoid code changes that require retranslating these messages.
+  if (obj.tableId) {
+    gristNotify(t(
+      "Table {{tableId}} was subsequently removed in action #{{actionNum}}",
+      {tableId: obj.tableId, actionNum}
+    ));
+  }
+  if (obj.colId) {
+      gristNotify(t(
+        "Column {{colId}} was subsequently removed in action #{{actionNum}}",
+        {colId: obj.colId, actionNum}
+      ));
+  }
+  if (obj.thisRow) {
+    gristNotify(t("This row was subsequently removed in action {{actionNum}}", {actionNum}));
+  }
+}
+
+interface DeletedObject {
+  thisRow?: boolean;
+  colId?: string;
+  tableId?: string;
 }

--- a/app/client/components/GristDoc.ts
+++ b/app/client/components/GristDoc.ts
@@ -51,6 +51,7 @@ import {DocSettingsPage} from 'app/client/ui/DocumentSettings';
 import {isTourActive, isTourActiveObs} from "app/client/ui/OnBoardingPopups";
 import {DefaultPageWidget, IPageWidget, toPageWidget} from 'app/client/ui/PageWidgetPicker';
 import {linkFromId, NoLink, selectBy} from 'app/client/ui/selectBy';
+import {ProposedChangesPage} from 'app/client/ui/ProposedChangesPage';
 import {TimingPage} from 'app/client/ui/TimingPage';
 import {WebhookPage} from 'app/client/ui/WebhookPage';
 import {startWelcomeTour} from 'app/client/ui/WelcomeTour';
@@ -803,6 +804,7 @@ export class GristDocImpl extends DisposableWithEvents implements GristDoc {
           content === 'code' ? dom.create(CodeEditorPanel, this) :
           content === 'acl' ? dom.create(AccessRules, this) :
           content === 'data' ? dom.create(RawDataPage, this) :
+          content === 'proposals' ? dom.create(ProposedChangesPage, this) :
           content === 'settings' ? dom.create(DocSettingsPage, this) :
           content === 'webhook' ? dom.create(WebhookPage, this) :
           content === 'timing' ? dom.create(TimingPage, this) :

--- a/app/client/models/TimeQuery.ts
+++ b/app/client/models/TimeQuery.ts
@@ -1,0 +1,34 @@
+import { DocData } from 'app/client/models/DocData';
+import { getActionColValues, getRowIdsFromDocAction } from 'app/common/DocActions';
+import { ITimeData, ResultRow } from 'app/common/TimeQuery';
+
+/**
+ * A client-side implementation of ITimeData, so we can do a
+ * TimeQuery to get context for actions in the action log.
+ */
+export class ClientTimeData implements ITimeData {
+  public constructor(public db: DocData) {
+  }
+
+  public async getColIds(tableId: string): Promise<string[]> {
+    const table = this.db.getTable(tableId);
+    return table?.getColIds() || [];
+  }
+
+  public async fetch(tableId: string, colIds: string[], rowIds?: number[]): Promise<ResultRow[]> {
+    await this.db.fetchTable(tableId);
+    const table = this.db.getTable(tableId);
+    const data = table?.getTableDataAction(rowIds, colIds);
+    if (!data) { return []; }
+    const records = getRowIdsFromDocAction(data).map((rowId, i) => {
+      const rec: Record<string, any> = {id: rowId};
+      for (const [colId, values] of Object.entries(getActionColValues(data))) {
+        if (colId !== 'id') {
+          rec[colId] = values[i];
+        }
+      }
+      return rec;
+    });
+    return records;
+  }
+}

--- a/app/client/ui/ProposedChangesPage.ts
+++ b/app/client/ui/ProposedChangesPage.ts
@@ -1,0 +1,171 @@
+import { ActionLogPart, computeContext, showCell } from 'app/client/components/ActionLog';
+import { GristDoc } from 'app/client/components/GristDoc';
+import { testId } from 'app/client/lib/dom';
+import { makeT } from 'app/client/lib/localization';
+import { docListHeader } from 'app/client/ui/DocMenuCss';
+import { replaceTrunkWithFork } from 'app/client/ui/MakeCopyMenu';
+import { buildOriginalUrlId } from 'app/client/ui/ShareMenu';
+import { bigPrimaryButton } from 'app/client/ui2018/buttons';
+import { mediaSmall, theme, vars } from 'app/client/ui2018/cssVars';
+import { ActionSummary } from 'app/common/ActionSummary';
+import { parseUrlId } from 'app/common/gristUrls';
+import { DocStateComparison, DocStateComparisonDetails } from 'app/common/UserAPI';
+import { Disposable, dom, Observable, styled } from 'grainjs';
+import * as ko from 'knockout';
+
+const t = makeT('ProposedChangesPage');
+
+/**
+ * This is a page to show the differences between the current document
+ * (the "fork") and an original document (the "trunk"). The differences
+ * are shown in ActionLog format, which at the time of writing is very
+ * weak, so this page inherits that weakness.
+ * TODO: improve the rendering of differences.
+ *
+ * The page is assumed to be shown when working on an unsaved copy. It
+ * could be useful to show in other circumstances, but the goal is to
+ * use it for a crowdsourcing workflow. At that point, the page will
+ * have a "Propose Changes" button rather than just what it has now,
+ * a "Replace Original" button.
+ */
+export class ProposedChangesPage extends Disposable {
+  public readonly isInitalized = Observable.create(this, false);
+  private _comparison?: DocStateComparison;
+  private _context = ko.observable({});
+
+  constructor(public gristDoc: GristDoc) {
+    super();
+    this.load();
+  }
+
+  /**
+   * Use the API to compare this doc with the original.
+   * TODO: make sure the comparison remains live either by recomputing
+   * or by concatenating incoming changes to the computed difference.
+   */
+  public load() {
+    const urlId = this.gristDoc.docPageModel.currentDocId.get();
+    const parts = parseUrlId(urlId || '');
+    if (urlId && parts.trunkId && parts.forkId) {
+      const comparisonUrlId = parts.trunkId;
+      this.gristDoc.appModel.api.getDocAPI(urlId).compareDoc(
+        comparisonUrlId, { detail: true }
+      ).then(comparison => {
+        this._comparison = comparison;
+        this.isInitalized.set(true);
+      }).catch(reportError);
+    } else if (urlId) {
+      // TODO: bring in handling for trunk view. The idea is that it
+      // would list proposed changes from forks. I've omitted it for now
+      // to tackle that part separately. We just avoid showing the page
+      // when not on a fork.
+      throw new Error('ProposedChangesPage opened unexpectedly');
+    }
+  }
+
+  public buildDom() {
+    return cssContainer(
+      cssHeader(t('Proposed Changes'), betaTag('Beta')),
+      cssDataRow(
+        dom.maybe((use) => use(this.isInitalized), () => {
+          const details = this._comparison?.details;
+          if (details) {
+            return this._renderComparisonDetails(details);
+          }
+        })),
+      cssControlRow(
+        bigPrimaryButton(
+          t("Replace Original"),
+          dom.on('click', async () => {
+            const docModel = this.gristDoc.docPageModel;
+            const doc = docModel.currentDoc.get();
+            if (doc) {
+              const origUrlId = buildOriginalUrlId(doc.id, doc.isSnapshot);
+              replaceTrunkWithFork(doc, docModel, origUrlId).catch(reportError);
+            }
+          }),
+          testId('replace'),
+        )
+      )
+    );
+  }
+
+  private _renderComparisonDetails(details: DocStateComparisonDetails) {
+    // In the comparison, the current doc is the left (or local)
+    // document, and the trunk is the right (or remote) document.
+    // We want to look at the changes from their most recent
+    // common ancestor and the current doc, which are the
+    // "leftChanges".
+    const actionSummary = details.leftChanges;
+    const part = new ActionLogPartInProposal(this.gristDoc, actionSummary);
+    return [
+      dom('p',
+          t('This is a list of changes relative to the original document.'),
+         ),
+      part.renderTabularDiffs(actionSummary, "", this._context),
+    ];
+  }
+}
+
+class ActionLogPartInProposal extends ActionLogPart {
+  public constructor(
+    private _gristDoc: GristDoc,
+    private _summary: ActionSummary
+  ) {
+    super(_gristDoc);
+  }
+
+  public showForTable(): boolean {
+    return true;
+  }
+
+  public async selectCell(rowId: number, colId: string, tableId: string): Promise<void> {
+    await showCell(this._gristDoc, {tableId, colId, rowId});
+  }
+
+  public async getContext() {
+    return computeContext(this._gristDoc, this._summary);
+  }
+}
+
+const cssHeader = styled(docListHeader, `
+  margin-bottom: 0;
+  &:not(:first-of-type) {
+    margin-top: 40px;
+  }
+`);
+
+const cssDataRow = styled('div', `
+  margin: 16px 0px;
+  font-size: ${vars.mediumFontSize};
+  color: ${theme.text};
+  width: 360px;
+`);
+
+const cssContainer = styled('div', `
+  overflow-y: auto;
+  position: relative;
+  height: 100%;
+  padding: 32px 64px 24px 64px;
+  @media ${mediaSmall} {
+    & {
+      padding: 32px 24px 24px 24px;
+    }
+  }
+`);
+
+const cssControlRow = styled('div', `
+  flex: none;
+  margin-bottom: 16px;
+  margin-top: 16px;
+  display: flex;
+  gap: 16px;
+`);
+
+
+export const betaTag = styled('span', `
+  text-transform: uppercase;
+  vertical-align: super;
+  font-size: ${vars.xsmallFontSize};
+  color: ${theme.accentText};
+`);

--- a/app/client/ui/ShareMenu.ts
+++ b/app/client/ui/ShareMenu.ts
@@ -34,7 +34,7 @@ import {cssMenuItem, MenuCreateFunc} from 'popweasel';
 
 const t = makeT('ShareMenu');
 
-function buildOriginalUrlId(urlId: string, isSnapshot: boolean): string {
+export function buildOriginalUrlId(urlId: string, isSnapshot: boolean): string {
   const parts = parseUrlId(urlId);
   return isSnapshot ? buildUrlId({...parts, snapshotId: undefined}) : parts.trunkId;
 }

--- a/app/client/ui/Tools.ts
+++ b/app/client/ui/Tools.ts
@@ -96,6 +96,17 @@ export function tools(owner: Disposable, gristDoc: GristDoc, leftPanelOpen: Obse
       cssPageButton(cssPageIcon('Log'), cssLinkText(t("Document History")), testId('log'),
         dom.on('click', () => gristDoc.showTool('docHistory')))
     ),
+    dom.maybe(docPageModel.isFork, () => {
+      return cssPageEntry(
+        cssPageEntry.cls('-selected', (use) => use(gristDoc.activeViewId) === 'proposals'),
+        cssPageLink(
+          cssPageIcon('EyeShow'),
+          cssLinkText(t("Proposed Changes")),
+          testId('proposals'),
+          urlState().setLinkUrl({docPage: 'proposals'})
+        )
+      );
+    }),
     cssPageEntry(
       cssPageEntry.cls('-selected', (use) => use(gristDoc.activeViewId) === 'code'),
       cssPageLink(cssPageIcon('Code'),

--- a/app/common/ActionSummary.ts
+++ b/app/common/ActionSummary.ts
@@ -1,6 +1,5 @@
 import {CellDelta, TabularDiff, TabularDiffs} from 'app/common/TabularDiff';
 import {ResultRow} from 'app/common/TimeQuery';
-// import cloneDeep = require('lodash/cloneDeep');
 import toPairs = require('lodash/toPairs');
 
 /**
@@ -129,7 +128,7 @@ export function createEmptyTableDelta(): TableDelta {
  * Distill a summary further, into tabular form, for ease of rendering.
  *
  * If context is supplied, in the form of row data for tables, then
- * it the difference information is overlaid on it.
+ * the difference information is overlaid on it.
  */
 export function asTabularDiffs(summary: ActionSummary,
                                context?: Record<string, ResultRow[]>): TabularDiffs {
@@ -143,22 +142,21 @@ export function asTabularDiffs(summary: ActionSummary,
     // need order to be row-dominant for visualization purposes.
     const perRow: {[row: number]: {[name: string]: any}} = {};
     const activeCols = new Set<string>();
-    const activeColOrder: Array<string> = [];
     // First add any background context we have been handed.
     for (const row of singleTableContext || []) {
+      if (!(typeof row.id === 'number')) {
+        // Should not happen.
+        throw new Error(`asTabularDiffs saw a non-numeric id: ${row.id}`);
+      }
       perRow[row.id] = row;
       for (const col of Object.keys(row)) {
         if (!activeCols.has(col)) {
           activeCols.add(col);
-          activeColOrder.push(col);
         }
       }
     }
     // Now iterate through the differences provided, and overlay them.
     for (const [col, perCol] of toPairs(td.columnDeltas)) {
-      if (!activeCols.has(col)) {
-        activeColOrder.push(col);
-      }
       activeCols.add(col);
       for (const row of Object.keys(perCol)) {
         if (!perRow[row as any]) { perRow[row as any] = {}; }
@@ -166,7 +164,7 @@ export function asTabularDiffs(summary: ActionSummary,
       }
     }
     // TODO: recover row numbers (as opposed to rowIds)
-    const activeColsWithoutManualSort = [...activeColOrder].filter(c => c !== 'manualSort');
+    const activeColsWithoutManualSort = [...activeCols].filter(c => c !== 'manualSort');
     tableChanges.header = activeColsWithoutManualSort;
     const addedRows = new Set(td.addRows);
     const removedRows = new Set(td.removeRows);

--- a/app/common/ActionSummary.ts
+++ b/app/common/ActionSummary.ts
@@ -1,4 +1,6 @@
 import {CellDelta, TabularDiff, TabularDiffs} from 'app/common/TabularDiff';
+import {ResultRow} from 'app/common/TimeQuery';
+// import cloneDeep = require('lodash/cloneDeep');
 import toPairs = require('lodash/toPairs');
 
 /**
@@ -125,29 +127,46 @@ export function createEmptyTableDelta(): TableDelta {
 
 /**
  * Distill a summary further, into tabular form, for ease of rendering.
+ *
+ * If context is supplied, in the form of row data for tables, then
+ * it the difference information is overlaid on it.
  */
-export function asTabularDiffs(summary: ActionSummary): TabularDiffs {
+export function asTabularDiffs(summary: ActionSummary,
+                               context?: Record<string, ResultRow[]>): TabularDiffs {
   const allChanges: TabularDiffs = {};
   for (const [tableId, td] of toPairs(summary.tableDeltas)) {
+    const singleTableContext = context?.[tableId];
     const tableChanges: TabularDiff = allChanges[tableId] = {
       header: [],
       cells: [],
     };
-    // swap order to row-dominant for visualization purposes
+    // need order to be row-dominant for visualization purposes.
     const perRow: {[row: number]: {[name: string]: any}} = {};
     const activeCols = new Set<string>();
-    // iterate through the column-dominant representation grist prefers internally
+    const activeColOrder: Array<string> = [];
+    // First add any background context we have been handed.
+    for (const row of singleTableContext || []) {
+      perRow[row.id] = row;
+      for (const col of Object.keys(row)) {
+        if (!activeCols.has(col)) {
+          activeCols.add(col);
+          activeColOrder.push(col);
+        }
+      }
+    }
+    // Now iterate through the differences provided, and overlay them.
     for (const [col, perCol] of toPairs(td.columnDeltas)) {
+      if (!activeCols.has(col)) {
+        activeColOrder.push(col);
+      }
       activeCols.add(col);
-      // iterate through the rows for that column, writing out the row-dominant
-      // results we want for visualization.
       for (const row of Object.keys(perCol)) {
         if (!perRow[row as any]) { perRow[row as any] = {}; }
         perRow[row as any][col] = perCol[row as any];
       }
     }
-    // TODO: recover order of columns; recover row numbers (as opposed to rowIds)
-    const activeColsWithoutManualSort = [...activeCols].filter(c => c !== 'manualSort');
+    // TODO: recover row numbers (as opposed to rowIds)
+    const activeColsWithoutManualSort = [...activeColOrder].filter(c => c !== 'manualSort');
     tableChanges.header = activeColsWithoutManualSort;
     const addedRows = new Set(td.addRows);
     const removedRows = new Set(td.removeRows);
@@ -168,8 +187,11 @@ export function asTabularDiffs(summary: ActionSummary): TabularDiffs {
         // We signal this visually with a "..." row.  The order of where this should
         // go isn't well defined at this point (there's a row number TODO above).
         if (rowId > droppedRows[0]) {
-          tableChanges.cells.push(['...', droppedRows[0],
-                                   activeColsWithoutManualSort.map(x => [null, null] as [null, null])]);
+          tableChanges.cells.push({
+            type: '...',
+            rowId: droppedRows[0],
+            cellDeltas: activeColsWithoutManualSort.map(x => [null, null] as [null, null])
+          });
           while (rowId > droppedRows[0]) {
             droppedRows.shift();
           }
@@ -185,9 +207,15 @@ export function asTabularDiffs(summary: ActionSummary): TabularDiffs {
         versions.push(['+', (diff) => [null, diff[1]]]);
       } else {
         let code: string = '...';
-        if (updatedRows.has(rowId)) { code = '→'; }
-        if (addedRows.has(rowId))   { code = '+';  }
-        if (removedRows.has(rowId)) { code = '-';  }
+        if (updatedRows.has(rowId)) {
+          code = '→';
+        }
+        if (addedRows.has(rowId)) {
+          code = '+';
+        }
+        if (removedRows.has(rowId)) {
+          code = '-';
+        }
         versions.push([code, (diff) => diff]);
       }
       for (const [code, transform] of versions) {
@@ -201,7 +229,11 @@ export function asTabularDiffs(summary: ActionSummary): TabularDiffs {
             acc.push(transform(diff));
           }
         });
-        tableChanges.cells.push([code, rowId, acc]);
+        tableChanges.cells.push({
+          type: code,
+          rowId,
+          cellDeltas: acc
+        });
       }
     }
   }

--- a/app/common/TabularDiff.ts
+++ b/app/common/TabularDiff.ts
@@ -19,10 +19,16 @@ export type CellDelta = [[any]|"?"|null, [any]|"?"|null];
 /** a special column indicating what changes happened on row (addition, update, removal) */
 export type RowChangeType = string;
 
+interface TabularDiffRow {
+  type: RowChangeType;
+  rowId: number;
+  cellDeltas: CellDelta[];
+}
+
 /** differences for an individual table */
 export interface TabularDiff {
   header: string[];  /** labels for columns */
-  cells: Array<[RowChangeType, number, CellDelta[]]>;  // "number" is rowId
+  cells: Array<TabularDiffRow>;
 }
 
 /** differences for a collection of tables */

--- a/app/common/TimeQuery.ts
+++ b/app/common/TimeQuery.ts
@@ -1,0 +1,234 @@
+import {ActionSummary, ColumnDelta, createEmptyActionSummary, createEmptyTableDelta} from 'app/common/ActionSummary';
+import {CellDelta} from 'app/common/TabularDiff';
+import {concatenateSummaries} from 'app/common/ActionSummarizer';
+import cloneDeep = require('lodash/cloneDeep');
+import keyBy = require('lodash/keyBy');
+import matches = require('lodash/matches');
+import sortBy = require('lodash/sortBy');
+import toPairs = require('lodash/toPairs');
+
+/**
+ * We can combine an ActionSummary with the current state of the database
+ * to answer questions about the state of the database in the past.  This
+ * is particularly useful for grist metadata tables, which are needed to
+ * interpret the content of user tables fully.
+ *   - TimeCursor is a simple container for the db and an ActionSummary
+ *   - TimeQuery offers a db-like interface for a given table and set of columns
+ *   - TimeLayout answers a couple of concrete questions about table meta-data using a
+ *     set of TimeQuery objects hooked up to _grist_* tables.
+ */
+
+export interface ResultRow {
+  [column: string]: any;
+}
+
+export interface ITimeData {
+  fetch(tableId: string, colIds: string[], rowIds?: number[]): Promise<ResultRow[]>;
+  getColIds(tableId: string): Promise<string[]>;
+}
+
+/** Track the state of the database at a particular time. */
+export class TimeCursor {
+  public summary: ActionSummary;
+
+  constructor(public db: ITimeData) {
+    this.summary = createEmptyActionSummary();
+  }
+
+  /**
+   * Add a summary of an action just before the last action applied to
+   * the TimeCursor, so we stretch further back in time.
+   */
+  public prepend(prevSummary: ActionSummary) {
+    this.summary = concatenateSummaries([prevSummary, this.summary]);
+  }
+
+  /**
+   * Add a summary of an action just after the last action applied to
+   * the TimeCursor, going one step closer to current time. When the
+   * cursor is used, the summary is assumed to extend right up to
+   * current time.
+   */
+  public append(nextSummary: ActionSummary) {
+    // TODO: concatenation appears to modify its inputs, so we
+    // need to clone to avoid propagating that. Look to see if
+    // a safe version of concatenation could be written to save
+    // cloning.
+    this.summary = concatenateSummaries([this.summary, cloneDeep(nextSummary)]);
+  }
+}
+
+/** internal class for storing a ResultRow dictionary, keyed by rowId */
+class ResultRows {
+  [rowId: number]: ResultRow;
+}
+
+/**
+ * Query the state of a particular table in the past, given a TimeCursor holding the
+ * current db and a summary of all changes between that past time and now.
+ * For the moment, for simplicity, names of tables and columns are assumed not to
+ * change, and TimeQuery should only be used for _grist_* tables.
+ */
+export class TimeQuery {
+  private _currentRows: ResultRow[];
+  private _pastRows: ResultRow[];
+
+  constructor(public tc: TimeCursor,
+              public tableId: string,
+              public colIds: string[] | '*',
+              public rowIds?: number[]) {
+  }
+
+  public reset(tableId: string, colIds: string[] | '*', rowIds?: number[]) {
+    this.tableId = tableId;
+    this.colIds = colIds;
+    this.rowIds = rowIds;
+    this._currentRows = [];
+    this._pastRows = [];
+  }
+
+  /**
+   * Get fresh data from DB and overlay with any past data.
+   * TODO: optimize.
+   */
+  public async update(): Promise<ResultRow[]> {
+    this._currentRows = [];
+    this._pastRows = [];
+
+    const tableRenameDelta = this.tc.summary.tableRenames.find(
+      (delta) => delta[0] === this.tableId
+    );
+    const tableRenamed = tableRenameDelta ? tableRenameDelta[1] : this.tableId;
+    // Table no longer exists.
+    if (!tableRenamed) { return []; }
+
+    // Let's see everything the summary has accumulated about the table back then.
+    const td = this.tc.summary.tableDeltas[tableRenamed] || createEmptyTableDelta();
+
+    const columnForwardRenames: Record<string, string|null> =
+        Object.fromEntries(td.columnRenames.filter(delta => delta[0]));
+    const columnBackwardRenames: Record<string, string|null> =
+        Object.fromEntries(td.columnRenames.map(([a, b]) => [b, a]).filter(delta => delta[0]));
+
+    const colIdsExpanded = this.colIds === '*' ?
+        (await this.tc.db.getColIds(tableRenamed)).map(colId => columnBackwardRenames[colId] ?? colId) :
+        this.colIds;
+
+    const colIdsRenamed =
+        colIdsExpanded.map(colId => columnForwardRenames[colId] ?? colId).filter(colId => colId);
+    this._currentRows = await this.tc.db.fetch(
+      tableRenamed,
+      ['id', ...colIdsRenamed],
+      this.rowIds,
+    );
+
+    // Now rewrite the summary as a ResultRow dictionary, to make it comparable
+    // with database.
+    const summaryRows: ResultRows = {};
+    for (const [colId, columns] of toPairs(td.columnDeltas)) {
+      for (const [rowId, cell] of toPairs(columns) as unknown as Array<[keyof ColumnDelta, CellDelta]>) {
+        if (!summaryRows[rowId]) { summaryRows[rowId] = {}; }
+        const val = cell[0];
+        summaryRows[rowId][colId] = (val !== null && typeof val === 'object' ) ? val[0] : null;
+      }
+    }
+
+    // Prepare to access the current database state by rowId.
+    const rowsById = keyBy(this._currentRows, r => (r.id as number));
+
+    // Prepare a list of rowIds at the time of interest.
+    // The past rows are whatever the db has now, omitting rows that were added
+    // since the past time, and adding back any rows that were removed since then.
+    // Careful about the order of this, since rows could be replaced.
+    const additions = new Set(td.addRows);
+    const pastRowIds =
+      new Set([...this._currentRows.map(r => r.id as number).filter(r => !additions.has(r)),
+               ...td.removeRows]);
+
+    // Now prepare a row for every expected rowId, using current db data if available
+    // and relevant, and overlaying past data when available.
+    this._pastRows = new Array<ResultRow>();
+    const colIdsOfInterest = new Set(colIdsExpanded);
+    for (const id of Array.from(pastRowIds).sort()) {
+      const rowCurrent: ResultRow = rowsById[id] || {id};
+      const row: ResultRow = {};
+      for (const colId of ['id', ...colIdsExpanded]) {
+        const colIdRenamed = columnForwardRenames[colId] ?? colId;
+        if (!colIdRenamed) { continue; }
+        row[colId] = rowCurrent[colIdRenamed];
+      }
+      if (summaryRows[id] && !additions.has(id)) {
+        for (const [colId, val] of toPairs(summaryRows[id])) {
+          const colIdRenamed = columnBackwardRenames[colId] ?? colId;
+          if (colIdsOfInterest.has(colIdRenamed)) {
+            row[colIdRenamed] = val;
+          }
+        }
+      }
+      this._pastRows.push(row);
+    }
+    return this._pastRows;
+  }
+
+  /**
+   * Do a query with a single result, specifying any desired filters.  Exception thrown
+   * if there is no result.
+   */
+  public one(args: {[name: string]: any}): ResultRow {
+    const result = this._pastRows.find(matches(args));
+    if (!result) {
+      throw new Error(`could not find: ${JSON.stringify(args)} for ${this.tableId}`);
+    }
+    return result;
+  }
+
+  /** Get all results for a query. */
+  public all(args?: {[name: string]: any}): ResultRow[] {
+    if (!args) { return this._pastRows; }
+    return this._pastRows.filter(matches(args));
+  }
+}
+
+/**
+ * Put some TimeQuery queries to work answering questions about column order and
+ * user-facing name of tables.
+ */
+export class TimeLayout {
+  public tables: TimeQuery;
+  public fields: TimeQuery;
+  public columns: TimeQuery;
+  public views: TimeQuery;
+  public sections: TimeQuery;
+
+  constructor(public tc: TimeCursor) {
+    this.tables = new TimeQuery(tc, '_grist_Tables', ['tableId', 'primaryViewId', 'rawViewSectionRef']);
+    this.fields = new TimeQuery(tc, '_grist_Views_section_field',
+                                ['parentId', 'parentPos', 'colRef']);
+    this.columns = new TimeQuery(tc, '_grist_Tables_column', ['parentId', 'colId']);
+    this.views = new TimeQuery(tc, '_grist_Views', ['id', 'name']);
+    this.sections = new TimeQuery(tc, '_grist_Views_section', ['id', 'title']);
+  }
+
+  /** update from TimeCursor */
+  public async update() {
+    await this.tables.update();
+    await this.columns.update();
+    await this.fields.update();
+    await this.views.update();
+    await this.sections.update();
+  }
+
+  public getColumnOrder(tableId: string): string[] {
+    const primaryViewId = this.tables.one({tableId}).primaryViewId;
+    const preorder = this.fields.all({parentId: primaryViewId});
+    const precol = keyBy(this.columns.all(), 'id');
+    const ordered = sortBy(preorder, 'parentPos');
+    const names = ordered.map(r => precol[r.colRef].colId);
+    return names;
+  }
+
+  public getTableName(tableId: string): string {
+    const rawViewSectionRef = this.tables.one({tableId}).rawViewSectionRef;
+    return this.sections.one({id: rawViewSectionRef}).title;
+  }
+}

--- a/app/common/TimeQuery.ts
+++ b/app/common/TimeQuery.ts
@@ -10,7 +10,7 @@ import toPairs = require('lodash/toPairs');
 /**
  * We can combine an ActionSummary with the current state of the database
  * to answer questions about the state of the database in the past.  This
- * is particularly useful for grist metadata tables, which are needed to
+ * is particularly useful for Grist metadata tables, which are needed to
  * interpret the content of user tables fully.
  *   - TimeCursor is a simple container for the db and an ActionSummary
  *   - TimeQuery offers a db-like interface for a given table and set of columns
@@ -59,7 +59,7 @@ export class TimeCursor {
 }
 
 /** internal class for storing a ResultRow dictionary, keyed by rowId */
-class ResultRows {
+interface ResultRows {
   [rowId: number]: ResultRow;
 }
 

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -22,7 +22,10 @@ import * as t from "ts-interface-checker";
 
 const { ICommonUrls: ICommonUrlsChecker } = t.createCheckers(ICommonUrlsTI);
 
-export const SpecialDocPage = StringUnion('code', 'acl', 'data', 'GristDocTour', 'settings', 'webhook', 'timing');
+export const SpecialDocPage = StringUnion(
+  'code', 'acl', 'data', 'GristDocTour',
+  'proposals', 'settings', 'webhook', 'timing',
+);
 type SpecialDocPage = typeof SpecialDocPage.type;
 export type IDocPage = number | SpecialDocPage;
 

--- a/app/server/lib/TimeQuery.ts
+++ b/app/server/lib/TimeQuery.ts
@@ -1,167 +1,18 @@
-import {ActionSummary, ColumnDelta, createEmptyActionSummary, createEmptyTableDelta} from 'app/common/ActionSummary';
-import {CellDelta} from 'app/common/TabularDiff';
-import {concatenateSummaries} from 'app/common/ActionSummarizer';
-import {ISQLiteDB, quoteIdent, ResultRow} from 'app/server/lib/SQLiteDB';
-import keyBy = require('lodash/keyBy');
-import matches = require('lodash/matches');
-import sortBy = require('lodash/sortBy');
-import toPairs = require('lodash/toPairs');
+import { ITimeData } from 'app/common/TimeQuery';
+import { ISQLiteDB, quoteIdent, ResultRow } from 'app/server/lib/SQLiteDB';
 
-/**
- * We can combine an ActionSummary with the current state of the database
- * to answer questions about the state of the database in the past.  This
- * is particularly useful for grist metadata tables, which are needed to
- * interpret the content of user tables fully.
- *   - TimeCursor is a simple container for the db and an ActionSummary
- *   - TimeQuery offers a db-like interface for a given table and set of columns
- *   - TimeLayout answers a couple of concrete questions about table meta-data using a
- *     set of TimeQuery objects hooked up to _grist_* tables.  It could be used to
- *     improve the rendering of the ActionLog, for example, although it is not (yet).
- */
-
-/** Track the state of the database at a particular time. */
-export class TimeCursor {
-  public summary: ActionSummary;
-
-  constructor(public db: ISQLiteDB) {
-    this.summary = createEmptyActionSummary();
+export class SQLiteTimeData implements ITimeData {
+  public constructor(public db: ISQLiteDB) {
   }
 
-  /** add a summary of an action just before the last action applied to the TimeCursor */
-  public prepend(prevSummary: ActionSummary) {
-    this.summary = concatenateSummaries([prevSummary, this.summary]);
+  public async getColIds(tableId: string): Promise<string[]> {
+    const columns = await this.db.all(`PRAGMA table_info(${quoteIdent(tableId)})`);
+    return columns.map(column => column.name);
   }
 
-  /** add a summary of an action just after the last action applied to the TimeCursor */
-  public append(nextSummary: ActionSummary) {
-    this.summary = concatenateSummaries([this.summary, nextSummary]);
-  }
-}
-
-/** internal class for storing a ResultRow dictionary, keyed by rowId */
-class ResultRows {
-  [rowId: number]: ResultRow;
-}
-
-/**
- * Query the state of a particular table in the past, given a TimeCursor holding the
- * current db and a summary of all changes between that past time and now.
- * For the moment, for simplicity, names of tables and columns are assumed not to
- * change, and TimeQuery should only be used for _grist_* tables.
- */
-export class TimeQuery {
-  private _currentRows: ResultRow[];
-  private _pastRows: ResultRow[];
-
-  constructor(public tc: TimeCursor, public tableId: string, public colIds: string[]) {
-  }
-
-  /** Get fresh data from DB and overlay with any past data */
-  public async update(): Promise<ResultRow[]> {
-    this._currentRows = await this.tc.db.all(
-      `select ${['id', ...this.colIds].map(quoteIdent).join(',')} from ${quoteIdent(this.tableId)}`);
-
-    // Let's see everything the summary has accumulated about the table back then.
-    const td = this.tc.summary.tableDeltas[this.tableId] || createEmptyTableDelta();
-
-    // Now rewrite the summary as a ResultRow dictionary, to make it comparable
-    // with database.
-    const summaryRows: ResultRows = {};
-    for (const [colId, columns] of toPairs(td.columnDeltas)) {
-      for (const [rowId, cell] of toPairs(columns) as unknown as Array<[keyof ColumnDelta, CellDelta]>) {
-        if (!summaryRows[rowId]) { summaryRows[rowId] = {}; }
-        const val = cell[0];
-        summaryRows[rowId][colId] = (val !== null && typeof val === 'object' ) ? val[0] : null;
-      }
-    }
-
-    // Prepare to access the current database state by rowId.
-    const rowsById = keyBy(this._currentRows, r => (r.id as number));
-
-    // Prepare a list of rowIds at the time of interest.
-    // The past rows are whatever the db has now, omitting rows that were added
-    // since the past time, and adding back any rows that were removed since then.
-    // Careful about the order of this, since rows could be replaced.
-    const additions = new Set(td.addRows);
-    const pastRowIds =
-      new Set([...this._currentRows.map(r => r.id as number).filter(r => !additions.has(r)),
-               ...td.removeRows]);
-
-    // Now prepare a row for every expected rowId, using current db data if available
-    // and relevant, and overlaying past data when available.
-    this._pastRows = new Array<ResultRow>();
-    const colIdsOfInterest = new Set(this.colIds);
-    for (const id of Array.from(pastRowIds).sort()) {
-      const row: ResultRow = rowsById[id] || {id};
-      if (summaryRows[id] && !additions.has(id)) {
-        for (const [colId, val] of toPairs(summaryRows[id])) {
-          if (colIdsOfInterest.has(colId)) { row[colId] = val; }
-        }
-      }
-      this._pastRows.push(row);
-    }
-    return this._pastRows;
-  }
-
-  /**
-   * Do a query with a single result, specifying any desired filters.  Exception thrown
-   * if there is no result.
-   */
-  public one(args: {[name: string]: any}): ResultRow {
-    const result = this._pastRows.find(matches(args));
-    if (!result) {
-      throw new Error(`could not find: ${JSON.stringify(args)} for ${this.tableId}`);
-    }
-    return result;
-  }
-
-  /** Get all results for a query. */
-  public all(args?: {[name: string]: any}): ResultRow[] {
-    if (!args) { return this._pastRows; }
-    return this._pastRows.filter(matches(args));
-  }
-}
-
-/**
- * Put some TimeQuery queries to work answering questions about column order and
- * user-facing name of tables.
- */
-export class TimeLayout {
-  public tables: TimeQuery;
-  public fields: TimeQuery;
-  public columns: TimeQuery;
-  public views: TimeQuery;
-  public sections: TimeQuery;
-
-  constructor(public tc: TimeCursor) {
-    this.tables = new TimeQuery(tc, '_grist_Tables', ['tableId', 'primaryViewId', 'rawViewSectionRef']);
-    this.fields = new TimeQuery(tc, '_grist_Views_section_field',
-                                ['parentId', 'parentPos', 'colRef']);
-    this.columns = new TimeQuery(tc, '_grist_Tables_column', ['parentId', 'colId']);
-    this.views = new TimeQuery(tc, '_grist_Views', ['id', 'name']);
-    this.sections = new TimeQuery(tc, '_grist_Views_section', ['id', 'title']);
-  }
-
-  /** update from TimeCursor */
-  public async update() {
-    await this.tables.update();
-    await this.columns.update();
-    await this.fields.update();
-    await this.views.update();
-    await this.sections.update();
-  }
-
-  public getColumnOrder(tableId: string): string[] {
-    const primaryViewId = this.tables.one({tableId}).primaryViewId;
-    const preorder = this.fields.all({parentId: primaryViewId});
-    const precol = keyBy(this.columns.all(), 'id');
-    const ordered = sortBy(preorder, 'parentPos');
-    const names = ordered.map(r => precol[r.colRef].colId);
-    return names;
-  }
-
-  public getTableName(tableId: string): string {
-    const rawViewSectionRef = this.tables.one({tableId}).rawViewSectionRef;
-    return this.sections.one({id: rawViewSectionRef}).title;
+  public async fetch(tableId: string, colIds: string[], rowIds?: number[]): Promise<ResultRow[]> {
+    if (rowIds) { throw new Error('not yet'); }
+    return this.db.all(
+      `select ${colIds.map(quoteIdent).join(',')} from ${quoteIdent(tableId)}`);
   }
 }

--- a/sandbox/grist/imports/import_csv.py
+++ b/sandbox/grist/imports/import_csv.py
@@ -10,6 +10,8 @@ import chardet
 import parse_data
 from imports import import_utils
 
+import sys
+csv.field_size_limit(sys.maxsize)
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)

--- a/sandbox/grist/imports/import_csv.py
+++ b/sandbox/grist/imports/import_csv.py
@@ -11,6 +11,9 @@ import parse_data
 from imports import import_utils
 
 import sys
+# Remove rather small default limit on individual csv fields.
+# While hand-written CSV files are unlikely to have large fields,
+# there can be large fields when CSV is used for interoperability.
 csv.field_size_limit(sys.maxsize)
 
 log = logging.getLogger(__name__)

--- a/test/nbrowser/ActionLog.ts
+++ b/test/nbrowser/ActionLog.ts
@@ -131,7 +131,7 @@ describe('ActionLog', function() {
 
   it("should show clickable tabular diffs", async function() {
     const item0 = await getActionLogItem(0);
-    assert.equal(await item0.find('table caption').getText(), 'Table1');
+    assert.equal(await item0.find('table caption').getText(), 'Table1 >');
     assert.equal(await item0.find('table th:nth-child(2)').getText(), 'A');
     assert.equal(await item0.find('table td:nth-child(2)').getText(), 'f');
     assert.equal(await gu.getActiveCell().getText(), 'a');
@@ -151,7 +151,7 @@ describe('ActionLog', function() {
     // actions though -- e.g. the action below still mentions 'A' for column name -- and it's
     // unclear if it should.)
     const item2 = await getActionLogItem(2);
-    assert.equal(await item2.find('table caption').getText(), 'Table1');
+    assert.equal(await item2.find('table caption').getText(), 'Table1 >');
     assert.equal(await item2.find('table td:nth-child(2)').getText(), 'f');
     await gu.getCell({rowNum: 1, col: 0}).click();
     assert.notEqual(await gu.getActiveCell().getText(), 'f');
@@ -185,7 +185,7 @@ describe('ActionLog', function() {
 
     assert.lengthOf(await getActionLogItems(), 2);
 
-    assert.equal(await getActionLogItem(0).find("table:not([style*='display: none']) caption").getText(), 'Table1');
+    assert.equal(await getActionLogItem(0).find("table:not([style*='display: none']) caption").getText(), 'Table1 >');
     assert.equal(await getActionLogItem(1).find('.action_log_rename').getText(), 'Add Table1');
     await gu.renameTable('Table1', 'Table1Renamed');
     assert.equal(await getActionLogItem(0).find('.action_log_rename').getText(),
@@ -195,9 +195,9 @@ describe('ActionLog', function() {
     assert.equal(await getActionLogItem(0).find('.action_log_rename').getText(),
       'Rename Table1Renamed.A to ARenamed');
     await gu.getPageItem('Table2').click();
-    assert.equal(await getActionLogItem(0).find("table:not([style*='display: none']) caption").getText(), 'Table2');
+    assert.equal(await getActionLogItem(0).find("table:not([style*='display: none']) caption").getText(), 'Table2 >');
     await gu.getPageItem('Table3').click();
-    assert.equal(await getActionLogItem(0).find("table:not([style*='display: none']) caption").getText(), 'Table3');
+    assert.equal(await getActionLogItem(0).find("table:not([style*='display: none']) caption").getText(), 'Table3 >');
 
       // Now show all tables and make sure the result is a longer (visible) log.
     const filteredCount = (await getActionLogItems()).length;

--- a/test/nbrowser/ProposedChangesPage.ts
+++ b/test/nbrowser/ProposedChangesPage.ts
@@ -1,0 +1,56 @@
+import {assert, driver} from 'mocha-webdriver';
+import * as gu from 'test/nbrowser/gristUtils';
+import {setupTestSuite} from 'test/nbrowser/testUtils';
+
+describe('ProposedChangesPage', function() {
+  this.timeout(60000);
+  const cleanup = setupTestSuite();
+
+  it('show comparison and functions as expected', async function() {
+    const session = await gu.session().teamSite.login();
+    // const api = session.createHomeApi();
+    await session.tempDoc(cleanup, 'Hello.grist');
+    // Open the share menu and click item to work on a copy.
+    await gu.getCell('A', 1).click();
+    await gu.waitAppFocus();
+    await gu.enterCell('test1');
+    await driver.find('.test-tb-share').click();
+    await driver.find('.test-work-on-copy').click();
+    await gu.waitForServer();
+    await gu.getCell('A', 1).click();
+    await gu.waitAppFocus();    
+    await gu.enterCell('test2');
+    await driver.find('.test-tools-proposals').click();
+    await driver.findContentWait('.test-main-content', /Proposed Changes/, 2000);
+    await driver.findWait('.action_log_table', 2000);
+    assert.lengthOf(await driver.findAll('.action_log_table'), 1);
+    assert.equal(
+      await driver.find('.action_log_table tr:first-of-type').getText(),
+      'A E'
+    );
+    assert.equal(
+      await driver.find('.action_log_table tr:nth-of-type(2)').getText(),
+      '→\ntest1test2\nTEST1TEST2'
+    );
+    assert.equal(await driver.find('.action_log_table button').getText(), '>');
+    await driver.find('.action_log_table button').click();
+    assert.equal(await driver.find('.action_log_table button').getText(), '<');
+    assert.equal(
+      await driver.findContentWait('.action_log_table tr:first-of-type', /id/, 2000).getText(),
+      'id A B C D E'
+    );
+    assert.equal(
+      await driver.find('.action_log_table tr:nth-of-type(2)').getText(),
+      '→ 1\ntest1test2\nTEST1TEST2'
+    );
+    await driver.find('[data-test-id=replace]').click();
+    let confirmButton = driver.findWait('.test-modal-confirm', 3000);
+    assert.equal(await confirmButton.getText(), 'Update');
+    await confirmButton.click();
+
+    // check we're no longer on a fork, but still have the change made on the fork.
+    await gu.waitForUrl(/^[^~]*$/, 6000);
+    await gu.waitForDocToLoad();
+    assert.equal(await gu.getCell({rowNum: 1, col: 0}).getText(), 'test2');
+  });
+});

--- a/test/nbrowser/ProposedChangesPage.ts
+++ b/test/nbrowser/ProposedChangesPage.ts
@@ -43,7 +43,7 @@ describe('ProposedChangesPage', function() {
       await driver.find('.action_log_table tr:nth-of-type(2)').getText(),
       '→ 1\ntest1test2\nTEST1TEST2'
     );
-    await driver.find('[data-test-id=replace]').click();
+    await driver.find('.test-replace').click();
     const confirmButton = driver.findWait('.test-modal-confirm', 3000);
     assert.equal(await confirmButton.getText(), 'Update');
     await confirmButton.click();

--- a/test/nbrowser/ProposedChangesPage.ts
+++ b/test/nbrowser/ProposedChangesPage.ts
@@ -18,7 +18,7 @@ describe('ProposedChangesPage', function() {
     await driver.find('.test-work-on-copy').click();
     await gu.waitForServer();
     await gu.getCell('A', 1).click();
-    await gu.waitAppFocus();    
+    await gu.waitAppFocus();
     await gu.enterCell('test2');
     await driver.find('.test-tools-proposals').click();
     await driver.findContentWait('.test-main-content', /Proposed Changes/, 2000);
@@ -44,7 +44,7 @@ describe('ProposedChangesPage', function() {
       '→ 1\ntest1test2\nTEST1TEST2'
     );
     await driver.find('[data-test-id=replace]').click();
-    let confirmButton = driver.findWait('.test-modal-confirm', 3000);
+    const confirmButton = driver.findWait('.test-modal-confirm', 3000);
     assert.equal(await confirmButton.getText(), 'Update');
     await confirmButton.click();
 

--- a/test/server/lib/ActionSummary.ts
+++ b/test/server/lib/ActionSummary.ts
@@ -142,14 +142,14 @@ describe("ActionSummary", function() {
     assert.sameDeepMembers(tabularDiffs.Frogs.header,
                            ['species', 'color', 'place']);
     assert.lengthOf(tabularDiffs.Frogs.cells, 3);
-    const rowTypes = tabularDiffs.Frogs.cells.map(row => row[0]);
+    const rowTypes = tabularDiffs.Frogs.cells.map(row => row.type);
     assert.sameDeepMembers(rowTypes, ['+', '-', '→']);
     const colsList = tabularDiffs.Frogs.header.map((name, idx) => [name, idx] as [string, number]);
     const cols = new Map<string, number>(colsList);
-    const rows = keyBy(tabularDiffs.Frogs.cells, row => row[0]);
-    assert.deepEqual(rows['+'][2][cols.get('species')!], [null, ['gretons']]);
-    assert.deepEqual(rows['→'][2][cols.get('place')!], [['Alaskers'], ['Alaska']]);
-    assert.deepEqual(rows['-'][2][cols.get('species')!], [['parrots'], null]);
+    const rows = keyBy(tabularDiffs.Frogs.cells, row => row.type);
+    assert.deepEqual(rows['+'].cellDeltas[cols.get('species')!], [null, ['gretons']]);
+    assert.deepEqual(rows['→'].cellDeltas[cols.get('place')!], [['Alaskers'], ['Alaska']]);
+    assert.deepEqual(rows['-'].cellDeltas[cols.get('species')!], [['parrots'], null]);
   });
 
   it ('produces reasonable tabular diffs of simple bulk actions', async function() {
@@ -175,7 +175,7 @@ describe("ActionSummary", function() {
     assert.sameDeepMembers(tabularDiffs.Frogs.header,
                            ['species', 'color', 'place']);
     assert(tabularDiffs.Frogs.cells.length < ids.length);
-    const rowTypes = tabularDiffs.Frogs.cells.map(row => row[0]);
+    const rowTypes = tabularDiffs.Frogs.cells.map(row => row.type);
     assert.equal(rowTypes.length - 1, rowTypes.filter(label => label === '+').length);
     assert.equal(1, rowTypes.filter(label => label === '...').length);
   });
@@ -200,8 +200,8 @@ describe("ActionSummary", function() {
     const tabularDiffs = asTabularDiffs(sum);
     assert.lengthOf(tabularDiffs.Duck.cells, 2);
     assert.sameDeepMembers(tabularDiffs.Duck.cells,
-                           [["-", 1, [[["yellow"], null]]],
-                            ["+", 1, [[null, ["red"]]]]]);
+                           [{type: "-", rowId: 1, cellDeltas: [[["yellow"], null]]},
+                            {type: "+", rowId: 1, cellDeltas: [[null, ["red"]]]}]);
   });
 
   it ('summarizes ReplaceTableData actions', async function() {

--- a/test/server/lib/TimeQuery.ts
+++ b/test/server/lib/TimeQuery.ts
@@ -123,7 +123,9 @@ describe("TimeQuery", function() {
     const cursor = new TimeCursor(new SQLiteTimeData(db));
     const session = docTools.createFakeSession();
 
-    // Create a table with three columns.
+    // Create a table with three columns. In this test, we will rename
+    // the table and a column and make sure the renames don't affect
+    // querying information prior to those changes.
     await doc.applyUserActions(session, [
       ["AddTable", "Fish", [{id: "age"}, {id: "species"}, {id: "color"}]],
       ["AddRecord", "Fish", null, {age: "11", species: "flounder", color: "blue"}],

--- a/test/server/lib/TimeQuery.ts
+++ b/test/server/lib/TimeQuery.ts
@@ -1,7 +1,8 @@
 import {summarizeAction} from 'app/common/ActionSummarizer';
 import {ActionSummary} from 'app/common/ActionSummary';
+import {TimeCursor, TimeLayout, TimeQuery} from 'app/common/TimeQuery';
 import {ActiveDoc} from 'app/server/lib/ActiveDoc';
-import {TimeCursor, TimeLayout, TimeQuery} from 'app/server/lib/TimeQuery';
+import {SQLiteTimeData} from 'app/server/lib/TimeQuery';
 import {createDocTools} from 'test/server/docTools';
 import * as testUtils from 'test/server/testUtils';
 import {assert} from 'test/server/testUtils';
@@ -23,7 +24,7 @@ describe("TimeQuery", function() {
   it ('can view state of table in past', async function() {
     const doc: ActiveDoc = await docTools.createDoc('test.grist');
     const db = doc.docStorage;
-    const cursor = new TimeCursor(db);
+    const cursor = new TimeCursor(new SQLiteTimeData(db));
 
     // We'll be interested in viewing the state of table "Fish", column "age".
     const fish = new TimeQuery(cursor, 'Fish', ['age']);
@@ -65,7 +66,7 @@ describe("TimeQuery", function() {
   it ('can track column order and user-facing table name', async function() {
     const doc: ActiveDoc = await docTools.createDoc('test.grist');
     const db = doc.docStorage;
-    const cursor = new TimeCursor(db);
+    const cursor = new TimeCursor(new SQLiteTimeData(db));
     const layout = new TimeLayout(cursor);
     const session = docTools.createFakeSession();
 
@@ -114,4 +115,106 @@ describe("TimeQuery", function() {
                   /could not find/);
   });
 
+  it ('can handle renames', async function() {
+    this.timeout(10000);
+
+    const doc: ActiveDoc = await docTools.createDoc('test.grist');
+    const db = doc.docStorage;
+    const cursor = new TimeCursor(new SQLiteTimeData(db));
+    const session = docTools.createFakeSession();
+
+    // Create a table with three columns.
+    await doc.applyUserActions(session, [
+      ["AddTable", "Fish", [{id: "age"}, {id: "species"}, {id: "color"}]],
+      ["AddRecord", "Fish", null, {age: "11", species: "flounder", color: "blue"}],
+      ["AddRecord", "Fish", null, {age: "22", species: "bounder", color: "red"}],
+    ]);
+    await doc.applyUserActions(session, [
+      ["RenameTable", "Fish", "Fish2"]
+    ]);
+    cursor.append(await summarizeLastAction(doc));
+    const query = new TimeQuery(cursor, 'Fish', ['species']);
+    const expectedResult = [
+      { id: 1, species: 'flounder' },
+      { id: 2, species: 'bounder' }
+    ];
+    let result = await query.update();
+    assert.deepEqual(result, expectedResult);
+
+    await doc.applyUserActions(session, [
+      ["RenameColumn", "Fish2", "species", "species2"]
+    ]);
+    cursor.append(await summarizeLastAction(doc));
+    result = await query.update();
+    assert.deepEqual(result, expectedResult);
+
+    await doc.applyUserActions(session, [
+      ["RenameColumn", "Fish2", "color", "color2"],
+      ["RenameColumn", "Fish2", "species2", "color"],
+    ]);
+    cursor.append(await summarizeLastAction(doc));
+    result = await query.update();
+    assert.deepEqual(result, expectedResult);
+
+    await doc.applyUserActions(session, [
+      ["AddTable", "Fish", [{id: "species"}]],
+      ["AddRecord", "Fish", null, {species: "tadpole"}],
+    ]);
+    cursor.append(await summarizeLastAction(doc));
+    result = await query.update();
+    assert.deepEqual(result, expectedResult);
+
+    await doc.applyUserActions(session, [
+      ["UpdateRecord", "Fish2", 1, {color: "whale"}]
+    ]);
+    cursor.append(await summarizeLastAction(doc));
+    result = await query.update();
+    assert.deepEqual(result, expectedResult);
+
+    // Double check that we've actually made all the changes we think we have.
+    assert.deepEqual(await doc.fetchQuery(session, {tableId: 'Fish2', filters: {}}), {
+      "tableData": [
+        "TableData",
+        "Fish2",
+        [ 1, 2 ],
+        {
+          "manualSort": [
+            1,
+            2
+          ],
+          "age": [
+            "11",
+            "22"
+          ],
+          "color2": [
+            "blue",
+            "red"
+          ],
+          "color": [
+            "whale",
+            "bounder"
+          ]
+        }
+      ]
+    });
+
+    query.reset('Fish', '*');
+    result = await query.update();
+    assert.deepEqual(result, [
+      {
+        id: 1,
+        manualSort: 1,
+        age: '11',
+        species: 'flounder',
+        color: 'blue'
+      },
+      {
+        id: 2,
+        manualSort: 2,
+        age: '22',
+        species: 'bounder',
+        color: 'red'
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
This adds a page to forked documents to show their differences from the trunk using the same format used to show document activity (the `ActionLog` component).

How to test:

  * Use the `fly.dev` preview linked in this thread.
  * Log in and make a document with a table with some content.
  * From the share menu, select "Work on a Copy"  and then make some change to it.
  * In the left sidebar, there should be a new "Proposed Changes" page.

<img width="1006" height="552" alt="Screenshot from 2025-09-17 17-15-37" src="https://github.com/user-attachments/assets/819e9fb4-ed11-498d-b6a8-de87f1001f23" />

The ActionLog format is really bad! Incomplete, out of order, buggy. This work does not fix that. It moves some of the code around without fixing it or improving it. Yet.

This is a placeholder for work on crowdsourcing, where this page will also appear in trunk documents, showing any contributions from forks that the fork owner has chosen to "propose". That step of the work is not included.

There is one change made to the representation of diffs. A little ">" is shown beside tables which, if pressed, adds more context information to them. Currently this adds all current cells in the rows shown in the diff. This is experimental work just to test how practical it is to access this data.

Part of this project: https://github.com/gristlabs/grist-core/issues/1829
