### PR TITLE
Bump @types/underscore to 1.11.15

### DIFF
--- a/app/client/components/GridView.ts
+++ b/app/client/components/GridView.ts
@@ -669,7 +669,7 @@ export default class GridView extends BaseView {
     // from a different peer.
 
     // convert row-wise data to column-wise so that it better resembles a user action
-    let pasteData = _.unzip(data);
+    let pasteData = unzipPasteData(data);
     const pasteHeight = pasteData[0].length;
     const pasteWidth = pasteData.length;
     // figure out the size of the paste area
@@ -687,7 +687,7 @@ export default class GridView extends BaseView {
     const leftIndex = this.cellSelector.colLower();
     const updateColIndices = _.range(leftIndex, leftIndex + outputWidth);
 
-    pasteData = gutil.growMatrix(pasteData, updateColIndices.length, updateRowIds.length);
+    pasteData = growPasteDataMatrix(pasteData, updateColIndices.length, updateRowIds.length);
 
     const fields = this.viewSection.viewFields().peek();
     const pasteFields = updateColIndices.map(i => fields[i] || null);
@@ -2259,6 +2259,16 @@ export default class GridView extends BaseView {
       }
     });
   }
+}
+
+// Provide a type-safe wrapper around _.unzip
+function unzipPasteData(pasteData: PasteData): PasteData {
+  return _.unzip<any>(pasteData) as PasteData;
+}
+
+// Provide a type-safe wrapper around growMatrix
+function growPasteDataMatrix(pasteData: PasteData, r: number, c: number): PasteData {
+  return gutil.growMatrix<any>(pasteData, r, c) as PasteData;
 }
 
 interface ComputedRule {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@types/swagger-ui": "3.52.4",
     "@types/tmp": "0.2.6",
     "@types/uuid": "10.0.0",
+    "@types/underscore": "1.11.15",
     "@types/webpack-dev-server": "4.7.2",
     "@types/which": "2.0.1",
     "@types/ws": "^8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1523,6 +1523,11 @@
   resolved "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.0.tgz"
   integrity sha512-ipNAQLgRnG0EWN1cTtfdVHp5AyTW/PAMJ1PxLN4bAKSHbusSZbj48mIHiydQpN7GgQrYqwfnvZ573OVfJm5Nzg==
 
+"@types/underscore@1.11.15":
+  version "1.11.15"
+  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.11.15.tgz#29c776daecf6f1935da9adda17509686bf979947"
+  integrity sha512-HP38xE+GuWGlbSRq9WrZkousaQ7dragtZCruBVMi0oX1migFZavZ3OROKHSkNp/9ouq82zrWtZpg18jFnVN96g==
+
 "@types/uuid@10.0.0":
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"


### PR DESCRIPTION
## Context

1. @types/underscore's recent versions introduce a generic variant of `_.unzip`, which causes the existing type inference to break.
2. We're using @types/underscore implicitly from transitive dependencies (despite using underscore directly). 

This issue would be hit eventually when the version is updated. This case has already been in hit in Grist Desktop, which uses @types/underscore 1.11.15 instead of 1.11.0, preventing core compilation. 

## Proposed solution

This adds @types/underscore at 1.11.15 as an explicit dependency, and updates `GridView.ts` to compile with the new type signatures for `_.unzip`.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
