### PR TITLE
Update CI to use bitnamilegacy/minio

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,9 +215,9 @@ jobs:
           path: ${{ runner.temp }}/test-logs  # only exists for webdriver tests
 
     services:
-      # https://github.com/bitnami/bitnami-docker-minio/issues/16
+      # https://github.com/bitnami/containers/issues/83267
       minio:
-        image: ${{ matrix.os == 'ubuntu-24.04' && 'bitnami/minio:2025.4.22' || '' }} 
+        image: ${{ matrix.os == 'ubuntu-24.04' && 'bitnamilegacy/minio:2025.4.22' || '' }} 
         env:
           MINIO_DEFAULT_BUCKETS: "grist-docs-test:public"
           MINIO_ROOT_USER: administrator


### PR DESCRIPTION
## Context

See https://github.com/bitnami/containers/issues/83267.

## Proposed solution

Use `bitnamilegacy/minio` image.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->