### PR TITLE
Updating autosize code in GridView

### DIFF
--- a/app/client/components/GridView.ts
+++ b/app/client/components/GridView.ts
@@ -2388,10 +2388,7 @@ export default class GridView extends BaseView {
 
     bundleChanges(() => {
       fields.forEach((field, index) => {
-        const recordedWidth = fieldMaxWidths.get(index) || 100;
-        // If field can be wrapped, we will use 100 as minimum width.
-        const fareWidth = field.wrap.peek() ? Math.max(recordedWidth, 100) : recordedWidth;
-        const maxWidth = fareWidth || 100;
+        const maxWidth = fieldMaxWidths.get(index) || 100;
         field.width(maxWidth + 20);
       });
     });


### PR DESCRIPTION
## Context
Method to autosize GridView (used by VirtualDoc) wasn't working properly for wrapped columns, which weren't properly measured by the scrolly initially.
Now wrapped columns have minimum widths of 100px, and scrolly is updated before checking the total height of columns

## Has this been tested?
Manual tests only
