### PR TITLE
I18n: add missing t() functions in AccessRules

### DIFF
--- a/app/client/aclui/AccessRules.ts
+++ b/app/client/aclui/AccessRules.ts
@@ -842,7 +842,7 @@ class TableRules extends Disposable {
           // TODO: could be worth also flagging multiple rulesets with the same columns as
           // undesirable.
           throw new UserError(
-            t('Column {{colId}} appears in multiple rules for table {{this.tableId}} \
+            t('Column {{colId}} appears in multiple rules for table {{tableId}} \
 that might be order-dependent. Try splitting rules up differently?', {colId, tableId: this.tableId}
             )
           );

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -45,7 +45,7 @@
         "Add table-wide rule": "Add table-wide rule",
         "Access rules have changed. Click Reset to revert your changes and refresh the rules.": "Access rules have changed. Click Reset to revert your changes and refresh the rules.",
         "All": "All",
-        "Column {{colId}} appears in multiple rules for table {{this.tableId}} that might be order-dependent. Try splitting rules up differently?": "Column {{colId}} appears in multiple rules for table {{this.tableId}} that might be order-dependent. Try splitting rules up differently?",
+        "Column {{colId}} appears in multiple rules for table {{tableId}} that might be order-dependent. Try splitting rules up differently?": "Column {{colId}} appears in multiple rules for table {{tableId}} that might be order-dependent. Try splitting rules up differently?",
         "Columns": "Columns",
         "Condition cannot be blank": "Condition cannot be blank",
         "Default resource missing in resource map": "Default resource missing in resource map",


### PR DESCRIPTION
## Context

Some strings are not translated in advanced access rules pane.

## Proposed solution

Add some t() functions here and there to add new strings to translation collection

## Has this been tested?


- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
