### PR TITLE
Add page name to document.title

### DIFF
--- a/app/client/ui/AppUI.ts
+++ b/app/client/ui/AppUI.ts
@@ -161,13 +161,15 @@ function pagePanelsDoc(owner: IDisposableOwner, appModel: AppModel, appObj: App)
   const rightPanel = Computed.create(owner, pageModel.gristDoc, (use, gristDoc) =>
     gristDoc ? RightPanel.create(use.owner, gristDoc, rightPanelOpen) : null);
 
-  // Set document title to strings like "DocName - Grist"
-  owner.autoDispose(subscribe(pageModel.currentDocTitle, (use, docName) => {
+  // Set document title to strings like "PageName - DocName - Grist"
+  owner.autoDispose(subscribe(pageModel.gristDoc, pageModel.currentDocTitle, (use, gristDoc, docName) => {
     // If the document hasn't loaded yet, don't update the title; since the HTML document already has
     // a title element with the document's name, there's no need for further action.
     if (!pageModel.currentDoc.get()) { return; }
 
-    document.title = `${docName}${getPageTitleSuffix(getGristConfig())}`;
+    const pageName = gristDoc ? (use(gristDoc.currentPageName) || "") : "";
+    const title = pageName ? `${pageName} - ${docName}` : docName;
+    document.title = `${title}${getPageTitleSuffix(getGristConfig())}`;
   }));
 
   // Called after either panel is closed, opened, or resized.

--- a/test/nbrowser/NewDocument.ntest.js
+++ b/test/nbrowser/NewDocument.ntest.js
@@ -19,7 +19,7 @@ describe("NewDocument.ntest", function() {
     await gu.actions.createNewDoc("Untitled");
     assert.equal(await gu.actions.getDocTitle(), "Untitled");
 
-    const expectedTitle = "Untitled - Grist";
+    const expectedTitle = "Table1 - Untitled - Grist";
     assert.equal(await driver.getTitle(), expectedTitle);
     assert.equal(await driver.find('meta[name="twitter:title"]').getAttribute("content"), expectedTitle);
     assert.equal(await driver.find('meta[property="og:title"]').getAttribute("content"), expectedTitle);

--- a/test/nbrowser/NewDocument.ntest.js
+++ b/test/nbrowser/NewDocument.ntest.js
@@ -19,6 +19,8 @@ describe("NewDocument.ntest", function() {
     await gu.actions.createNewDoc("Untitled");
     assert.equal(await gu.actions.getDocTitle(), "Untitled");
 
+    await driver.sleep(500); // wait for the page to load in
+
     const expectedTitle = "Table1 - Untitled - Grist";
     assert.equal(await driver.getTitle(), expectedTitle);
     assert.equal(await driver.find('meta[name="twitter:title"]').getAttribute("content"), expectedTitle);

--- a/test/nbrowser/NewDocument.ntest.js
+++ b/test/nbrowser/NewDocument.ntest.js
@@ -2,6 +2,7 @@
 
 import { assert, driver } from "mocha-webdriver";
 import { $, gu, test } from "test/nbrowser/gristUtil-nbrowser";
+import { waitForDocToLoad } from "./gristUtils";
 
 describe("NewDocument.ntest", function() {
   test.setupTestSuite(this);
@@ -19,12 +20,13 @@ describe("NewDocument.ntest", function() {
     await gu.actions.createNewDoc("Untitled");
     assert.equal(await gu.actions.getDocTitle(), "Untitled");
 
-    await driver.sleep(500); // wait for the page to load in
+    await waitForDocToLoad();
 
     const expectedTitle = "Table1 - Untitled - Grist";
+    const expectedMetaTitle = "Untitled - Grist";
     assert.equal(await driver.getTitle(), expectedTitle);
-    assert.equal(await driver.find('meta[name="twitter:title"]').getAttribute("content"), expectedTitle);
-    assert.equal(await driver.find('meta[property="og:title"]').getAttribute("content"), expectedTitle);
+    assert.equal(await driver.find('meta[name="twitter:title"]').getAttribute("content"), expectedMetaTitle);
+    assert.equal(await driver.find('meta[property="og:title"]').getAttribute("content"), expectedMetaTitle);
 
     const expectedDescription = "A modern, open source spreadsheet that goes beyond the grid";
     assert.equal(await driver.find('meta[name="description"]').getAttribute("content"), expectedDescription);

--- a/test/nbrowser/gristUtil-nbrowser.js
+++ b/test/nbrowser/gristUtil-nbrowser.js
@@ -401,10 +401,12 @@ const gu = {
     getTabs: () => {
       return $(".test-docpage-label");
     },
-    renameDoc: (newName) => {
+    renameDoc: async (newName) => {
+      const currentTitle = await driver.getTitle();
+      const pageName = currentTitle.split(" - ")[0];
       $(".test-bc-doc").click();
       $.driver.sendKeys(newName, $.ENTER);
-      return $.wait(1000, () => $.driver.getTitle().startsWith(newName + " - "));
+      return $.wait(1000, () => $.driver.getTitle().startsWith(pageName + " - " + newName + " - "));
     },
     selectTabView: async (viewTitle) => {
       const isOpen = await gu.isSidePanelOpen("left");


### PR DESCRIPTION
## Context

<!-- Please include a summary of the change, with motivation and context -->
<!-- Bonus: if you are comfortable writing one, please insert a user-story https://en.wikipedia.org/wiki/User_story#Common_templates -->
This PR implements the suggestion to show the active page name in the document title from #846.

## Proposed solution

<!-- Describe here how you address the issue -->
I read in the page name in AppUI.tsx instead of just the document name (with a fallback to just the document name while no page has loaded yet).
Special pages like "settings", "acl", etc. are currently shown raw. There doesn't seem to be a centralized way for localization of these strings so I'm not sure how it should be done here.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->
Closes #846 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
<img width="287" height="50" alt="image" src="https://github.com/user-attachments/assets/8ce5cd49-537a-4a93-93e8-0bcf1f4ba6f5" />
<img width="287" height="50" alt="image" src="https://github.com/user-attachments/assets/519a334c-e2ee-4af5-9915-48a3e1124aa4" />
<img width="286" height="54" alt="image" src="https://github.com/user-attachments/assets/08517e82-5860-40d0-a4a3-fb7a665ab9d7" />

