### PR TITLE
Several improvements to RecordSet handling.

### DIFF
--- a/sandbox/grist/column.py
+++ b/sandbox/grist/column.py
@@ -649,8 +649,11 @@ class ReferenceListColumn(BaseReferenceColumn):
         result.append(lookup_value)
       val = result
 
-    if isinstance(val, int) and val:
-      val = [val]
+    if val:
+      if isinstance(val, int):
+        val = [val]
+      elif self._target_table and isinstance(val, self._target_table.Record):
+        val = [val.id]
 
     return super(ReferenceListColumn, self).convert(val)
 


### PR DESCRIPTION
## Context

1. When looking up `.RefCol` or `.RefListCol` on an empty reference list, return an empty RecordSet. This allows e.g. `Table.lookupRecords(...).RefCol.Name` to be used even when lookupRecords() returns an empty set. This previously didn't work.
2. When looking up `.RefListCol` on a reference list, return a merged `RecordSet`. This already worked when e.g. `Table.lookupRecords(...).RefListCol` was set as the value for a RefList column, but now `Table.lookupRecords(...).RefListCol.Name` is similarly allowed.
3. Allow RefList to get set to a single compatible reference value, turning it into a list.

## Related issues

Resolves #1987 and #1985, which include some of the scenarios being addressed.

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
