### PR TITLE
Re-enable arm64 grist-ee Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,7 @@ on:
 env:
   TAG: ${{ inputs.tag || 'stable' }}
   DOCKER_HUB_OWNER: ${{ vars.DOCKER_HUB_OWNER || github.repository_owner }}
+  PLATFORMS: ${{ vars.PLATFORMS || 'linux/amd64,linux/arm64/v8' }}
 
 jobs:
   push_to_registry:
@@ -92,7 +93,7 @@ jobs:
           context: .
           build-args: GRIST_ALLOW_AUTOMATIC_VERSION_CHECKING=${{ matrix.image.name == 'grist-oss' && 'false' || 'true' }}
           push: true
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: ${{ env.PLATFORMS }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Context

arm64 Docker builds of grist-ee have not been published for some time due to a regression that went unnoticed.

## Proposed solution

Finish rest of work on `PLATFORMS` variable introduced by regression to make grist-ee Docker builds include an arm64 image again.

## Related issues

#1931

## Has this been tested?

Tested new action manually on [my fork of grist-core](https://github.com/georgegevoian/grist-core/actions/runs/19314283459).