### PR TITLE
Change signature of enterCell in prevision of bumping chrome driver

### DIFF
--- a/test/nbrowser/AccessRules4.ts
+++ b/test/nbrowser/AccessRules4.ts
@@ -62,7 +62,7 @@ describe("AccessRules4", function() {
     assert.isFalse(await gu.getCell("Toggle", 1).find(".widget_checkmark").isDisplayed());
 
     await gu.getCell("Another", 1).click();
-    await gu.enterCell("owner");
+    await gu.enterCell(["owner"]);
     await gu.getCell("Toggle", 1).mouseMove();
     await gu.getCell("Toggle", 1).find(".widget_checkbox").click();
     await gu.waitForServer();
@@ -83,7 +83,7 @@ describe("AccessRules4", function() {
     assert.isFalse(await gu.getCell("Toggle", 1).find(".widget_checkmark").isDisplayed());
 
     await gu.getCell("Another", 1).click();
-    await gu.enterCell("user2");
+    await gu.enterCell(["user2"]);
     await gu.getCell("Toggle", 1).mouseMove();
     await gu.getCell("Toggle", 1).find(".widget_checkbox").click();
     await gu.waitForServer();

--- a/test/nbrowser/AccessRulesAttrs.ts
+++ b/test/nbrowser/AccessRulesAttrs.ts
@@ -168,7 +168,7 @@ describe("AccessRulesAttrs", function() {
     assert.deepEqual(await gu.getVisibleGridCells({ cols: ["SomeText", "OtherText"], rowNums: [2] }), ["FoO", "FoO"]);
     // We can edit data (rule restricting edits is valid because type is Text, and doesn't match).
     await gu.getCell({ rowNum: 2, col: "SomeText" }).click();
-    await gu.enterCell(Key.DELETE);
+    await gu.pressKeysOnCell(Key.DELETE);
     assert.deepEqual(await gu.getVisibleGridCells({ cols: ["SomeText", "OtherText"], rowNums: [2] }), ["", "2"]);
     await gu.checkForErrors();
     await gu.undo();
@@ -179,10 +179,10 @@ describe("AccessRulesAttrs", function() {
     // The rule preventing edits will still work for text values, but should show error for
     // non-text values.
     await gu.getCell({ rowNum: 2, col: "SomeText" }).click();
-    await gu.enterCell("ciao");
+    await gu.enterCell(["ciao"]);
     assert.deepEqual(await gu.getVisibleGridCells({ cols: ["SomeText", "OtherText"], rowNums: [2] }), ["ciao", "ciao"]);
     await gu.checkForErrors();
-    await gu.enterCell(Key.DELETE);
+    await gu.pressKeysOnCell(Key.DELETE);
     assert.deepEqual(await gu.getVisibleGridCells({ cols: ["SomeText", "OtherText"], rowNums: [2] }), ["ciao", "ciao"]);
     assert.match((await gu.getToasts())[0], /Rule.*has an error: Not a function: 'newRec.OtherText.lower'/);
     await gu.undo();

--- a/test/nbrowser/ActionLog.ts
+++ b/test/nbrowser/ActionLog.ts
@@ -109,7 +109,7 @@ describe("ActionLog", function() {
   it("should indicate that actions that cannot be redone are buried", async function() {
     // Add an item after the undo actions and check that they get buried.
     await gu.getCell({ rowNum: 1, col: 0 }).click();
-    await gu.enterCell("e");
+    await gu.enterCell(["e"]);
     assert.deepEqual(await getActionUndoState(4), ["default", "buried", "default", "default"]);
 
     // Check that undos skip the buried actions.
@@ -117,7 +117,7 @@ describe("ActionLog", function() {
     assert.deepEqual(await getActionUndoState(4), ["undone", "buried", "undone", "default"]);
 
     // Check that burying around already buried actions works.
-    await gu.enterCell("f");
+    await gu.enterCell(["f"]);
     await gu.waitForServer();
     assert.deepEqual(await getActionUndoState(5), ["default", "buried", "buried", "buried", "default"]);
   });

--- a/test/nbrowser/CellColor.ts
+++ b/test/nbrowser/CellColor.ts
@@ -14,9 +14,9 @@ describe("CellColor", function() {
     const mainSession = await gu.session().login();
     doc = await mainSession.tempNewDoc(cleanup, "CellColor");
     // add records
-    await gu.enterCell("a");
-    await gu.enterCell("b");
-    await gu.enterCell("c");
+    await gu.enterCell(["a"]);
+    await gu.enterCell(["b"]);
+    await gu.enterCell(["c"]);
     await gu.toggleSidePanel("right", "open");
     await driver.find(".test-right-tab-field").click();
   });
@@ -122,7 +122,7 @@ describe("CellColor", function() {
     // First let's add an Hyperlink column
     await gu.getSection("TABLE1").click();
     let cell = await gu.getCell("B", 1).doClick();
-    await gu.enterCell("foo");
+    await gu.enterCell(["foo"]);
     await gu.setFieldWidgetType("HyperLink");
 
     // check default color of hyperlink
@@ -141,10 +141,10 @@ describe("CellColor", function() {
 
     // Add new record
     await gu.getCell("A", 1).click();
-    await gu.enterCell("e");
+    await gu.enterCell(["e"]);
     await gu.getCell("A", 4).click();
-    await gu.enterCell("f", Key.TAB);
-    await gu.enterCell("foo");
+    await gu.enterCell(["f", Key.TAB]);
+    await gu.enterCell(["foo"]);
 
     // get the forkid
     const forkId = await gu.getCurrentUrlId();
@@ -234,7 +234,7 @@ describe("CellColor", function() {
 
     // empty cell
     let cell = await gu.getCell("A", 1).find(".field_clip").doClick();
-    await gu.enterCell(Key.DELETE);
+    await gu.pressKeysOnCell(Key.DELETE);
 
     // check cell type
     cell = await gu.getCell("A", 1).find(".field_clip");
@@ -360,7 +360,7 @@ describe("CellColor", function() {
 
     // empty cell
     await gu.getCell("A", 1).click();
-    await gu.enterCell(Key.DELETE);
+    await gu.pressKeysOnCell(Key.DELETE);
 
     // open color picker
     await gu.openCellColorPicker();
@@ -391,7 +391,7 @@ describe("CellColor", function() {
 
     // enter text
     await gu.getCell("A", 1).click();
-    await gu.enterCell("foo");
+    await gu.enterCell(["foo"]);
 
     // open color picker
     await gu.openCellColorPicker();
@@ -530,7 +530,7 @@ describe("CellColor", function() {
 
     // enter 'true'
     await gu.getCell("E", 1).click();
-    await gu.enterCell("true");
+    await gu.enterCell(["true"]);
 
     // check the color
     const cell = () => gu.getCell("E", 1).find(".field_clip");

--- a/test/nbrowser/Comments.ts
+++ b/test/nbrowser/Comments.ts
@@ -560,7 +560,7 @@ describe("Comments", function() {
     await gu.addNewTable("Table2");
     await gu.getCell("A", 1).click();
     await gu.waitAppFocus();
-    await gu.enterCell("1");
+    await gu.enterCell(["1"]);
     await gu.getCell("A", 1).click();
 
     await openCommentsWithKey();
@@ -1254,7 +1254,7 @@ describe("Comments", function() {
     ]);
     // Hide B comment (it is on Table1)
     await gu.getCell("A", 1).click();
-    await gu.enterCell("1");
+    await gu.enterCell(["1"]);
     // We should see only 1 comment as editor (since second row is hidden now)
     assert.equal(await commentCount("panel"), 1);
     assert.equal(await readComment(0, "panel"), "C,2");
@@ -1309,7 +1309,7 @@ describe("Comments", function() {
     ]);
     // Now censor column B in the first row.
     await gu.getCell("A", 1).click();
-    await gu.enterCell("0");
+    await gu.enterCell(["0"]);
     await gu.getCell("B", 1).click();
     // Test that all comments from B,1 are hidden.
     assert.equal(await commentCount("panel"), 1);
@@ -1330,7 +1330,7 @@ describe("Comments", function() {
     // Now show them
     await gu.getCell("A", 1).click();
     await gu.waitAppFocus();
-    await gu.enterCell("2");
+    await gu.enterCell(["2"]);
     await gu.getCell("B", 1).click();
     await gu.waitAppFocus();
     assert.equal(await commentCount("panel"), 2);
@@ -1594,7 +1594,7 @@ describe("Comments", function() {
     ]);
     // Hide 4th row, by setting it to 0
     await gu.getCell("A", 4).click();
-    await gu.enterCell("99");
+    await gu.enterCell(["99"]);
     await assertClientComments([
       "CENSORED",
       "Second",
@@ -1658,7 +1658,7 @@ describe("Comments", function() {
     await addComment("A", 1, "From owner");
     await gu.getCell("A", 1).click();
     await gu.waitAppFocus(true);
-    await gu.enterCell("1");
+    await gu.enterCell(["1"]);
     // Switch to editor
     await asSupport();
     await assertClientComments([

--- a/test/nbrowser/Comparison.ts
+++ b/test/nbrowser/Comparison.ts
@@ -25,7 +25,7 @@ describe("Comparison", function() {
     // Make a fork of the document with a change.
     await mainSession.loadDoc(`/doc/${doc.id}/m/fork`);
     await gu.getCell({ rowNum: 1, col: 0 }).click();
-    await gu.enterCell("123");
+    await gu.enterCell(["123"]);
     await gu.waitForServer();
     assert.equal(await gu.getCell({ rowNum: 1, col: 0 }).getText(), "123");
     const forkId = await gu.getCurrentUrlId();
@@ -76,7 +76,7 @@ describe("Comparison", function() {
 
     // Change a cell
     await gu.getCell({ rowNum: 1, col: 1 }).click();
-    await gu.enterCell("800");
+    await gu.enterCell(["800"]);
     await gu.waitForServer();
 
     // Remove a row
@@ -85,7 +85,7 @@ describe("Comparison", function() {
     // Add a row
     await (await gu.openRowMenu(5)).findContent("li", /Insert row above/).click();
     await gu.waitForServer();
-    await gu.enterCell("Unicorny");
+    await gu.enterCell(["Unicorny"]);
     await gu.waitForServer();
 
     const forkId = await gu.getCurrentUrlId();
@@ -106,10 +106,10 @@ describe("Comparison", function() {
     await mainSession.loadDoc(`/doc/${forkId}`);
     await gu.getPageItem("Performances").click();
     await gu.getCell({ rowNum: 1, col: "Film" }).click();
-    await gu.enterCell("The Avengers");
+    await gu.enterCell(["The Avengers"]);
     await gu.waitForServer();
     await gu.getCell({ rowNum: 2, col: "Film" }).click();
-    await gu.enterCell("Unicorny");
+    await gu.enterCell(["Unicorny"]);
     await gu.waitForServer();
 
     // Check that reference changes are visible, including one as an effect of
@@ -143,7 +143,7 @@ describe("Comparison", function() {
 
       // Change a cell
       await gu.getCell({ rowNum: 1, col: 1 }).click();
-      await gu.enterCell("800");
+      await gu.enterCell(["800"]);
       await gu.waitForServer();
 
       // Remove a row
@@ -152,16 +152,16 @@ describe("Comparison", function() {
       // Add a row
       await (await gu.openRowMenu(5)).findContent("li", /Insert row above/).click();
       await gu.waitForServer();
-      await gu.enterCell("Unicorny");
+      await gu.enterCell(["Unicorny"]);
       await gu.waitForServer();
 
       // Now change some references.
       await gu.getPageItem("Performances").click();
       await gu.getCell({ rowNum: 1, col: "Film" }).click();
-      await gu.enterCell("The Avengers");
+      await gu.enterCell(["The Avengers"]);
       await gu.waitForServer();
       await gu.getCell({ rowNum: 2, col: "Film" }).click();
-      await gu.enterCell("Unicorny");
+      await gu.enterCell(["Unicorny"]);
       await gu.waitForServer();
 
       const forkId = await gu.getCurrentUrlId();
@@ -171,7 +171,7 @@ describe("Comparison", function() {
 
       // Change a cell
       await gu.getCell({ rowNum: 2, col: 1 }).click();
-      await gu.enterCell("400");
+      await gu.enterCell(["400"]);
       await gu.waitForServer();
 
       // Remove a row
@@ -180,19 +180,19 @@ describe("Comparison", function() {
       // Add a row
       await (await gu.openRowMenu(2)).findContent("li", /Insert row above/).click();
       await gu.waitForServer();
-      await gu.enterCell("Pegasusy");
+      await gu.enterCell(["Pegasusy"]);
       await gu.waitForServer();
 
       // Now change some references.
       await gu.getPageItem("Performances").click();
       await gu.getCell({ rowNum: 4, col: "Film" }).click();
-      await gu.enterCell("Pegasusy");
+      await gu.enterCell(["Pegasusy"]);
       await gu.waitForServer();
       await gu.removeRow(3);
       await (await gu.openRowMenu(10)).findContent("li", /Insert row above/).click();
       await gu.waitForServer();
       await gu.getCell({ rowNum: 10, col: "Film" }).click();
-      await gu.enterCell("The Dark Knight");
+      await gu.enterCell(["The Dark Knight"]);
       await gu.waitForServer();
 
       // Check that comparing original with changed doc results in a difference.
@@ -313,7 +313,7 @@ describe("Comparison", function() {
     // Set some cells.
     for (let rowNum = 1; rowNum <= 4; rowNum++) {
       await gu.getCell({ rowNum, col: 1 }).click();
-      await gu.enterCell("V0");
+      await gu.enterCell(["V0"]);
     }
     await gu.waitForServer();
 
@@ -322,18 +322,18 @@ describe("Comparison", function() {
 
     // Change two of the cells.
     await gu.getCell({ rowNum: 1, col: 1 }).click();
-    await gu.enterCell("V1");
+    await gu.enterCell(["V1"]);
     await gu.getCell({ rowNum: 2, col: 1 }).click();
-    await gu.enterCell("V1");
+    await gu.enterCell(["V1"]);
     await gu.waitForServer();
 
     // Change two cells in trunk.
     const forkId = await gu.getCurrentUrlId();
     await mainSession.loadDoc(`/doc/${doc.id}`, { skipAlert: true });
     await gu.getCell({ rowNum: 2, col: 1 }).click();
-    await gu.enterCell("V2");
+    await gu.enterCell(["V2"]);
     await gu.getCell({ rowNum: 3, col: 1 }).click();
-    await gu.enterCell("V2");
+    await gu.enterCell(["V2"]);
     await gu.waitForServer();
 
     // Load comparison, and sanity-check it.
@@ -366,7 +366,7 @@ describe("Comparison", function() {
 
     // Set a cell to some text.
     await gu.getCell({ rowNum: 1, col: 1 }).click();
-    await gu.enterCell("This is some cell content");
+    await gu.enterCell(["This is some cell content"]);
     await gu.waitForServer();
 
     // Wrap text to make it all visible.
@@ -380,7 +380,7 @@ describe("Comparison", function() {
 
     // Change cell a bit more.
     await gu.getCell({ rowNum: 1, col: 1 }).click();
-    await gu.enterCell("This is some cell content!");
+    await gu.enterCell(["This is some cell content!"]);
     await gu.waitForServer();
 
     const forkId = await gu.getCurrentUrlId();
@@ -400,7 +400,7 @@ describe("Comparison", function() {
 
     // Set a cell to some text.
     await gu.getCell({ rowNum: 1, col: 1 }).click();
-    await gu.enterCell("test1");
+    await gu.enterCell(["test1"]);
     await gu.waitForServer();
 
     // Make a fork of the document.
@@ -408,7 +408,7 @@ describe("Comparison", function() {
 
     // Change cell a bit more.
     await gu.getCell({ rowNum: 1, col: 1 }).click();
-    await gu.enterCell("test2");
+    await gu.enterCell(["test2"]);
     await gu.waitForServer();
 
     // And rename the table.
@@ -446,7 +446,7 @@ describe("Comparison", function() {
     await gu.waitToPass(async () => assert.equal(await driver.find(".field_clip.has_cursor").getText(), "Dublin"));
     await driver.sendKeys(Key.ESCAPE);
     await driver.sleep(500);
-    await gu.enterCell("Baile Átha Cliath");
+    await gu.enterCell(["Baile Átha Cliath"]);
     await gu.waitForServer();
 
     await driver.find(".test-tb-share").click();

--- a/test/nbrowser/CustomView.ts
+++ b/test/nbrowser/CustomView.ts
@@ -280,7 +280,7 @@ describe("CustomView", function() {
 
         // Change a cell in Friends
         await gu.getCell({ section: "FRIENDS", col: 0, rowNum: 1 }).click();
-        await gu.enterCell("Rabbit");
+        await gu.enterCell(["Rabbit"]);
         await gu.waitForServer();
         // Return to the cell after automatically going to next row.
         await gu.getCell({ section: "FRIENDS", col: 0, rowNum: 1 }).click();

--- a/test/nbrowser/CustomWidgetsConfig.ts
+++ b/test/nbrowser/CustomWidgetsConfig.ts
@@ -481,7 +481,7 @@ describe("CustomWidgetsConfig", function() {
     await gu.selectSectionByTitle("Table");
     await gu.addColumn("B");
     await gu.getCell("B", 1).click();
-    await gu.enterCell("99");
+    await gu.enterCell(["99"]);
     await gu.addColumn("C");
     await gu.selectSectionByTitle("Widget");
     // Column M1 should be mappable to all 3, column M4 only to A and C
@@ -553,7 +553,7 @@ describe("CustomWidgetsConfig", function() {
     await gu.selectSectionByTitle("Table");
     await gu.addColumn("B");
     await gu.getCell("B", 1).click();
-    await gu.enterCell("99");
+    await gu.enterCell(["99"]);
     await gu.addColumn("C");
     await gu.selectSectionByTitle("Widget");
     await widget.waitForPendingRequests();

--- a/test/nbrowser/Fork.ts
+++ b/test/nbrowser/Fork.ts
@@ -40,7 +40,7 @@ describe("Fork", function() {
     const session = isLoggedIn ? await team.login() : await team.anon.login();
     await session.loadDoc(`/doc/${doc.id}/m/fork`);
     await gu.getCell({ rowNum: 1, col: 0 }).click();
-    await gu.enterCell("1");
+    await gu.enterCell(["1"]);
     await gu.waitForServer();
     assert.equal(await gu.getCell({ rowNum: 1, col: 0 }).getText(), "1");
     const forkUrl = await driver.getCurrentUrl();
@@ -48,7 +48,7 @@ describe("Fork", function() {
     await gu.refreshDismiss();
     await session.loadDoc((new URL(forkUrl)).pathname + "/m/fork");
     await gu.getCell({ rowNum: 1, col: 0 }).click();
-    await gu.enterCell("2");
+    await gu.enterCell(["2"]);
     await gu.waitForServer();
     await driver.findContentWait(
       ".test-notifier-toast-wrapper",
@@ -119,7 +119,7 @@ describe("Fork", function() {
             }
             // editing should work
             await gu.getCell({ rowNum: 1, col: 0 }).click();
-            await gu.enterCell("123");
+            await gu.enterCell(["123"]);
             await gu.waitForServer();
             assert.equal(await gu.getCell({ rowNum: 1, col: 0 }).getText(), "123");
             await gu.refreshDismiss();
@@ -128,7 +128,7 @@ describe("Fork", function() {
             assert.equal(await gu.getCell({ rowNum: 1, col: 0 }).getText(), "123");
             // edits should still work
             await gu.getCell({ rowNum: 1, col: 0 }).click();
-            await gu.enterCell("234");
+            await gu.enterCell(["234"]);
             await gu.waitForServer();
             assert.equal(await gu.getCell({ rowNum: 1, col: 0 }).getText(), "234");
             await gu.refreshDismiss();
@@ -153,7 +153,7 @@ describe("Fork", function() {
         const anonSession = await team.anon.login();
         await anonSession.loadDoc(`/doc/${doc.id}`);
         await gu.getCell({ rowNum: 1, col: 0 }).click();
-        await gu.enterCell("123");
+        await gu.enterCell(["123"]);
         await gu.waitForServer();
         assert.notEqual(await gu.getCell({ rowNum: 1, col: 0 }).value(), "123");
         // check that there is no tag
@@ -162,7 +162,7 @@ describe("Fork", function() {
         // Anon forks the document, tries to modify, and succeeds
         await anonSession.loadDoc(`/doc/${doc.id}/m/fork`);
         await gu.getCell({ rowNum: 1, col: 0 }).click();
-        await gu.enterCell("123");
+        await gu.enterCell(["123"]);
 
         // Check that we show some indicators of what's happening to the user in notification toasts
         // (but allow for possibility that things are changing fast).
@@ -174,7 +174,7 @@ describe("Fork", function() {
 
         assert.equal(await gu.getCell({ rowNum: 1, col: 0 }).getText(), "123");
         await gu.getCell({ rowNum: 2, col: 0 }).click();
-        await gu.enterCell("234");
+        await gu.enterCell(["234"]);
         await gu.waitForServer();
         assert.equal(await gu.getCell({ rowNum: 2, col: 0 }).getText(), "234");
 
@@ -203,7 +203,7 @@ describe("Fork", function() {
         const anonSession = await team.anon.login();
         await anonSession.loadDoc(`/doc/${doc.id}/m/fork`);
         await gu.getCell({ rowNum: 1, col: 0 }).click();
-        await gu.enterCell("1");
+        await gu.enterCell(["1"]);
         await gu.waitForServer();
         assert.equal(await gu.getCell({ rowNum: 1, col: 0 }).getText(), "1");
         const fork1 = await driver.getCurrentUrl();
@@ -211,7 +211,7 @@ describe("Fork", function() {
 
         await anonSession.loadDoc(`/doc/${doc.id}/m/fork`);
         await gu.getCell({ rowNum: 1, col: 0 }).click();
-        await gu.enterCell("2");
+        await gu.enterCell(["2"]);
         await gu.waitForServer();
         assert.equal(await gu.getCell({ rowNum: 1, col: 0 }).getText(), "2");
         const fork2 = await driver.getCurrentUrl();
@@ -249,11 +249,11 @@ describe("Fork", function() {
           // Dismiss forms announcement popup, if present.
           await gu.dismissBehavioralPrompts();
           await gu.getCell({ rowNum: 1, col: 0 }).click();
-          await gu.enterCell("123");
+          await gu.enterCell(["123"]);
           await gu.waitForServer();
           assert.equal(await driver.findWait(".test-unsaved-tag", 4000).isPresent(), true);
           await gu.getCell({ rowNum: 2, col: 0 }).click();
-          await gu.enterCell("234");
+          await gu.enterCell(["234"]);
           await gu.waitForServer();
           assert.equal(await gu.getCell({ rowNum: 2, col: 0 }).getText(), "234");
 
@@ -283,7 +283,7 @@ describe("Fork", function() {
 
           // Check we still have editing rights
           await gu.getCell({ rowNum: 1, col: 0 }).click();
-          await gu.enterCell("1234");
+          await gu.enterCell(["1234"]);
           await gu.waitForServer();
           await gu.refreshDismiss();
           await userSession.loadDoc((new URL(forkUrl)).pathname);
@@ -296,7 +296,7 @@ describe("Fork", function() {
           assert.equal(await gu.getEmail(), team.email);
           assert.equal(await gu.getCell({ rowNum: 1, col: 0 }).getText(), "1234");
           await gu.getCell({ rowNum: 1, col: 0 }).click();
-          await gu.enterCell("12345");
+          await gu.enterCell(["12345"]);
           await gu.waitForServer();
           await gu.refreshDismiss();
           await team.loadDoc((new URL(forkUrl)).pathname);
@@ -307,7 +307,7 @@ describe("Fork", function() {
           assert.equal(await gu.getEmail(), "anon@getgrist.com");
           assert.equal(await gu.getCell({ rowNum: 1, col: 0 }).getText(), "1234");
           await gu.getCell({ rowNum: 1, col: 0 }).click();
-          await gu.enterCell("12345");
+          await gu.enterCell(["12345"]);
           await gu.waitForServer();
           await gu.refreshDismiss();
           await anonSession.loadDoc((new URL(forkUrl)).pathname);
@@ -322,7 +322,7 @@ describe("Fork", function() {
         await team.login();
         await team.loadDoc(`/doc/${doc2.id}/m/fork`);
         await gu.getCell({ rowNum: 1, col: 0 }).click();
-        await gu.enterCell("123");
+        await gu.enterCell(["123"]);
         await gu.waitForServer();
 
         // The url of the doc should now be that of a fork
@@ -340,7 +340,7 @@ describe("Fork", function() {
 
         // Check we still have editing rights
         await gu.getCell({ rowNum: 1, col: 0 }).click();
-        await gu.enterCell("1234");
+        await gu.enterCell(["1234"]);
         await gu.waitForServer();
         await gu.refreshDismiss();
         await team.loadDoc((new URL(forkUrl)).pathname);
@@ -413,7 +413,7 @@ describe("Fork", function() {
         // make a fork
         await team.loadDoc(`/doc/${trunk.id}/m/fork`);
         await gu.getCell({ rowNum: 1, col: 0 }).click();
-        await gu.enterCell("123");
+        await gu.enterCell(["123"]);
         await gu.waitForServer();
         const forkUrl = await driver.getCurrentUrl();
         assert.match(forkUrl, /~/);
@@ -437,7 +437,7 @@ describe("Fork", function() {
         const initialUrl = await driver.getCurrentUrl();
         assert.equal(await driver.find(".test-unsaved-tag").isPresent(), false);
         await gu.getCell({ rowNum: 1, col: 0 }).click();
-        await gu.enterCell("2");
+        await gu.enterCell(["2"]);
         await gu.waitForServer();
         assert.equal(await gu.getCell({ rowNum: 1, col: 0 }).getText(), "2");
         const forkUrl = await driver.getCurrentUrl();
@@ -464,7 +464,7 @@ describe("Fork", function() {
         await team.loadDoc(`/doc/${doc.id}/m/fork`);
         assert.equal(await driver.find(".test-bc-doc").getAttribute("disabled"), null);
         await gu.getCell({ rowNum: 1, col: 0 }).click();
-        await gu.enterCell("2");
+        await gu.enterCell(["2"]);
         await gu.waitForServer();
         await gu.waitToPass(async () => {
           assert.equal(await driver.find(".test-bc-doc").getAttribute("disabled"), "true");
@@ -480,7 +480,7 @@ describe("Fork", function() {
 
         // edit one cell
         await gu.getCell({ rowNum: 1, col: 0 }).click();
-        await gu.enterCell("2");
+        await gu.enterCell(["2"]);
         await gu.waitForServer();
 
         // check we're on a fork
@@ -512,7 +512,7 @@ describe("Fork", function() {
         await gu.getCell({ rowNum: 2, col: 0 }).click();
         const v1 = await gu.getCell({ rowNum: 2, col: 0 }).getText();
         const v2 = `${v1}_tweaked`;
-        await gu.enterCell(v2);
+        await gu.enterCell([v2]);
         await gu.waitForServer();
 
         // check we're on a fork
@@ -539,7 +539,7 @@ describe("Fork", function() {
         const altDoc = await altSession.tempDoc(cleanup, "Hello.grist");
         await gu.dismissWelcomeTourIfNeeded();
         await gu.getCell({ rowNum: 2, col: 0 }).click();
-        await gu.enterCell("altDoc");
+        await gu.enterCell(["altDoc"]);
         await gu.waitForServer();
 
         // replacement should fail for document not found
@@ -567,7 +567,7 @@ describe("Fork", function() {
         await gu.getCell({ rowNum: 2, col: 0 }).click();
         const v1 = await gu.getCell({ rowNum: 2, col: 0 }).getText();
         const v2 = `${v1}_tweaked`;
-        await gu.enterCell(v2);
+        await gu.enterCell([v2]);
         await gu.waitForServer();
 
         // check we're on a fork.
@@ -590,7 +590,7 @@ describe("Fork", function() {
         // edit the cell again.
         await gu.getCell({ rowNum: 2, col: 0 }).click();
         const v3 = `${v2}_tweaked`;
-        await gu.enterCell(v3);
+        await gu.enterCell([v3]);
         await gu.waitForServer();
 
         // revisit the fork.
@@ -635,7 +635,7 @@ describe("Fork", function() {
           await gu.getCell({ rowNum: 2, col: 0 }).click();
           const v1 = await gu.getCell({ rowNum: 2, col: 0 }).getText();
           const v2 = `${v1}_tweaked`;
-          await gu.enterCell(v2);
+          await gu.enterCell([v2]);
           await gu.waitForServer();
 
           // check we're on a fork.

--- a/test/nbrowser/HeaderColor.ts
+++ b/test/nbrowser/HeaderColor.ts
@@ -44,9 +44,9 @@ describe("HeaderColor", function() {
 
   it("should save by clicking away", async function() {
     // add records
-    await gu.enterCell("a");
-    await gu.enterCell("b");
-    await gu.enterCell("c");
+    await gu.enterCell(["a"]);
+    await gu.enterCell(["b"]);
+    await gu.enterCell(["c"]);
     await gu.toggleSidePanel("right", "open");
     await driver.find(".test-right-tab-field").click();
 

--- a/test/nbrowser/MultiColumn.ts
+++ b/test/nbrowser/MultiColumn.ts
@@ -72,7 +72,7 @@ describe("MultiColumn", function() {
       await gu.openColumnPanel();
       // Should be able to change type.
       await gu.getDetailCell("Test1", 1);
-      await gu.enterCell("aa");
+      await gu.enterCell(["aa"]);
       await gu.setType("Integer", { apply: true });
       assert.equal(await gu.getType(), "Integer");
     });
@@ -83,9 +83,9 @@ describe("MultiColumn", function() {
       await selectColumns("Test1", "Test2");
       await gu.setType("Reference");
       await gu.getCell("Test1", 1).click();
-      await gu.enterCell("Table1", Key.ENTER);
+      await gu.enterCell(["Table1", Key.ENTER]);
       await gu.getCell("Test2", 3).click();
-      await gu.enterCell("Table1", Key.ENTER);
+      await gu.enterCell(["Table1", Key.ENTER]);
       await selectColumns("Test1", "Test2");
       await gu.openCellColorPicker();
       await gu.setFillColor(blue);
@@ -182,9 +182,9 @@ describe("MultiColumn", function() {
       assert.equal(await alignment(), "left");
 
       // Make them all data columns
-      await gu.getCell("Test1", 1).click(); await gu.enterCell("a");
-      await gu.getCell("Test2", 1).click(); await gu.enterCell("a");
-      await gu.getCell("Test3", 1).click(); await gu.enterCell("a");
+      await gu.getCell("Test1", 1).click(); await gu.enterCell(["a"]);
+      await gu.getCell("Test2", 1).click(); await gu.enterCell(["a"]);
+      await gu.getCell("Test3", 1).click(); await gu.enterCell(["a"]);
       await selectColumns("Test1", "Test3");
       assert.equal(await gu.columnBehavior(), "Data columns");
       await selectColumns("Test1");

--- a/test/nbrowser/NumericEditor.ts
+++ b/test/nbrowser/NumericEditor.ts
@@ -96,7 +96,7 @@ describe("NumericEditor", function() {
         for (const [i, entry] of Object.entries(entriesByColumn)) {
           await gu.getCell({ rowNum: 1, col: Number(i) }).click();
           await entry.workaround?.();
-          await gu.enterCell(entry.initial);
+          await gu.enterCell([entry.initial]);
           assert.equal(await gu.getCell({ rowNum: 1, col: Number(i) }).getText(), entry.expect);
         }
 

--- a/test/nbrowser/Printing.ts
+++ b/test/nbrowser/Printing.ts
@@ -135,7 +135,7 @@ describe("Printing", function() {
   it("should not display link icon when printing", async function() {
     await gu.getPageItem("Countries").click();
     await gu.getCell(0, 1).click();
-    await gu.enterCell("http://getgrist.com");
+    await gu.enterCell(["http://getgrist.com"]);
     await gu.waitForServer();
 
     const checkLinkIsDisplayed = async (expected: boolean) => {
@@ -157,7 +157,7 @@ describe("Printing", function() {
     await gu.openColumnPanel("Name");
     await gu.setFieldWidgetType("Markdown");
     await gu.getCell({ rowNum: 1, col: "Name" }).click();
-    await gu.enterCell("[Aruba](https://getgrist.com/#aruba)");
+    await gu.enterCell(["[Aruba](https://getgrist.com/#aruba)"]);
 
     const link = driver.findContentWait(".test-text-link", "Aruba", 1000);
     assert.equal(await link.isDisplayed(), true);

--- a/test/nbrowser/ProposedChangesPage.ts
+++ b/test/nbrowser/ProposedChangesPage.ts
@@ -55,7 +55,7 @@ describe("ProposedChangesPage", function() {
     // Put something known in the first cell.
     await gu.getCell("A", 1).click();
     await gu.waitAppFocus();
-    await gu.enterCell("test1");
+    await gu.enterCell(["test1"]);
 
     // Work on a copy.
     await driver.find(".test-tb-share").click();
@@ -66,7 +66,7 @@ describe("ProposedChangesPage", function() {
     // Change the content of the first cell.
     await gu.getCell("A", 1).click();
     await gu.waitAppFocus();
-    await gu.enterCell("test2");
+    await gu.enterCell(["test2"]);
 
     // Go to the propose-changes page.
     assert.equal(await driver.find(".test-tools-proposals").getText(),
@@ -153,7 +153,7 @@ describe("ProposedChangesPage", function() {
     // Make a change.
     await gu.getCell("B", 1).click();
     await gu.waitAppFocus();
-    await gu.enterCell("Bird");
+    await gu.enterCell(["Bird"]);
 
     await proposeChange();
 
@@ -161,14 +161,14 @@ describe("ProposedChangesPage", function() {
     await workOnCopy(url);
     await gu.getCell("B", 2).click();
     await gu.waitAppFocus();
-    await gu.enterCell("Mammal");
+    await gu.enterCell(["Mammal"]);
     await proposeChange();
 
     // Work on another copy and propose a different change.
     await workOnCopy(url);
     await gu.getCell("B", 3).click();
     await gu.waitAppFocus();
-    await gu.enterCell("SpaceDuck");
+    await gu.enterCell(["SpaceDuck"]);
     await proposeChange();
 
     // Click on the "original document" to see how things are there now.
@@ -228,7 +228,7 @@ describe("ProposedChangesPage", function() {
     // Make a change.
     await gu.getCell("B", 1).click();
     await gu.waitAppFocus();
-    await gu.enterCell("Bird");
+    await gu.enterCell(["Bird"]);
 
     await proposeChange();
 
@@ -284,7 +284,7 @@ describe("ProposedChangesPage", function() {
     // Make a change.
     await gu.getCell("B", 1).click();
     await gu.waitAppFocus();
-    await gu.enterCell("Bird");
+    await gu.enterCell(["Bird"]);
 
     assert.equal(await driver.find(".test-tools-proposals").getText(),
       "Suggest changes (1)");
@@ -292,7 +292,7 @@ describe("ProposedChangesPage", function() {
     // Make another change.
     await gu.getCell("A", 2).click();
     await gu.waitAppFocus();
-    await gu.enterCell("15");
+    await gu.enterCell(["15"]);
 
     assert.equal(await driver.find(".test-tools-proposals").getText(),
       "Suggest changes (2)");
@@ -320,7 +320,7 @@ describe("ProposedChangesPage", function() {
     await gu.openPage("Life");
     await gu.getCell("A", 1).click();
     await gu.waitAppFocus();
-    await gu.enterCell("13");
+    await gu.enterCell(["13"]);
     assert.equal(await driver.find(".test-tools-proposals").getText(),
       "Suggest changes (1)");
     assert.notInclude(await driver.find(".test-undo").getAttribute("class"), "-disable");
@@ -334,12 +334,12 @@ describe("ProposedChangesPage", function() {
     await gu.openPage("Life");
     await gu.getCell("A", 1).click();
     await gu.waitAppFocus();
-    await gu.enterCell("1");
+    await gu.enterCell(["1"]);
 
     await driver.get(forkUrl);
     await gu.getCell("A", 1).click();
     await gu.waitAppFocus();
-    await gu.enterCell("99");
+    await gu.enterCell(["99"]);
     assert.equal(await driver.find(".test-tools-proposals").getText(),
       "Suggest changes (1)");
     await proposeChange();
@@ -348,7 +348,7 @@ describe("ProposedChangesPage", function() {
     await gu.openPage("Life");
     await gu.getCell("A", 1).click();
     await gu.waitAppFocus();
-    await gu.enterCell("999");
+    await gu.enterCell(["999"]);
     assert.equal(await driver.find(".test-tools-proposals").getText(),
       "Suggest changes (1)");
     await proposeChange();
@@ -378,13 +378,13 @@ describe("ProposedChangesPage", function() {
     // Make a change to the Life table.
     await gu.getCell("B", 1).click();
     await gu.waitAppFocus();
-    await gu.enterCell("Bird");
+    await gu.enterCell(["Bird"]);
 
     // Make a change to the Plants table.
     await gu.openPage("Plants");
     await gu.getCell("Type", 1).click();
     await gu.waitAppFocus();
-    await gu.enterCell("Deciduous Tree");
+    await gu.enterCell(["Deciduous Tree"]);
 
     // Check that the count shows 2 changes
     assert.equal(await driver.find(".test-tools-proposals").getText(),
@@ -461,7 +461,7 @@ describe("ProposedChangesPage", function() {
     await gu.getCell("Habitat", 1).click();
 
     await gu.waitAppFocus();
-    await gu.enterCell("Desert");
+    await gu.enterCell(["Desert"]);
 
     // Check that the count shows 1 change
     assert.equal(await driver.find(".test-tools-proposals").getText(),
@@ -527,9 +527,9 @@ describe("ProposedChangesPage", function() {
     // Change the reference list for Fish: remove Forest, add Desert and Arctic
     await gu.getCell("Habitats", 1).click();
     await gu.waitAppFocus();
-    await gu.enterCell("Ocean");
-    await gu.enterCell("Desert");
-    await gu.enterCell("Arctic");
+    await gu.enterCell(["Ocean"]);
+    await gu.enterCell(["Desert"]);
+    await gu.enterCell(["Arctic"]);
     await driver.sendKeys(Key.ENTER);
     await gu.waitForServer();
 
@@ -672,7 +672,7 @@ describe("ProposedChangesPage", function() {
     await gu.waitAppFocus();
 
     // Add existing reference
-    await gu.enterCell("Ocean");
+    await gu.enterCell(["Ocean"]);
 
     // Add a new reference by typing and clicking "add new"
     await driver.sendKeys("Desert");
@@ -751,7 +751,7 @@ describe("ProposedChangesPage", function() {
     await gu.openPage("Life");
     await gu.getCell("B", 1).click();
     await gu.waitAppFocus();
-    await gu.enterCell("Fizh");
+    await gu.enterCell(["Fizh"]);
 
     // Go to the propose-changes page.
     await driver.find(".test-tools-proposals").click();

--- a/test/nbrowser/RegionFocusSwitcher.ts
+++ b/test/nbrowser/RegionFocusSwitcher.ts
@@ -289,7 +289,7 @@ describe("RegionFocusSwitcher", function() {
     const session = await gu.session().teamSite.login();
     await session.tempNewDoc(cleanup);
 
-    await gu.enterCell("test");
+    await gu.enterCell(["test"]);
     await driver.find(".test-undo").click();
     await assertPanelFocus("top", false);
     await expectClipboardFocus(true, 0);

--- a/test/nbrowser/Search3.ts
+++ b/test/nbrowser/Search3.ts
@@ -43,7 +43,7 @@ describe("Search3", async function() {
   it("should search after toggling columns", async () => {
     await mainSession.loadDoc(`/doc/${docId}/p/1`);
     await gu.getCell("A", 1).click();
-    await gu.enterCell("a", Key.ENTER);
+    await gu.enterCell(["a", Key.ENTER]);
     await gu.openWidgetPanel();
     await gu.moveToHidden("B");
 

--- a/test/nbrowser/SectionFilter.ts
+++ b/test/nbrowser/SectionFilter.ts
@@ -113,14 +113,14 @@ describe("SectionFilter", function() {
 
       // Update first row to Oranges; it should remain shown.
       await gu.getCell(0, 1).click();
-      await gu.enterCell("Oranges");
+      await gu.enterCell(["Oranges"]);
 
       // Enter a new row using a keyboard shortcut.
       await driver.find("body").sendKeys(Key.chord(await gu.modKey(), Key.ENTER));
 
       // Enter a new row by typing in a value into the "add-row".
       await driver.find(".gridview_row .record-add .field").click();
-      await gu.enterCell("Bananas");
+      await gu.enterCell(["Bananas"]);
 
       // Ensure all 3 changes are visible.
       assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3, 4, 5, 6]),
@@ -170,22 +170,22 @@ describe("SectionFilter", function() {
 
       // Update Oranges to Apples and make sure it's not filtered out
       await (await gu.getCell(0, 1)).click();
-      await gu.enterCell("Apples");
+      await gu.enterCell(["Apples"]);
 
       assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3]),
         ["Apples", "Bananas", "Bananas"]);
 
       // Set back to Oranges and make sure it stays
       await driver.sendKeys(Key.UP);
-      await gu.enterCell("Oranges");
+      await gu.enterCell(["Oranges"]);
 
       assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3]),
         ["Oranges", "Bananas", "Bananas"]);
 
       // Enter two new rows and make sure they're also not filtered out
       await driver.find(".gridview_row .record-add .field").click();
-      await gu.enterCell("Apples");
-      await gu.enterCell("Bananas");
+      await gu.enterCell(["Apples"]);
+      await gu.enterCell(["Bananas"]);
 
       // Enter a new row using a keyboard shortcut.
       await driver.find("body").sendKeys(Key.chord(await gu.modKey(), Key.ENTER));

--- a/test/nbrowser/SelectByRefList.ts
+++ b/test/nbrowser/SelectByRefList.ts
@@ -223,7 +223,7 @@ async function checkSelectingRecords(selectBy: string, sourceData: string[][], n
 
   // Create a new record with rownum=99
   await gu.getCell({ section: "LINKTARGET", col: "rownum", rowNum: numSourceRows }).click();
-  await gu.enterCell("99");
+  await gu.enterCell(["99"]);
 
   assert.deepEqual(
     await gu.getVisibleGridCells({

--- a/test/nbrowser/SelectBySummary.ts
+++ b/test/nbrowser/SelectBySummary.ts
@@ -122,8 +122,8 @@ describe("SelectBySummary", function() {
       // Create new records with rownum = 99 and 100
       await gu.getCell({ section: "TABLE1", col: "rownum", rowNum: 3 }).click();
       await gu.waitAppFocus();
-      await gu.enterCell("99");
-      await gu.enterCell("100");
+      await gu.enterCell(["99"]);
+      await gu.enterCell(["100"]);
       await driver.sleep(100); // there is some setTimeout in Grist somewhere here.
 
       assert.deepEqual(

--- a/test/nbrowser/Smoke.ts
+++ b/test/nbrowser/Smoke.ts
@@ -40,7 +40,7 @@ describe("Smoke", function() {
     // Shouldn't be necessary, but an attempt to reduce flakiness that has shown up about opening the cell for editing.
     await gu.sendKeys(Key.ENTER);
 
-    await gu.enterCell("123");
+    await gu.enterCell(["123"]);
     await gu.refreshDismiss({ ignore: true });
     assert.equal(await gu.getCell("A", 1).getText(), "123");
   });

--- a/test/nbrowser/TwoWayReference.ts
+++ b/test/nbrowser/TwoWayReference.ts
@@ -80,7 +80,7 @@ describe("TwoWayReference", function() {
     await gu.selectColumn("Friend");
     await gu.setRefShowColumn("Name");
     await gu.getCell("Friend", 1).click();
-    await gu.enterCell("Bob", Key.ENTER);
+    await gu.enterCell(["Bob", Key.ENTER]);
     await gu.waitForServer();
 
     // Now rename the Pets table to start with a number and contain a space + person emoji.
@@ -239,7 +239,7 @@ describe("TwoWayReference", function() {
     // Make sure we can change data.
     await gu.selectSectionByTitle("PETS");
     await gu.getCell("Owner", 1).click();
-    await gu.enterCell("Bob", Key.ENTER);
+    await gu.enterCell(["Bob", Key.ENTER]);
     await gu.waitForServer();
     await gu.checkForErrors();
 
@@ -282,7 +282,7 @@ describe("TwoWayReference", function() {
     // Move Rex to Bob.
     await gu.selectSectionByTitle("PETS");
     await gu.getCell("Owner", 1).click();
-    await gu.enterCell("Bob", Key.ENTER);
+    await gu.enterCell(["Bob", Key.ENTER]);
     await gu.waitForServer();
 
     // Make sure Rex is owned by Bob, in both tables.
@@ -299,7 +299,7 @@ describe("TwoWayReference", function() {
     // Now move Rex to Alice.
     await gu.selectSectionByTitle("PETS");
     await gu.getCell("Owner", 1).click();
-    await gu.enterCell("Alice", Key.ENTER);
+    await gu.enterCell(["Alice", Key.ENTER]);
     await gu.waitForServer();
     await gu.assertGridData("OWNERS", [
       [0, "Name", "Pets"],
@@ -314,7 +314,7 @@ describe("TwoWayReference", function() {
     // And check that after moving Rex to Bob, it's not shown in the Owners table.
     await gu.selectSectionByTitle("PETS");
     await gu.getCell("Owner", 1).click();
-    await gu.enterCell("Bob", Key.ENTER);
+    await gu.enterCell(["Bob", Key.ENTER]);
     await gu.waitForServer();
     await gu.checkForErrors();
 
@@ -345,7 +345,7 @@ describe("TwoWayReference", function() {
     // Move Rex to Bob again.
     await gu.selectSectionByTitle("PETS");
     await gu.getCell("Owner", 1).click();
-    await gu.enterCell("Bob", Key.ENTER);
+    await gu.enterCell(["Bob", Key.ENTER]);
     await gu.waitForServer();
     await gu.checkForErrors();
 
@@ -550,9 +550,9 @@ describe("TwoWayReference", function() {
     // Now assign Bob to Backend and Alice to Apps.
     await gu.selectSectionByTitle("Projects");
     await gu.getCell("Owner", 1).click();
-    await gu.enterCell("Alice");
+    await gu.enterCell(["Alice"]);
     await gu.getCell("Owner", 2).click();
-    await gu.enterCell("Bob");
+    await gu.enterCell(["Bob"]);
 
     // And now make sure the reverse reference is correct.
     await gu.selectSectionByTitle("People");

--- a/test/nbrowser/WebhookOverflow.ts
+++ b/test/nbrowser/WebhookOverflow.ts
@@ -65,7 +65,7 @@ describe("WebhookOverflow", function() {
   async function overflowWebhook() {
     await gu.openPage("Table2");
     await gu.getCell("A", 1).click();
-    await gu.enterCell(new Date().toString());
+    await gu.enterCell([new Date().toString()]);
     await gu.getCell("B", 1).click();
     await enterCellWithoutWaitingOnServer(new Date().toString());
     await gu.waitToPass(async () => {

--- a/test/nbrowser/WebhookPage.ts
+++ b/test/nbrowser/WebhookPage.ts
@@ -313,7 +313,7 @@ describe("WebhookPage", function() {
 
 async function setField(rowNum: number, col: string, text: string) {
   await gu.getDetailCell({ col, rowNum }).click();
-  await gu.enterCell(text);
+  await gu.enterCell([text]);
 }
 
 async function getField(rowNum: number, col: string) {

--- a/test/nbrowser/duplicateWidget.ts
+++ b/test/nbrowser/duplicateWidget.ts
@@ -27,8 +27,8 @@ describe("duplicateWidget", function() {
 
       await gu.getCell("A", 1).click();
       await gu.waitAppFocus();
-      await gu.enterCell(testCellContent);
-      await gu.enterCell(testCellContent2);
+      await gu.enterCell([testCellContent]);
+      await gu.enterCell([testCellContent2]);
 
       // Set as many properties on the widget as possible that we can check when duplicating.
       // Filters happen before widget change, as the gristUtils helpers are better for tables.

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -686,15 +686,41 @@ namespace gristUtils {
   }
 
   /**
- * Type keys in the currently active cell, then hit Enter to save, and wait for the server.
- * If the last key is TAB, DELETE, or ENTER, we assume the cell is already taken out of editing
- * mode, and don't send another ENTER.
- */
-  export async function enterCell(...keys: string[]) {
-    const lastKey = keys[keys.length - 1];
-    if (![Key.ENTER, Key.TAB, Key.DELETE].includes(lastKey)) {
+   * Display the active cell editor and type keys in it, then hit Enter to save, and wait for the server.
+   * If the last key is TAB or ENTER, we assume the cell is already taken out of editing
+   * mode, and don't send another ENTER.
+   *
+   * @param options
+   * @param options.clear Whether the existing content of the cell should be cleared
+   */
+  export async function enterCell(
+    keys: string[],
+    options: { clear?: boolean, validate?: boolean } = {},
+  ) {
+    const { clear = true, validate = true } = options;
+    const lastKey = keys.at(-1);
+    // If the caller has not requested
+    if (![Key.ENTER, Key.TAB].includes(lastKey!) && validate) {
       keys.push(Key.ENTER);
     }
+    // Press enter to display the editor
+    await driver.sendKeys(Key.ENTER);
+    // Wait for the editor to appear
+    await driver.wait(() => driver.find(".cell_editor").isDisplayed(), 1000);
+    // Select the content (so it is cleared) and press the keys requested by the caller
+    await sendKeys(
+      ...(clear ? [await selectAllKey(), Key.BACK_SPACE] : []),
+      ...keys,
+    );
+    await waitForServer();    // Wait for the value to be saved
+  }
+
+  /**
+   * Press keys on a cell and wait for the server to react.
+   * Call it with a validation (to either use only the DELETE key
+   * or entering the editors and validate with ENTER or TAB)
+   */
+  export async function pressKeysOnCell(...keys: string[]) {
     await driver.sendKeys(...keys);
     await waitForServer();    // Wait for the value to be saved
   }
@@ -771,7 +797,11 @@ namespace gristUtils {
       await getCell({ ...cell, rowNum: cell.rowNum + i }).click();
       // Enter all values, advancing with a TAB
       for (const value of rowsOfValues[i]) {
-        await enterCell(value || Key.DELETE, Key.TAB);
+        if (value) {
+          await enterCell([value, Key.TAB]);
+        } else {
+          await pressKeysOnCell(Key.DELETE, Key.TAB);
+        }
       }
     }
   }

--- a/test/nbrowser/links.ts
+++ b/test/nbrowser/links.ts
@@ -23,7 +23,7 @@ describe("links", function() {
 
   async function assertSameDocumentLink(value: string, expected: RegExp) {
     await gu.sendKeys(Key.chord(await gu.modKey(), Key.ARROW_UP));
-    await gu.enterCell(value);
+    await gu.enterCell([value]);
     const link = await gu.getCell(0, 1).find("a");
     const href = await link.getAttribute("href");
     assert.match(href, expected);
@@ -41,7 +41,7 @@ describe("links", function() {
     expected: RegExp | null,
   ) {
     await gu.sendKeys(Key.chord(await gu.modKey(), Key.ARROW_UP));
-    await gu.enterCell(value);
+    await gu.enterCell([value]);
     if ((await gu.getFieldWidgetType()) === "TextBox" && expected === null) {
       assert.isFalse(await gu.getCell(0, 1).find("a").isPresent());
       return;
@@ -96,7 +96,7 @@ describe("links", function() {
         // Previously, URLs in Markdown cells were treated as being relative to
         // the document origin if they were missing a scheme. This was inconsistent
         // with how HyperLink cells treated such URLs (with `http://` inferred).
-        await gu.enterCell(makeLink("google.com"));
+        await gu.enterCell([makeLink("google.com")]);
         if (type !== "TextBox") {
           assert.equal(
             await gu.getCell(0, 1).find("a").getAttribute("href"),
@@ -110,7 +110,7 @@ describe("links", function() {
       it(`have ${
         type === "Markdown" ? "a null" : 'an "about:blank"'
       } URL when invalid`, async function() {
-        await gu.enterCell(makeLink("javascript:alert()"));
+        await gu.enterCell([makeLink("javascript:alert()")]);
         if (type !== "TextBox") {
           assert.equal(
             await gu.getCell(0, 1).find("a").getAttribute("href"),


### PR DESCRIPTION
This PR prepares changes required for bumping Chrome.
Most of the failure are due to the way the cell edition were done (just pressing key and immediately resume the rest of the instructions).
With the Chrome upgrade, it looks necessary to wait for the  editor to appear, otherwise the tests involving cell edition becomes very flaky (some of the characters pressed were not printed into the cell).

I open this PR to remove noise in #2093.