### PR TITLE
fix suggestions on documents with deleted tables

### DIFF
--- a/app/client/ui/ProposedChangesPage.ts
+++ b/app/client/ui/ProposedChangesPage.ts
@@ -492,7 +492,8 @@ class ActionLogPartInProposal extends ActionLogPart {
     }
     const lst = Object.entries(diffs).map(([table, tdiff]: [string, TabularDiff]) => {
       const data = convertTabularDiffToTableData(table, tdiff);
-      const tableRow = this._gristDoc.docModel.tables.rowModels.find(tr => tr.tableId() === table);
+      // Careful, there can be blank rowModels if tables were removed.
+      const tableRow = this._gristDoc.docModel.tables.rowModels.find(tr => tr?.tableId() === table);
       const columnRows = tableRow ? this._gristDoc.docModel.columns.rowModels.filter(
         cr => cr.parentId() === tableRow.id(),
       ) : null;

--- a/test/nbrowser/ProposedChangesPage.ts
+++ b/test/nbrowser/ProposedChangesPage.ts
@@ -365,9 +365,13 @@ describe("ProposedChangesPage", function() {
     const { api, doc } = await makeLifeDoc();
     const url = await driver.getCurrentUrl();
 
-    // Add a second table
+    // Add a second table.
+    // Create and delete a table around it for that "aged document" feel
+    // (there was a bug where an offset in table row ids caused a problem).
     await gu.sendActions([
+      ["AddTable", "OldPlants", [{ id: "Name", type: "Text" }, { id: "Type", type: "Text" }]],
       ["AddTable", "Plants", [{ id: "Name", type: "Text" }, { id: "Type", type: "Text" }]],
+      ["RemoveTable", "OldPlants"],
       ["AddRecord", "Plants", 1, { Name: "Oak", Type: "Tree" }],
       ["AddRecord", "Plants", 2, { Name: "Rose", Type: "Flower" }],
     ]);


### PR DESCRIPTION
If tables have been deleted from a document, it looks like rowModels can exist but be empty. This led to an error in suggestions.
## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
