### PR TITLE
make access control on /attachments/N endpoint consistent

### DIFF
--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -85,6 +85,7 @@ import log from "app/server/lib/log";
 import {
   getDocId,
   getDocScope,
+  getExtraAttachmentOptions,
   getScope,
   integerParam,
   isParameterOn,
@@ -468,26 +469,22 @@ export class DocWorkerApi {
     // Returns cleaned metadata for a given attachment ID (i.e. a rowId in _grist_Attachments table).
     this._app.get("/api/docs/:docId/attachments/:attId", canView, withDoc(async (activeDoc, req, res) => {
       const attId = integerParam(req.params.attId, "attId");
-      const attRecord = activeDoc.getAttachmentMetadata(attId);
+      const options = getExtraAttachmentOptions(req);
+      const attRecord = await activeDoc.getAttachmentMetadata(docSessionFromRequest(req), attId, options);
       res.json(cleanAttachmentRecord(attRecord));
     }));
 
     // Responds with attachment contents, with suitable Content-Type and Content-Disposition.
     this._app.get("/api/docs/:docId/attachments/:attId/download", canView, withDoc(async (activeDoc, req, res) => {
       const attId = integerParam(req.params.attId, "attId");
-      const tableId = optStringParam(req.params.tableId, "tableId");
-      const colId = optStringParam(req.params.colId, "colId");
-      const rowId = optIntegerParam(req.params.rowId, "rowId");
-      if ((tableId || colId || rowId) && !(tableId && colId && rowId)) {
-        throw new ApiError("define all of tableId, colId and rowId, or none.", 400);
-      }
-      const attRecord = activeDoc.getAttachmentMetadata(attId);
-      const cell = (tableId && colId && rowId) ? { tableId, colId, rowId } : undefined;
+      const options = getExtraAttachmentOptions(req);
+      // getAttachmentData below will throw if user does not have access to attachment.
+      const attRecord = activeDoc.getAttachmentMetadataWithoutAccessControl(attId);
       const fileIdent = attRecord.fileIdent as string;
       const ext = path.extname(fileIdent);
       const origName = attRecord.fileName as string;
       const fileName = ext ? path.basename(origName, path.extname(origName)) + ext : origName;
-      const fileData = await activeDoc.getAttachmentData(docSessionFromRequest(req), attRecord, { cell });
+      const fileData = await activeDoc.getAttachmentData(docSessionFromRequest(req), attRecord, options);
       res.status(200)
         .type(ext)
         // Construct a content-disposition header of the form 'attachment; filename="NAME"'

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,12 +20,13 @@ module.exports = defineConfig([
     "!test/",
     "!plugins/",
     "!sandbox/",
+    "sandbox/pyodide/_build/",
     "!stubs/",
     "!buildtools/",
     "!ext/",
     "!core/",
     "core/static/*.js",
-    "test/video-scripts/"
+    "test/video-scripts/",
   ]),
   {
     extends: [


### PR DESCRIPTION
The access control on the /attachments/N endpoint was not the same as for /attachments/N/download. This harmonizes them. The complexity is from the fact that whether a given user has access to a given attachment depends on whether the document contains at least one reference of that attachment in at least one cell that the user has access to.
