### PR TITLE
update assistant limit test to provide a valid payload

### DIFF
--- a/test/gen-server/lib/limits.ts
+++ b/test/gen-server/lib/limits.ts
@@ -1,4 +1,5 @@
 import {ApiError} from 'app/common/ApiError';
+import {AssistanceRequestV1, AssistanceRequestV2} from 'app/common/Assistance';
 import {Features} from 'app/common/Features';
 import {resetOrg} from 'app/common/resetOrg';
 import {UserAPI, UserAPIImpl} from 'app/common/UserAPI';
@@ -575,14 +576,22 @@ describe('limits', function() {
 
     const sendAndAssert = async ({fulfilled}: {fulfilled: boolean}) => {
       const version = home.server.getAssistant()?.version;
-      const response = docApi.getAssistance({
+      const sharedPayload = {
         conversationId: 'id',
         text: 'text',
-        context: (version === 1) ? {
+      };
+      const v1: AssistanceRequestV1 = {
+        ...sharedPayload,
+        context: {
           tableId: '',
           colId: '',
-        } : {},
-      });
+        }
+      };
+      const v2: AssistanceRequestV2 = {
+        ...sharedPayload,
+        context: {}
+      };
+      const response = docApi.getAssistance(version === 1 ? v1 : v2);
       if (fulfilled) {
         await assert.isFulfilled(response);
       } else {


### PR DESCRIPTION
The assistant limit test produced a payload that is correct for V2 and not V1 and which was failing stricter checks.
