### PR TITLE
feat(i18n): Add 2 translations to the links of an account breadcrumb

### DIFF
--- a/app/client/ui/AccountPage.ts
+++ b/app/client/ui/AccountPage.ts
@@ -181,11 +181,11 @@ designed to ensure that you're the only person who can access your account, even
       cssBreadcrumbs({ style: "margin-left: 16px;" },
         cssLink(
           urlState().setLinkUrl({}),
-          "Home",
+          t("Home"),
           testId("home"),
         ),
         separator(" / "),
-        dom("span", "Account"),
+        dom("span", t("Account")),
       ),
       createTopBarHome(this._appModel),
     );


### PR DESCRIPTION
## Context

I'm on a French instance and I see the menu in English.


## Proposed solution

Added 2 translations to the links of an account breadcrumb.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<img width="274" height="43" alt="image" src="https://github.com/user-attachments/assets/b5546b20-65d0-4f05-a5cc-b5d84b9a70ce" />

