### PR TITLE
fix problem in onNewRecordRequest call caught by lint

### DIFF
--- a/app/client/ui/NewRecordButton.ts
+++ b/app/client/ui/NewRecordButton.ts
@@ -42,7 +42,7 @@ function newRecordButton(view: BaseView) {
     icon('Plus'),
     dom('span', translationString),
     dom.on('click', () => {
-      view.onNewRecordRequest?.();
+      view.onNewRecordRequest?.()?.catch(reportError);
     }),
     testId('new-record-button')
   );


### PR DESCRIPTION
After more code was ported from javascript to typescript, a call to onNewRecordRequest was flagged as potentially a floating promise.