### PR TITLE
Makes CursorSaving tests reliable

### DIFF
--- a/test/nbrowser/CursorSaving.ts
+++ b/test/nbrowser/CursorSaving.ts
@@ -239,9 +239,7 @@ describe("CursorSaving", function() {
   });
 
   async function getAnchorLink() {
-    let anchor: string = "";
-    await clipboard.lockAndPerform(async () => { anchor = await gu.getAnchor(); });
-    return anchor;
+    return await clipboard.lockAndPerform(async () => gu.getAnchor());
   }
 
   async function getDifferentAnchorLink(oldAnchorLink?: string) {

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -3909,7 +3909,7 @@ namespace gristUtils {
 
     }
 
-    public async lockAndPerform(callback: (clipboard: IClipboard) => Promise<void>) {
+    public async lockAndPerform<T>(callback: (clipboard: IClipboard) => Promise<T>) {
       this._unlock = await lock(path.resolve(getAppRoot(), "test"), {
         lockfilePath: path.join(path.resolve(getAppRoot(), "test"), ".clipboard.lock"),
         retries: {
@@ -3920,7 +3920,7 @@ namespace gristUtils {
         },
       });
       try {
-        await callback(new Clipboard());
+        return await callback(new Clipboard());
       } finally {
         await this.unlock();
       }


### PR DESCRIPTION
## Context

The CursorSaving tests wouldn't run locally due to:
- Trying to read the anchor links before they were updated to match the selected rows
- Trying to navigate to the anchor links, but not waiting for the cursors to be updated

## Proposed solution

This refactors the tests to use helpers that wait for the UI state to be fully updated before continuing.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [X] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
