### PR TITLE
Resolves DocPluginManager._tmpDir on creation

### DIFF
--- a/app/server/lib/DocPluginManager.ts
+++ b/app/server/lib/DocPluginManager.ts
@@ -16,9 +16,9 @@ import { GristServer } from 'app/server/lib/GristServer';
 import log from 'app/server/lib/log';
 import { SafePythonComponent } from 'app/server/lib/SafePythonComponent';
 import { UnsafeNodeComponent } from 'app/server/lib/UnsafeNodeComponent';
+import { createTmpDir } from 'app/server/lib/uploads';
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import * as tmp from 'tmp-promise';
 
 /**
  * Implements GristDocAPI interface.
@@ -192,7 +192,7 @@ export class DocPluginManager {
   }
 
   private async _initialize(): Promise<void> {
-    this._tmpDir = await fse.realpath((await tmp.dir({ prefix: 'grist-tmp-', unsafeCleanup: true })).path);
+    this._tmpDir = (await createTmpDir({ prefix: 'grist-tmp-', unsafeCleanup: true })).tmpDir;
     for (const plugin of this._localPlugins) {
       try {
         // todo: once Comm has been replaced by grain-rpc, pluginInstance.rpc should forward '*' to client

--- a/app/server/lib/DocPluginManager.ts
+++ b/app/server/lib/DocPluginManager.ts
@@ -192,7 +192,7 @@ export class DocPluginManager {
   }
 
   private async _initialize(): Promise<void> {
-    this._tmpDir = (await tmp.dir({ prefix: 'grist-tmp-', unsafeCleanup: true })).path;
+    this._tmpDir = await fse.realpath((await tmp.dir({ prefix: 'grist-tmp-', unsafeCleanup: true })).path);
     for (const plugin of this._localPlugins) {
       try {
         // todo: once Comm has been replaced by grain-rpc, pluginInstance.rpc should forward '*' to client


### PR DESCRIPTION
## Context

Grist Desktop 0.3.6 errors when MacOS users attempt to import files. (https://github.com/gristlabs/grist-desktop/issues/91)

This is caused by having any symlink in the temporary dir paths used by DocPluginManager or uploads. 

The `tmp` library resolves the paths of temporary directories, but only under specific sets of parameters (e.g. `dir` is provided as a parameter to `tmp.dir` ).

This can result in imports failing due to them being imported into a temporary directory inside the `DocPluginManager` temporary directory, which isn't fully resolved.

The nested temporary directory is fully resolved, meaning the path is no longer relative to DocPluginManager._tmpDir, causing problems.

## Proposed solution

This fully resolves `DocPluginManager._tmpDir` on creation, and also resolves `tmp.dir` in `moveUpload` to make this behaviour explicit. 

## Related issues

https://github.com/gristlabs/grist-desktop/issues/91

## Has this been tested?

Yes, it's been tested manually on MacOS. 
