### PR TITLE
Update lazy-object-proxy version to 1.12.0

### DIFF
--- a/sandbox/pyodide/package_filenames.json
+++ b/sandbox/pyodide/package_filenames.json
@@ -6,7 +6,7 @@
   "executing-1.1.1-cp311-none-any.whl",
   "friendly_traceback-0.7.48-cp311-none-any.whl",
   "iso8601-0.1.12-cp311-none-any.whl",
-  "lazy_object_proxy-1.6.0-cp311-cp311-emscripten_3_1_32_wasm32.whl",
+  "lazy_object_proxy-1.12.0-cp311-cp311-emscripten_3_1_32_wasm32.whl",
   "openpyxl-3.0.10-cp311-none-any.whl",
   "phonenumberslite-8.12.57-cp311-none-any.whl",
   "pure_eval-0.2.2-cp311-none-any.whl",

--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -22,7 +22,7 @@ friendly-traceback==0.7.48
     # via -r core/sandbox/requirements.in
 iso8601==0.1.12
     # via -r core/sandbox/requirements.in
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.12.0
     # via astroid
 openpyxl==3.0.10
     # via -r core/sandbox/requirements.in


### PR DESCRIPTION
## Context

We can't install the dependencies of the Python sandbox.
See https://github.com/gristlabs/grist-core/issues/2102

## Proposed solution

Bump `lazy-object-proxy` to version 1.12.0

## Related issues

Fixes #2102 
Fixes https://github.com/YunoHost-Apps/grist_ynh/issues/125
(we need to see whether the CI passes)

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->