### PR TITLE
Make LinkingBidirectional tests more stable

### DIFF
--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -3294,11 +3294,11 @@ export async function removeFilters(save = false) {
 export async function sortAndFilter() {
   const ctrl = {
     async addColumn() {
-      await driver.find('.test-filter-config-add-filter-btn').click();
+      await driver.findWait('.test-filter-config-add-filter-btn', 1000).click();
       return this;
     },
     async clickColumn(col: string) {
-      await driver.findContent(".test-sd-searchable-list-item", col).click();
+      await driver.findContentWait(".test-sd-searchable-list-item", col, 1000).click();
       return this;
     },
     async close() {
@@ -3306,7 +3306,7 @@ export async function sortAndFilter() {
       return this;
     },
     async save() {
-      await driver.find('.test-section-menu-btn-save').click();
+      await driver.findWait('.test-section-menu-btn-save', 1000).click();
       await waitForServer();
       return this;
     },


### PR DESCRIPTION
## Context

I can't run locally the `LinkingBidirectional` nbrowser tests.

## Proposed solution

I have added timeout where I have encountered a failure with a timeout.

I ran the tests 20 times with no failure:
```bash
for i in $(seq 1 20); \
  do GREP_TESTS="LinkingBidirectional" LANGUAGE=en_US yarn test:nbrowser:ci || break; \
done
```

NB: I also see [flakiness with these tests on the CI side](https://github.com/gristlabs/grist-core/actions/runs/19545530956/job/55963191519?pr=1963#step:23:677). This PR does not address that.

## Related issues

Related to this PR: https://github.com/gristlabs/grist-core/pull/1963

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
