### PR TITLE
Fix translation untitled document

### DIFF
--- a/app/client/ui/CoreNewDocMethods.ts
+++ b/app/client/ui/CoreNewDocMethods.ts
@@ -1,14 +1,17 @@
 import {homeImports} from 'app/client/ui/HomeImports';
+import {makeT} from 'app/client/lib/localization';
 import {docUrl, urlState} from 'app/client/models/gristUrlState';
 import {HomeModel} from 'app/client/models/HomeModel';
 import {ImportSourceElement} from 'app/client/lib/ImportSourceElement';
 import {reportError} from 'app/client/models/AppModel';
 
+const t = makeT('CoreNewDocMethods');
+
 export async function createDocAndOpen(home: HomeModel) {
   const destWS = home.newDocWorkspace.get();
   if (!destWS) { return; }
   try {
-    const docId = await home.createDoc("Untitled document", destWS === "unsaved" ? "unsaved" : destWS.id);
+    const docId = await home.createDoc(t("Untitled document"), destWS === "unsaved" ? "unsaved" : destWS.id);
     // Fetch doc information including urlId.
     // TODO: consider changing API to return same response as a GET when creating an
     // object, which is a semi-standard.

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -1948,7 +1948,7 @@ export class DocWorkerApi {
   }): Promise<string> {
     const {documentName, workspaceId} = options;
     const {status, data, errMessage} = await this._dbManager.addDocument(getScope(req), workspaceId, {
-      name: documentName ?? 'Untitled document',
+      name: documentName ?? req.t('DocApi.UntitledDocument'),
     });
     if (status !== 200) {
       throw new ApiError(errMessage || 'unable to create document', status);

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -2515,5 +2515,8 @@
     },
     "selectBy": {
         "Select widget": "Select widget"
+    },
+    "CoreNewDocMethods": {
+        "Untitled document": "Untitled document"
     }
 }

--- a/static/locales/en.server.json
+++ b/static/locales/en.server.json
@@ -15,5 +15,8 @@
     "orgUser": "User is an owner of the admin organization defined by `GRIST_INSTALL_ADMIN_ORG={{org}}`",
     "noDefaultEmail": "Missing admin account because `GRIST_DEFAULT_EMAIL` is not set",
     "accountByEmail": "Admin account defined by `GRIST_DEFAULT_EMAIL={{defaultEmail}}`"
+  },
+  "DocApi": {
+    "UntitledDocument": "Untitled document"
   }
 }


### PR DESCRIPTION
## Context

The string "Untitled document" is not translated today

## Proposed solution

Translate it in back and front

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 👍 yes, locally in my browser
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

