### PR TITLE
Custom CSS: include it in widgets

### DIFF
--- a/app/client/components/WidgetFrame.ts
+++ b/app/client/components/WidgetFrame.ts
@@ -4,6 +4,7 @@ import * as commands from "app/client/components/commands";
 import { GristDoc } from "app/client/components/GristDoc";
 import { hooks } from "app/client/Hooks";
 import { get as getBrowserGlobals } from "app/client/lib/browserGlobals";
+import { withCustomCssVars } from "app/client/lib/customCssParser";
 import { makeTestId } from "app/client/lib/domUtils";
 import { sanitizeHttpUrl } from "app/client/lib/sanitizeUrl";
 import { ColumnRec, ViewSectionRec } from "app/client/models/DocModel";
@@ -766,19 +767,15 @@ export class ThemeNotifier extends BaseEventSource {
   private _update({ fromReady}: { fromReady?: boolean } = {}) {
     if (this.isDisposed()) { return; }
 
+    let themePayload = convertThemeKeysToCssVars(gristThemeObs().get());
+    if (getGristConfig().enableCustomCss) {
+      themePayload = withCustomCssVars(themePayload);
+    }
+
     this._notify({
-      theme: convertThemeKeysToCssVars(gristThemeObs().get()),
+      theme: themePayload,
       fromReady,
     });
-
-    const gristConfig = getGristConfig();
-    if (gristConfig.enableCustomCss && fromReady) {
-      // We tell the plugin API to load our instance's custom CSS file.
-      // That way, we don't care about where the grist-plugin-api.js file is hosted.
-      this._notify({
-        customCssUrl: new URL("custom.css", document.querySelector("base")!.href).href,
-      });
-    }
   }
 }
 

--- a/app/client/components/WidgetFrame.ts
+++ b/app/client/components/WidgetFrame.ts
@@ -770,6 +770,15 @@ export class ThemeNotifier extends BaseEventSource {
       theme: convertThemeKeysToCssVars(gristThemeObs().get()),
       fromReady,
     });
+
+    const gristConfig = getGristConfig();
+    if (gristConfig.enableCustomCss && fromReady) {
+      // We tell the plugin API to load our instance's custom CSS file.
+      // That way, we don't care about where the grist-plugin-api.js file is hosted.
+      this._notify({
+        customCssUrl: new URL("custom.css", document.querySelector("base")!.href).href,
+      });
+    }
   }
 }
 

--- a/app/client/lib/SafeBrowser.ts
+++ b/app/client/lib/SafeBrowser.ts
@@ -29,6 +29,7 @@
 
 import { ClientScope } from "app/client/components/ClientScope";
 import { get as getBrowserGlobals } from "app/client/lib/browserGlobals";
+import { withCustomCssVars } from "app/client/lib/customCssParser";
 import { Disposable } from "app/client/lib/dispose";
 import dom from "app/client/lib/dom";
 import * as Mousetrap from "app/client/lib/Mousetrap";
@@ -37,7 +38,7 @@ import { ActionRouter } from "app/common/ActionRouter";
 import { BaseComponent, BaseLogger, createRpcLogger, PluginInstance, warnIfNotReady } from "app/common/PluginInstance";
 import { tbind } from "app/common/tbind";
 import { convertThemeKeysToCssVars, Theme } from "app/common/ThemePrefs";
-import { getOriginUrl } from "app/common/urlUtils";
+import { getGristConfig, getOriginUrl } from "app/common/urlUtils";
 import { GristAPI, RPC_GRISTAPI_INTERFACE } from "app/plugin/GristAPI";
 import { RenderOptions, RenderTarget } from "app/plugin/RenderOptions";
 import { checkers } from "app/plugin/TypeCheckers";
@@ -329,7 +330,11 @@ class IframeProcess extends ViewProcess {
   }
 
   private async _sendTheme({ theme, fromReady = false}: { theme: Theme, fromReady?: boolean }) {
-    await this.rpc.postMessage({ theme: convertThemeKeysToCssVars(theme), fromReady });
+    let converted = convertThemeKeysToCssVars(theme);
+    if (getGristConfig().enableCustomCss) {
+      converted = withCustomCssVars(converted);
+    }
+    await this.rpc.postMessage({ theme: converted, fromReady });
   }
 }
 

--- a/app/client/lib/customCssParser.ts
+++ b/app/client/lib/customCssParser.ts
@@ -1,0 +1,123 @@
+import { ThemeWithCssVars } from "app/common/ThemePrefs";
+
+type Vars = Record<string, string>;
+
+/**
+ * Gets CSS variables defined in the #grist-custom-css stylesheet:
+ *
+ * - checks only for CSS defined in the `grist-custom` CSS layer
+ * - checks only for variables defined in `:root`-based selectors
+ * - includes variables seemingly unrelated to the grist theme, in case they are used themselves by
+ *   grist theme-related variables in the custom.css file.
+ */
+function getCustomCssVars(): Vars {
+  const customCssSheet = document.querySelector<HTMLLinkElement>("#grist-custom-css")?.sheet;
+  if (!customCssSheet) {
+    return {};
+  }
+  const vars: Vars = {};
+  for (const rule of customCssSheet.cssRules) {
+    // Only check the grist-custom layer
+    if (!(rule instanceof CSSLayerBlockRule) || rule.name !== "grist-custom") {
+      continue;
+    }
+
+    for (const subRule of rule.cssRules) {
+      // Only check direct children of the grist-custom layer
+      if (!(subRule instanceof CSSStyleRule)) {
+        continue;
+      }
+
+      // Important: only retrieve custom vars declared on the :root matching current theme/appearance
+      if (!document.documentElement.matches(subRule.selectorText)) {
+        continue;
+      }
+
+      const style = subRule.style;
+      for (let i = 0; i < style.length; i++) {
+        const prop = style.item(i);
+        if (!prop.startsWith("--")) {
+          continue;
+        }
+        const value = style.getPropertyValue(prop).trim();
+        if (value) {
+          vars[prop] = value;
+        }
+      }
+    }
+  }
+
+  return vars;
+}
+
+const GRIST_THEME_PREFIX = "--grist-theme-";
+
+/**
+ * Takes a list of CSS variables and returns two lists: one with variables matching the grist theme namings,
+ * and one with "external" variables
+ */
+const splitVariables = (cssVars: Vars): { grist: Vars; nonGrist: Vars } => {
+  const gristThemeVars: Vars = {};
+  const nonGristThemeVars: Vars = {};
+  for (const [name, value] of Object.entries(cssVars)) {
+    if (name.startsWith(GRIST_THEME_PREFIX)) {
+      gristThemeVars[name.slice(GRIST_THEME_PREFIX.length)] = value;
+    } else {
+      nonGristThemeVars[name.slice(2)] = value;
+    }
+  }
+  return { grist: gristThemeVars, nonGrist: nonGristThemeVars };
+};
+
+const CUSTOM_CSS_PREFIX = "custom-css-";
+
+/**
+ * Checks the values of the passed cssVars. When we detect a value targets a variable from the given list,
+ * we prefix it.
+ *
+ * This is done to prevent potential naming collisions issues once grist-plugin-api appends the variables.
+ *
+ * Example:
+ *   cssVars = { "accent-color": "var(--design-system-accent-color)" }
+ *   list = ["design-system-accent-color"]
+ *   returns { "accent-color": "var(--grist-theme-custom-css-design-system-accent-color)" }
+ */
+const prefixVariableValues = (cssVars: Vars, list: string[]): Vars => {
+  const prefixedCssVars = { ...cssVars };
+  for (const [name, value] of Object.entries(cssVars)) {
+    if (value.startsWith("var(--") && list.includes(value.slice(6, -1))) {
+      prefixedCssVars[name] = `var(${GRIST_THEME_PREFIX}${CUSTOM_CSS_PREFIX}${value.slice(6, -1)})`;
+    }
+  }
+  return prefixedCssVars;
+};
+
+const mergeVariables = (themeVars: Vars, newGristThemeVars: Vars, nonGristThemeVars: Vars): Vars => {
+  const allVars = { ...themeVars };
+  for (const [name, value] of Object.entries(newGristThemeVars)) {
+    allVars[name] = value;
+  }
+  for (const [name, value] of Object.entries(nonGristThemeVars)) {
+    allVars[CUSTOM_CSS_PREFIX + name] = value;
+  }
+  return allVars;
+};
+
+/**
+ * Takes a ThemeWithCssVars and returns a new ThemeWithCssVars that includes
+ * variables defined in the #grist-custom-css stylesheet.
+ */
+export function withCustomCssVars(theme: ThemeWithCssVars): ThemeWithCssVars {
+  const customCssVars = getCustomCssVars();
+
+  let { grist: newGristThemeVars, nonGrist: nonGristThemeVars } = splitVariables(customCssVars);
+  const nonGristThemeVarNames = Object.keys(nonGristThemeVars);
+
+  newGristThemeVars = prefixVariableValues(newGristThemeVars, nonGristThemeVarNames);
+  nonGristThemeVars = prefixVariableValues(nonGristThemeVars, nonGristThemeVarNames);
+
+  return {
+    ...theme,
+    colors: mergeVariables(theme.colors, newGristThemeVars, nonGristThemeVars),
+  };
+}

--- a/app/plugin/grist-plugin-api.ts
+++ b/app/plugin/grist-plugin-api.ts
@@ -446,6 +446,14 @@ function onThemeChange(callback: (theme: any) => unknown) {
   });
 }
 
+function onCustomCss(callback: (customCssUrl: string) => unknown) {
+  on("message", function(msg) {
+    if (msg.customCssUrl) {
+      callback(msg.customCssUrl);
+    }
+  });
+}
+
 /**
  * Calling `addImporter(...)` adds a safeBrowser importer. It is a short-hand for forwarding calls
  * to an `ImportSourceAPI` implementation registered in the file at `path`. It takes care of
@@ -589,6 +597,21 @@ onThemeChange((newTheme) => {
 
   _theme = newTheme;
   attachCssThemeVars(_theme);
+});
+
+onCustomCss((customCssUrl) => {
+  const customCssLink = document.getElementById("grist-custom-css");
+  if (customCssLink) {
+    (customCssLink as HTMLLinkElement).href = customCssUrl;
+    return;
+  }
+  const link = document.createElement("link");
+  link.id = "grist-custom-css";
+  link.rel = "stylesheet";
+  link.href = customCssUrl;
+  document.head.append(link as Node);
+  // This data-attribute helps the custom CSS authors apply widget-specific styles if needed.
+  document.documentElement.setAttribute("data-grist-widget", "true");
 });
 
 function attachCssThemeVars({ appearance, name, colors: cssVars }: any) {

--- a/app/plugin/grist-plugin-api.ts
+++ b/app/plugin/grist-plugin-api.ts
@@ -446,14 +446,6 @@ function onThemeChange(callback: (theme: any) => unknown) {
   });
 }
 
-function onCustomCss(callback: (customCssUrl: string) => unknown) {
-  on("message", function(msg) {
-    if (msg.customCssUrl) {
-      callback(msg.customCssUrl);
-    }
-  });
-}
-
 /**
  * Calling `addImporter(...)` adds a safeBrowser importer. It is a short-hand for forwarding calls
  * to an `ImportSourceAPI` implementation registered in the file at `path`. It takes care of
@@ -599,21 +591,6 @@ onThemeChange((newTheme) => {
   attachCssThemeVars(_theme);
 });
 
-onCustomCss((customCssUrl) => {
-  const customCssLink = document.getElementById("grist-custom-css");
-  if (customCssLink) {
-    (customCssLink as HTMLLinkElement).href = customCssUrl;
-    return;
-  }
-  const link = document.createElement("link");
-  link.id = "grist-custom-css";
-  link.rel = "stylesheet";
-  link.href = customCssUrl;
-  document.head.append(link as Node);
-  // This data-attribute helps the custom CSS authors apply widget-specific styles if needed.
-  document.documentElement.setAttribute("data-grist-widget", "true");
-});
-
 function attachCssThemeVars({ appearance, name, colors: cssVars }: any) {
   // Prepare the custom properties needed for applying the theme.
   const properties = Object.entries(cssVars)
@@ -638,6 +615,7 @@ ${properties.join("\n")}
   // Add data-attributes to let plugins easily identify theme name and appearance with CSS.
   document.documentElement.setAttribute("data-grist-theme", name);
   document.documentElement.setAttribute("data-grist-appearance", appearance);
+  document.documentElement.setAttribute("data-grist-widget", "true");
 }
 
 function getCssScrollbarProperties(appearance: "light" | "dark") {

--- a/test/fixtures/nbrowser/custom.css
+++ b/test/fixtures/nbrowser/custom.css
@@ -1,0 +1,18 @@
+/* Used to test custom CSS support in widgets */
+@layer grist-custom {
+  :root {
+    --fake-design-system-variable: #ff0000;
+    --really-fake-design-system-variable: var(--fake-design-system-variable);
+    --grist-theme-primary: var(--really-fake-design-system-variable);
+    --grist-theme-primary-dim: var(--fake-design-system-variable);
+    --grist-theme-primary-muted: #0000ff;
+  }
+
+  [data-grist-appearance="light"] {
+    --grist-theme-primary-muted: #000000;
+  }
+
+  [data-grist-appearance="dark"] {
+    --grist-theme-primary-muted: #ffff00;
+  }
+}

--- a/test/nbrowser/CustomWidgets.ts
+++ b/test/nbrowser/CustomWidgets.ts
@@ -934,6 +934,40 @@ describe("CustomWidgets", function() {
         assert.sameMembers(Object.keys(await result.json()), ["records"]);
       });
     });
+
+    it("should support custom CSS", async () => {
+      try {
+        // Enable custom CSS
+        process.env.APP_STATIC_INCLUDE_CUSTOM_CSS = "true";
+        await server.restart();
+        await gu.reloadDoc();
+
+        widgets = [widgetWithTheme];
+        await reloadWidgets();
+        await gu.toggleSidePanel("right", "open");
+        await recreatePanel();
+        await gu.setCustomWidget(widgetWithTheme.name);
+
+        // Check that the widget iframe has the custom CSS link tag
+        const iframe = await getCustomWidgetFrame();
+        await driver.switchTo().frame(iframe);
+        const customCssLink = await driver.find("link#grist-custom-css");
+        assert.isTrue(await customCssLink.isPresent());
+
+        // Check the widget-specific data attribute is there in the iframe document
+        const inWidgetAttribute = await driver.executeScript<string>(
+          "return document.documentElement.getAttribute('data-grist-widget')",
+        );
+        assert.equal(inWidgetAttribute, "true");
+
+        await driver.switchTo().defaultContent();
+      } finally {
+        // Restore old env and restart
+        delete process.env.APP_STATIC_INCLUDE_CUSTOM_CSS;
+        await server.restart();
+        await gu.reloadDoc();
+      }
+    });
   });
 
   describe("Bundling", function() {

--- a/test/nbrowser/CustomWidgets.ts
+++ b/test/nbrowser/CustomWidgets.ts
@@ -21,6 +21,20 @@ const widgetEndpoint = "/widget";
 // Custom URL label in selectbox.
 const CUSTOM_URL = "Custom URL";
 
+const STATIC_EXT_CUSTOM_CSS_PATH = path.join(getAppRoot(), "static_ext", "custom.css");
+const CUSTOM_CSS_WIDGET_TEST_FIXTURE = path.join(getAppRoot(), "test/fixtures/nbrowser/custom.css");
+
+async function useCustomCss(): Promise<void> {
+  await fse.mkdirp(path.dirname(STATIC_EXT_CUSTOM_CSS_PATH));
+  await fse.copy(CUSTOM_CSS_WIDGET_TEST_FIXTURE, STATIC_EXT_CUSTOM_CSS_PATH);
+  process.env.APP_STATIC_INCLUDE_CUSTOM_CSS = "true";
+}
+
+async function removeCustomCss(): Promise<void> {
+  delete process.env.APP_STATIC_INCLUDE_CUSTOM_CSS;
+  await fse.remove(STATIC_EXT_CUSTOM_CSS_PATH);
+}
+
 // Create some widgets:
 const widget1: ICustomWidget = {
   widgetId: "1",
@@ -332,6 +346,36 @@ describe("CustomWidgets", function() {
 
       // Check that the widget is back to using the GristLight text color.
       assert.equal(await getWidgetColor(), "rgba(38, 38, 51, 1)");
+    });
+
+    it("should support custom CSS", async function() {
+      await useCustomCss();
+      await server.restart();
+      await gu.reloadDoc();
+
+      await driver.switchTo().frame(await getCustomWidgetFrame());
+
+      const [primary, dim, muted, emphasis] = await driver.executeScript<
+        [string, string, string, string]
+      >(function() {
+        const getVar = (name: string) =>
+          window.getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+        return [
+          getVar("--grist-theme-primary"),
+          getVar("--grist-theme-primary-dim"),
+          getVar("--grist-theme-primary-muted"),
+          getVar("--grist-theme-primary-emphasis"),
+        ];
+      });
+      assert.equal(primary, "#ff0000");
+      assert.equal(dim, "#ff0000");
+      assert.equal(muted, "#000000");
+      assert.equal(emphasis, "#b1ffe2");
+
+      await driver.switchTo().defaultContent();
+      await removeCustomCss();
+      await server.restart();
+      await gu.reloadDoc();
     });
 
     it("should support widgets that don't use the plugin api", async () => {
@@ -933,40 +977,6 @@ describe("CustomWidgets", function() {
         const result = await fetch(tokenResult.baseUrl + `/tables/Table1/records?auth=${tokenResult.token}`);
         assert.sameMembers(Object.keys(await result.json()), ["records"]);
       });
-    });
-
-    it("should support custom CSS", async () => {
-      try {
-        // Enable custom CSS
-        process.env.APP_STATIC_INCLUDE_CUSTOM_CSS = "true";
-        await server.restart();
-        await gu.reloadDoc();
-
-        widgets = [widgetWithTheme];
-        await reloadWidgets();
-        await gu.toggleSidePanel("right", "open");
-        await recreatePanel();
-        await gu.setCustomWidget(widgetWithTheme.name);
-
-        // Check that the widget iframe has the custom CSS link tag
-        const iframe = await getCustomWidgetFrame();
-        await driver.switchTo().frame(iframe);
-        const customCssLink = await driver.find("link#grist-custom-css");
-        assert.isTrue(await customCssLink.isPresent());
-
-        // Check the widget-specific data attribute is there in the iframe document
-        const inWidgetAttribute = await driver.executeScript<string>(
-          "return document.documentElement.getAttribute('data-grist-widget')",
-        );
-        assert.equal(inWidgetAttribute, "true");
-
-        await driver.switchTo().defaultContent();
-      } finally {
-        // Restore old env and restart
-        delete process.env.APP_STATIC_INCLUDE_CUSTOM_CSS;
-        await server.restart();
-        await gu.reloadDoc();
-      }
     });
   });
 


### PR DESCRIPTION
## Context

Right now, on a Grist instance using a custom CSS file through the `APP_STATIC_INCLUDE_CUSTOM_CSS` env var, the custom CSS is not applied in widgets.

## Proposed solution

Make it so that when loading a widget iframe, we inject a the the custom CSS link to the file hosted on the grist instance.

## Has this been tested?

I added one test but I feel like I could do more on this maybe?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
