### PR TITLE
Fix custom widgets regression from 1.7.9

### DIFF
--- a/stubs/app/server/server.ts
+++ b/stubs/app/server/server.ts
@@ -42,6 +42,7 @@ setDefaultEnv("GRIST_WIDGET_LIST_URL", commonUrls.gristLabsWidgetRepository);
 // It's important that this comes after the setDefaultEnv calls above. MergedServer reads
 // some env vars at import time, including GRIST_WIDGET_LIST_URL.
 // TODO: Fix this reliance on side effects during import.
+// eslint-disable-next-line @import-x/order
 import { MergedServer, parseServerTypes } from "app/server/MergedServer";
 
 const G = {

--- a/test/nbrowser_with_stubs/CustomWidgets.ts
+++ b/test/nbrowser_with_stubs/CustomWidgets.ts
@@ -14,7 +14,7 @@ describe("CustomWidgets", function() {
 
   it("uses the Grist Labs widget repository by default", async function() {
     await gu.addNewSection("Custom", "Table1");
-    const widgetNames = new Set(await driver.findAll(".test-custom-widget-gallery-widget-name", e => e.getText()))
+    const widgetNames = new Set(await driver.findAll(".test-custom-widget-gallery-widget-name", e => e.getText()));
 
     assert.isTrue(widgetNames.has("Custom URL"));
     assert.isTrue(widgetNames.has("Calendar"));


### PR DESCRIPTION
## Context

Code in `stubs/app/server/server.ts` was relying on a particular import order for in-process changes to environment variables to take effect. The import order was changed recently due to ESLint upgrades, which silently broke one of these variables getting initialized (GRIST_WIDGET_LIST_URL). This caused custom widgets added from the default GRIST_WIDGET_LIST_URL to fail to load since they could no longer be found.

## Proposed solution

Restore the original import order.

## Related issues

#2044

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->