### PR TITLE
DocApi: add a `/records/delete` endpoint 

### DIFF
--- a/app/common/UserAPI.ts
+++ b/app/common/UserAPI.ts
@@ -1073,7 +1073,7 @@ export class DocAPIImpl extends BaseAPI implements DocAPI {
   }
 
   public async removeRows(tableId: string, removals: number[]): Promise<number[]> {
-    return this.requestJson(`${this._url}/tables/${tableId}/data/delete`, {
+    return this.requestJson(`${this._url}/tables/${tableId}/records/delete`, {
       body: JSON.stringify(removals),
       method: 'POST'
     });

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -896,6 +896,16 @@ export class DocWorkerApi {
       })
     );
 
+    // Delete records
+    this._app.post('/api/docs/:docId/tables/:tableId/records/delete', canEdit,
+      withDoc(async (activeDoc, req, res) => {
+        const rowIds = req.body;
+        const op = await getTableOperations(req, activeDoc);
+        await op.destroy(rowIds);
+        res.json(null);
+      })
+    );
+
     // Update columns given in records format
     this._app.patch('/api/docs/:docId/tables/:tableId/columns', canEdit, validate(ColumnsPatch),
       withDoc(async (activeDoc, req, res) => {

--- a/test/server/lib/DocApi.ts
+++ b/test/server/lib/DocApi.ts
@@ -1711,35 +1711,46 @@ function testDocApi(settings: {
       });
   });
 
-  it("POST /docs/{did}/tables/{tid}/data/delete deletes records", async function () {
-    let resp = await axios.post(
-      `${serverUrl}/api/docs/${docIds.TestDoc}/tables/Foo/data/delete`,
-      [3, 4, 5, 6],
-      chimpy,
-    );
-    assert.equal(resp.status, 200);
-    assert.deepEqual(resp.data, null);
-    resp = await axios.get(`${serverUrl}/api/docs/${docIds.TestDoc}/tables/Foo/data`, chimpy);
-    assert.deepEqual(resp.data, {
-      id: [1, 2],
-      A: ['Santa', 'Bob'],
-      B: ["1", "11"],
-      manualSort: [1, 2]
-    });
+  for(const {desc, url} of [
+    {
+      desc: 'POST /docs/{did}/tables/{tid}/data/delete deletes records',
+      url: 'tables/Foo/data/delete'
+    },
+    {
+      desc: 'POST /docs/{did}/tables/{tid}/records/delete deletes records',
+      url: 'tables/Foo/records/delete'
+    }
+  ]) {
+    it(desc, async function () {
+      let resp = await axios.post(
+        `${serverUrl}/api/docs/${docIds.TestDoc}/${url}`,
+        [3, 4, 5, 6],
+        chimpy,
+      );
+      assert.equal(resp.status, 200);
+      assert.deepEqual(resp.data, null);
+      resp = await axios.get(`${serverUrl}/api/docs/${docIds.TestDoc}/tables/Foo/data`, chimpy);
+      assert.deepEqual(resp.data, {
+        id: [1, 2],
+        A: ['Santa', 'Bob'],
+        B: ["1", "11"],
+        manualSort: [1, 2]
+      });
 
-    // restore rows
-    await axios.post(`${serverUrl}/api/docs/${docIds.TestDoc}/tables/Foo/data`, {
-      A: ['Alice', 'Felix'],
-      B: [2, 22]
-    }, chimpy);
-    resp = await axios.get(`${serverUrl}/api/docs/${docIds.TestDoc}/tables/Foo/data`, chimpy);
-    assert.deepEqual(resp.data, {
-      id: [1, 2, 3, 4],
-      A: ['Santa', 'Bob', 'Alice', 'Felix'],
-      B: ["1", "11", "2", "22"],
-      manualSort: [1, 2, 3, 4]
+      // restore rows
+      await axios.post(`${serverUrl}/api/docs/${docIds.TestDoc}/tables/Foo/data`, {
+        A: ['Alice', 'Felix'],
+        B: [2, 22]
+      }, chimpy);
+      resp = await axios.get(`${serverUrl}/api/docs/${docIds.TestDoc}/tables/Foo/data`, chimpy);
+      assert.deepEqual(resp.data, {
+        id: [1, 2, 3, 4],
+        A: ['Santa', 'Bob', 'Alice', 'Felix'],
+        B: ["1", "11", "2", "22"],
+        manualSort: [1, 2, 3, 4]
+      });
     });
-  });
+  }
 
   function checkError(status: number, test: RegExp | object, resp: AxiosResponse, message?: string) {
     assert.equal(resp.status, status);


### PR DESCRIPTION
This is in analogy with other `/records` endpoints. This is the intended replacement for the `/data/delete` endpoint. Accordingly, I just extended the `data/delete` test to also apply to `/records/delete`.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

