### PR TITLE
mark the en_GB translation as incomplete

### DIFF
--- a/static/locales/en_GB.client.json
+++ b/static/locales/en_GB.client.json
@@ -1,7 +1,4 @@
 {
-    "App": {
-        "Translators: please translate this only when your language is ready to be offered to users": ""
-    },
     "ACUserManager": {
         "Enter email address": ""
     }


### PR DESCRIPTION
This translation is very incomplete. Remove the key that marks it as usable.
