### PR TITLE
Make sure a Form Submit row can't be removed with keyboard

### DIFF
--- a/app/client/components/Forms/Submit.ts
+++ b/app/client/components/Forms/Submit.ts
@@ -6,6 +6,10 @@ import { dom } from "grainjs";
 const testId = makeTestId("test-forms-");
 
 export class SubmitModel extends BoxModel {
+  public canRemove() {
+    return false;
+  }
+
   public override render() {
     const text = this.view.viewSection.layoutSpecObj.prop('submitText');
     return dom(


### PR DESCRIPTION
## Context

In the form edit view, while we don't show the trash can icon to remove the submit button when hovering it (good), the submit model isn't actually prevented from being removed in other ways (bad).

When we use the tab key to navigate through form fields, at one point we are focused on the submit button. The focus ring isn't actually shown, but we are focused on it. Pressing Backspace deletes the submit button and there is no way to retrieve it after that.

## Proposed solution

This marks the `SubmitModel` as non-removable, so that the view can't remove it, even with keyboard presses.

An additional, better fix, would be to prevent the submit row to be focused. This would avoid this state of being focused on it but not showing it to the user as there is nothing to do with it anyway.  
But it seems this use-case of "some box models are non-user-focusable" doesn't exist right now?

This quick suggestion at least prevents from creating un-usable forms by mistake. I opened this because we had some user feedback where the submit button was missing on their form and we have trouble understanding why. This is what might have happened here.

## Has this been tested?

No test have been added (yet?).

## Screenshots / Screencasts


https://github.com/user-attachments/assets/7de000b5-d591-4534-a56d-65290536ad7f


