### PR TITLE
Support for subpath installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Grist can be configured in many ways. Here are the main environment variables it
 | GRIST_APP_ROOT | directory containing Grist sandbox and assets (specifically the sandbox and static subdirectories). |
 | GRIST_ATTACHMENT_THRESHOLD_MB | attachment storage limit per document beyond which Grist will recommend external storage (if available). Defaults to 50MB. |
 | GRIST_BACKUP_DELAY_SECS | wait this long after a doc change before making a backup |
+| GRIST_BASE_PATH | Path part of `APP_HOME_URL` if hosted on subpath |
 | GRIST_BOOT_KEY | if set, offer diagnostics at /boot/GRIST_BOOT_KEY |
 | GRIST_BROADCAST_TIMEOUT_MS | Set the maximum time a web client has to accept a broadcast message about a document before being disconnected (default: 1 minute). |
 | GRIST_DATA_DIR | Directory in which to store documents. Defaults to `docs/` relative to the Grist application directory. In Grist's default Docker image, its default value is /persist/docs so that it will be used as a mounted volume. |

--- a/app/client/lib/urlUtils.ts
+++ b/app/client/lib/urlUtils.ts
@@ -1,5 +1,5 @@
 import { parseFirstUrlPart } from "app/common/gristUrls";
-import { addOrgToPath } from "app/common/urlUtils";
+import { addOrgToPath, appendBasePath } from "app/common/urlUtils";
 
 export interface URLOptions {
   /**
@@ -46,7 +46,7 @@ export interface URLOptions {
 export function buildURL(path: string, options: URLOptions = {}): URL {
   const {base = window.location.href, hash, searchParams} = options;
   const url = new URL(base);
-  url.pathname = addOrgToPath('', base, true) + '/' + path.replace(/^\//, '');
+  url.pathname = appendBasePath(addOrgToPath('', base, true) + '/' + path.replace(/^\//, ''));
   if (hash !== undefined) {
     url.hash = hash ?? '';
   }

--- a/app/common/UserAPI.ts
+++ b/app/common/UserAPI.ts
@@ -22,7 +22,7 @@ import {
   WebhookSummaryCollection,
   WebhookUpdate
 } from 'app/common/Triggers';
-import {addCurrentOrgToPath, getGristConfig} from 'app/common/urlUtils';
+import {addCurrentOrgToPath, appendBasePath, getGristConfig, stripBasePath} from 'app/common/urlUtils';
 import {StringUnion} from 'app/common/StringUnion';
 import {AttachmentStore, AttachmentStoreDesc} from 'app/plugin/DocApiTypes';
 import {AxiosProgressEvent} from 'axios';
@@ -1374,8 +1374,8 @@ export type PublicDocWorkerUrlInfo = {
 }
 
 export function getUrlFromPrefix(homeUrl: string, prefix: string) {
-  const url = new URL(homeUrl);
-  url.pathname = prefix + url.pathname;
+  const url = new URL(stripBasePath(homeUrl));
+  url.pathname = appendBasePath(prefix + url.pathname);
   return url.href;
 }
 

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -5,7 +5,7 @@ import {Document} from 'app/common/UserAPI';
 import {encodeQueryParams, isAffirmative, removePrefix} from 'app/common/gutil';
 import {EngineCode} from 'app/common/DocumentSettings';
 import {Features as PlanFeatures} from 'app/common/Features';
-import {getGristConfig} from 'app/common/urlUtils';
+import {appendBasePath, getGristConfig, stripBasePath} from 'app/common/urlUtils';
 import {IAttachedCustomWidget} from "app/common/widgetTypes";
 import {ICommonUrls} from 'app/common/ICommonUrls';
 import {LocalPlugin} from 'app/common/plugin';
@@ -408,7 +408,7 @@ export function encodeUrl(gristConfig: Partial<GristLoadConfig>,
   }
   const queryStr = encodeQueryParams(queryParams);
 
-  url.pathname = parts.join('');
+  url.pathname = appendBasePath(parts.join(''), gristConfig);
   url.search = queryStr;
 
   if (state.homePageTab) {
@@ -450,7 +450,8 @@ export function decodeUrl(gristConfig: Partial<GristLoadConfig>, location: Locat
 }): IGristUrlState {
   location = new URL(location.href);  // Make sure location is a URL.
   options?.tweaks?.preDecode?.({ url: location });
-  const parts = location.pathname.slice(1).split('/');
+  const pathname = stripBasePath(location.pathname, gristConfig);
+  const parts = pathname.slice(1).split('/');
   const state: IGristUrlState = {};
 
   // Bare minimum we can do to detect API URLs: if it starts with /api/ or /o/{org}/api/...
@@ -978,6 +979,9 @@ export interface GristLoadConfig {
 
   // Maximum users to display for user presence features (e.g. active user list)
   userPresenceMaxUsers?: number;
+
+  // When served on subpath
+  basePath?: string;
 }
 
 export const Features = StringUnion(

--- a/app/common/urlUtils.ts
+++ b/app/common/urlUtils.ts
@@ -97,7 +97,7 @@ export function stripBasePath(path: string, config: Partial<GristLoadConfig> | n
   if (config == null) {
     config = getGristConfig();
   }
-  const basePath = getGristConfig().basePath;
+  const basePath = config.basePath;
   if (!basePath) {
     return path;
   }

--- a/app/common/urlUtils.ts
+++ b/app/common/urlUtils.ts
@@ -81,3 +81,26 @@ export function fetchFromHome(path: string, opts: RequestInit): Promise<Response
   const baseUrl = addCurrentOrgToPath(getGristConfig().homeUrl!);
   return window.fetch(`${baseUrl}${path}`, opts);
 }
+
+export function appendBasePath(path: string, config: Partial<GristLoadConfig> | null = null): string {
+  if (config == null) {
+    config = getGristConfig();
+  }
+  const basePath = config.basePath;
+  if (!basePath) {
+    return path;
+  }
+  return basePath + path;
+}
+
+export function stripBasePath(path: string, config: Partial<GristLoadConfig> | null = null): string {
+  if (config == null) {
+    config = getGristConfig();
+  }
+  const basePath = getGristConfig().basePath;
+  if (!basePath) {
+    return path;
+  }
+
+  return path.startsWith(basePath)? path.substring(basePath.length) : path;
+}

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -2419,12 +2419,19 @@ export class FlexServer implements GristServer {
     const config = this.getGristConfig();
     const {hostname, orgInPath} = getOrgUrlInfo(subdomain, req.get('host')!, config);
     const redirectUrl = new URL(pathname, getOriginUrl(req));
+    if (config.homeUrl)
+    {
+      redirectUrl.port = new URL(config.homeUrl).port;
+    }
     if (hostname) {
       redirectUrl.hostname = hostname;
     }
     if (orgInPath) {
-      redirectUrl.pathname = `/o/${orgInPath}` + redirectUrl.pathname;
+      redirectUrl.pathname = (config.basePath || '') + `/o/${orgInPath}` + redirectUrl.pathname;
+    } else if (config.basePath) {
+      redirectUrl.pathname = config.basePath + redirectUrl.pathname;
     }
+
     return redirectUrl.href;
   }
 

--- a/app/server/lib/requestUtils.ts
+++ b/app/server/lib/requestUtils.ts
@@ -384,7 +384,10 @@ export interface RequestWithGristInfo extends Request {
 export function getOriginUrl(req: IncomingMessage) {
   const host = req.headers.host;
   const protocol = getEndUserProtocol(req);
-  return `${protocol}://${host}`;
+  const defaultPort = (protocol == 'https')? '443': '80';
+  const port = req.headers['x-forwarded-port'] || defaultPort;
+  const portPart = (port == defaultPort)? '' : `:${port}`;
+  return `${protocol}://${host}${portPart}`;
 }
 
 /**

--- a/app/server/lib/sendAppPage.ts
+++ b/app/server/lib/sendAppPage.ts
@@ -138,6 +138,7 @@ export function makeGristConfig(options: MakeGristConfigOptions): GristLoadConfi
     formFraming: GRIST_FEATURE_FORM_FRAMING as FormFraming,
     adminDefinedUrls: process.env.GRIST_CUSTOM_COMMON_URLS,
     userPresenceMaxUsers: getUserPresenceMaxUsers(),
+    basePath: process.env.GRIST_BASE_PATH,
     ...extra,
   };
 }


### PR DESCRIPTION
## Context

As an IT guy at small company I am interested in using grist without subdomain using a subpath on our main domain.
But it was designed to use whole subdomain which is not fit for me.
So I run it as a docker container behind main Nginx.

## Proposed solution

I introduced a new environment variable GRIST_BASE_PATH and stored it into GristLoadConfig.
So for single organization on subdomain it should be provided like 
```
-e GRIST_BASE_PATH="/gristsubpath" \
-e APP_STATIC_URL="/gristsubpath" \
...
```

## Has this been tested?

- [x] 🙋 no, because I need help with different deployment scenarios and not familiar with typescript testing practices.
