### PR TITLE
UserManager: fix flakiness with timeouts

### DIFF
--- a/test/nbrowser/UserManager.ts
+++ b/test/nbrowser/UserManager.ts
@@ -12,7 +12,7 @@ const editWsAcls = stackWrapFunc(async function(wsName: string): Promise<void> {
   // to close before attempting to open the account menu.
   await driver.wait(async () => !(await driver.find('.test-modal-dialog').isPresent()), 3000);
   await gu.openWsDropdown(wsName);
-  await driver.find('.test-dm-workspace-access').click();
+  await driver.findWait('.test-dm-workspace-access', 1000).click();
   await driver.wait(() => driver.find('.test-um-members').isPresent(), 3000);
 });
 
@@ -23,14 +23,14 @@ const editDocAcls = stackWrapFunc(async function(docName: string): Promise<void>
   // to close before attempting to open the account menu.
   await driver.wait(async () => !(await driver.find('.test-modal-dialog').isPresent()), 3000);
   await gu.openDocDropdown(docName);
-  await driver.find('.test-dm-doc-access').click();
+  await driver.findWait('.test-dm-doc-access', 1000).click();
   await driver.wait(() => driver.find('.test-um-members').isPresent(), 3000);
 });
 
 // Opens the doc acl edit menu for the currently open doc via the Share menu.
 const editDocAclsShareMenu = stackWrapFunc(async function(): Promise<void> {
-  await driver.find('.test-tb-share').doClick();
-  await driver.findContent('.test-tb-share-option', /(Access Details)|(Manage Users)/).doClick();
+  await driver.findWait('.test-tb-share', 2000).doClick();
+  await driver.findContentWait('.test-tb-share-option', /(Access Details)|(Manage Users)/, 1000).doClick();
   await driver.wait(() => driver.find('.test-um-members').isPresent(), 3000);
 });
 
@@ -138,7 +138,7 @@ describe('UserManager', function() {
     await driver.get(`${server.getHost()}/o/fish`);
     await gu.waitForDocMenuToLoad();
     await driver.find('.test-user-icon').click();
-    await canEditAccess(driver.find('.test-dm-org-access'), false);
+    await canEditAccess(driver.findWait('.test-dm-org-access', 1000), false);
 
     // Charon should be able to remove themselves.
     await driver.sendKeys(Key.ESCAPE);
@@ -168,7 +168,7 @@ describe('UserManager', function() {
     await driver.get(`${server.getHost()}/o/fish`);
     await gu.waitForDocMenuToLoad();
     await driver.find('.test-user-icon').click();
-    await canEditAccess(driver.find('.test-dm-org-access'), true);
+    await canEditAccess(driver.findWait('.test-dm-org-access', 1000), true);
   });
 
   it('allows updating workspace permissions', async () => {
@@ -848,7 +848,7 @@ describe('UserManager', function() {
     // Make a document, and start editing shares.
     await session.tempDoc(cleanup, 'Hello.grist', {load: true});
     await driver.findWait('.test-tb-share', 2000).click();
-    await driver.findContent('.test-tb-share-option', /Manage users/).click();
+    await driver.findContentWait('.test-tb-share-option', /Manage users/, 1000).click();
 
 
     // Check that Open Access Rules is shown.

--- a/test/nbrowser/UserManager2.ts
+++ b/test/nbrowser/UserManager2.ts
@@ -354,7 +354,7 @@ describe('UserManager2', function() {
       // this button wasn't shown to the user. Error was caused by server which was trying to
       // get shared users from not persisted document).
       await driver.findContentWait('button', 'View as', 3000).click();
-      await driver.findContentWait('.test-acl-user-item', 'viewer@example.com', 100).click();
+      await driver.findContentWait('.test-acl-user-item', 'viewer@example.com', 1000).click();
       await gu.isAlertShown().then(v => v ? gu.acceptAlert() : Promise.resolve());
       await gu.waitForUrl(/aclAsUser/);
       await gu.waitForDocToLoad();
@@ -497,7 +497,7 @@ async function openAccessDetails() {
 
 async function openManageUsers() {
   await driver.findWait('.test-tb-share', 2000).click();
-  await driver.findContent('.test-tb-share-option', /Manage users/).click();
+  await driver.findContentWait('.test-tb-share-option', /Manage users/, 2000).click();
   await driver.findWait('.test-um-header', 2000);
 }
 


### PR DESCRIPTION
## Context

When running UserManager tests locally, I have encountered tests failures due to flakiness.

## Proposed solution

I have added / increased timeouts for elements that could not be reached.

After this commit, I have found that the tests are more stable, though there are still occasional failures with UserManager2 that I have not solved yet. Still the improvements are notable.

To check the tests stability, I run this script:

```bash
for i in $(seq 1 20); do GREP_TESTS="UserManager" LANGUAGE=en_US yarn test:nbrowser || break; done
```

## Related issues


## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
