### PR TITLE
add download menu option to document list

### DIFF
--- a/app/client/ui/DocList.ts
+++ b/app/client/ui/DocList.ts
@@ -8,6 +8,7 @@ import { workspaceName } from "app/client/models/WorkspaceInfo";
 import { contextMenu } from "app/client/ui/contextMenu";
 import { buildDocIcon, stripIconFromName } from "app/client/ui/DocIcon";
 import { STICKY_HEADER_HEIGHT_PX } from "app/client/ui/DocMenuCss";
+import { downloadDocModal } from "app/client/ui/MakeCopyMenu";
 import { showRenameDocModal } from "app/client/ui/RenameDocModal";
 import { shadowScroll } from "app/client/ui/shadowScroll";
 import { makeShareDocUrl } from "app/client/ui/ShareMenu";
@@ -23,7 +24,7 @@ import { icon as cssIcon } from "app/client/ui2018/icons";
 import { unstyledButton, unstyledH2, unstyledUl } from "app/client/ui2018/unstyled";
 import { stretchedLink } from "app/client/ui2018/stretchedLink";
 import { visuallyHidden } from "app/client/ui2018/visuallyHidden";
-import { menu, menuItem, select } from "app/client/ui2018/menus";
+import { menu, menuIcon, menuItem, select } from "app/client/ui2018/menus";
 import { confirmModal, saveModal } from "app/client/ui2018/modals";
 import { HomePageTab } from "app/common/gristUrls";
 import { SortPref } from "app/common/Prefs";
@@ -248,6 +249,7 @@ export class DocList extends Disposable {
 export function makeDocOptionsMenu(home: HomeModel, doc: Document) {
   const org = home.app.currentOrg;
   const orgAccess: roles.Role | null = org ? org.access : null;
+  const isElectron = (window as any).isRunningUnderElectron;
 
   function deleteDoc() {
     confirmModal(
@@ -311,6 +313,16 @@ export function makeDocOptionsMenu(home: HomeModel, doc: Document) {
       roles.canEditAccess(doc.access) ? t("Manage users") : t("Access details"),
       testId("doc-access")
     ),
+    // The electron method for "downloading" documents only works
+    // with a websocket currently, so downloads are only easy
+    // to support when the document is open.
+    // TODO: support showItemInFolder with electron in a better way.
+    (isElectron ? null :
+        menuItem(
+          () => downloadDocModal(doc, home.app),
+          menuIcon('Download'), t("Download document..."),
+          testId('tb-share-option'))
+        ),
   ];
 }
 

--- a/app/client/ui/MakeCopyMenu.ts
+++ b/app/client/ui/MakeCopyMenu.ts
@@ -327,9 +327,9 @@ class SaveCopyModal extends Disposable {
 
 type DownloadOption = 'full' | 'nohistory' | 'template';
 
-export function downloadDocModal(doc: Document, pageModel: DocPageModel) {
+export function downloadDocModal(doc: Document, appModel: AppModel) {
   return modal((ctl, owner) => {
-    const docApi = pageModel.appModel.api.getDocAPI(doc.id);
+    const docApi = appModel.api.getDocAPI(doc.id);
     const selected = Observable.create<DownloadOption>(owner, 'full');
 
     const attachmentStatusObs = Observable.create<DocAttachmentsLocation | undefined | 'unknown'>(owner, undefined);

--- a/app/client/ui/ShareMenu.ts
+++ b/app/client/ui/ShareMenu.ts
@@ -304,7 +304,7 @@ function menuExports(doc: Document, pageModel: DocPageModel) {
     (isElectron ?
       menuItem(() => gristDoc.app.comm.showItemInFolder(doc.name),
         t("Show in folder"), testId('tb-share-option')) :
-        menuItem(() => downloadDocModal(doc, pageModel),
+        menuItem(() => downloadDocModal(doc, pageModel.appModel),
         menuIcon('Download'), t("Download document..."), testId('tb-share-option'))
     ),
     menuItem(


### PR DESCRIPTION
This is easier to get to if the document is in a bad state. The endpoint will still attempt to open the document, but at least there's no need to render the web client. And the endpoint allows downloads to owners even if granular access control gets messed up.

## Context

There are several ways to get a document into a bad state. Once in a bad state, the web client may not function correctly, which currently could impede access to the UI for downloading a document. There's a somewhat robust endpoint for downloading, but it would be nice to have reliably available UI.

## Proposed solution

Add a download option for documents in listings, not just in the share menu when they are open.

## Related issues

https://github.com/gristlabs/grist-core/issues/1784

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

TODO
