### PR TITLE
Fix unreadable dark mode colors in banners

### DIFF
--- a/app/client/components/Banner.ts
+++ b/app/client/components/Banner.ts
@@ -1,6 +1,6 @@
 import { colors, isNarrowScreenObs } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
-import { tokens } from "app/common/ThemePrefs.ts";
+import { tokens } from "app/common/ThemePrefs";
 
 import { Disposable, dom, DomArg, DomElementArg, makeTestId, Observable, styled } from "grainjs";
 

--- a/app/client/ui/tooltips.ts
+++ b/app/client/ui/tooltips.ts
@@ -12,7 +12,7 @@ import { colors, testId, theme, vars } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
 import { makeLinks } from "app/client/ui2018/links";
 import { menuCssClass } from "app/client/ui2018/menus";
-import { tokens } from "app/common/ThemePrefs.ts";
+import { tokens } from "app/common/ThemePrefs";
 
 import { BindableValue, dom, DomContents, DomElementArg, DomElementMethod, Observable, styled } from "grainjs";
 import merge from "lodash/merge";


### PR DESCRIPTION
## Context

Banners were using light colors in dark mode instead of dark colors, which when combined with the yellow background color of banners made text and icons almost impossible to read.

## Proposed solution

Switch to using `black` and `white` variables from `tokens` for banner colors.

## Has this been tested?

Tested manually.