### PR TITLE
Fix formatting for Advanced Admin Controls in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ If you evaluate Grist by using the hosted version at [getgrist.com](https://getg
     - If you have many users who need help building documents or working with data, you may care about this one.
   * [Invite Notifications](https://support.getgrist.com/self-managed/#how-do-i-set-up-email-notifications) (2025)
     - When a user is added to a document, or a workspace, or a site, with email notifications they will get emailed a link to access the resource.
-  - This link isn't special, with `grist-core` you can just send a link yourself or a colleague.
-  - For a big Grist installation with users who aren't in close communication, emails might be nice? Hard to guess if you'll care about this one.
+    - This link isn't special, with `grist-core` you can just send a link yourself or a colleague.
+    - For a big Grist installation with users who aren't in close communication, emails might be nice? Hard to guess if you'll care about this one.
   * [Document Change and Comment Notifications](https://support.getgrist.com/document-settings/#notifications) (2025)
     - You can achieve change notifications in `grist-core` using webhooks, but it is less convenient.
-  - People have been asking for this one for years. If you need an excuse to get your boss to pay for Grist, this might finally be the one that works?
+    - People have been asking for this one for years. If you need an excuse to get your boss to pay for Grist, this might finally be the one that works?
 
 ## Using Grist
 


### PR DESCRIPTION
## Context

<!-- Please include a summary of the change, with motivation and context -->
<!-- Bonus: if you are comfortable writing one, please insert a user-story https://en.wikipedia.org/wiki/User_story#Common_templates -->

Bullet points weren't indented for the Advanced Admin Controls in the README file.

## Proposed solution

<!-- Describe here how you address the issue -->

Indented the bullets.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [X] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->


