### PR TITLE
Fixes overlapping text and makes styling consistent when a filter-linked row is unavailable due to ACLs

### DIFF
--- a/app/client/components/DetailView.css
+++ b/app/client/components/DetailView.css
@@ -198,20 +198,6 @@
   border-top: none;
 }
 
-.detailview_record_unavailable_overlay {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: var(--grist-medium-font-size);
-  font-weight: 700;
-}
-
 /*** compact theme ***/
 .detail_theme_record_compact {
   /* 12px is enough margin on the right to include most of the floating scrollbar on MacOS */

--- a/app/client/components/DetailView.ts
+++ b/app/client/components/DetailView.ts
@@ -381,9 +381,10 @@ export default class DetailView extends BaseView {
         }
         else {
           return dom.domComputed((use) => {
-            if (use(this.cursor.rowIndex) === null) {
+            // If this.disableEditing is set, there's already an overlay in place hiding this view.
+            if (use(this.cursor.rowIndex) === null && !use(this.disableEditing)) {
               return dom("div",
-                dom("div.detailview_record_unavailable_overlay", t("This row is unavailable or does not exist")),
+                dom("div.disable_viewpane.flexvbox", t("This row is unavailable or does not exist")),
               );
             }
             else {


### PR DESCRIPTION
## Context

When any widget is filter-linked to another, it only shows records connected to the one selected in the linked widget. If no row is selected, it shows "No row selected in ${X}".

When a card widget is linked to another, it only shows a single record connected to the one selected in the linked widget. If that record is filtered out the ACLs, it shows "This row is unavailable or does not exist". This also occurs in any situation where a view's cursor ends up set to null. 

If these two scenarios occur at the same time, the text overlaps:
<img width="872" height="538" alt="image" src="https://github.com/user-attachments/assets/93537a1f-5338-4b7a-a813-4c31a2c1071c" />

## Proposed solution

This changes the logic for "This row is unavailable or does not exist" to only show if the widget isn't hidden due to filter linking.

Separately, this standardizes the styling for "This row is unavailable or does not exist" and "No row selected in ${X}".

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<img width="914" height="460" alt="image" src="https://github.com/user-attachments/assets/4b8032e3-140d-48a4-b1b1-f8176739dbdc" />
<img width="907" height="498" alt="image" src="https://github.com/user-attachments/assets/c36c0c5d-fdad-4b3f-85d9-14a9117a27b4" />

