### PR TITLE
Use log.rawInfo to log worker load

### DIFF
--- a/app/gen-server/lib/DocWorkerMap.ts
+++ b/app/gen-server/lib/DocWorkerMap.ts
@@ -337,7 +337,10 @@ export class DocWorkerMap implements IDocWorkerMap {
    * Note: This method should only be called by the worker.
    */
   public async setWorkerLoad(workerInfo: DocWorkerInfo, load: number): Promise<void> {
-    log.info(`DocWorkerMap.setWorkerLoad ${workerInfo.id} ${load}`);
+    log.rawInfo('DocWorkerMap.setWorkerLoad', {
+      workerId: workerInfo.id,
+      load,
+    });
     const group = workerInfo.group || DEFAULT_GROUP;
     // The "XX" argument means only update the key if it exists.
     await this._client.zaddAsync(`workers-available-by-load-${group}`, 'XX', load, workerInfo.id);


### PR DESCRIPTION
## Context

It would be useful to be able to extract worker ID and load from logs to build visualizations in OpenSearch.

## Proposed solution

The worker ID and load are now passed as metadata when logging worker load in DocWorkerMap.ts. This will result in them being indexed as fields in OpenSearch.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
