### PR TITLE
fix: missing translation key in PageWidgetPicker

### DIFF
--- a/app/client/ui/PageWidgetPicker.ts
+++ b/app/client/ui/PageWidgetPicker.ts
@@ -365,7 +365,7 @@ export class PageWidgetSelect extends Disposable {
           testId('data'),
           header(t("Select data")),
           cssEntry(
-            cssIcon('TypeTable'), 'New Table',
+            cssIcon('TypeTable'), t('New Table'),
             // prevent the selection of 'New Table' if it is disabled
             dom.on('click', (ev) => !this._isNewTableDisabled.get() && this._selectTable('New Table')),
             this._behavioralPromptsManager.attachPopup('pageWidgetPicker', {

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -740,7 +740,8 @@
         "Building {{- label}} widget": "Building {{- label}} widget",
         "Group by": "Group by",
         "Select data": "Select data",
-        "Select widget": "Select widget"
+        "Select widget": "Select widget",
+        "New Table": "New Table"
     },
     "Pages": {
         "Delete": "Delete",


### PR DESCRIPTION
## Context

We are at Capitole du Libre listening @audez presentation about Grist.
We detect in the slides screenshotss a translation bug.

## Proposed solution

Add a t() were needed.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

