### PR TITLE
Fixes /copy endpoints not working with short url ids

### DIFF
--- a/app/server/lib/uploads.ts
+++ b/app/server/lib/uploads.ts
@@ -490,7 +490,7 @@ async function _fetchURL(url: string, accessId: string|null, options?: FetchUrlO
 export async function fetchDoc(
   server: GristServer,
   docWorkerMap: IDocWorkerMap,
-  docId: string,
+  urlId: string,
   req: Request,
   accessId: string|null,
   template: boolean
@@ -498,6 +498,8 @@ export async function fetchDoc(
   // Prepare headers that preserve credentials of current user.
   const headers = getTransitiveHeaders(req, { includeOrigin: false });
 
+  // Resolve urlId to the full docId needed to find the right doc worker.
+  const docId = (await server.getHomeDBManager().getRawDocById(urlId)).id;
   // Find the doc worker responsible for the document we wish to copy.
   // The backend needs to be well configured for this to work.
   const { selfPrefix, docWorker } = await getDocWorkerInfoOrSelfPrefix(docId, docWorkerMap, server.getTag());


### PR DESCRIPTION
## Context

`/docs/:docid/copy` fails when using the url id (the short identifier in the document's URL), when multiple doc workers are in use.

The following explanation is the most likely reason, but hasn't been confirmed through empirical testing.

When the copy request is made, it's assigned to a new doc worker to handle the copy and import of the new document. That doc worker first attempts to download the original document. This download is either from a doc worker that currently has that document assigned, or a newly assigned doc worker.

The copying doc worker attempts to lookup the doc worker to download from using its short id. This instead assigns a new doc worker, as doc worker lookups should only ever use the document's full id. 

This results in the download throwing an error, because the document is already assigned to another worker. 

## Proposed solution

This changes `fetchDoc` to resolve the full document id first, so that the doc worker lookup / assignment functions correctly.

## Has this been tested?

No, because testing this requires a complex multi-doc-worker setup that isn't readily supported by the test suite.
