### PR TITLE
Add shared auth pathway for REST and WebSocket auth

### DIFF
--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -205,7 +205,7 @@ async function getUserFromProfile(
   if (!profile?.email) {
     return dbManager.getAnonymousUser();
   }
-  return await dbManager.getUserByLoginWithRetry(profile.email, {profile, userOptions});
+  return await dbManager.getUserByLoginWithRetry(profile.email, { profile, userOptions });
 }
 
 /**
@@ -249,8 +249,8 @@ export async function resolveIdentity(
   },
 ): Promise<IdentityResult> {
   // 1. Access token via ?auth query parameter.
-  const url = new URL(req.url!, 'http://localhost');
-  const auth = url.searchParams.get('auth');
+  const url = new URL(req.url!, "http://localhost");
+  const auth = url.searchParams.get("auth");
   if (auth) {
     const tokens = options.gristServer.getAccessTokens();
     const accessToken = await tokens.verify(auth);

--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -155,6 +155,288 @@ function setRequestUser(mreq: RequestWithLogin, dbManager: HomeDBAuth, user: Use
 }
 
 /**
+ * Validate an API key from a request's Authorization header.
+ * Returns the authenticated User if a valid "Bearer <key>" is found.
+ * Returns undefined if no Authorization header or not a Bearer token (caller should try other auth).
+ * Throws ApiError if credentials are present but invalid (bad key, expired service account, etc).
+ *
+ * Used by both the REST API middleware (addRequestUser) and the WebSocket connection handler (Comm).
+ */
+export async function getApiKeyUser(
+  req: IncomingMessage,
+  dbManager: HomeDBAuth,
+): Promise<User | undefined> {
+  if (!req.headers?.authorization) {
+    return undefined;
+  }
+  // header needs to be of form "Bearer XXXXXXXXX" to apply
+  const parts = String(req.headers.authorization).split(" ");
+  if (parts[0] !== "Bearer") {
+    return undefined;
+  }
+  const user = parts[1] ? await dbManager.getUserByKey(parts[1]) : undefined;
+  if (!user) {
+    throw new ApiError("Bad request: invalid API key", 401);
+  }
+  if (user.type === "service") {
+    const serviceAccount = (await dbManager.getServiceAccountByLoginWithOwner(user.loginEmail!))!;
+    if (serviceAccount.owner.disabledAt) {
+      throw new ApiError("Owner account is disabled", 403);
+    }
+    if (!serviceAccount.isActive()) {
+      throw new ApiError("Service Account has expired", 401);
+    }
+  }
+  if (user.id === dbManager.getAnonymousUserId()) {
+    throw new ApiError("Credentials cannot be presented for the anonymous user account via API key", 401);
+  }
+  return user;
+}
+
+/**
+ * Resolve a User from a session profile.
+ * Returns the matching User if the profile has an email, or the anonymous user otherwise.
+ */
+async function getUserFromProfile(
+  dbManager: HomeDBAuth,
+  profile: UserProfile | null,
+  userOptions?: UserOptions,
+): Promise<User> {
+  if (!profile?.email) {
+    return dbManager.getAnonymousUser();
+  }
+  return await dbManager.getUserByLoginWithRetry(profile.email, {profile, userOptions});
+}
+
+/**
+ * Result of resolving a user's identity from a request.
+ * Used by both REST (addRequestUser) and WebSocket (Comm) auth paths.
+ */
+export interface IdentityResult {
+  user: User;                    // The resolved user (or anonymous)
+  accessToken?: AccessTokenInfo; // Set if ?auth token was used
+  specialPermit?: Permit;        // Set if permit header was used
+  hasApiKey: boolean;            // Whether API key was used (for telemetry)
+  // True when the user presented explicit credentials (API key, boot key, permit,
+  // access token). False for ambient browser-based auth (session cookie, forward-auth
+  // header) and anonymous. Used by REST middleware for CSRF protection: mutating
+  // requests without explicit credentials must include a CORS-triggering header
+  // (X-Requested-With or Content-Type: application/json) to guard against
+  // cross-site form submissions that the browser would send with session cookies.
+  explicitAuth: boolean;
+}
+
+/**
+ * Shared auth resolution for both REST and WebSocket paths.
+ * Walks the auth chain in order (access token, API key, boot key, permit,
+ * override profile, session profile) and returns the first match.
+ * Falls back to anonymous if nothing matches.
+ *
+ * Throws ApiError on auth failures (bad key, invalid permit, etc.).
+ * Does NOT check user.disabledAt — callers handle that with their own policies.
+ */
+export async function resolveIdentity(
+  req: IncomingMessage,
+  dbManager: HomeDBAuth,
+  options: {
+    gristServer: GristServer;
+    permitStore: IPermitStore;
+    overrideProfile?: (req: IncomingMessage) => Promise<UserProfile | null | undefined>;
+    getSessionProfile?: () => Promise<{
+      profile: UserProfile | null;
+      userOptions?: UserOptions;
+    }>;
+  },
+): Promise<IdentityResult> {
+  // 1. Access token via ?auth query parameter.
+  const url = new URL(req.url!, 'http://localhost');
+  const auth = url.searchParams.get('auth');
+  if (auth) {
+    const tokens = options.gristServer.getAccessTokens();
+    const accessToken = await tokens.verify(auth);
+    // Access tokens don't set a userId in the original code, so CSRF
+    // protection still applies (explicitAuth: false). In practice these
+    // are GET requests for attachments, but we keep the check for parity.
+    return {
+      user: dbManager.getAnonymousUser(),
+      accessToken,
+      hasApiKey: false,
+      explicitAuth: false,
+    };
+  }
+
+  // 2. API key (Bearer header).
+  // Note: API key does NOT immediately return — a permit header (step 4) can
+  // override it. This matches the original behavior where internal requests
+  // may forward API key headers but authorize via permit.
+  const apiKeyUser = await getApiKeyUser(req, dbManager);
+
+  // 3. Boot key (x-boot-key header). Takes priority over permit.
+  if (req.headers?.["x-boot-key"]) {
+    const reqBootKey = String(req.headers["x-boot-key"]);
+    const bootKey = options.gristServer.getBootKey();
+    if (!bootKey || bootKey !== reqBootKey) {
+      throw new ApiError("Bad request: invalid Boot key", 401);
+    }
+    const admin = options.gristServer.getInstallAdmin();
+    const user = await admin.getAdminUser();
+    if (!user) {
+      throw new ApiError("No admin user available", 500);
+    }
+    return { user, hasApiKey: false, explicitAuth: true };
+  }
+
+  // 4. Permit (permit header). Overrides API key if both are present.
+  if (req.headers?.permit) {
+    const permitKey = String(req.headers.permit);
+    let permit: Permit | null;
+    try {
+      permit = await options.permitStore.getPermit(permitKey);
+    } catch (err) {
+      log.error(`problem reading permit: ${err}`);
+      throw new ApiError("Bad request: permit could not be read", 401);
+    }
+    if (!permit) {
+      throw new ApiError("Bad request: unknown permit", 401);
+    }
+    return {
+      user: dbManager.getAnonymousUser(),
+      specialPermit: permit,
+      hasApiKey: false,
+      explicitAuth: true,
+    };
+  }
+
+  // If API key was found (and no boot key/permit overrode it), return now.
+  if (apiKeyUser) {
+    return { user: apiKeyUser, hasApiKey: true, explicitAuth: true };
+  }
+
+  // 5. Override profile (e.g. forward-auth header).
+  if (options.overrideProfile) {
+    const candidateProfile = await options.overrideProfile(req);
+    if (candidateProfile !== undefined) {
+      if (candidateProfile) {
+        const user = await getUserFromProfile(dbManager, candidateProfile);
+        return { user, hasApiKey: false, explicitAuth: false };
+      }
+      // null means explicitly anonymous, skip session.
+      return { user: dbManager.getAnonymousUser(), hasApiKey: false, explicitAuth: false };
+    }
+  }
+
+  // 6. Session profile.
+  if (options.getSessionProfile) {
+    const { profile, userOptions } = await options.getSessionProfile();
+    if (profile) {
+      const user = await getUserFromProfile(dbManager, profile, userOptions);
+      return { user, hasApiKey: false, explicitAuth: false };
+    }
+  }
+
+  // 7. Anonymous fallback.
+  return { user: dbManager.getAnonymousUser(), hasApiKey: false, explicitAuth: false };
+}
+
+/**
+ * Extract a session profile from the Express session for the current request.
+ * Handles custom-domain sessionID validation, profile-to-org linking,
+ * and cookie maxAge bookkeeping.
+ *
+ * Side effects: sets mreq.users and may mutate session state (cookie maxAge, orgToUser).
+ * Returns `{ profile, userOptions, customHostSession }`.
+ * Throws ApiError on session-hijack detection.
+ */
+async function getExpressSessionProfile(
+  mreq: RequestWithLogin,
+  dbManager: HomeDBAuth,
+): Promise<{
+  profile: UserProfile | null;
+  userOptions?: UserOptions;
+  customHostSession: string;
+}> {
+  let customHostSession = "";
+  const session = mreq.session;
+  if (!(session?.users && session.users.length > 0 && mreq.org !== undefined)) {
+    return { profile: null, customHostSession };
+  }
+
+  // Prevent using custom-domain sessionID to authorize to a different domain, since
+  // custom-domain owner could hijack such sessions.
+  const allowedOrg = getAllowedOrgForSessionID(mreq.sessionID);
+  if (allowedOrg) {
+    if (allowHost(mreq, allowedOrg.host)) {
+      customHostSession = ` custom-host-match ${allowedOrg.host}`;
+    } else {
+      // We need an exception for internal forwarding from home server to doc-workers. These use
+      // internal hostnames, so we can't expect a custom domain. These requests do include an
+      // Organization header, which we'll use to grant the exception, but security issues remain.
+      // TODO Issue 1: an attacker can use a custom-domain request to get an API key, which is an
+      // open door to all orgs accessible by this user.
+      // TODO Issue 2: Organization header is easy for an attacker (who has stolen a session
+      // cookie) to include too; it does nothing to prove that the request is internal.
+      const org = mreq.header("organization");
+      if (org && org === allowedOrg.org) {
+        customHostSession = ` custom-host-fwd ${org}`;
+      } else {
+        // Log error and fail.
+        log.warn("Auth[%s]: sessionID for host %s org %s; wrong for host %s org %s", mreq.method,
+          allowedOrg.host, allowedOrg.org, mreq.get("host"), mreq.org);
+        throw new ApiError("Bad request: invalid session ID", 403);
+      }
+    }
+  }
+
+  mreq.users = getSessionProfiles(session);
+
+  // If we haven't set a maxAge yet, set it now.
+  if (session?.cookie && !session.cookie.maxAge) {
+    if (COOKIE_MAX_AGE !== null) {
+      session.cookie.maxAge = COOKIE_MAX_AGE;
+      forceSessionChange(session);
+    }
+  }
+
+  // See if we have a profile linked with the active organization already.
+  // TODO: implement userSelector for rest API, to allow "sticky" user selection on pages.
+  let sessionUser: SessionUserObj | null = getSessionUser(session, mreq.org,
+    optStringParam(mreq.query.user, "user") || "");
+
+  if (!sessionUser) {
+    // No profile linked yet, so let's elect one.
+    // Choose a profile that is no worse than the others available.
+    const option = await dbManager.getBestUserForOrg(mreq.users, mreq.org);
+    if (option) {
+      // Modify request session object to link the current org with our choice of
+      // profile.  Express-session will save this change.
+      sessionUser = linkOrgWithEmail(session, option.email, mreq.org);
+    } else {
+      // No profile has access to this org.  We could choose to
+      // link no profile, in which case user will end up
+      // immediately presented with a sign-in page, or choose to
+      // link an arbitrary profile (say, the first one the user
+      // logged in as), in which case user will end up with a
+      // friendlier page explaining the situation and offering to
+      // add an account to resolve it.  We go ahead and pick an
+      // arbitrary profile.
+      sessionUser = session.users[0];
+      if (!session.orgToUser) { throw new Error("Session misconfigured"); }
+      // Express-session will save this change.
+      session.orgToUser[mreq.org] = 0;
+    }
+  }
+
+  const profile = sessionUser?.profile ?? null;
+  const userOptions: UserOptions = {};
+  if (profile?.loginMethod === "Email + Password") {
+    // Link the session authSubject, if present, to the user. This has no effect
+    // if the user already has an authSubject set in the db.
+    userOptions.authSubject = sessionUser?.authSubject;
+  }
+  return { profile, userOptions, customHostSession };
+}
+
+/**
  * Returns the express request object with user information added, if it can be
  * found based on passed in headers or the session.  Specifically, sets:
  *   - req.userId: the id of the user in the database users table
@@ -173,101 +455,58 @@ export async function addRequestUser(
   req: Request, res: Response, next: NextFunction,
 ) {
   const mreq = req as RequestWithLogin;
-  let profile: UserProfile | undefined;
 
-  // We support multiple method of authentication. This flag gets set once
-  // we need not try any more. Specifically, it is used to avoid processing
-  // anything else after setting an access token, for simplicity in reasoning
-  // about this case.
-  let authDone: boolean = false;
+  // A bit of extra info we'll add to the "Auth" log message when this request passes the check
+  // for custom-host-specific sessionID.
+  let customHostSession = "";
 
-  let hasApiKey: boolean = false;
+  const skipSession = options.skipSession;
 
-  // Support providing an access token via an `auth` query parameter.
-  // This is useful for letting the browser load assets like image
-  // attachments.
-  const auth = optStringParam(mreq.query.auth, "auth");
-  if (auth) {
-    const tokens = options.gristServer.getAccessTokens();
-    const token = await tokens.verify(auth);
-    mreq.accessToken = token;
-    // Once an accessToken is supplied, we don't consider anything else.
-    // User is treated as anonymous apart from having an accessToken.
-    authDone = true;
+  // Resolve the user identity. Errors (invalid API key, expired token, etc.)
+  // propagate to Express's JSON error handler via expressWrap.
+  const identity = await resolveIdentity(mreq, dbManager, {
+    gristServer: options.gristServer,
+    permitStore,
+    overrideProfile: options.overrideProfile,
+    getSessionProfile: skipSession ? undefined : async () => {
+      const { customHostSession: chs, ...sessionResult } = await getExpressSessionProfile(mreq, dbManager);
+      customHostSession = chs;
+      return sessionResult;
+    },
+  });
+
+  // Initialize altSessionId from the session. The original code guarded this with
+  // `!authDone && !skipSession`, which excluded access-token and boot-key paths.
+  // We now use just `!skipSession`, which is slightly broader: access-token and
+  // boot-key requests will also get an altSessionId. This is harmless because
+  // access-token requests are GETs for attachments (no trigger formulas) and
+  // boot-key requests are admin-only. The alternative — threading authDone through
+  // the IdentityResult — would complicate the interface for no practical benefit.
+  if (!skipSession) {
+    const session = mreq.session;
+    if (session && !session.altSessionId) {
+      session.altSessionId = makeId();
+      forceSessionChange(session);
+    }
+    mreq.altSessionId = session?.altSessionId;
   }
 
-  // Now, check for an apiKey
-  if (!authDone && mreq.headers?.authorization) {
-    // header needs to be of form "Bearer XXXXXXXXX" to apply
-    const parts = String(mreq.headers.authorization).split(" ");
-    if (parts[0] === "Bearer") {
-      const user = parts[1] ? await dbManager.getUserByKey(parts[1]) : undefined;
-      if (!user) {
-        return res.status(401).send("Bad request: invalid API key");
-      }
-      if (user.type === "service") {
-        const serviceAccount = (await dbManager.getServiceAccountByLoginWithOwner(user.loginEmail!))!;
-        if (serviceAccount.owner.disabledAt) {
-          return res.status(403).send("Owner account is disabled");
-        }
-        if (!serviceAccount.isActive()) {
-          return res.status(401).send("Service Account has expired");
-        }
-      }
-      if (user.id === dbManager.getAnonymousUserId()) {
-        // We forbid the anonymous user to present an api key.  That saves us
-        // having to think through the consequences of authorized access to the
-        // anonymous user's profile via the api (e.g. how should the api key be managed).
-        return res.status(401).send("Credentials cannot be presented for the anonymous user account via API key");
-      }
-      setRequestUser(mreq, dbManager, user);
-      hasApiKey = true;
-    }
-  }
+  // Set mreq fields from the identity result.
+  setRequestUser(mreq, dbManager, identity.user);
+  if (identity.accessToken) { mreq.accessToken = identity.accessToken; }
+  if (identity.specialPermit) { mreq.specialPermit = identity.specialPermit; }
 
-  // Check if we have a boot key. This is a fallback mechanism for an
-  // administrator to authenticate themselves by demonstrating access
-  // to the environment.
-  if (!authDone && mreq.headers?.["x-boot-key"]) {
-    const reqBootKey = String(mreq.headers["x-boot-key"]);
-    const bootKey = options.gristServer.getBootKey();
-    if (!bootKey || bootKey !== reqBootKey) {
-      return res.status(401).send("Bad request: invalid Boot key");
-    }
-    const admin = options.gristServer.getInstallAdmin();
-    const user = await admin.getAdminUser();
-    if (!user) {
-      return res.status(500).send("No admin user available");
-    }
-    setRequestUser(mreq, dbManager, user);
-    authDone = true;
-  }
-
-  // Special permission header for internal housekeeping tasks
-  if (!authDone && mreq.headers?.permit) {
-    const permitKey = String(mreq.headers.permit);
-    try {
-      const permit = await permitStore.getPermit(permitKey);
-      if (!permit) { return res.status(401).send("Bad request: unknown permit"); }
-      setRequestUser(mreq, dbManager, dbManager.getAnonymousUser());
-      mreq.specialPermit = permit;
-    } catch (err) {
-      log.error(`problem reading permit: ${err}`);
-      return res.status(401).send("Bad request: permit could not be read");
-    }
-  }
-
-  // If we haven't already been authenticated, and this is not a GET/HEAD/OPTIONS, then
-  // require a header that would trigger a CORS pre-flight request, either:
+  // When the user was NOT authenticated by explicit credentials (API key, boot key,
+  // permit, or access token), require mutating requests to include a header that would
+  // trigger a CORS pre-flight request. This guards against cross-site form submissions
+  // where the browser would automatically include the session cookie. Accepted headers:
   //   - X-Requested-With: XMLHttpRequest
   //       - https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#use-of-custom-request-headers
   //       - https://markitzeroday.com/x-requested-with/cors/2017/06/29/csrf-mitigation-for-ajax-requests.html
   //   - Content-Type: application/json
   //       - https://www.directdefense.com/csrf-in-the-age-of-json/
-  // This is trivial for legitimate web clients to do, and an obstacle to
-  // nefarious ones.
   if (
-    !mreq.userId &&
+    !identity.explicitAuth &&
     !(mreq.xhr || mreq.get("content-type") === "application/json") &&
     !["GET", "HEAD", "OPTIONS"].includes(mreq.method)
   ) {
@@ -275,134 +514,6 @@ export async function addRequestUser(
       error: "Unauthenticated requests require one of the headers" +
         "'Content-Type: application/json' or 'X-Requested-With: XMLHttpRequest'",
     });
-  }
-
-  // For some configurations, the user profile can be determined from the request.
-  // If this is the case, we won't use session information.
-  let skipSession: boolean = options.skipSession || authDone;
-  if (!authDone && !mreq.userId) {
-    const candidateProfile = await options.overrideProfile?.(mreq);
-    if (candidateProfile !== undefined) {
-      // Either a valid or a null profile tells us that another login system determined the user,
-      // and that we should skip sessions.
-      skipSession = true;
-      if (candidateProfile) {
-        profile = candidateProfile;
-        const user = await dbManager.getUserByLoginWithRetry(profile.email, { profile });
-        if (user) {
-          setRequestUser(mreq, dbManager, user);
-        }
-      }
-    }
-  }
-
-  // A bit of extra info we'll add to the "Auth" log message when this request passes the check
-  // for custom-host-specific sessionID.
-  let customHostSession = "";
-
-  if (!authDone && !skipSession) {
-    // If we haven't selected a user by other means, and have profiles available in the
-    // session, then select a user based on those profiles.
-    const session = mreq.session;
-    if (session && !session.altSessionId) {
-      // Create a default alternative session id for use in documents.
-      session.altSessionId = makeId();
-      forceSessionChange(session);
-    }
-    mreq.altSessionId = session?.altSessionId;
-    if (!mreq.userId && session?.users && session.users.length > 0 &&
-      mreq.org !== undefined) {
-      // Prevent using custom-domain sessionID to authorize to a different domain, since
-      // custom-domain owner could hijack such sessions.
-      const allowedOrg = getAllowedOrgForSessionID(mreq.sessionID);
-      if (allowedOrg) {
-        if (allowHost(req, allowedOrg.host)) {
-          customHostSession = ` custom-host-match ${allowedOrg.host}`;
-        } else {
-          // We need an exception for internal forwarding from home server to doc-workers. These use
-          // internal hostnames, so we can't expect a custom domain. These requests do include an
-          // Organization header, which we'll use to grant the exception, but security issues remain.
-          // TODO Issue 1: an attacker can use a custom-domain request to get an API key, which is an
-          // open door to all orgs accessible by this user.
-          // TODO Issue 2: Organization header is easy for an attacker (who has stolen a session
-          // cookie) to include too; it does nothing to prove that the request is internal.
-          const org = req.header("organization");
-          if (org && org === allowedOrg.org) {
-            customHostSession = ` custom-host-fwd ${org}`;
-          } else {
-            // Log error and fail.
-            log.warn("Auth[%s]: sessionID for host %s org %s; wrong for host %s org %s", mreq.method,
-              allowedOrg.host, allowedOrg.org, mreq.get("host"), mreq.org);
-            return res.status(403).send("Bad request: invalid session ID");
-          }
-        }
-      }
-
-      mreq.users = getSessionProfiles(session);
-
-      // If we haven't set a maxAge yet, set it now.
-      if (session?.cookie && !session.cookie.maxAge) {
-        if (COOKIE_MAX_AGE !== null) {
-          session.cookie.maxAge = COOKIE_MAX_AGE;
-          forceSessionChange(session);
-        }
-      }
-
-      // See if we have a profile linked with the active organization already.
-      // TODO: implement userSelector for rest API, to allow "sticky" user selection on pages.
-      let sessionUser: SessionUserObj | null = getSessionUser(session, mreq.org,
-        optStringParam(mreq.query.user, "user") || "");
-
-      if (!sessionUser) {
-        // No profile linked yet, so let's elect one.
-        // Choose a profile that is no worse than the others available.
-        const option = await dbManager.getBestUserForOrg(mreq.users, mreq.org);
-        if (option) {
-          // Modify request session object to link the current org with our choice of
-          // profile.  Express-session will save this change.
-          sessionUser = linkOrgWithEmail(session, option.email, mreq.org);
-          const userOptions: UserOptions = {};
-          if (sessionUser?.profile?.loginMethod === "Email + Password") {
-            // Link the session authSubject, if present, to the user. This has no effect
-            // if the user already has an authSubject set in the db.
-            userOptions.authSubject = sessionUser.authSubject;
-          }
-          // In this special case of initially linking a profile, we need to look up the user's info.
-          const user = await dbManager.getUserByLogin(option.email, { userOptions });
-          setRequestUser(mreq, dbManager, user);
-        } else {
-          // No profile has access to this org.  We could choose to
-          // link no profile, in which case user will end up
-          // immediately presented with a sign-in page, or choose to
-          // link an arbitrary profile (say, the first one the user
-          // logged in as), in which case user will end up with a
-          // friendlier page explaining the situation and offering to
-          // add an account to resolve it.  We go ahead and pick an
-          // arbitrary profile.
-          sessionUser = session.users[0];
-          if (!session.orgToUser) { throw new Error("Session misconfigured"); }
-          // Express-session will save this change.
-          session.orgToUser[mreq.org] = 0;
-        }
-      }
-
-      profile = sessionUser?.profile ?? undefined;
-
-      // If we haven't computed a userId yet, check for one using an email address in the profile.
-      // A user record will be created automatically for emails we've never seen before.
-      if (profile && !mreq.userId) {
-        const userOptions: UserOptions = {};
-        if (profile?.loginMethod === "Email + Password") {
-          // Link the session authSubject, if present, to the user. This has no effect
-          // if the user already has an authSubject set in the db.
-          userOptions.authSubject = sessionUser.authSubject;
-        }
-        const user = await dbManager.getUserByLoginWithRetry(profile.email, { profile, userOptions });
-        if (user) {
-          setRequestUser(mreq, dbManager, user);
-        }
-      }
-    }
   }
 
   // Disabled users get no rights, not even public pages. Almost
@@ -425,11 +536,6 @@ export async function addRequestUser(
     }
   }
 
-  // If no userId has been found yet fall back on anonymous.
-  if (!mreq.userId) {
-    setRequestUser(mreq, dbManager, dbManager.getAnonymousUser());
-  }
-
   if (mreq.userId) {
     if (mreq.user?.options?.locale) {
       mreq.language = mreq.user.options.locale;
@@ -449,7 +555,7 @@ export async function addRequestUser(
     altSessionId: mreq.altSessionId,
   };
   log.rawDebug(`Auth[${meta.method}]: ${meta.host} ${meta.path}`, meta);
-  if (hasApiKey) {
+  if (identity.hasApiKey) {
     options.gristServer.getTelemetry().logEvent(mreq, "apiUsage", {
       full: {
         method: mreq.method,

--- a/app/server/lib/Comm.ts
+++ b/app/server/lib/Comm.ts
@@ -32,19 +32,21 @@
  * In other words, there is an opportunity for untangling and simplifying.
  */
 
+import { ApiError } from "app/common/ApiError";
 import { parseFirstUrlPart } from "app/common/gristUrls";
 import { safeJsonParse } from "app/common/gutil";
-import { UserProfile } from "app/common/LoginSessionAPI";
 import * as version from "app/common/version";
 import { HomeDBAuth } from "app/gen-server/lib/homedb/Interfaces";
+import { resolveIdentity } from "app/server/lib/Authorizer";
 import { AuthSession } from "app/server/lib/AuthSession";
 import { ScopedSession } from "app/server/lib/BrowserSession";
 import { Client, ClientMethod } from "app/server/lib/Client";
 import { Hosts, RequestWithOrg } from "app/server/lib/extractOrg";
-import { GristLoginMiddleware } from "app/server/lib/GristServer";
+import { GristLoginMiddleware, GristServer } from "app/server/lib/GristServer";
 import { GristServerSocket } from "app/server/lib/GristServerSocket";
 import { GristSocketServer } from "app/server/lib/GristSocketServer";
 import log from "app/server/lib/log";
+import { IPermitStore } from "app/server/lib/Permit";
 import { trustOrigin } from "app/server/lib/requestUtils";
 import { localeFromRequest } from "app/server/lib/ServerLocale";
 import { fromCallback } from "app/server/lib/serverUtils";
@@ -64,6 +66,8 @@ export interface CommOptions {
   loginMiddleware?: GristLoginMiddleware; // If set, use custom getProfile method if available
   httpsServer?: https.Server;   // An optional HTTPS server to listen on too.
   i18Instance?: i18n;           // The i18next instance to use for translations.
+  gristServer?: GristServer;            // The GristServer instance, needed for resolveIdentity.
+  permitStore?: IPermitStore;            // Permit store, needed for resolveIdentity.
 }
 
 /**
@@ -175,18 +179,6 @@ export class Comm extends EventEmitter {
   }
 
   /**
-   * Returns a profile based on the request or session.
-   */
-  private async _getSessionProfile(
-    scopedSession: ScopedSession, req: http.IncomingMessage,
-  ): Promise<UserProfile | null> {
-    return (
-      (await this._options.loginMiddleware?.overrideProfile?.(req)) ??
-      (await scopedSession.getSessionProfile())
-    );
-  }
-
-  /**
    * Processes a new websocket connection, and associates the websocket and a Client object.
    */
   private async _onWebSocketConnection(websocket: GristServerSocket, req: http.IncomingMessage) {
@@ -210,11 +202,37 @@ export class Comm extends EventEmitter {
 
     log.rawInfo("Comm: Got Websocket connection", { ...client.getLogMeta(), urlPath: req.url, reuseClient });
 
-    // Parse the cookie in the request to get the sessionId.
-    const sessionId = this.sessions.getSessionIdFromRequest(req);
-    const scopedSession = this.sessions.getOrCreateSession(sessionId!, (req as RequestWithOrg).org, userSelector);
-    const profile = await this._getSessionProfile(scopedSession, req);
-    const authSession = await getAuthSession(this._options.dbManager, scopedSession, profile);
+    const dbManager = this._options.dbManager;
+    let authSession: AuthSession;
+    if (!dbManager || !this._options.gristServer || !this._options.permitStore) {
+      authSession = AuthSession.unauthenticated();
+    } else {
+      let scopedSession: ScopedSession | undefined;
+      const identity = await resolveIdentity(req, dbManager, {
+        gristServer: this._options.gristServer,
+        permitStore: this._options.permitStore,
+        overrideProfile: this._options.loginMiddleware?.overrideProfile,
+        getSessionProfile: async () => {
+          const sessionId = this.sessions.getSessionIdFromRequest(req);
+          scopedSession = this.sessions.getOrCreateSession(
+            sessionId!, (req as RequestWithOrg).org, userSelector);
+          // Use scopedSession directly — overrideProfile is already handled by
+          // resolveIdentity at step 5, so we don't call _getSessionProfile here
+          // (which would check overrideProfile a second time).
+          const profile = await scopedSession.getSessionProfile();
+          return { profile };
+        },
+      });
+
+      if (identity.user.disabledAt) {
+        throw new ApiError("User is disabled", 403);
+      }
+
+      const org = (req as RequestWithOrg).org || "";
+      const fullUser = dbManager.makeFullUser(identity.user);
+      const altSessionId = scopedSession?.getAltSessionId();
+      authSession = AuthSession.fromUser(fullUser, org, altSessionId);
+    }
 
     client.setConnection({ websocket, req, counter, browserSettings, authSession });
 
@@ -264,15 +282,3 @@ export class Comm extends EventEmitter {
   }
 }
 
-// This is a subset of the logic in Authorizer addRequestUser(), but sufficient for websocket
-// connections, which rely on having an existing session.
-async function getAuthSession(
-  dbManager: HomeDBAuth | undefined, scopedSession: ScopedSession, profile: UserProfile | null,
-): Promise<AuthSession> {
-  if (!dbManager) {
-    return AuthSession.unauthenticated();
-  }
-  const user = profile?.email ? await dbManager.getUserByLogin(profile.email) : dbManager.getAnonymousUser();
-  const fullUser = dbManager.makeFullUser(user);
-  return AuthSession.fromUser(fullUser, scopedSession.org, scopedSession.getAltSessionId());
-}

--- a/app/server/lib/Comm.ts
+++ b/app/server/lib/Comm.ts
@@ -281,4 +281,3 @@ export class Comm extends EventEmitter {
     return wss;
   }
 }
-

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1346,6 +1346,8 @@ export class FlexServer implements GristServer {
       httpsServer: this.httpsServer,
       i18Instance: this.i18Instance,
       dbManager: this.getHomeDBManager(),
+      gristServer: this,
+      permitStore: this._internalPermitStore,
     });
   }
 

--- a/test/gen-server/ApiServer.ts
+++ b/test/gen-server/ApiServer.ts
@@ -2596,7 +2596,7 @@ describe("ApiServer", function() {
         const accessOfServiceAccountAfter = await axios.get(`${homeUrl}/api/orgs/${oid}`, serviceAccountReqConfig);
         assert.equal(accessOfServiceAccountAfter.status, 401,
           "Service Account should not be granted access to NASA org");
-        assert.match(accessOfServiceAccountAfter.data, /invalid API key/);
+        assert.match(accessOfServiceAccountAfter.data.error, /invalid API key/);
       });
 
       // outdated service account can't do api calls
@@ -2614,7 +2614,7 @@ describe("ApiServer", function() {
         // The error is checked below in any case.
         const accessToNasa = await axios.get(`${homeUrl}/api/orgs/${oid}`, serviceAccountConfig);
         assert.equal(accessToNasa.status, 401);
-        assert.equal(accessToNasa.data, "Service Account has expired");
+        assert.equal(accessToNasa.data.error, "Service Account has expired");
       });
 
       describe("On owner disabled", function() {

--- a/test/gen-server/ApiServerAccess.ts
+++ b/test/gen-server/ApiServerAccess.ts
@@ -2236,7 +2236,7 @@ describe("ApiServerAccess", function() {
     // check that chimpy's apikey does not work any more
     resp = await axios.get(`${homeUrl}/api/orgs`, chimpy);
     assert.equal(resp.status, 401);
-    assert.deepEqual(resp.data, "Bad request: invalid API key");
+    assert.deepEqual(resp.data.error, "Bad request: invalid API key");
 
     // check that the apikey '' does not work either
     resp = await axios.get(`${homeUrl}/api/orgs`, {
@@ -2245,7 +2245,7 @@ describe("ApiServerAccess", function() {
       headers: { Authorization: "Bearer " },
     });
     assert.equal(resp.status, 401);
-    assert.deepEqual(resp.data, "Bad request: invalid API key");
+    assert.deepEqual(resp.data.error, "Bad request: invalid API key");
 
     // check that db encoded null for the apikey
     const chimpyUser = (await User.findOne({ where: { name: "Chimpy" } }))!;
@@ -2272,7 +2272,7 @@ describe("ApiServerAccess", function() {
       // check that old apikey does not work any more
       resp = await axios.get(`${homeUrl}/api/orgs`, kiwi);
       assert.equal(resp.status, 401);
-      assert.deepEqual(resp.data, "Bad request: invalid API key");
+      assert.deepEqual(resp.data.error, "Bad request: invalid API key");
 
       // check that the new api key works
       kiwi.headers = { Authorization: "Bearer " + apiKey };

--- a/test/server/lib/resolveIdentity.ts
+++ b/test/server/lib/resolveIdentity.ts
@@ -1,0 +1,397 @@
+import { ApiError } from "app/common/ApiError";
+import { UserProfile } from "app/common/LoginSessionAPI";
+import { User } from "app/gen-server/entity/User";
+import { HomeDBAuth } from "app/gen-server/lib/homedb/Interfaces";
+import { AccessTokenInfo, IAccessTokens } from "app/server/lib/AccessTokens";
+import { resolveIdentity } from "app/server/lib/Authorizer";
+import { createDummyGristServer, GristServer } from "app/server/lib/GristServer";
+import { InstallAdmin } from "app/server/lib/InstallAdmin";
+import { IPermitStore, Permit } from "app/server/lib/Permit";
+
+import { ServiceAccount } from "app/gen-server/entity/ServiceAccount";
+
+import { assert } from "chai";
+import { IncomingMessage } from "http";
+
+function makeUser(id: number, name: string, extra?: Partial<User>): User {
+  return { id, name, disabledAt: null, type: "login", ...extra } as User;
+}
+
+const ANON_ID = 1;
+const ANON = makeUser(ANON_ID, "Anonymous");
+const ALICE = makeUser(10, "Alice");
+const ALICE_PROFILE: UserProfile = { email: "alice@x.com", name: "Alice" };
+const ADMIN = makeUser(99, "Admin");
+
+function makeRequest(url: string = "/test", headers: Record<string, string> = {}): IncomingMessage {
+  return { url, headers } as IncomingMessage;
+}
+
+function makeDbManager(overrides?: Partial<HomeDBAuth>): HomeDBAuth {
+  return {
+    getAnonymousUserId: () => ANON_ID,
+    getSupportUserId: () => 2,
+    getAnonymousUser: () => ANON,
+    getUser: async () => undefined,
+    getUserByKey: async () => undefined,
+    getUserByLogin: async () => ALICE,
+    getUserByLoginWithRetry: async () => ALICE,
+    getBestUserForOrg: async () => null,
+    getServiceAccountByLoginWithOwner: async () => null,
+    makeFullUser: (user: User) => ({
+      id: user.id, name: user.name, email: "", loginEmail: "",
+    }),
+    ...overrides,
+  } as HomeDBAuth;
+}
+
+function makePermitStore(overrides?: Partial<IPermitStore>): IPermitStore {
+  return {
+    getPermit: async () => null,
+    setPermit: async () => "",
+    removePermit: async () => {},
+    close: async () => {},
+    getKeyPrefix: () => "test",
+    ...overrides,
+  };
+}
+
+function opts(extra?: Partial<Parameters<typeof resolveIdentity>[2]>): Parameters<typeof resolveIdentity>[2] {
+  return {
+    gristServer: createDummyGristServer(),
+    permitStore: makePermitStore(),
+    ...extra,
+  };
+}
+
+describe("resolveIdentity", function() {
+
+  it("returns anonymous when no credentials are provided", async function() {
+    const result = await resolveIdentity(makeRequest(), makeDbManager(), opts());
+    assert.equal(result.user.id, ANON_ID);
+    assert.isFalse(result.hasApiKey);
+    assert.isFalse(result.explicitAuth);
+    assert.isUndefined(result.accessToken);
+    assert.isUndefined(result.specialPermit);
+  });
+
+  describe("access token", function() {
+    it("resolves access token from ?auth query param", async function() {
+      const tokenInfo: AccessTokenInfo = { userId: 10, docId: "doc1", readOnly: false };
+      const result = await resolveIdentity(
+        makeRequest("/test?auth=tok"), makeDbManager(),
+        opts({
+          gristServer: {
+            ...createDummyGristServer(),
+            getAccessTokens: () => ({
+              verify: async (t: string) => {
+                if (t === "tok") { return tokenInfo; }
+                throw new ApiError("bad token", 401);
+              },
+            } as IAccessTokens),
+          },
+        }),
+      );
+      assert.equal(result.user.id, ANON_ID, "access token uses anonymous user");
+      assert.deepEqual(result.accessToken, tokenInfo);
+      assert.isFalse(result.explicitAuth, "access token keeps CSRF enforced");
+    });
+
+    it("access token takes priority over API key", async function() {
+      const tokenInfo: AccessTokenInfo = { userId: 10, docId: "doc1", readOnly: false };
+      const db = makeDbManager({ getUserByKey: async () => ALICE });
+      const result = await resolveIdentity(
+        makeRequest("/test?auth=tok", { authorization: "Bearer good-key" }), db,
+        opts({
+          gristServer: {
+            ...createDummyGristServer(),
+            getAccessTokens: () => ({
+              verify: async () => tokenInfo,
+            } as unknown as IAccessTokens),
+          },
+        }),
+      );
+      assert.isDefined(result.accessToken, "access token wins");
+      assert.isFalse(result.hasApiKey, "API key not used");
+    });
+  });
+
+  describe("API key", function() {
+    it("resolves user from valid API key", async function() {
+      const db = makeDbManager({ getUserByKey: async (k) => k === "good" ? ALICE : undefined });
+      const result = await resolveIdentity(
+        makeRequest("/test", { authorization: "Bearer good" }), db, opts(),
+      );
+      assert.equal(result.user.id, ALICE.id);
+      assert.isTrue(result.hasApiKey);
+      assert.isTrue(result.explicitAuth);
+    });
+
+    it("throws on invalid API key", async function() {
+      const db = makeDbManager({ getUserByKey: async () => undefined });
+      try {
+        await resolveIdentity(
+          makeRequest("/test", { authorization: "Bearer bad" }), db, opts(),
+        );
+        assert.fail("should have thrown");
+      } catch (err: any) {
+        assert.equal(err.status, 401);
+        assert.match(err.message, /invalid API key/);
+      }
+    });
+
+    it("rejects API key for anonymous user", async function() {
+      const db = makeDbManager({ getUserByKey: async () => ANON });
+      try {
+        await resolveIdentity(
+          makeRequest("/test", { authorization: "Bearer anon-key" }), db, opts(),
+        );
+        assert.fail("should have thrown");
+      } catch (err: any) {
+        assert.equal(err.status, 401);
+        assert.match(err.message, /anonymous/i);
+      }
+    });
+
+    it("rejects expired service account", async function() {
+      const svcUser = makeUser(20, "SvcBot", { type: "service", loginEmail: "bot@svc" } as any);
+      const db = makeDbManager({
+        getUserByKey: async () => svcUser,
+        getServiceAccountByLoginWithOwner: async () => ({
+          owner: makeUser(10, "Owner"),
+          isActive: () => false,
+        } as unknown as ServiceAccount),
+      });
+      try {
+        await resolveIdentity(
+          makeRequest("/test", { authorization: "Bearer svc-key" }), db, opts(),
+        );
+        assert.fail("should have thrown");
+      } catch (err: any) {
+        assert.equal(err.status, 401);
+        assert.match(err.message, /expired/i);
+      }
+    });
+
+    it("rejects service account whose owner is disabled", async function() {
+      const svcUser = makeUser(20, "SvcBot", { type: "service", loginEmail: "bot@svc" } as any);
+      const db = makeDbManager({
+        getUserByKey: async () => svcUser,
+        getServiceAccountByLoginWithOwner: async () => ({
+          owner: makeUser(10, "Owner", { disabledAt: new Date() }),
+          isActive: () => true,
+        } as unknown as ServiceAccount),
+      });
+      try {
+        await resolveIdentity(
+          makeRequest("/test", { authorization: "Bearer svc-key" }), db, opts(),
+        );
+        assert.fail("should have thrown");
+      } catch (err: any) {
+        assert.equal(err.status, 403);
+        assert.match(err.message, /disabled/i);
+      }
+    });
+
+    it("ignores non-Bearer authorization header", async function() {
+      const result = await resolveIdentity(
+        makeRequest("/test", { authorization: "Basic dXNlcjpwYXNz" }),
+        makeDbManager(), opts(),
+      );
+      assert.equal(result.user.id, ANON_ID);
+      assert.isFalse(result.hasApiKey);
+    });
+  });
+
+  describe("boot key", function() {
+    it("resolves admin user from valid boot key", async function() {
+      const result = await resolveIdentity(
+        makeRequest("/test", { "x-boot-key": "secret-boot" }), makeDbManager(),
+        opts({
+          gristServer: {
+            ...createDummyGristServer(),
+            getBootKey: () => "secret-boot",
+            getInstallAdmin: () => ({ getAdminUser: async () => ADMIN } as InstallAdmin),
+          },
+        }),
+      );
+      assert.equal(result.user.id, ADMIN.id);
+      assert.isTrue(result.explicitAuth);
+    });
+
+    it("throws on invalid boot key", async function() {
+      try {
+        await resolveIdentity(
+          makeRequest("/test", { "x-boot-key": "wrong" }), makeDbManager(),
+          opts({
+            gristServer: { ...createDummyGristServer(), getBootKey: () => "real-key" },
+          }),
+        );
+        assert.fail("should have thrown");
+      } catch (err: any) {
+        assert.equal(err.status, 401);
+        assert.match(err.message, /invalid Boot key/);
+      }
+    });
+
+    it("boot key takes priority over API key", async function() {
+      const db = makeDbManager({ getUserByKey: async () => ALICE });
+      const result = await resolveIdentity(
+        makeRequest("/test", { authorization: "Bearer good", "x-boot-key": "bk" }), db,
+        opts({
+          gristServer: {
+            ...createDummyGristServer(),
+            getBootKey: () => "bk",
+            getInstallAdmin: () => ({ getAdminUser: async () => ADMIN } as InstallAdmin),
+          },
+        }),
+      );
+      assert.equal(result.user.id, ADMIN.id, "boot key wins over API key");
+      assert.isFalse(result.hasApiKey);
+    });
+  });
+
+  describe("permit", function() {
+    it("resolves permit as anonymous with specialPermit", async function() {
+      const permit: Permit = { docId: "doc1" };
+      const permitStore = makePermitStore({
+        getPermit: async (k) => k === "pk" ? permit : null,
+      });
+      const result = await resolveIdentity(
+        makeRequest("/test", { permit: "pk" }), makeDbManager(),
+        opts({ permitStore }),
+      );
+      assert.equal(result.user.id, ANON_ID);
+      assert.deepEqual(result.specialPermit, permit);
+      assert.isTrue(result.explicitAuth);
+    });
+
+    it("permit overrides API key", async function() {
+      const permit: Permit = { docId: "doc1" };
+      const db = makeDbManager({ getUserByKey: async () => ALICE });
+      const permitStore = makePermitStore({
+        getPermit: async () => permit,
+      });
+      const result = await resolveIdentity(
+        makeRequest("/test", { authorization: "Bearer key", permit: "pk" }), db,
+        opts({ permitStore }),
+      );
+      assert.equal(result.user.id, ANON_ID, "permit sets anonymous");
+      assert.isDefined(result.specialPermit);
+      assert.isFalse(result.hasApiKey, "API key not reported when permit takes over");
+    });
+
+    it("throws on unknown permit", async function() {
+      try {
+        await resolveIdentity(
+          makeRequest("/test", { permit: "bad" }), makeDbManager(), opts(),
+        );
+        assert.fail("should have thrown");
+      } catch (err: any) {
+        assert.equal(err.status, 401);
+        assert.match(err.message, /unknown permit/);
+      }
+    });
+
+    it("throws when permit store errors", async function() {
+      try {
+        await resolveIdentity(
+          makeRequest("/test", { permit: "pk" }), makeDbManager(),
+          opts({ permitStore: makePermitStore({ getPermit: async () => { throw new Error("redis down"); } }) }),
+        );
+        assert.fail("should have thrown");
+      } catch (err: any) {
+        assert.equal(err.status, 401);
+        assert.match(err.message, /permit could not be read/);
+      }
+    });
+  });
+
+  describe("override profile", function() {
+    it("resolves user from override profile", async function() {
+      const result = await resolveIdentity(makeRequest(), makeDbManager(), {
+        ...opts(),
+        overrideProfile: async () => ALICE_PROFILE,
+      });
+      assert.equal(result.user.id, ALICE.id);
+      assert.isFalse(result.explicitAuth, "forward-auth is ambient, not explicit");
+    });
+
+    it("override profile returning null means anonymous (skip session)", async function() {
+      const sessionCalled = { value: false };
+      const result = await resolveIdentity(makeRequest(), makeDbManager(), {
+        ...opts(),
+        overrideProfile: async () => null,
+        getSessionProfile: async () => { sessionCalled.value = true; return { profile: null }; },
+      });
+      assert.equal(result.user.id, ANON_ID);
+      assert.isFalse(sessionCalled.value, "session should be skipped after null override");
+    });
+
+    it("override profile returning undefined falls through to session", async function() {
+      const result = await resolveIdentity(makeRequest(), makeDbManager(), {
+        ...opts(),
+        overrideProfile: async () => undefined,
+        getSessionProfile: async () => ({ profile: ALICE_PROFILE }),
+      });
+      assert.equal(result.user.id, ALICE.id);
+    });
+  });
+
+  describe("session", function() {
+    it("resolves user from session profile", async function() {
+      const result = await resolveIdentity(makeRequest(), makeDbManager(), {
+        ...opts(),
+        getSessionProfile: async () => ({ profile: ALICE_PROFILE }),
+      });
+      assert.equal(result.user.id, ALICE.id);
+      assert.isFalse(result.explicitAuth);
+    });
+
+    it("session with null profile falls through to anonymous", async function() {
+      const result = await resolveIdentity(makeRequest(), makeDbManager(), {
+        ...opts(),
+        getSessionProfile: async () => ({ profile: null }),
+      });
+      assert.equal(result.user.id, ANON_ID);
+    });
+  });
+
+  describe("priority", function() {
+    it("full priority: access token > boot key > permit > API key > override > session", async function() {
+      // When everything is present except access token, boot key wins.
+      const db = makeDbManager({ getUserByKey: async () => ALICE });
+      const permit: Permit = { docId: "d" };
+      const gristServer: GristServer = {
+        ...createDummyGristServer(),
+        getBootKey: () => "bk",
+        getInstallAdmin: () => ({ getAdminUser: async () => ADMIN } as InstallAdmin),
+      };
+      const permitStore = makePermitStore({ getPermit: async () => permit });
+
+      const result = await resolveIdentity(
+        makeRequest("/test", { authorization: "Bearer key", "x-boot-key": "bk", permit: "pk" }),
+        db,
+        {
+          gristServer, permitStore,
+          overrideProfile: async () => ALICE_PROFILE,
+          getSessionProfile: async () => ({ profile: ALICE_PROFILE }),
+        },
+      );
+      assert.equal(result.user.id, ADMIN.id, "boot key wins");
+
+      // Without boot key, permit wins over API key.
+      const result2 = await resolveIdentity(
+        makeRequest("/test", { authorization: "Bearer key", permit: "pk" }),
+        db,
+        {
+          ...opts({ permitStore }),
+          overrideProfile: async () => ALICE_PROFILE,
+          getSessionProfile: async () => ({ profile: ALICE_PROFILE }),
+        },
+      );
+      assert.isDefined(result2.specialPermit, "permit wins over API key");
+      assert.equal(result2.user.id, ANON_ID);
+    });
+  });
+});

--- a/test/server/lib/resolveIdentity.ts
+++ b/test/server/lib/resolveIdentity.ts
@@ -1,5 +1,6 @@
 import { ApiError } from "app/common/ApiError";
 import { UserProfile } from "app/common/LoginSessionAPI";
+import { ServiceAccount } from "app/gen-server/entity/ServiceAccount";
 import { User } from "app/gen-server/entity/User";
 import { HomeDBAuth } from "app/gen-server/lib/homedb/Interfaces";
 import { AccessTokenInfo, IAccessTokens } from "app/server/lib/AccessTokens";
@@ -8,10 +9,9 @@ import { createDummyGristServer, GristServer } from "app/server/lib/GristServer"
 import { InstallAdmin } from "app/server/lib/InstallAdmin";
 import { IPermitStore, Permit } from "app/server/lib/Permit";
 
-import { ServiceAccount } from "app/gen-server/entity/ServiceAccount";
+import { IncomingMessage } from "http";
 
 import { assert } from "chai";
-import { IncomingMessage } from "http";
 
 function makeUser(id: number, name: string, extra?: Partial<User>): User {
   return { id, name, disabledAt: null, type: "login", ...extra } as User;
@@ -65,7 +65,6 @@ function opts(extra?: Partial<Parameters<typeof resolveIdentity>[2]>): Parameter
 }
 
 describe("resolveIdentity", function() {
-
   it("returns anonymous when no credentials are provided", async function() {
     const result = await resolveIdentity(makeRequest(), makeDbManager(), opts());
     assert.equal(result.user.id, ANON_ID);
@@ -118,7 +117,7 @@ describe("resolveIdentity", function() {
 
   describe("API key", function() {
     it("resolves user from valid API key", async function() {
-      const db = makeDbManager({ getUserByKey: async (k) => k === "good" ? ALICE : undefined });
+      const db = makeDbManager({ getUserByKey: async k => k === "good" ? ALICE : undefined });
       const result = await resolveIdentity(
         makeRequest("/test", { authorization: "Bearer good" }), db, opts(),
       );
@@ -237,7 +236,7 @@ describe("resolveIdentity", function() {
     it("boot key takes priority over API key", async function() {
       const db = makeDbManager({ getUserByKey: async () => ALICE });
       const result = await resolveIdentity(
-        makeRequest("/test", { authorization: "Bearer good", "x-boot-key": "bk" }), db,
+        makeRequest("/test", { "authorization": "Bearer good", "x-boot-key": "bk" }), db,
         opts({
           gristServer: {
             ...createDummyGristServer(),
@@ -255,7 +254,7 @@ describe("resolveIdentity", function() {
     it("resolves permit as anonymous with specialPermit", async function() {
       const permit: Permit = { docId: "doc1" };
       const permitStore = makePermitStore({
-        getPermit: async (k) => k === "pk" ? permit : null,
+        getPermit: async k => k === "pk" ? permit : null,
       });
       const result = await resolveIdentity(
         makeRequest("/test", { permit: "pk" }), makeDbManager(),
@@ -370,7 +369,7 @@ describe("resolveIdentity", function() {
       const permitStore = makePermitStore({ getPermit: async () => permit });
 
       const result = await resolveIdentity(
-        makeRequest("/test", { authorization: "Bearer key", "x-boot-key": "bk", permit: "pk" }),
+        makeRequest("/test", { "authorization": "Bearer key", "x-boot-key": "bk", "permit": "pk" }),
         db,
         {
           gristServer, permitStore,


### PR DESCRIPTION
Extract a single `resolveIdentity()` function in `Authorizer.ts` that both the REST middleware (`addRequestUser`) and websocket handler (`Comm.ts`) call, so any auth method added to one path automatically works on the other. Currently they have diverged quite widely.

This would allow uses of Grist such as a console-based client, or (when some extra work) something like custom widgets that live outside the document.

The auth chain is: access token, API key, boot key, permit, override profile, session profile, anonymous fallback.

Websocket connections now support access tokens, boot keys, permits, and API keys in addition to session cookies.

Auth error responses also now return more standard json error messages instead of plain-text strings. Status codes are unchanged.
