### PR TITLE
Document list: accessibility improvements on view mode buttons

### DIFF
--- a/app/client/ui/DocMenu.ts
+++ b/app/client/ui/DocMenu.ts
@@ -268,8 +268,8 @@ function buildPrefs(viewSettings: ViewSettings, ...args: DomArg<HTMLElement>[]) 
 
     // The View selector.
     buttonSelect<ViewPref>(viewSettings.currentView, [
-        {value: 'icons', icon: 'TypeTable'},
-        {value: 'list', icon: 'TypeCardList'},
+        {value: 'icons', icon: 'TypeTable', tooltip: t("Grid view")},
+        {value: 'list', icon: 'TypeCardList', tooltip: t("List view")},
       ],
       cssButtonSelect.cls("-light"),
       testId('view-mode')

--- a/app/client/ui2018/buttonSelect.ts
+++ b/app/client/ui2018/buttonSelect.ts
@@ -1,6 +1,8 @@
+import {hoverTooltip} from 'app/client/ui/tooltips';
 import {colors, testId, theme, vars} from 'app/client/ui2018/cssVars';
 import {IconName} from 'app/client/ui2018/IconList';
 import {icon} from 'app/client/ui2018/icons';
+import {unstyledButton} from 'app/client/ui2018/unstyled';
 import {isColorDark} from 'app/common/gutil';
 import {components} from 'app/common/ThemePrefs';
 import {dom, DomElementArg, Observable, styled} from 'grainjs';
@@ -9,6 +11,7 @@ import debounce = require('lodash/debounce');
 export interface ISelectorOptionFull<T> {
   value: T;
   label?: string;
+  tooltip?: string;
   icon?: IconName;
 }
 
@@ -113,7 +116,11 @@ export function makeButtonSelect<T>(
     dom.forEach(optionArray, (option: ISelectorOption<T>) => {
       const value = getOptionValue(option);
       const label = getOptionLabel(option);
+      const tooltip = isFullOption(option) && option.tooltip;
+      const screenReaderLabel = !label && tooltip;
       return cssSelectorBtn(
+        tooltip ? hoverTooltip(tooltip) : null,
+        screenReaderLabel ? {"aria-label": screenReaderLabel} : null,
         cssSelectorBtn.cls('-selected', (use) => use(obs) === value),
         dom.on('click', () => onClick(value)),
         isFullOption(option) && option.icon ? icon(option.icon) : null,
@@ -154,11 +161,7 @@ export const cssButtonSelect = styled('div', `
   }
 `);
 
-const cssSelectorBtn = styled('div', `
-  /* Resets */
-  position: relative;
-  outline: none;
-  border-style: none;
+const cssSelectorBtn = styled(unstyledButton, `
   display: flex;
   align-items: center;
   justify-content: center;

--- a/app/client/ui2018/buttonSelect.ts
+++ b/app/client/ui2018/buttonSelect.ts
@@ -2,6 +2,7 @@ import {colors, testId, theme, vars} from 'app/client/ui2018/cssVars';
 import {IconName} from 'app/client/ui2018/IconList';
 import {icon} from 'app/client/ui2018/icons';
 import {isColorDark} from 'app/common/gutil';
+import {components} from 'app/common/ThemePrefs';
 import {dom, DomElementArg, Observable, styled} from 'grainjs';
 import debounce = require('lodash/debounce');
 
@@ -206,23 +207,28 @@ const cssSelectorBtn = styled('div', `
   }
 
   /* Styles when container includes cssButtonSelect.cls('-light') */
+  .${cssButtonSelect.className}-light {
+    gap: 4px;
+  }
+
+  .${cssButtonSelect.className}-light > &:hover:not(&-selected) {
+    background: ${components.buttonGroupLightBg};
+  }
+
   .${cssButtonSelect.className}-light > & {
-    border: none;
+    border: 1px solid transparent;
     border-radius: ${vars.controlBorderRadius};
     margin-left: 0px;
-    padding: 8px;
+    padding: 5px;
+    min-width: 28px;
     color: ${theme.buttonGroupLightFg};
     --icon-color: ${theme.buttonGroupLightFg};
   }
   .${cssButtonSelect.className}-light > &-selected {
-    border: none;
+    border-color: ${theme.buttonGroupLightSelectedFg};
     color: ${theme.buttonGroupLightSelectedFg};
     --icon-color: ${theme.buttonGroupLightSelectedFg};
-    background-color: initial;
-  }
-  .${cssButtonSelect.className}-light > &:hover {
-    border: none;
-    background-color: ${theme.hover};
+    background-color: ${components.buttonGroupLightSelectedBg};
   }
 `);
 

--- a/app/common/ThemePrefs.ts
+++ b/app/common/ThemePrefs.ts
@@ -454,6 +454,7 @@ export const componentsCssMapping = {
   infoButtonActiveFg: 'info-button-active-fg',
   buttonGroupFg: 'button-group-fg',
   buttonGroupLightFg: 'button-group-light-fg',
+  buttonGroupLightBg: 'button-group-light-bg',
   buttonGroupBg: 'button-group-bg',
   buttonGroupBgHover: 'button-group-bg-hover',
   buttonGroupIcon: 'button-group-icon',
@@ -461,6 +462,7 @@ export const componentsCssMapping = {
   buttonGroupBorderHover: 'button-group-border-hover',
   buttonGroupSelectedFg: 'button-group-selected-fg',
   buttonGroupLightSelectedFg: 'button-group-light-selected-fg',
+  buttonGroupLightSelectedBg: 'button-group-light-selected-bg',
   buttonGroupSelectedBg: 'button-group-selected-bg',
   buttonGroupSelectedBorder: 'button-group-selected-border',
   accessRulesTableHeaderFg: 'access-rules-table-header-fg',
@@ -1258,10 +1260,12 @@ export interface BaseThemeTokens {
     buttonGroupBg: Token;
     buttonGroupFg: Token;
     buttonGroupLightFg: Token;
+    buttonGroupLightBg: Token;
     buttonGroupIcon: Token;
     buttonGroupBorder: Token;
     buttonGroupSelectedFg: Token;
     buttonGroupLightSelectedFg: Token;
+    buttonGroupLightSelectedBg: Token;
     buttonGroupSelectedBg: Token;
     buttonGroupSelectedBorder: Token;
     accessRulesTableHeaderFg: Token;

--- a/app/common/themes/Base.ts
+++ b/app/common/themes/Base.ts
@@ -392,11 +392,13 @@ export const Base: BaseThemeTokens = {
     /* Button Groups */
     buttonGroupBg: 'transparent',
     buttonGroupFg: tokens.body,
+    buttonGroupLightBg: tokens.bgSecondary,
     buttonGroupLightFg: tokens.secondary,
     buttonGroupIcon: tokens.secondary,
     buttonGroupBorder: tokens.decoration,
     buttonGroupSelectedFg: tokens.veryLight,
     buttonGroupLightSelectedFg: tokens.primary,
+    buttonGroupLightSelectedBg: tokens.selectionOpaque,
     buttonGroupSelectedBg: tokens.bgEmphasis,
     buttonGroupSelectedBorder: tokens.bgEmphasis,
 

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -300,6 +300,8 @@
         "Examples & Templates": "Examples & Templates",
         "Examples and Templates": "Examples and Templates",
         "Featured": "Featured",
+        "Grid view": "Grid view",
+        "List view": "List view",
         "Manage Users": "Manage Users",
         "More Examples and Templates": "More Examples and Templates",
         "Move": "Move",


### PR DESCRIPTION
## Context

The buttons allowing us to switch from list view to grid view, in some document lists (templates listing or trash for example), have some accessibility issues:

- the active button is only differentiated with a color change, making it hard to understand at a glance what is the active or inactive button for some people
- we can't focus the buttons with keyboard
- with a screen reader, we don't understand what the buttons do as there is no text alternative for the icons

## Proposed solution

Here a couple of commits to improve things on all issues listed above. [The figma design agreed upon](https://www.figma.com/design/wcpetFt6aOKzTszcvPPWLQ/-05-24--Grist-Design?node-id=2630-83557&t=oIGJCiWUjV8HYIOl-4) has been implemented.

I also added a tooltip on buttons, to better explain what the buttons to everyone.

## Related issues

This is related to https://github.com/gristlabs/grist-core/issues/1244 where other similar visual issues are listed.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

Before:

<img width="239" height="111" alt="image" src="https://github.com/user-attachments/assets/8029ee7a-a4a3-425a-80d1-df97103aac08" />

After:

<img width="280" height="154" alt="image" src="https://github.com/user-attachments/assets/ec93d21d-7bdf-4b95-a7c4-d6f8bb3f15c8" />

<!-- delete if not relevant -->
