### PR TITLE
Restore test for GVISOR_LIMIT_NPROC

### DIFF
--- a/test/server/Sandbox.ts
+++ b/test/server/Sandbox.ts
@@ -410,7 +410,7 @@ return 'done'
 
     it("gvisor and pyodide should fail after unreasonable number of calls to os.fork()", async function() {
       // TODO: This test fails in Jenkins CI when run with gvisor. It doesn't appear to be enforcing GVISOR_LIMIT_NPROC.
-      if (![/* "gvisor", */"pyodide"].includes(sandbox.getFlavor())) {
+      if (!["gvisor", "pyodide"].includes(sandbox.getFlavor())) {
         this.skip();
       }
 


### PR DESCRIPTION
Restore the tests to check Grist against fork bomb attack, as they pass the Github CI.

Needs more information from Grist Labs of the reason the tests fail in their internal CI.