### PR TITLE
update node version in translation key workflow

### DIFF
--- a/.github/workflows/translation_keys.yml
+++ b/.github/workflows/translation_keys.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Install Node.js packages
         run: yarn install


### PR DESCRIPTION
This updates the node version in the workflow for scanning for new translation keys, since it is incompatible with recent changes.

See e.g. https://github.com/gristlabs/grist-core/actions/runs/20467895658/job/58816052204