### PR TITLE
Makes Airtable import single record link fields as "Ref" columns

### DIFF
--- a/app/common/airtable/AirtableSchemaImporter.ts
+++ b/app/common/airtable/AirtableSchemaImporter.ts
@@ -380,7 +380,7 @@ const AirtableFieldMappers: { [type: string]: AirtableFieldMapper } = {
         originalId: field.id,
         desiredGristId: field.name,
         label: field.name,
-        type: "RefList",
+        type: field.options?.prefersSingleRecordLink ? "Ref" : "RefList",
         ref: {
           originalTableId: field.options?.linkedTableId,
         },

--- a/test/common/airtable/AirtableSchemaImporter.ts
+++ b/test/common/airtable/AirtableSchemaImporter.ts
@@ -448,34 +448,47 @@ describe("AirtableSchemaImporter", function() {
       });
     });
 
-    it("correctly converts a multipleRecordLinks column", () => {
-      const field = {
-        ...createBasicAirtableField("A multipleRecordLinks column", "multipleRecordLinks"),
-        options: {
-          linkedTableId: firstTableId,
-          isReversed: false,
-          prefersSingleRecordLink: false,
-          inverseLinkFieldId: "",
-        },
-      };
-      const inverseField = {
-        ...createBasicAirtableField("An inverse multipleRecordLinks column", "multipleRecordLinks"),
-        options: {
-          linkedTableId: firstTableId,
-          isReversed: true,
-          prefersSingleRecordLink: false,
-          inverseLinkFieldId: field.id,
-        },
-      };
-      field.options.inverseLinkFieldId = inverseField.id;
-      const fieldDependenciesByTable = {
-        [firstTableId]: [inverseField],
-      };
-      const { testField, testColumn } = convertAirtableField({ field, fieldDependenciesByTable });
-      runBasicFieldTest(testField, testColumn);
-      assert.deepInclude(testColumn, {
-        type: "RefList",
-        ref: { originalTableId: firstTableId },
+    [
+      {
+        name: "single record",
+        options: { prefersSingleRecordLink: true },
+        expectedColProps: { type: "Ref" },
+      },
+      {
+        name: "multiple records",
+        options: { prefersSingleRecordLink: false },
+        expectedColProps: { type: "RefList" },
+      },
+    ].forEach(({ name: variantName, options: variantOptions, expectedColProps }) => {
+      it(`correctly converts a multipleRecordLinks column - ${variantName}`, () => {
+        const field = {
+          ...createBasicAirtableField("A multipleRecordLinks column", "multipleRecordLinks"),
+          options: {
+            linkedTableId: firstTableId,
+            isReversed: false,
+            inverseLinkFieldId: "",
+            ...variantOptions,
+          },
+        };
+        const inverseField = {
+          ...createBasicAirtableField("An inverse multipleRecordLinks column", "multipleRecordLinks"),
+          options: {
+            linkedTableId: firstTableId,
+            isReversed: true,
+            inverseLinkFieldId: field.id,
+            ...variantOptions,
+          },
+        };
+        field.options.inverseLinkFieldId = inverseField.id;
+        const fieldDependenciesByTable = {
+          [firstTableId]: [inverseField],
+        };
+        const { testField, testColumn } = convertAirtableField({ field, fieldDependenciesByTable });
+        runBasicFieldTest(testField, testColumn);
+        assert.deepInclude(testColumn, {
+          ref: { originalTableId: firstTableId },
+          ...expectedColProps,
+        });
       });
     });
 


### PR DESCRIPTION
## Context

Airtable has an option on the "multipleRecordLinks" field that forces the Airtable UI to only allow a single record to be linked, analogous to our "Ref" column.

This option doesn't guarantee cells only contain a single record. The field may still contain multiple record links, if inserted via the API (for example). 

Currently, "multipleRecordLinks" fields are imported as "RefList" columns, regardless of whether or not this option is set.

## Proposed solution

This checks the `prefersSingleRecordLink` on the Airtable field, and imports it as a "Ref" column if set (instead of a "RefList").

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [X] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

