### PR TITLE
minio client: retry on some errors

### DIFF
--- a/app/server/lib/MinIOExternalStorage.ts
+++ b/app/server/lib/MinIOExternalStorage.ts
@@ -189,7 +189,7 @@ export class MinIOExternalStorage implements ExternalStorage {
   }
 
   public isFatalError(err: any) {
-    // Fatal errors are all errors except that are neither expected nor retryable.
+    // Fatal errors are all errors that are neither expected nor retryable.
     return !this.isExpectedNotFoundError(err) && !this.isRetryableError(err);
   }
 

--- a/test/server/lib/HostedStorageManager.ts
+++ b/test/server/lib/HostedStorageManager.ts
@@ -1100,9 +1100,9 @@ describe('HostedStorageManager', function() {
 
         // Wait a little bit, the promise should not be resolved
         await setTimeout(1000);
-        assert.isTrue(promiseIsPending, 'prepareLocalDoc should continue retrying joining the MinIO server');
+        assert.isTrue(promiseIsPending, 'prepareLocalDoc should still be retrying to join the MinIO server');
         assert.isTrue(stub.called, 'the stub should have been called preventing '
-          + ' the external storage to access to MinIO');
+          + ' the external storage to access MinIO');
 
         // Now let's unblock the access to the MinIO server
         stub.restore();


### PR DESCRIPTION
## Context

In #1874 we made a hotfix that would fix a bug where Grist would override an existing document with an empty one when the MinIOExternalStorage client was encountering ECONNRESET or InternalErrors. @paulfitz suggested that it would be even better if the client would retry on those errors.

## Proposed solution

<del>### Option 1
This is the simplest possible solution : introduce the concept of "retryable errors" in the MinIOExternalStorage class, and implement a one-time, 10sec retry for those errors. </del>

<del>### Option 2 (reworking the `ChecksummedExternalStorage` class)
Looking at the code, it seems that it would be even cleaned if we could simply benefit from the `ChecksummedExternalStorage` retry logic that's already implemented and that wraps `MinIOExternalStorage`.</del>

<del>As of now, it seems that  `ChecksummedExternalStorage.exists` is correctly calling the underlying `MinIOExternalStorage.exists` method with `_retryWithExistenceCheck`, which calls directly `MinIOExternalStorage.head` and so basically `ChecksummedExternalStorage.head` (the one that would allow for a retry) is never called.</del>

### Option 3  (this PR)

Teach MinIOExternalStorage about what a true FatalError is, and let the ChecksummedExternalStorage handle the retries.

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help -- I haven't seen much retrying logic being tested in the codebase so far
