### PR TITLE
keep an onerror handler on WebSocket at all times

### DIFF
--- a/app/server/lib/Client.ts
+++ b/app/server/lib/Client.ts
@@ -191,6 +191,11 @@ export class Client {
   public interruptConnection() {
     if (this._websocket) {
       this._websocket.removeAllListeners();
+      // It is important to keep an onerror handler, since otherwise
+      // errors bring down the server.
+      this._websocket.onerror = (err: Error) => {
+        this._log.warn(null, "Error after interruption", err);
+      };
       this._websocket.terminate();  // close() is inadequate when ws routed via loadbalancer
       this._websocket = null;
     }


### PR DESCRIPTION
An onerror handler is necessary to prevent errors from being treated as critical and bringing down the server.

  https://github.com/websockets/ws/issues/1825#issuecomment-745248318

This is a speculative fix for an issue we saw in our SaaS. Thanks Dmitry for the tips.
