### PR TITLE
Triggers: add a `previous` property to payloads for update events

### DIFF
--- a/app/server/lib/Triggers.ts
+++ b/app/server/lib/Triggers.ts
@@ -260,9 +260,20 @@ export class DocTriggers {
     const meta = { numTriggers: triggers.length, numRecords: bulkColValues.id.length };
     this._log(`Processing triggers`, meta);
 
-    const makePayload = _.memoize((rowIndex: number) =>
-      _.mapValues(bulkColValues, col => col[rowIndex]) as RowRecord,
-    );
+    const makePayload = _.memoize((rowIndex: number) => {
+      const payload = _.mapValues(bulkColValues, col => col[rowIndex]) as RowRecord;
+      const rowId = bulkColValues.id[rowIndex];
+      const recordDelta = recordDeltas.get(rowId)!;
+      if (recordDelta.existedBefore) {
+        return {
+          payload,
+          previous: {
+            ...payload, ...rowRecordFromCellDeltas(tableDelta, rowId),
+          },
+        };
+      }
+      return { payload };
+    });
 
     const result: ActionPayload[] = [];
     for (const trigger of triggers) {
@@ -315,7 +326,7 @@ export class DocTriggers {
 
       for (const action of actions) {
         for (const rowIndex of rowIndexesToSend) {
-          const event = { id: action.id, action, payload: makePayload(rowIndex) };
+          const event = { id: action.id, action, ...makePayload(rowIndex) };
           result.push(event);
         }
       }

--- a/app/server/lib/WebhookQueue.ts
+++ b/app/server/lib/WebhookQueue.ts
@@ -34,6 +34,7 @@ promisifyAll(RedisClient.prototype);
 export interface ActionPayload<A extends TriggerAction = TriggerAction> {
   id: string; // Action id (each action has unique id, for webhooks this a an id from home db)
   payload: RowRecord; // The record data to use with the action
+  previous?: RowRecord; // The previous state of the record, if any
   action: A;
 }
 


### PR DESCRIPTION
## Context

When looking at the payload of an `update` webhook, it can be helpful to know what was the previous state of a changed record. This adds a `previous` field.

## Proposed solution

An extra top-level field seems like a necessary implementation detail for two reasons. One, it is more backwards-compatible to add a new field than modifying an existing field. Two, any name for the field inside the existing `payload` field could clash with a field (column name) supplied by the user.

## Related issues

closes: #2131 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
