### PR TITLE
i18n: add some missing translation keys

### DIFF
--- a/app/client/ui/PageWidgetPicker.ts
+++ b/app/client/ui/PageWidgetPicker.ts
@@ -424,7 +424,7 @@ export class PageWidgetSelect extends Disposable {
           dom.maybe((use) => this._selectByOptions && use(this._selectByOptions).length > 1, () =>
             withInfoTooltip(
               cssSelectBy(
-                cssSmallLabel('SELECT BY'),
+                cssSmallLabel(t('SELECT BY')),
                 dom.update(cssSelect(this._value.link, this._selectByOptions!),
                           testId('selectby'))
               ),

--- a/app/client/ui/ViewSectionMenu.ts
+++ b/app/client/ui/ViewSectionMenu.ts
@@ -88,7 +88,7 @@ export function viewSectionMenu(
           // Fill background when there are some filters. Ignore sort options.
           cssFilterIconWrapper.cls('-any', anyFilter),
           cssFilterIcon('Filter'),
-          hoverTooltip('Sort and filter', {key: 'sortFilterBtnTooltip'}),
+          hoverTooltip(t('Sort and filter'), {key: 'sortFilterBtnTooltip'}),
         ),
       ),
       // [Save] [Revert] buttons when there are unsaved options.

--- a/app/client/ui/selectBy.ts
+++ b/app/client/ui/selectBy.ts
@@ -1,3 +1,4 @@
+import { makeT } from 'app/client/lib/localization';
 import { DocModel, ViewSectionRec } from 'app/client/models/DocModel';
 import { IPageWidget } from 'app/client/ui/PageWidgetPicker';
 import {
@@ -13,6 +14,8 @@ import {
 } from 'app/common/LinkNode';
 import { IOptionFull } from 'grainjs';
 import isEqual = require('lodash/isEqual');
+
+const t = makeT('selectBy');
 
 // some unicode characters
 const BLACK_CIRCLE = '\u2022';
@@ -37,10 +40,6 @@ export const NoLink = linkId({
   targetColRef: 0
 });
 
-const NoLinkOption: IOptionFull<string> = {
-  label: "Select widget",
-  value: NoLink
-};
 
 // Represents the differents way to reference to a section for linking
 type MaybeSection = ViewSectionRec|IPageWidget;
@@ -59,6 +58,11 @@ export function selectBy(docModel: DocModel, sources: ViewSectionRec[],
     ? createNodesFromViewSections(docModel, [target])
     : createNodesFromPageWidget(docModel, target);
 
+
+  const NoLinkOption: IOptionFull<string> = {
+    label: t("Select widget"),
+    value: NoLink
+  };
   const options = [NoLinkOption];
   for (const srcNode of sourceNodes) {
     const validTargets = targetNodes.filter((tgt) => isValidLink(srcNode, tgt));
@@ -165,7 +169,7 @@ function createNodesFromPageWidget(docModel: DocModel, pageWidget: IPageWidget):
   let tableExists = true;
   if (isSummary) {
     const summaryTable = docModel.tables.rowModels.find(
-      t => t?.summarySourceTable.peek() && isEqual(t.summarySourceColRefs.peek(), groupbyColumns));
+      tr  => tr?.summarySourceTable.peek() && isEqual(tr.summarySourceColRefs.peek(), groupbyColumns));
     if (summaryTable) {
       // The selected source table and groupby columns correspond to this existing summary table.
       table = summaryTable;

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -741,7 +741,8 @@
         "Group by": "Group by",
         "Select data": "Select data",
         "Select widget": "Select widget",
-        "New Table": "New Table"
+        "New Table": "New Table",
+        "SELECT BY": "SELECT BY"
     },
     "Pages": {
         "Delete": "Delete",
@@ -1006,7 +1007,8 @@
         "Revert": "Revert",
         "SORT": "SORT",
         "Save": "Save",
-        "Update Sort&Filter settings": "Update Sort&Filter settings"
+        "Update Sort&Filter settings": "Update Sort&Filter settings",
+        "Sort and filter": "Sort and filter"
     },
     "VisibleFieldsConfig": {
         "Cannot drop items into Hidden Fields": "Cannot drop items into Hidden Fields",
@@ -2510,5 +2512,8 @@
         "Year": "Year",
         "Years since": "Years since",
         "Years until": "Years until"
+    },
+    "selectBy": {
+        "Select widget": "Select widget"
     }
 }


### PR DESCRIPTION
## Context

Small fix of missing t() function here and there.

## Proposed solution

Just add it, and may i18n a better world.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

