### PR TITLE
Update lazy-object-proxy version to 1.12.0

### DIFF
--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -22,7 +22,7 @@ friendly-traceback==0.7.48
     # via -r core/sandbox/requirements.in
 iso8601==0.1.12
     # via -r core/sandbox/requirements.in
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.12.0
     # via astroid
 openpyxl==3.0.10
     # via -r core/sandbox/requirements.in


### PR DESCRIPTION
## Context

We can't install the dependencies of the Python sandbox.
See https://github.com/gristlabs/grist-core/issues/2102

## Proposed solution

Bump `lazy-object-proxy` to version 1.12.0

## Related issues

Fixes #2102 
(we need to see whether the CI passes)

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
