### PR TITLE
Upgrade typeorm monkeypatches

### DIFF
--- a/app/gen-server/lib/TypeORMPatches.ts
+++ b/app/gen-server/lib/TypeORMPatches.ts
@@ -18,11 +18,12 @@ import {delay} from 'app/common/delay';
 import log from 'app/server/lib/log';
 import {Mutex, MutexInterface} from 'async-mutex';
 import isEqual = require('lodash/isEqual');
-import {EntityManager, QueryRunner} from 'typeorm';
+import {EntityManager, QueryRunner, TypeORMError} from 'typeorm';
 import {PostgresDriver} from 'typeorm/driver/postgres/PostgresDriver';
 import {PostgresQueryRunner} from 'typeorm/driver/postgres/PostgresQueryRunner';
 import {SqliteDriver} from 'typeorm/driver/sqlite/SqliteDriver';
 import {SqliteQueryRunner} from 'typeorm/driver/sqlite/SqliteQueryRunner';
+import {IsolationLevel} from 'typeorm/driver/types/IsolationLevel';
 import {
   QueryRunnerProviderAlreadyReleasedError
 } from 'typeorm/error/QueryRunnerProviderAlreadyReleasedError';
@@ -95,20 +96,34 @@ SqliteDriver.prototype.createQueryRunner = SqliteDriverPatched.prototype.createQ
 
 export function applyPatch() {
   // tslint: disable-next-line
-  EntityManager.prototype.transaction = async function <T>(arg1: any,  arg2?: any): Promise<T> {
+  EntityManager.prototype.transaction = async function<T>(
+      arg1: IsolationLevel | ((entityManager: EntityManager) => Promise<T>),
+      arg2?: (entityManager: EntityManager) => Promise<T>): Promise<T>
+    {
+    const isolation =
+      typeof arg1 === "string"
+        ? arg1
+        : undefined;
+    const runInTransaction =
+      typeof arg1 === "function"
+        ? arg1
+        : arg2;
+
+    if (!runInTransaction) {
+      throw new TypeORMError(
+        `Transaction method requires callback in second parameter if isolation level is supplied.`,
+      );
+    }
+
     if (this.queryRunner && this.queryRunner.isReleased) {
       throw new QueryRunnerProviderAlreadyReleasedError();
     }
-    if (this.queryRunner && this.queryRunner.isTransactionActive) {
-      throw new Error(`Cannot start transaction because its already started`);
-    }
-    const queryRunner = this.connection.createQueryRunner();
-    const runInTransaction = typeof arg1 === "function" ? arg1 : arg2;
+    const queryRunner = this.queryRunner || this.connection.createQueryRunner();
     const isSqlite = this.connection.driver.options.type === 'sqlite';
     try {
-      async function runOrRollback() {
+      const runOrRollback = async () => {
         try {
-          await queryRunner.startTransaction();
+          await queryRunner.startTransaction(isolation);
 
           const start = Date.now();
 
@@ -139,7 +154,7 @@ export function applyPatch() {
           }
           throw err;
         }
-      }
+      };
       if (isSqlite) {
         return await callWithRetry(runOrRollback, {
           // Transactions may fail immediately if there are connections from
@@ -212,12 +227,13 @@ declare module 'typeorm/query-builder/QueryBuilder' {
 }
 
 abstract class QueryBuilderPatched<T> extends QueryBuilder<T> {
+  private static _origSetParameter = QueryBuilder.prototype.setParameter;
   public setParameter(key: string, value: any): this {
     const prev = this.expressionMap.parameters[key];
     if (prev !== undefined && !isEqual(prev, value)) {
       throw new Error(`TypeORM parameter collision for key '${key}' ('${prev}' vs '${value}')`);
     }
-    this.expressionMap.parameters[key] = value;
+    QueryBuilderPatched._origSetParameter.call(this, key, value);
     return this;
   }
 


### PR DESCRIPTION
## Context

Follow-up of #1950.

We maintain monkey patches which aren't up to date with the latest version of TypeORM

## Proposed solution

1. For `EntityManager.prototype.transaction`, resync the code with [the upstream version](https://github.com/typeorm/typeorm/blob/02e7b713ed09e5aa23d453c11fbdaafe60d8dcac/src/entity-manager/EntityManager.ts#L125) (assuming the version of the code when the monkey patch was created used [to look like this one](https://github.com/typeorm/typeorm/blob/d8f8ecc06882afe8be38ef75fdd1e7a5d67af8f1/src/entity-manager/EntityManager.ts#L93)). 
2. For `QueryBuilderPatched.prototype.setParameter`, simply call the parent method

## Related issues

#1950

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
