### PR TITLE
Adds platform path handling to sandbox file imports

### DIFF
--- a/app/plugin/FileParserAPI-ti.ts
+++ b/app/plugin/FileParserAPI-ti.ts
@@ -26,6 +26,7 @@ export const ParseOptionSchema = t.iface([], {
 
 export const FileSource = t.iface([], {
   "path": "string",
+  "pathFlavor": t.union(t.lit("windows"), t.lit("posix")),
   "origName": "string",
 });
 

--- a/app/plugin/FileParserAPI.ts
+++ b/app/plugin/FileParserAPI.ts
@@ -41,6 +41,14 @@ export interface FileSource {
   path: string;
 
   /**
+   * The platform-specific flavor of the path stored in the {path} property.
+   * Certain sandboxed environments may have a different path convention to the local OS.
+   * E.g. Pyodide (WASM Python in Node/Deno) uses POSIX paths, even on a Windows host OS.
+   * This enables the path above to be interpreted correctly / converted.
+   */
+  pathFlavor: "windows" | "posix";
+
+  /**
    * Plugins that want to know the original filename should use origName. Depending on the source
    * of the data, it may or may not be meaningful.
    */

--- a/app/server/lib/DocPluginManager.ts
+++ b/app/server/lib/DocPluginManager.ts
@@ -125,7 +125,8 @@ export class DocPluginManager {
       const name = plugin.definition.id;
       try {
         log.info(`DocPluginManager.parseFile: calling to ${name} with ${filePath}`);
-        const result = await parseFileStub.parseFile({ path: filePath, origName: fileName }, parseOptions);
+        const pathFlavor = process.platform === "win32" ? "windows" : "posix";
+        const result = await parseFileStub.parseFile({ path: filePath, origName: fileName, pathFlavor }, parseOptions);
         checkers.ParseFileResult.check(result);
         checkReferences(result.tables);
         return result;

--- a/sandbox/grist/imports/import_csv.py
+++ b/sandbox/grist/imports/import_csv.py
@@ -79,7 +79,7 @@ SCHEMA = [
           ]
 
 def parse_file_source(file_source, options):
-  parsing_options, export_list = parse_file(import_utils.get_path(file_source["path"]), options)
+  parsing_options, export_list = parse_file(import_utils.get_path(file_source), options)
   return {"parseOptions": parsing_options, "tables": export_list}
 
 def parse_file(file_path, parse_options=None):

--- a/sandbox/grist/imports/import_json.py
+++ b/sandbox/grist/imports/import_json.py
@@ -109,7 +109,7 @@ DEFAULT_PARSE_OPTIONS = {
 
 def parse_file(file_source, parse_options):
   "Deserialize `file_source` into a python object and dumps it into jgrist form"
-  path = import_utils.get_path(file_source['path'])
+  path = import_utils.get_path(file_source)
   name, ext = os.path.splitext(file_source['origName'])
   if 'SCHEMA' not in parse_options:
     parse_options.update(DEFAULT_PARSE_OPTIONS)

--- a/sandbox/grist/imports/import_utils.py
+++ b/sandbox/grist/imports/import_utils.py
@@ -5,6 +5,7 @@ import itertools
 import logging
 import os
 from collections import defaultdict
+from pathlib import Path, PureWindowsPath, PurePosixPath
 
 log = logging.getLogger(__name__)
 
@@ -33,8 +34,19 @@ def empty(value):
 
 # Get path to an imported file.
 def get_path(file_source):
+  """Constructs the full path to an imported file, handling cross-platform path conventions."""
   importdir = os.environ.get('IMPORTDIR') or '/importdir'
-  return os.path.join(importdir, file_source)
+  file_source_path = file_source['path']
+  path_flavor = file_source.get('pathFlavor', 'posix')
+  
+  # Parse the incoming path using the appropriate pathlib class
+  if path_flavor == "windows":
+    incoming_path = PureWindowsPath(file_source_path)
+  else:
+    incoming_path = PurePosixPath(file_source_path)
+  
+  final_path = Path(importdir) / incoming_path
+  return str(final_path)
 
 def capitalize(word):
   """Capitalize the first character in the word (without lowercasing the rest)."""

--- a/sandbox/grist/imports/import_xls.py
+++ b/sandbox/grist/imports/import_xls.py
@@ -29,7 +29,7 @@ _reader.from_excel = new_from_excel
 
 
 def import_file(file_source):
-  path = import_utils.get_path(file_source["path"])
+  path = import_utils.get_path(file_source)
   parse_options, tables = parse_file(path)
   return {"parseOptions": parse_options, "tables": tables}
 


### PR DESCRIPTION
## Context

Pyodide's sandbox security was improved by changing it to copy import folders into the sandbox, rather than mounting the host's filesystem directly.

This resulted in Grist's file imports breaking on Windows, due to the Pyodide sandbox using POSIX-style paths and the Grist node process using Windows-style paths.

The node process would produce import paths similar to `my_temp_dir\my_file_to_import.csv`, which Pyodide would interpret as a file name (rather than a directory and a file).

## Proposed solution

This adds "pathFlavor" to the FileSource object passed to the sandbox, describing if the path is Windows or POSIX formatted. This allows the sandbox to parse and re-format the path as needed for the sandbox's filesystem.

## Related issues

https://github.com/gristlabs/grist-desktop/issues/101

## Has this been tested?

This fix has been tested on Windows with a custom Grist Desktop build, but not automatically as core doesn't have any Windows test runners configured.
