### PR TITLE
Restore recently-broken notifier: getNotifier() should succeed even if notifier is empty.

### DIFF
--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -455,8 +455,9 @@ export class FlexServer implements GristServer {
   }
 
   public getNotifier(): INotifier {
-    // Check that our internal notifier implementation is in place.
-    if (!this.hasNotifier()) { throw new Error('no notifier available'); }
+    // We only warn if we are in a server that doesn't configure notifiers (i.e. not a home
+    // server). But actually having a working notifier isn't required.
+    if (!this._has('notifier')) { throw new Error('no notifier available'); }
     // Expose a wrapper around it that emits actions.
     return this._emitNotifier;
   }


### PR DESCRIPTION
Prior to 43faaba, getNotifier() wasn't using the hasNotifier() check, but succeeded whenever a notifier was "configured" (by adding addNotifier()), even if it was configured with the "empty notifier".

This restores previous behavior. Any home server calls addNotifier(), and the updated check restores the behavior of only checking if addNotifier() has been called.

## Has this been tested?

Tests have been failing since 43faaba, and should now pass.