### PR TITLE
Endpoint for clearing auth provider config and tests for session clear upon restart

### DIFF
--- a/app/server/lib/ConfigBackendAPI.ts
+++ b/app/server/lib/ConfigBackendAPI.ts
@@ -54,16 +54,14 @@ export class ConfigBackendAPI {
     }));
 
     // PATCH /api/config/auth-providers?provider=...
+    // Configures an authentication provider or removes its configuration.
     app.patch("/api/config/auth-providers", requireInstallAdmin, expressWrap(async (req, resp) => {
       stringParam(req.query.provider, "provider", { allowed: [GETGRIST_COM_PROVIDER_KEY] });
 
       const gristComSecret = "GRIST_GETGRISTCOM_SECRET";
 
       // And expect just a secret key in the body.
-      const key = req.body[gristComSecret]?.split(/\s+/).join("");
-      if (!key) {
-        throw new ApiError("Request doesn't contain valid getgrist.com configuration parameter", 400);
-      }
+      const key = req.body[gristComSecret]?.split(/\s+/).join("") || undefined;
       const newSettings = new AppSettings("grist");
       const currentEnvVars = (await this._activations.current()).prefs?.envVars || {};
       const newEnvVars = { ...currentEnvVars, [gristComSecret]: key };
@@ -73,9 +71,14 @@ export class ConfigBackendAPI {
         readGetGristComConfigFromSettings(newSettings);
       }
       catch (e) {
-        // If still not configured, something is wrong with the provided key, but we don't know what exactly,
-        // as the check function thinks nothing is configured, if the key was invalid it would have thrown earlier.
-        throw new ApiError("Error configuring provider with the provided key.", 400);
+        if (!NotConfiguredError.is(e)) {
+          // If still not configured, something is wrong with the provided key, but we don't know what exactly,
+          // as the check function thinks nothing is configured, if the key was invalid it would have thrown earlier.
+          throw new ApiError("Error configuring provider with the provided key.", 400);
+        }
+        else {
+          log.debug(`Removing ${GETGRIST_COM_PROVIDER_KEY} configuration`);
+        }
       }
       await this._activations.updateAppEnvFile({ [gristComSecret]: key });
       // TODO: Restart may not always be required. When this endpoint evolves to support other

--- a/app/server/lib/ConfigBackendAPI.ts
+++ b/app/server/lib/ConfigBackendAPI.ts
@@ -71,7 +71,7 @@ export class ConfigBackendAPI {
         readGetGristComConfigFromSettings(newSettings);
       }
       catch (e) {
-        if (!NotConfiguredError.is(e)) {
+        if (!(e instanceof NotConfiguredError)) {
           // If still not configured, something is wrong with the provided key, but we don't know what exactly,
           // as the check function thinks nothing is configured, if the key was invalid it would have thrown earlier.
           throw new ApiError("Error configuring provider with the provided key.", 400);

--- a/app/server/lib/loginSystemHelpers.ts
+++ b/app/server/lib/loginSystemHelpers.ts
@@ -35,7 +35,9 @@ export function getActiveLoginSystemTypeSource(settings: AppSettings) {
  * Exception thrown by the login system configuration readers when the system is not configured.
  */
 export class NotConfiguredError extends Error {
-
+  public static is(e: any): e is NotConfiguredError {
+    return e instanceof NotConfiguredError;
+  }
 }
 
 /**

--- a/app/server/lib/loginSystemHelpers.ts
+++ b/app/server/lib/loginSystemHelpers.ts
@@ -35,9 +35,7 @@ export function getActiveLoginSystemTypeSource(settings: AppSettings) {
  * Exception thrown by the login system configuration readers when the system is not configured.
  */
 export class NotConfiguredError extends Error {
-  public static is(e: any): e is NotConfiguredError {
-    return e instanceof NotConfiguredError;
-  }
+
 }
 
 /**


### PR DESCRIPTION
## Context

- Endpoint for configuring auth provider can now reset the configuration,
- Adding tests for session clear that happens when auth provider is changed.

## Has this been tested?

- [X] 👍 yes, I added tests to the test suite