### PR TITLE
Adds support for multipleLookupValue Airtable fields

### DIFF
--- a/app/common/airtable/AirtableSchemaImporter.ts
+++ b/app/common/airtable/AirtableSchemaImporter.ts
@@ -347,7 +347,32 @@ const AirtableFieldMappers: { [type: string]: AirtableFieldMapper } = {
       },
     };
   },
-  // todo - multiple lookup values
+  multipleLookupValues({ field, table, getTableIdForField }) {
+    let formula: FormulaTemplate = { formula: "" };
+    const fieldOptions = field.options;
+    if (fieldOptions?.recordLinkFieldId && fieldOptions.fieldIdInLinkedTable) {
+      formula = {
+        formula: "$[R0].[R1]",
+        replacements: [
+          { originalTableId: table.id, originalColId: fieldOptions.recordLinkFieldId },
+          {
+            originalTableId: getTableIdForField(fieldOptions.fieldIdInLinkedTable),
+            originalColId: fieldOptions.fieldIdInLinkedTable,
+          },
+        ],
+      };
+    }
+    return {
+      column: {
+        originalId: field.id,
+        desiredGristId: field.name,
+        label: field.name,
+        type: "Any",
+        isFormula: true,
+        formula,
+      },
+    };
+  },
   multipleRecordLinks({ field }) {
     return {
       column: {


### PR DESCRIPTION
## Context

Currently, the Airtable import does not support multipleLookupValue fields from Airtable.

## Proposed solution

This adds support for multipleLookupValue fields, that shows the contents of the referenced column using an easy-to-understand formula that's identical to the current rollup field.

## Has this been tested?

- [X] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

