### PR TITLE
[tiny] Service Account: remove unused getServiceAccountWithOwner method

### DIFF
--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -3562,10 +3562,6 @@ export class HomeDBManager implements HomeDBAuth {
     return this._serviceAccountsManager.getServiceAccount(serviceId);
   }
 
-  public async getServiceAccountWithOwner(serviceId: number) {
-    return this._serviceAccountsManager.getServiceAccountWithOwner(serviceId);
-  }
-
   public async getServiceAccountByLoginWithOwner(login: string) {
     return this._serviceAccountsManager.getServiceAccountByLoginWithOwner(login);
   }

--- a/app/gen-server/lib/homedb/ServiceAccountsManager.ts
+++ b/app/gen-server/lib/homedb/ServiceAccountsManager.ts
@@ -91,21 +91,6 @@ export class ServiceAccountsManager {
   /**
    * Like getServiceAccount but also returns informations of the owner.
    */
-  public async getServiceAccountWithOwner(
-    serviceAccountId: number,
-    transaction?: EntityManager
-  ): Promise<ServiceAccount|null> {
-    return await this._runInTransaction(transaction, async manager => {
-      return await this._buildServiceAccountQuery(manager)
-        .innerJoinAndSelect("serviceAccount.owner", "owner")
-        .where("ServiceAccount.id = :id", {id: serviceAccountId})
-        .getOne();
-    });
-  }
-
-  /**
-   * Like getServiceAccount but also returns informations of the owner.
-   */
   public async getServiceAccountByLoginWithOwner(
     serviceAccountLogin: string,
     transaction?: EntityManager


### PR DESCRIPTION
## Context

I have found an unused method in ServiceAccountsManager, which seem to be dead code.

## Proposed solution

Remove that method.

## Related issues


## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->