### PR TITLE
avoid using disposed resource in access rules UI

### DIFF
--- a/app/client/aclui/AccessRules.ts
+++ b/app/client/aclui/AccessRules.ts
@@ -283,6 +283,8 @@ export class AccessRules extends Disposable {
       this._uiState.set(rules.haveRules() ? "rules" : "intro");
     }
     catch (e) {
+      // We might have failed somewhere in Promise.all
+      if (this.isDisposed()) { return; }
       this._uiState.set("error");
       throw e;
     }


### PR DESCRIPTION
If I spam the access rules UI I can often tickle an error message when a resource is set after it has been disposed. This is prompted by tests that have recently become unreliable, but may or may not help with that.
