### PR TITLE
Adds tool for generating document tables from a static schema

### DIFF
--- a/app/common/DocSchemaImport.ts
+++ b/app/common/DocSchemaImport.ts
@@ -23,8 +23,8 @@ export interface TableImportSchema {
   // Original ID of the table in the source (e.g. airtable), or an arbitrary ID
   // Can be referenced in other parts of the schema, and will be converted to a real Grist id during import.
   originalId: string;
-  // Name for the table in Grist
-  name: string;
+  // ID / name the table should have in Grist. This will be transformed during import and won't match exactly.
+  desiredGristId: string;
   columns: ColumnImportSchema[];
 }
 
@@ -171,7 +171,7 @@ export class DocSchemaImportTool {
       addTableActions.push([
         "AddTable",
         // This will be transformed into a valid id
-        tableSchema.name,
+        tableSchema.desiredGristId,
         tableSchema.columns.map(colInfo => ({
           // This will be transformed into a valid id
           id: colInfo.desiredGristId,

--- a/test/common/DocSchemaImport.ts
+++ b/test/common/DocSchemaImport.ts
@@ -15,7 +15,7 @@ function createTestSchema(): ImportSchema {
     tables: [
       {
         originalId: "1",
-        name: "Table A",
+        desiredGristId: "Table A",
         columns: [
           {
             originalId: "1",
@@ -39,7 +39,7 @@ function createTestSchema(): ImportSchema {
       },
       {
         originalId: "2",
-        name: "Table B",
+        desiredGristId: "Table B",
         columns: [
           {
             originalId: "1",
@@ -404,7 +404,7 @@ describe("DocSchemaImport", function() {
 
       schema.tables.push({
         originalId: "Test1",
-        name: "Test Table 1",
+        desiredGristId: "Test Table 1",
         columns: [
           {
             originalId: "1",
@@ -462,7 +462,7 @@ describe("DocSchemaImport", function() {
 
       schema.tables.push({
         originalId: "Test1",
-        name: "Test Table 1",
+        desiredGristId: "Test Table 1",
         columns: [
           {
             originalId: "1",


### PR DESCRIPTION
## Context

Importing directly from Airtable is a feature under active development, that requires the existing Airtable schema to be converted into a Grist document schema.

## Proposed solution

This adds a tool that accepts a static Grist document schema, and uses it to generate tables and columns in an existing Grist document. 

It additionally adds:
- Validation for the schema, with the aim of ensuring referential integrity
- Transformation for the schema, allowing tables to be skipped or remapped to existing tables.

This means the Airtable import tool to only needs to generate a Grist document schema from an Airtable base schema, and not have to directly create the relevant tables/columns/etc in Grist.

This tool lives in app/common, so that it can be used on both the frontend and the backend as-needed. 

## Related issues

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [X] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
