### PR TITLE
Hides personal orgs if they're disabled on the server

### DIFF
--- a/app/client/ui/WelcomeSitePicker.ts
+++ b/app/client/ui/WelcomeSitePicker.ts
@@ -9,6 +9,7 @@ import { FullUser } from "app/common/LoginSessionAPI";
 import { getOrgName } from "app/common/UserAPI";
 
 import { Computed, dom, DomContents, IDisposableOwner, styled } from "grainjs";
+import { getGristConfig } from "app/common/urlUtils";
 
 const t = makeT("WelcomeSitePicker");
 
@@ -26,19 +27,22 @@ export function buildWelcomeSitePicker(owner: IDisposableOwner, appModel: AppMod
         cssHeading(t("Welcome back")),
         cssMessage(t("You have access to the following Grist sites.")),
         cssColumns(
-          cssColumn(
-            cssColumnLabel(css.horizontalLine(), css.lightText("Personal"), css.horizontalLine()),
-            dom.forEach(appModel.topAppModel.users, user => (
-              cssOrgButton(
-                cssPersonalOrg(
-                  createUserImage(user, "small"),
-                  dom("div", user.email, testId("personal-org-email")),
-                ),
-                dom.attr("href", use => urlState().makeUrl({ org: use(personalOrg) })),
-                dom.on("click", (ev) => { void (switchToPersonalUrl(ev, appModel, personalOrg.get(), user)); }),
-                testId("personal-org"),
-              )
-            )),
+          dom.maybe(
+            () => getGristConfig().enablePersonalOrgs,
+            () => cssColumn(
+              cssColumnLabel(css.horizontalLine(), css.lightText("Personal"), css.horizontalLine()),
+              dom.forEach(appModel.topAppModel.users, user => (
+                cssOrgButton(
+                  cssPersonalOrg(
+                    createUserImage(user, "small"),
+                    dom("div", user.email, testId("personal-org-email")),
+                  ),
+                  dom.attr("href", use => urlState().makeUrl({ org: use(personalOrg) })),
+                  dom.on("click", (ev) => { void (switchToPersonalUrl(ev, appModel, personalOrg.get(), user)); }),
+                  testId("personal-org"),
+                )
+              )),
+            ),
           ),
           cssColumn(
             cssColumnLabel(css.horizontalLine(), css.lightText("Team"), css.horizontalLine()),

--- a/app/client/ui/WelcomeSitePicker.ts
+++ b/app/client/ui/WelcomeSitePicker.ts
@@ -6,10 +6,10 @@ import { createUserImage } from "app/client/ui/UserImage";
 import { bigBasicButtonLink } from "app/client/ui2018/buttons";
 import { testId, theme } from "app/client/ui2018/cssVars";
 import { FullUser } from "app/common/LoginSessionAPI";
+import { getGristConfig } from "app/common/urlUtils";
 import { getOrgName } from "app/common/UserAPI";
 
 import { Computed, dom, DomContents, IDisposableOwner, styled } from "grainjs";
-import { getGristConfig } from "app/common/urlUtils";
 
 const t = makeT("WelcomeSitePicker");
 

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -873,6 +873,9 @@ export interface GristLoadConfig {
   // If set, allow non-admins to create new organizations
   canAnyoneCreateOrgs?: boolean;
 
+  // If set, allow access to each user's personal organization
+  enablePersonalOrgs?: boolean;
+
   // If set, allow selection of the specified engines.
   // TODO: move this list to a separate endpoint.
   supportEngines?: EngineCode[];

--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -99,6 +99,7 @@ import {
 import { appSettings } from "app/server/lib/AppSettings";
 import { getOrCreateConnection } from "app/server/lib/dbUtils";
 import { StorageCoordinator } from "app/server/lib/GristServer";
+import { getPersonalOrgsEnabled } from "app/server/lib/gristSettings";
 import { makeId } from "app/server/lib/idUtils";
 import { EmitNotifier, INotifier } from "app/server/lib/INotifier";
 import log from "app/server/lib/log";
@@ -120,7 +121,6 @@ import {
   WhereExpressionBuilder,
 } from "typeorm";
 import { v4 as uuidv4 } from "uuid";
-import { getPersonalOrgsEnabled } from "app/server/lib/gristSettings";
 
 // Support transactions in Sqlite in async code.  This is a monkey patch, affecting
 // the prototypes of various TypeORM classes.

--- a/app/server/lib/gristSettings.ts
+++ b/app/server/lib/gristSettings.ts
@@ -1,4 +1,5 @@
 import { appSettings } from "app/server/lib/AppSettings";
+
 import memoize from "lodash/memoize";
 
 export function getTemplateOrg() {

--- a/app/server/lib/gristSettings.ts
+++ b/app/server/lib/gristSettings.ts
@@ -1,4 +1,5 @@
 import { appSettings } from "app/server/lib/AppSettings";
+import memoize from "lodash/memoize";
 
 export function getTemplateOrg() {
   let org = appSettings.section("templates").flag("org").readString({
@@ -27,23 +28,23 @@ export function getOnboardingTutorialDocId() {
   });
 }
 
-export function getAnonPlaygroundEnabled() {
-  return appSettings.section("orgs").flag("enableAnonPlayground").readBool({
+export const getAnonPlaygroundEnabled = memoize(() =>
+  appSettings.section("orgs").flag("enableAnonPlayground").readBool({
     envVar: "GRIST_ANON_PLAYGROUND",
     defaultValue: getCanAnyoneCreateOrgs(),
-  });
-}
+  }),
+);
 
-export function getCanAnyoneCreateOrgs() {
-  return appSettings.section("orgs").flag("canAnyoneCreateOrgs").readBool({
+export const getCanAnyoneCreateOrgs = memoize(() =>
+  appSettings.section("orgs").flag("canAnyoneCreateOrgs").readBool({
     envVar: "GRIST_ORG_CREATION_ANYONE",
     defaultValue: true,
-  });
-}
+  }),
+);
 
-export function getPersonalOrgsEnabled() {
-  return appSettings.section("orgs").flag("enablePersonalOrgs").readBool({
+export const getPersonalOrgsEnabled = memoize(() =>
+  appSettings.section("orgs").flag("enablePersonalOrgs").readBool({
     envVar: "GRIST_PERSONAL_ORGS",
     defaultValue: getCanAnyoneCreateOrgs(),
-  });
-}
+  }),
+);

--- a/app/server/lib/sendAppPage.ts
+++ b/app/server/lib/sendAppPage.ts
@@ -24,7 +24,7 @@ import { RequestWithOrg } from "app/server/lib/extractOrg";
 import { GristServer } from "app/server/lib/GristServer";
 import {
   getAnonPlaygroundEnabled, getCanAnyoneCreateOrgs,
-  getOnboardingTutorialDocId,
+  getOnboardingTutorialDocId, getPersonalOrgsEnabled,
   getTemplateOrg,
   getUserPresenceMaxUsers,
 } from "app/server/lib/gristSettings";
@@ -106,6 +106,7 @@ export function makeGristConfig(options: MakeGristConfigOptions): GristLoadConfi
     supportAnon: shouldSupportAnon(),
     enableAnonPlayground: getAnonPlaygroundEnabled(),
     canAnyoneCreateOrgs: getCanAnyoneCreateOrgs(),
+    enablePersonalOrgs: getPersonalOrgsEnabled(),
     supportEngines: getSupportedEngineChoices(),
     features: getFeatures(),
     pageTitleSuffix: configuredPageTitleSuffix(),

--- a/test/server/lib/docapi/DocApiCreation.ts
+++ b/test/server/lib/docapi/DocApiCreation.ts
@@ -30,7 +30,8 @@ function addCreationTests(getCtx: () => TestContext) {
   // because it requires GRIST_ANON_PLAYGROUND: "false" environment setting.
 
   it("guesses types of new columns", async () => {
-    const { serverUrl, docIds, chimpy } = getCtx();
+    const { serverUrl, chimpy, getOrCreateTestDoc } = getCtx();
+    const testDoc = await getOrCreateTestDoc();
     const userActions = [
       ["AddTable", "GuessTypes", []],
       // Make 5 blank columns of type Any
@@ -48,12 +49,12 @@ function addCreationTests(getCtx: () => TestContext) {
         Text: "hello",
       }],
     ];
-    const resp = await axios.post(`${serverUrl}/api/docs/${docIds.TestDoc}/apply`, userActions, chimpy);
+    const resp = await axios.post(`${serverUrl}/api/docs/${testDoc}/apply`, userActions, chimpy);
     assert.equal(resp.status, 200);
 
     // Check that the strings were parsed to typed values
     assert.deepEqual(
-      (await axios.get(`${serverUrl}/api/docs/${docIds.TestDoc}/tables/GuessTypes/records`, chimpy)).data,
+      (await axios.get(`${serverUrl}/api/docs/${testDoc}/tables/GuessTypes/records`, chimpy)).data,
       {
         records: [
           {
@@ -72,7 +73,7 @@ function addCreationTests(getCtx: () => TestContext) {
 
     // Check the column types
     assert.deepEqual(
-      (await axios.get(`${serverUrl}/api/docs/${docIds.TestDoc}/tables/GuessTypes/columns`, chimpy))
+      (await axios.get(`${serverUrl}/api/docs/${testDoc}/tables/GuessTypes/columns`, chimpy))
         .data.columns.map((col: any) => col.fields.type),
       ["Date", "DateTime:UTC", "Bool", "Numeric", "Text"],
     );

--- a/test/server/lib/docapi/DocApiDownloads.ts
+++ b/test/server/lib/docapi/DocApiDownloads.ts
@@ -29,7 +29,8 @@ describe("DocApiDownloads", function() {
 function addDownloadsTests(getCtx: () => TestContext) {
   // Set up test data that the CSV/table-schema download tests depend on
   before(async function() {
-    const { serverUrl, docIds, chimpy } = getCtx();
+    const { serverUrl, chimpy, getOrCreateTestDoc } = getCtx();
+    const testDoc = await getOrCreateTestDoc();
     // Create Foo table with test data in TestDoc
     const userActions = [
       ["AddTable", "Foo", [{ id: "A" }, { id: "B" }]],
@@ -38,7 +39,7 @@ function addDownloadsTests(getCtx: () => TestContext) {
         B: [1, 11, 2, 22],
       }],
     ];
-    await axios.post(`${serverUrl}/api/docs/${docIds.TestDoc}/apply`, userActions, chimpy);
+    await axios.post(`${serverUrl}/api/docs/${testDoc}/apply`, userActions, chimpy);
   });
 
   async function generateDocAndUrl(docName: string = "Dummy") {

--- a/test/server/lib/docapi/DocApiOrgLimitFlags.ts
+++ b/test/server/lib/docapi/DocApiOrgLimitFlags.ts
@@ -11,7 +11,7 @@ import {
   getCanAnyoneCreateOrgs,
   getPersonalOrgsEnabled,
 } from "app/server/lib/gristSettings";
-import { configForApiKey } from "test/gen-server/testUtils";
+import { configForApiKey, configForUser } from "test/gen-server/testUtils";
 import {
   addAllScenarios,
   makeUserApi,
@@ -99,6 +99,15 @@ function addPersonalOrgLimitTests(getCtx: () => TestContext) {
     assert.isNumber(id);
     const orgs = await newUserApi.getOrgs();
     const personalOrg = orgs.find(org => org.owner?.id === id);
+    assert.isUndefined(personalOrg);
+  });
+
+  it("should not allow users to view their existing personal orgs", async () => {
+    const { homeUrl } = getCtx();
+    // Chimpy has an existing personal org set up already.
+    const userApi = makeUserApi(homeUrl, ORG_NAME, configForUser("chimpy"));
+    const orgs = await userApi.getOrgs();
+    const personalOrg = orgs.find(org => Boolean(org.owner));
     assert.isUndefined(personalOrg);
   });
 }

--- a/test/server/lib/docapi/DocApiOrgLimitFlags.ts
+++ b/test/server/lib/docapi/DocApiOrgLimitFlags.ts
@@ -49,24 +49,47 @@ describe("DocApiOrgLimitFlags", function() {
     let oldEnv: EnvironmentSnapshot;
     before(async function() {
       oldEnv = new EnvironmentSnapshot();
+      delete process.env.GRIST_ORG_CREATION_ANYONE;
+      delete process.env.GRIST_PERSONAL_ORGS;
+      delete process.env.GRIST_ANON_PLAYGROUND;
+
+      // Clear memoized function cache.
+      getCanAnyoneCreateOrgs.cache.clear();
+      getAnonPlaygroundEnabled.cache.clear();
+      getPersonalOrgsEnabled.cache.clear();
+    });
+
+    afterEach(function() {
+      // Clear memoized function cache.
+      getCanAnyoneCreateOrgs.cache.clear();
+      getAnonPlaygroundEnabled.cache.clear();
+      getPersonalOrgsEnabled.cache.clear();
     });
 
     after(async function() {
       oldEnv.restore();
     });
 
-    it("GRIST_ORG_CREATION_ANYONE sets the default values of GRIST_PERSONAL_ORGS and GRIST_ANON_PLAYGROUND", () => {
-      process.env.GRIST_ORG_CREATION_ANYONE = "true";
-      delete process.env.GRIST_PERSONAL_ORGS;
-      delete process.env.GRIST_ANON_PLAYGROUND;
-      assert.equal(getCanAnyoneCreateOrgs(), true);
-      assert.equal(getAnonPlaygroundEnabled(), true);
-      assert.equal(getPersonalOrgsEnabled(), true);
+    describe("GRIST_ORG_CREATION_ANYONE sets default values of GRIST_PERSONAL_ORGS and GRIST_ANON_PLAYGROUND", () => {
+      it("defaults to true", () => {
+        assert.equal(getCanAnyoneCreateOrgs(), true);
+        assert.equal(getAnonPlaygroundEnabled(), true);
+        assert.equal(getPersonalOrgsEnabled(), true);
+      });
 
-      process.env.GRIST_ORG_CREATION_ANYONE = "false";
-      assert.equal(getCanAnyoneCreateOrgs(), false);
-      assert.equal(getAnonPlaygroundEnabled(), false);
-      assert.equal(getPersonalOrgsEnabled(), false);
+      it("sets them to true", () => {
+        process.env.GRIST_ORG_CREATION_ANYONE = "true";
+        assert.equal(getCanAnyoneCreateOrgs(), true);
+        assert.equal(getAnonPlaygroundEnabled(), true);
+        assert.equal(getPersonalOrgsEnabled(), true);
+      });
+
+      it("sets them to false", () => {
+        process.env.GRIST_ORG_CREATION_ANYONE = "false";
+        assert.equal(getCanAnyoneCreateOrgs(), false);
+        assert.equal(getAnonPlaygroundEnabled(), false);
+        assert.equal(getPersonalOrgsEnabled(), false);
+      });
     });
   });
 });


### PR DESCRIPTION
## Context

#2124 adds flags to prevent new users being able to create new organisations. However, existing personal orgs are still able to be used freely, which might not be apparent to admins of existing installations.

## Proposed solution

This disables personal organizations at a database level when `GRIST_PERSONAL_ORGS = false`. 

Existing personal orgs won't be accessible, and won't be displayed in team list. Grist will quietly treat them as not existing.

This hasn't shown any issues in initial testing (except for one area of the user interface, fixed in this PR), but it's difficult to be 100% certain without significant work on Grist's test suite.

## Related issues

#2124 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [X] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->