### PR TITLE
Bump js-yaml from 3.14.1 to 4.1.1

### DIFF
--- a/app/server/lib/manifest.ts
+++ b/app/server/lib/manifest.ts
@@ -66,7 +66,7 @@ async function _readManifest(pluginPath: string): Promise<object> {
     return await fse.readFile(path.join(pluginPath, "manifest." + fileExtension), "utf8");
   }
   try {
-    return yaml.safeLoad(await readManifestFile("yml"));
+    return yaml.load(await readManifestFile("yml")) as object;
   } catch (e) {
     if (e instanceof yaml.YAMLException) {
       throw new Error('error parsing yaml manifest: ' + e.message);

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/http-proxy": "1.17.9",
     "@types/i18next-fs-backend": "1.1.2",
     "@types/image-size": "0.0.29",
-    "@types/js-yaml": "3.11.2",
+    "@types/js-yaml": "4.0.9",
     "@types/jsdom": "21.1.6",
     "@types/jsesc": "3.0.1",
     "@types/jsonwebtoken": "7.2.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,10 +1240,10 @@
   dependencies:
     "@types/sizzle" "*"
 
-"@types/js-yaml@3.11.2":
-  version "3.11.2"
-  resolved "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.11.2.tgz"
-  integrity sha512-JRDtMPEqXrzfuYAdqbxLot1GvAr/QvicIZAnOAigZaj8xVMhuSJTg/xsv9E1TvyL+wujYhRLx9ZsQ0oFOSmwyA==
+"@types/js-yaml@4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
+  integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
 
 "@types/jsdom@21.1.6":
   version "21.1.6"


### PR DESCRIPTION
Replacement attempt for #1953 

I also bump the typescript definition and change the call of `safeLoad` to `load` as [described in the migration guide](https://github.com/nodeca/js-yaml/blob/74a01992953302040be3277c08ba214a06f00b87/migrate_v3_to_v4.md).