### PR TITLE
Enables "importFromAirtable" feature implicitly

### DIFF
--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -1017,6 +1017,10 @@ export const Features = StringUnion(
 );
 export type IFeature = typeof Features.type;
 
+// Features that are enabled, even if not explicitly listed in GRIST_UI_FEATURES.
+// These should be still be disabled if listed in GRIST_HIDE_UI_ELEMENTS.
+export const ImplicitlyEnabledFeatures: IFeature[] = ["importFromAirtable"];
+
 export function isFeatureEnabled(feature: IFeature): boolean {
   return (getGristConfig().features || []).includes(feature);
 }

--- a/app/server/lib/sendAppPage.ts
+++ b/app/server/lib/sendAppPage.ts
@@ -11,7 +11,7 @@ import {
   getTermsOfServiceUrl,
   getWebinarsUrl,
   GristLoadConfig,
-  IFeature,
+  IFeature, ImplicitlyEnabledFeatures,
 } from "app/common/gristUrls";
 import { isAffirmative } from "app/common/gutil";
 import { getTagManagerSnippet } from "app/common/tagManager";
@@ -276,7 +276,8 @@ function shouldSupportAnon() {
 
 function getFeatures(): IFeature[] {
   const disabledFeatures = process.env.GRIST_HIDE_UI_ELEMENTS?.split(",") ?? [];
-  const enabledFeatures = process.env.GRIST_UI_FEATURES?.split(",") ?? Features.values;
+  const explicitFeatures = process.env.GRIST_UI_FEATURES?.split(",") ?? Features.values;
+  const enabledFeatures = explicitFeatures.concat(ImplicitlyEnabledFeatures);
   return Features.checkAll(difference(enabledFeatures, disabledFeatures));
 }
 


### PR DESCRIPTION
## Context

GRIST_UI_FEATURES explicitly lists which Grist features should be enabled. When upgrading, it's possible for new features to not be enabled by default.

This occurred with "importFromAirtable", which should be enabled by default but does not show up in installations using GRIST_UI_FEATURES.

## Proposed solution

This enables "importFromAirtable" by default, even when GRIST_UI_FEATURES is used. It can still be disabled by using GRIST_HIDE_UI_ELEMENTS.

## Related issues

https://community.getgrist.com/t/february-2026-newsletter-import-from-airtable-and-vibe-view/13717/9

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->