### PR TITLE
Choices type transform: remove unnecessary fields from config popup

### DIFF
--- a/app/client/widgets/ChoiceTextBox.ts
+++ b/app/client/widgets/ChoiceTextBox.ts
@@ -88,9 +88,8 @@ export class ChoiceTextBox extends NTextBox {
     ];
   }
 
-  public buildTransformConfigDom(gristDoc: GristDoc) {
+  public buildTransformConfigDom() {
     return [
-      super.buildConfigDom(gristDoc),
       this.buildChoicesConfigDom(),
     ];
   }


### PR DESCRIPTION
## Context

In the right panel of a document, when setting a column type to "choice" or "choice list", in the popup appearing to configure the new type, we can edit the choices (good).

But above the choices list to edit, we can also edit the text alignment of the column, and, since recently, also the whole row height.

I have trouble understanding if this is actually wanted or some side effect that appeared some day[*]. Because I feel having the alignment/height fields visible here is a bit questionable. I'd argue it's stuff getting in the way, as I guess we'd mostly want to edit the choices at this moment, and not bother with text alignment or row height. Especially row height, as clicking on the "change" button triggers a tab change to the "table" tab of the creator panel.

[*]: I noticed this behavior was introduced with [this commit](https://github.com/gristlabs/grist-core/commit/3112433a58b08d17c2583c1107eda9f074bfab95#diff-aa13901a748a17d80373779ede1a9f286f1d301060dd09a62761b71f3a234f12L89) but I don't understand why it was introduced at the time.

@audez mentioned this to me and I'm opening this PR as a way to check whether or not this is actually intended, and suggest a fix if it's not ;)

## Proposed solution

This PR just removes the common config fields from the transform config popup, to focus on the choices edit. This matches the behavior of other column types.


## Related issues


## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

Before:

https://github.com/user-attachments/assets/a5fb7147-12ce-4a86-a3f8-66d29c1ef23e

After:

https://github.com/user-attachments/assets/3eba5e52-2361-4580-ab8a-835e32040929


