### PR TITLE
Eslint: Remove function appCommWaiter (dead code)

### DIFF
--- a/app/client/components/Comm.ts
+++ b/app/client/components/Comm.ts
@@ -222,13 +222,6 @@ export class Comm extends dispose.Disposable implements GristServerAPI, DocListA
   }
 
   /**
-   * Wait for all active requests to complete.
-   */
-  public async waitForActiveRequests(): Promise<void> {
-    await Promise.all(this.pendingRequests.values());
-  }
-
-  /**
    * Internal implementation of all the server methods. They differ only in the name of the server
    * method to call, and the arguments that it expects.
    *

--- a/test/client/clientUtil.js
+++ b/test/client/clientUtil.js
@@ -91,18 +91,6 @@ function querySelectorLast(el, selector) {
 }
 exports.querySelectorLast = querySelectorLast;
 
-var SERVER_TIMEOUT = 250; // How long to wait for pending requests to resolve
-var CLIENT_DELAY = 100; // How long to wait for browser to render the action
-
-function appCommWaiter(app) {
-  return function(timeout, delay) {
-    return Promise.resolve(app.comm.waitForActiveRequests())
-      .timeout(timeout || SERVER_TIMEOUT)
-      .delay(delay || CLIENT_DELAY);
-  };
-}
-exports.appCommWaiter = appCommWaiter;
-
 /*
  *
  * Takes and observable and returns a promise when the observable changes.


### PR DESCRIPTION
## Context

I open this PR while working on #2000. Eslint reports an accurate issue with `waitForActiveRequests()`.

While digging, I found that `appCommWaiter()` function had a implementation problem: it used `waitForActiveRequests()` which supposedly awaited for pending request to end. But the object awaited was not a promise and the result was resolved immediately. Also this function does not seem to be used elsewhere (at least from what I have found in grist-core).

## Proposed solution

1. Remove `appCommWaiter` which does not seem to be used.
2. Remove `waitForActiveRequests` which was only used in the above function

## Related issues

#1967 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
