### PR TITLE
Refactor mobile button detection logic

### DIFF
--- a/app/client/widgets/EditorButtons.ts
+++ b/app/client/widgets/EditorButtons.ts
@@ -1,22 +1,39 @@
-import {isDesktop} from 'app/client/lib/browserInfo';
-import {colors, theme} from 'app/client/ui2018/cssVars';
+import {colors, isNarrowScreen, theme} from 'app/client/ui2018/cssVars';
 import {icon} from 'app/client/ui2018/icons';
 import {IEditorCommandGroup} from 'app/client/widgets/NewBaseEditor';
 import {dom, styled} from 'grainjs';
 
 /**
+ * Detects if the device likely needs mobile editor buttons.
+ *
+ * Inspired by:
+ * https://stackoverflow.com/questions/4817029/whats-an-optimal-or-efficient-way-to-detect-a-touch-screen-device-using-j
+ * avas
+ */
+function needsMobileButtons(): boolean {
+  // Check for touch support
+  const hasTouchSupport = Boolean('ontouchstart' in window ||
+                         (navigator.maxTouchPoints && navigator.maxTouchPoints > 0));
+
+  // Check if primary pointer is coarse (finger/stylus) vs fine (mouse)
+  const primaryPointerIsCoarse = window.matchMedia('(pointer: coarse)').matches;
+
+  // Show mobile buttons if device has narrow screen OR (touch AND coarse pointer)
+  return isNarrowScreen() || (hasTouchSupport && primaryPointerIsCoarse);
+}
+
+/**
  * Creates Save/Cancel icon buttons to show next to the cell editor.
  */
 export function createMobileButtons(commands: IEditorCommandGroup) {
-  // TODO A better check may be to detect a physical keyboard or touch support.
-  return isDesktop() ? null : [
+  return needsMobileButtons() ? [
     cssCancelBtn(cssIconWrap(cssFinishIcon('CrossSmall')), dom.on('mousedown', commands.fieldEditCancel)),
     cssSaveBtn(cssIconWrap(cssFinishIcon('Tick')), dom.on('mousedown', commands.fieldEditSaveHere)),
-  ];
+  ] : null;
 }
 
 export function getButtonMargins() {
-  return isDesktop() ? undefined : {left: 20, right: 20, top: 0, bottom: 0};
+  return needsMobileButtons() ? {left: 20, right: 20, top: 0, bottom: 0} : undefined;
 }
 
 const cssFinishBtn = styled('div', `


### PR DESCRIPTION
Currently Grist detects mobile browser by looking at the `UserAgent` browser settings, but some browsers
hide that for security reasons.

## Proposed solution

Instead of detecting the mobile platform, Grist will now check what is the primary input device or if
the screen is small enough to assume it is a mobile device.

## Has this been tested?

Only manual tests on mobile browsers
