### PR TITLE
Fix how zero Date/DateTimes look to other formulas

### DIFF
--- a/sandbox/grist/column.py
+++ b/sandbox/grist/column.py
@@ -289,7 +289,7 @@ class DateColumn(NumericColumn):
   to midnight of specific UTC dates. Accessing them yields date objects.
   """
   def _make_rich_value(self, typed_value):
-    return typed_value and moment.ts_to_date(typed_value)
+    return moment.ts_to_date(typed_value) if isinstance(typed_value, float) else typed_value
 
   def sample_value(self):
     return _sample_date
@@ -304,7 +304,8 @@ class DateTimeColumn(NumericColumn):
     self._timezone = col_info.type_obj.timezone
 
   def _make_rich_value(self, typed_value):
-    return typed_value and moment.ts_to_dt(typed_value, self._timezone)
+    return (moment.ts_to_dt(typed_value, self._timezone)
+        if isinstance(typed_value, float) else typed_value)
 
   def sample_value(self):
     return _sample_datetime

--- a/sandbox/grist/test_date_types.py
+++ b/sandbox/grist/test_date_types.py
@@ -1,0 +1,47 @@
+"""
+Test that Date/DateTimes produce correct types as seen by other formulas.
+"""
+import datetime
+import testutil
+import test_engine
+import moment
+
+def D(year, month, day):
+  return moment.date_to_ts(datetime.date(year, month, day))
+
+class TestDateTypes(test_engine.EngineTestCase):
+  def test_date_types(self):
+    date1 = D(2025, 12, 6)
+    datetime1 = D(2025, 12, 6) + (9 * 60 + 30) * 60   # Make it 9:30 on that date.
+    dateZero = D(1970, 1, 1)        # This should just be 0
+    datetimeZero = D(1970, 1, 1)    # This should just be 0
+    self.load_sample(testutil.parse_test_sample({
+      "SCHEMA": [
+        [1, "Test", [
+          [1, "DateCol",        "Date",     False],
+          [2, "DateColType",    "Any",      True, "type($DateCol).__name__"],
+          [3, "DTCol",          "DateTime:UTC", False],
+          [4, "DTColType",      "Any",      True, "type($DTCol).__name__"],
+        ]]
+      ],
+      "DATA": {
+        "Test": [
+          ["id",  "DateCol",      "DTCol"],
+          [   1,  date1,          datetime1],
+          [   2,  dateZero,       datetimeZero],
+          [   3,  0,              0],
+          [   5,  None,           None],
+          [   6,  "n/a",          "unknown"],
+        ]
+      }
+    }))
+
+    self.apply_user_action(["CreateViewSection", 1, 0, "record", [1], None])
+    self.assertTableData('Test', cols="all", data=[
+      ["id",  "DateCol",    "DTCol",      "DateColType",  "DTColType"],
+      [   1,  date1,        datetime1,    "date",         "datetime"],
+      [   2,  dateZero,     datetimeZero, "date",         "datetime"],
+      [   3,  0,            0,            "date",         "datetime"],
+      [   5,  None,         None,         "NoneType",     "NoneType"],
+      [   6,  "n/a",        "unknown",    "AltText",      "AltText"],
+    ])


### PR DESCRIPTION
## Context

The date 1970-01-01 is incorrectly cast as a float in formula columns. See #1994 for more details.

Resolves #1994 

## Proposed solution

Date/DateTime values are stored as floats. To check if it should be presented as a date/datetime object, we should check if we have a float rather than if the value is truthy (as that incorrectly interprets zeros as non-dates).

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
