### PR TITLE
Fixes cases where attachment archive downloads can crash the Grist server

### DIFF
--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -626,9 +626,9 @@ export class DocWorkerApi {
           altSessionId: req.altSessionId,
         };
         if (err?.code === "ERR_STREAM_PREMATURE_CLOSE") {
-          log.warn("Client closed archive download stream before completion", meta);
+          log.rawWarn("Client closed archive download stream before completion", meta);
         } else {
-          log.error("Error while packing attachment archive", meta, err);
+          log.rawError(`Error while packing attachment archive: ${err.stack ?? err.message}`, meta);
         }
       }
       res.end();

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -620,6 +620,7 @@ export class DocWorkerApi {
         // Sending headers then resetting the connection shows as 'Download failed', regardless of the
         // 'download' attribute being set.
         res.destroy(err);
+        log.error("Error while packing attachment archive", err);
       }
       res.end();
     }));

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -620,7 +620,11 @@ export class DocWorkerApi {
         // Sending headers then resetting the connection shows as 'Download failed', regardless of the
         // 'download' attribute being set.
         res.destroy(err);
-        log.error("Error while packing attachment archive", err);
+        if (err?.code === "ERR_STREAM_PREMATURE_CLOSE") {
+          log.warn("Client closed archive download stream before completion");
+        } else {
+          log.error("Error while packing attachment archive", err);
+        }
       }
       res.end();
     }));

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -620,10 +620,15 @@ export class DocWorkerApi {
         // Sending headers then resetting the connection shows as 'Download failed', regardless of the
         // 'download' attribute being set.
         res.destroy(err);
+        const meta = {
+          docId: activeDoc.doc?.id,
+          archiveFormat,
+          altSessionId: req.altSessionId,
+        };
         if (err?.code === "ERR_STREAM_PREMATURE_CLOSE") {
-          log.warn("Client closed archive download stream before completion");
+          log.warn("Client closed archive download stream before completion", meta);
         } else {
-          log.error("Error while packing attachment archive", err);
+          log.error("Error while packing attachment archive", meta, err);
         }
       }
       res.end();


### PR DESCRIPTION
## Context

Certain situations could result in a stream erroring before the error handler was attached, crashing the Node process with an unhandled error exception.

## Proposed solution

This restructures the logic used to pack attachment archives to ensure the handlers are always attached.

## Has this been tested?

Tested manually for this case, and this endpoint is covered by existing tests. 
