### PR TITLE
HomeDBManager: split document member retrieval query from main document query

### DIFF
--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -5007,21 +5007,15 @@ export class HomeDBManager {
                                transaction?: EntityManager): Promise<Document> {
     return await this.runInTransaction(transaction, async manager => {
 
-      const docQuery = this._doc(scope, {manager, markPermissions})
-      // Join the workspace so we know what should be inherited.  We will join
-      // the workspace member groups/users as a separate query, since
-      // SQL results are flattened, and multiplying the number of rows we have already
-      // by the number of workspace users could get excessive.
-      .leftJoinAndSelect('docs.workspace', 'workspace');
+      const docQuery = this._doc(scope, {manager, markPermissions});
       const queryResult = await verifyEntity(docQuery);
       const doc: Document = this.unwrapQueryResult(queryResult);
 
-      // Join the doc's ACL rules and groups/users so we can edit them.
-      // As for the workspace, we do this as a separate query to avoid
-      // repeating the document row (which can be particulary costly
-      // since the main document query contains some non-trivial
-      // subqueries and postgres will re-execute them for each
-      // repeated document row).
+      // Retrieve the doc's ACL rules and groups/users so we can edit them.
+      // We do this as a separate query to avoid repeating the document
+      // row (which can be particulary costly since the main document
+      // query contains some non-trivial subqueries and postgres
+      // will re-execute them for each repeated document row).
       const aclQuery = this._docs(manager)
       .where({ id: doc.id })
       .leftJoinAndSelect('docs.aclRules', 'acl_rules')


### PR DESCRIPTION
## Context

Some operations involving access lists can become very slow on documents which have a lot of members. In particular, opening the document member list to add or remove people can take several seconds on a largely shared (hundreds of members) document.

This was observed in production with a document having about 800 users invited to it. It can easily be reproduced locally by mass-inviting a few thousand generated email addresses to a document.

## Analysis

@fflorent did the bulk of the analysis.

The subqueries generated by `HomeDBManager._markIsPermitted` are re-executed for each result row if the `docs` table is joined with another (the PostgreSQL optimizer is not smart enough to realize that since the document ID is the same on every row of the result, it could do each subquery just once).

Since each of these subqueries scans the users attached to the document via `acl_rules` itself, the cost of a query that includes these subqueries and also retrieves the document members via a join to `acl_rules` grows quadratically with the number of users attached to the document.

## Proposed solution

What we do in this PR is to split the retrieval of the document member list from the initial document query, as was already applied for the workspace and organization members.

## Related issues

@fflorent did a first attempt at a fix here: #1871 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here (it's a query optimization issue, I don't think this is being tested directly)
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
