### PR TITLE
fix(MinioExternalStorage): ECONNRESET and InternalError are fatalErrors

### DIFF
--- a/app/server/lib/MinIOExternalStorage.ts
+++ b/app/server/lib/MinIOExternalStorage.ts
@@ -82,6 +82,10 @@ export class MinIOExternalStorage implements ExternalStorage {
         ...head.metaData && { metadata: toGristMetadata(head.metaData) },
       };
     } catch (err) {
+      // NotFound and NoSuchKey are "expected" errors when checking for existence of a document
+      // and should return a falsy null.
+      // Other errors like 'ECONNRESET' and 'InternalError' are fatal errors and should be thrown
+      // in order to avoir weird behavior when MinIO is experiencing hiccups.
       if (!this.isFatalError(err)) { return null; }
       throw err;
     }
@@ -185,13 +189,10 @@ export class MinIOExternalStorage implements ExternalStorage {
   }
 
   public isFatalError(err: any) {
-    // ECONNRESET should not count as fatal:
-    //   https://github.com/aws/aws-sdk-js/pull/3739
-    // Likewise for "We encountered an internal error. Please try again."
-    // These are errors associated with the AWS S3 backend, and which
-    // the AWS S3 SDK would typically handle.
-    return err.code !== 'NotFound' && err.code !== 'NoSuchKey' &&
-      err.code !== 'ECONNRESET' && err.code !== 'InternalError';
+    // NotFound and NoSuchKey are "expected" errors when checking for existence of a document
+    // Other errors like 'ECONNRESET' and 'InternalError' were added to the list by mistake
+    // which caused problems like overriding an existing document when MinIO was experiencing hiccups.
+    return err.code !== 'NotFound' && err.code !== 'NoSuchKey';
   }
 
   public async close() {


### PR DESCRIPTION
## Context

https://github.com/gristlabs/grist-core/commit/e6692c279332d3e6a168df5d1f304c38da6d0dde mistakenly added 2 error codes to the `isfatalError` method which acts as a sort of whitelist for MinIO errors that should be safe to ignore. ECONNRESET and InternalErrors **are** fatal errors.

In production, this meant that when our MinIO server was experiencing restarts or overall hiccups, the MinioExternalStorage could create a new document when one already existed, and then push it to MinIO, overwritting the existing document on the bucket 🥵 

## Proposed solution

Remove ECONNRESET and InternalErrors from the list of error codes MinioExternalStorage should ignore.

## Related issues

Wondering whether the naming of the method lead to confusion in the first place, should we maybe rename it to `isNotExistingError` or `isExpectedError` ? I feel like the logic of the code in `head` would read better (although the comment I added should hopefully fix it).

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [x] 🙋 no, because I need help

I'm not sure whether I need to add a test here, but apparently the faulty code was added in order to fix test-related weirdness, so hoping the tests will pass now.
