### PR TITLE
DocIcon: when the second word of the doc name is an emoji, ignore it

### DIFF
--- a/app/client/ui/DocIcon.ts
+++ b/app/client/ui/DocIcon.ts
@@ -75,6 +75,11 @@ function getIconFromName(name: string) {
     .join("")
     // https://www.regular-expressions.info/unicode.html
     .replace(/[^\p{L}\p{Nd}]$/u, "")
+    // Circumvent weird behavior (regression?) found in Chromium since r1566276
+    // Normally at this point, the above regex should have removed any emoji.
+    // See this discussion for more information:
+    // https://github.com/gristlabs/grist-core/pull/2170/changes#r2923385260
+    .replace(emojiRegex(), "")
     .toUpperCase();
 }
 


### PR DESCRIPTION
## Context

When running `GREP_TESTS="DocMenu" yarn run test:projects -- --bail` locally, the tests don't pass.
The line that does not pass is this one: https://github.com/gristlabs/grist-core/blob/ce8aaffdefeab50e1bf6b2fc29f1b322228298f9/test/projects/DocMenu.ts#L118

It's weird that the test pass on the CI (due to Chrome version? 🤯 I have checked using Chromium 144)

When testing the case manually, I can confirm that the implementation seems  wrong (⚠️ Needs Chromium in version 145.0.7632.159).

## Proposed solution

If the second word of the doc name is an emoji, ignore it for the document icon.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

When entering  the following doc name: `A😀 😀` (with a space between the two emojis) 

#### Before

<img width="488" height="372" alt="the doc icon is a letter and the emoji" src="https://github.com/user-attachments/assets/d8b5cf17-000b-457e-abb4-32a12df7c919" />


#### After

<img width="492" height="378" alt="the doc icon is only a letter" src="https://github.com/user-attachments/assets/161dd6a1-90b7-4455-afe8-150de7a77a4c" />