### PR TITLE
check whether a /copy endpoint is being exercised by app

### DIFF
--- a/app/common/UserAPI.ts
+++ b/app/common/UserAPI.ts
@@ -1195,14 +1195,6 @@ export class DocAPIImpl extends BaseAPI implements DocAPI {
     return this.requestJson(url.href);
   }
 
-  public async copyDoc(workspaceId: number, options: CopyDocOptions): Promise<string> {
-    const {documentName, asTemplate} = options;
-    return this.requestJson(`${this._url}/copy`, {
-      body: JSON.stringify({workspaceId, documentName, asTemplate}),
-      method: 'POST'
-     });
-  }
-
   public async compareVersion(leftHash: string, rightHash: string): Promise<DocStateComparison> {
     const url = new URL(`${this._url}/compare`);
     url.searchParams.append('left', leftHash);

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -1602,19 +1602,7 @@ export class DocWorkerApi {
     }));
 
     this._app.post('/api/docs/:docId/copy', canView, expressWrap(async (req, res) => {
-      const userId = getUserId(req);
-
-      const parameters: {[key: string]: any} = req.body;
-
-      const docId = await this._copyDocToWorkspace(req, {
-        userId,
-        sourceDocumentId: stringParam(req.params.docId, 'docId'),
-        workspaceId: integerParam(parameters.workspaceId, 'workspaceId'),
-        documentName: stringParam(parameters.documentName, 'documentName'),
-        asTemplate: optBooleanParam(parameters.asTemplate, 'asTemplate'),
-      });
-
-      return res.status(200).json(docId);
+      throw new Error('who uses this');
     }));
 
     /**


### PR DESCRIPTION
There's a report of a problem with POST /api/docs/:docId/copy endpoint. Checking if it is exercised by the app. It is documented in REST API.

If the app doesn't rely on it, that would explain how the problem wasn't noticed.

This is not a real PR, just using CI to check things.