### PR TITLE
Add native node:sqlite adapter with worker-per-document architecture

### DIFF
--- a/PORT.md
+++ b/PORT.md
@@ -1,0 +1,197 @@
+# Porting from node-sqlite3 to Node.js built-in `node:sqlite`
+
+## What this is
+
+A prototype adapter that lets Grist use Node.js's built-in `node:sqlite`
+module instead of the `@gristlabs/sqlite3` native addon.
+
+Activate with `GRIST_SQLITE_VARIANT=native` (wired into `SQLiteDB.ts`'s
+`getVariant()`).
+
+## Architecture: worker-per-document
+
+`node:sqlite`'s `DatabaseSync` API is synchronous — it blocks the thread
+during SQLite operations. To keep the main event loop responsive, each
+database connection runs in a dedicated `Worker` thread:
+
+```
+Main thread                          Worker thread (one per document)
+─────────────────────────────────    ──────────────────────────────────
+SqliteNative.ts                      SqliteNativeWorker.ts
+  NativeSqliteDatabaseAdapter          DatabaseSync connection
+    ._call(method, args)  ──────►      handleMessage()
+       postMessage({id,method,args})     dispatch(method, args)
+    ◄──────                              postMessage({id, result})
+       resolve pending promise
+```
+
+**Why one worker per document:** Grist already uses one `DocStorage` per
+`ActiveDoc`. A shared pool would require cross-document serialization and
+complicate connection lifecycle. One-to-one mapping is simple, matches the
+existing model, and avoids contention.
+
+**Thread overhead:** ~2 MB per Worker. For typical Grist deployments with
+tens of open documents, this is negligible. The overhead is comparable to
+the existing `@gristlabs/sqlite3` thread pool (which uses one thread per
+connection internally).
+
+## Files
+
+- `app/server/lib/SqliteNative.ts` — main-thread adapter implementing
+  `MinDB` by dispatching to a Worker thread via `postMessage`
+- `app/server/lib/SqliteNativeWorker.ts` — worker thread script that owns
+  the `DatabaseSync` connection and handles all SQLite operations
+- `test/server/lib/SqliteNative.ts` — 28 tests
+- `app/server/lib/SQLiteDB.ts` — one-line change to `getVariant()` for
+  `GRIST_SQLITE_VARIANT=native`
+
+## Test results
+
+106 passing, 0 failing across 5 test suites with `GRIST_SQLITE_VARIANT=native`:
+
+| Suite | Pass | Fail |
+|---|---|---|
+| SqliteNative (new) | 28 | 0 |
+| DocStorage | 29 | 0 |
+| DocStorageQuery | 6 | 0 |
+| ActionHistory | 26 | 0 |
+| SQLiteDB | 17 | 0 |
+
+All tests also pass with the default `@gristlabs/sqlite3` variant (78
+passing). The DQS fixes to test SQL are backward compatible.
+
+## What went well
+
+**Grist's abstraction layer made this easy.** The `MinDB`/`SqliteVariant`
+interfaces in `SqliteCommon.ts` are well designed. The new adapter follows
+the same pattern as the existing `SqliteBetter.ts` (for better-sqlite3)
+in grist-static.
+
+**API coverage is good.** `node:sqlite` covers all the core operations Grist
+needs: `exec`, `prepare`/`run`/`get`/`all`, custom aggregate functions
+(for `grist_marshal`), backup, and open modes.
+
+**Worker threads are a natural fit.** One worker per document matches
+Grist's existing one-connection-per-DocStorage model. The async
+`postMessage` boundary maps cleanly onto the `MinDB` async interface.
+
+**No native compilation.** The main win: eliminates the `@gristlabs/sqlite3`
+native addon dependency entirely, simplifying builds and cross-platform
+support.
+
+## What was a problem
+
+### DQS (Double-Quoted Strings) — the biggest issue
+
+`node:sqlite` disables DQS by default, which is correct per the SQL
+standard. SQLite's DQS misfeature treats `"hello"` as a string literal when
+no column named `hello` exists. `@gristlabs/sqlite3` allows this.
+
+Impact and fixes:
+- `allMarshalQuery()` in `SqliteCommon.ts` relies on DQS — it uses
+  `quoteIdent()` (double quotes) to embed column names as string literals in
+  a UNION. The adapter overrides `allMarshal` with proper `'name' AS "name"`
+  syntax.
+- Several tests used `VALUES ("hello")` instead of `VALUES ('hello')`.
+  Fixed to use single-quoted string literals (backtick JS template literals
+  where needed). Production code was already clean.
+- The ATTACH-blocking test expected a specific error message from
+  `sqlite3_limit`; updated to also accept the authorizer's "not authorized".
+
+DQS was arguably a latent bug that the old SQLite wrapper was masking.
+
+### Error code differences
+
+`node:sqlite` throws errors with `code: 'ERR_SQLITE_ERROR'` and a numeric
+`errcode`, while `@gristlabs/sqlite3` uses string codes like
+`'SQLITE_ERROR'`, `'SQLITE_READONLY'`, `'SQLITE_CANTOPEN'`. Grist code
+checks both `err.code` and `err.message` for these strings.
+
+Fixed with a translation layer in `SqliteNativeWorker.ts` that maps numeric
+errcodes (including extended codes like 2067 = `SQLITE_CONSTRAINT_UNIQUE`)
+to the expected string codes and prefixes messages.
+
+### Uint8Array vs Buffer (double conversion)
+
+`node:sqlite` returns `Uint8Array` for BLOB columns. `Buffer` extends
+`Uint8Array` but they differ on `.toString()`: `Buffer.toString()` gives
+UTF-8 text, `Uint8Array.toString()` gives comma-separated numbers.
+
+With the worker architecture, this requires conversion in **two places**:
+1. In the worker (`fixRow()`) — converts before sending results
+2. On the main thread (`_fixRow()`) — converts again because structured
+   clone across the worker boundary turns Buffer back into Uint8Array
+
+### undefined parameters
+
+`node:sqlite` rejects `undefined` as a bound parameter (throws
+`TypeError`). `@gristlabs/sqlite3` silently treats it as NULL. Fixed by
+converting `undefined` to `null` in `tweakParams()`.
+
+### ATTACH limiting mechanism
+
+`@gristlabs/sqlite3` uses `sqlite3_limit(SQLITE_LIMIT_ATTACHED, 0)`.
+The `node:sqlite` constructor `limits: { attach: 0 }` option exists but
+doesn't work on Node 24. Used `setAuthorizer()` to deny `SQLITE_ATTACH`
+instead — functionally equivalent but produces a different error message.
+
+### Missing `interrupt()`
+
+`node:sqlite` doesn't expose `sqlite3_interrupt()`. The adapter reports
+`canInterrupt: false`. This means long-running queries can't be cancelled,
+which matters for server responsiveness but isn't a correctness issue.
+With the worker architecture, adding interrupt support would require a
+cross-thread signaling mechanism (e.g. `SharedArrayBuffer` or a control
+channel).
+
+### Backup API mismatch
+
+`node:sqlite` has an async `backup(db, path, options)` function instead of
+the step-based `db.backup(path).step(pages, cb)` API. The adapter exposes
+`backupTo()` directly rather than shimming the step-based interface.
+`backupSqliteDatabase.ts` would need a separate code path to use this.
+
+### Maturity
+
+`node:sqlite` is experimental on Node 22 (Grist's current target per
+`.nvmrc`), requiring `--experimental-sqlite`. It reached release candidate
+status in Node 25.7. Practical deployment depends on Grist's Node version
+policy.
+
+### Type definitions
+
+The project's `@types/node` doesn't include `node:sqlite` types. The adapter
+uses `require()` and `any` casts. Not a runtime issue but reduces type
+safety.
+
+## Remaining concerns
+
+### Node version requirement (the real gate)
+
+The worker architecture, DQS handling, error translation, and type
+conversions are all solved — 106/106 tests pass. The blocker for production
+use is that `node:sqlite` is experimental on Node 22 (Grist's current
+target), requiring `--experimental-sqlite`, and only reached stable in
+Node 25.7. Deploying means either accepting API churn risk on Node 22 or
+waiting for Grist to bump its Node version.
+
+### No clean query cancellation
+
+`worker.terminate()` can kill a runaway query, but it destroys the entire
+connection rather than cancelling one statement. A real fix requires Node.js
+to expose `sqlite3_interrupt()`, or a `SharedArrayBuffer`-based signaling
+mechanism to the worker thread.
+
+### Structured clone overhead
+
+Every result set is deep-copied across the worker boundary (only raw
+`Buffer`/`Uint8Array` values transfer zero-copy). For typical Grist
+workloads this is likely fine, but bulk operations like large imports could
+see measurable overhead vs. in-process `@gristlabs/sqlite3`.
+
+### DQS dependency in shared code
+
+The adapter overrides `allMarshal` to avoid the DQS-dependent
+`allMarshalQuery()` in `SqliteCommon.ts`. If any other caller hits
+`allMarshalQuery()` directly, it would break with the native adapter.
+Worth auditing.

--- a/app/server/lib/SQLiteDB.ts
+++ b/app/server/lib/SQLiteDB.ts
@@ -94,6 +94,10 @@ export type RunResult = MinRunResult;
 const asyncLocalStorage = new AsyncLocalStorage<boolean>();
 
 function getVariant(): SqliteVariant {
+  if (process.env.GRIST_SQLITE_VARIANT === 'native') {
+    const { NativeSqliteVariant } = require("app/server/lib/SqliteNative");
+    return new NativeSqliteVariant();
+  }
   return create.getSqliteVariant?.() || new NodeSqliteVariant();
 }
 

--- a/app/server/lib/SqliteCommon.ts
+++ b/app/server/lib/SqliteCommon.ts
@@ -138,28 +138,38 @@ interface GristMarshalIntermediateValue {
 }
 
 /**
+ * Quote a string as a SQL string literal (single quotes, with escaping).
+ */
+export function quoteLiteral(s: string): string {
+  return "'" + s.replace(/'/g, "''") + "'";
+}
+
+/**
  * Run Grist marshalling as a SQLite query, assuming
  * a custom aggregation has been added as "grist_marshal".
  * The marshalled result needs to contain the column
- * identifiers embedded in it. This is a little awkward
- * to organize - hence the hacky UNION here. This is
- * for compatibility with the existing marshalling method,
- * which could be replaced instead.
+ * identifiers embedded in it. The first row of the UNION
+ * embeds column names as single-quoted string literals
+ * (not double-quoted identifiers, which would rely on DQS).
  */
 export async function allMarshalQuery(db: MinDB, sql: string, ...params: any[]): Promise<Buffer> {
   const statement = await db.prepare(sql);
   const columns = statement.columns();
   const quotedColumnList = columns.map(quoteIdent).join(",");
+  const nameExprs = columns.map(
+    (c: string) => quoteLiteral(c) + " AS " + quoteIdent(c)
+  ).join(",");
   const query = await db.all(`select grist_marshal(${quotedColumnList}) as buf FROM ` +
-    `(select ${quotedColumnList} UNION ALL select * from (` + sql + "))", ..._fixParameters(params));
+    `(select ${nameExprs} UNION ALL select * from (` + sql + "))", ...fixParameters(params));
   return query[0].buf;
 }
 
 /**
  * Booleans need to be cast to 1 or 0 for SQLite.
  * The node-sqlite3 wrapper does this automatically, but other
- * wrappers do not.
+ * wrappers do not. Also converts undefined to null for wrappers
+ * that reject undefined (e.g. node:sqlite).
  */
-function _fixParameters(params: any[]) {
-  return params.map(p => p === true ? 1 : (p === false ? 0 : p));
+export function fixParameters(params: any[]) {
+  return params.map(p => p === true ? 1 : (p === false ? 0 : (p === undefined ? null : p)));
 }

--- a/app/server/lib/SqliteNative.ts
+++ b/app/server/lib/SqliteNative.ts
@@ -1,0 +1,227 @@
+/**
+ * SQLite adapter using Node.js built-in node:sqlite module (available from Node 22.5+).
+ *
+ * Each database connection runs in a dedicated Worker thread, so SQLite's
+ * synchronous operations don't block the main event loop. One worker per
+ * Grist document matches the existing one-connection-per-DocStorage model.
+ *
+ * The worker script is SqliteNativeWorker.ts, which owns the DatabaseSync
+ * and handles all SQLite operations. This file is the main-thread adapter
+ * that implements MinDB by sending messages to the worker.
+ *
+ * Status: prototype. Requires Node 22.5+ with --experimental-sqlite flag,
+ * or Node 25.7+ where it is stable.
+ *
+ * Known limitations vs @gristlabs/sqlite3:
+ *  - No interrupt() support (node:sqlite doesn't expose sqlite3_interrupt)
+ *  - Backup uses node:sqlite's single-call async backup()
+ *  - Structured clone overhead for parameters and results crossing the
+ *    thread boundary (Buffers are transferred zero-copy)
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { Worker } from "worker_threads";
+
+import { OpenMode } from "app/server/lib/SQLiteDB";
+import {
+  MinDB,
+  MinDBOptions,
+  MinRunResult,
+  PreparedStatement,
+  ResultRow,
+  SqliteVariant,
+} from "app/server/lib/SqliteCommon";
+
+/**
+ * Resolves the path to the compiled worker script.
+ * In development the source is in app/server/lib/ but the compiled JS
+ * is in _build/app/server/lib/.
+ */
+function getWorkerPath(): string {
+  // __dirname at runtime is _build/app/server/lib (compiled output).
+  return path.join(__dirname, 'SqliteNativeWorker.js');
+}
+
+
+export class NativeSqliteVariant implements SqliteVariant {
+  public opener(dbPath: string, mode: OpenMode): Promise<MinDB> {
+    return NativeSqliteDatabaseAdapter.opener(dbPath, mode);
+  }
+}
+
+
+export class NativeSqliteDatabaseAdapter implements MinDB {
+  private _worker: Worker;
+  private _nextId = 1;
+  private _pending = new Map<number, { resolve: (v: any) => void; reject: (e: Error) => void }>();
+  private _closed = false;
+
+  public static async opener(dbPath: string, mode: OpenMode): Promise<MinDB> {
+    const readOnly = mode === OpenMode.OPEN_READONLY;
+
+    // node:sqlite doesn't have a fileMustExist option. For OPEN_EXISTING
+    // (readwrite but no create), check existence manually.
+    if (mode === OpenMode.OPEN_EXISTING) {
+      if (!fs.existsSync(dbPath)) {
+        const err: any = new Error(`SQLITE_CANTOPEN: unable to open database file`);
+        err.code = 'SQLITE_CANTOPEN';
+        throw err;
+      }
+    }
+
+    const adapter = new NativeSqliteDatabaseAdapter();
+    await adapter._call('open', dbPath, readOnly);
+    return adapter;
+  }
+
+  private constructor() {
+    this._worker = new Worker(getWorkerPath());
+    this._worker.on('message', (msg: { id: number; result?: any; error?: { message: string; code?: string } }) => {
+      const pending = this._pending.get(msg.id);
+      if (!pending) { return; }
+      this._pending.delete(msg.id);
+      if (msg.error) {
+        const err: any = new Error(msg.error.message);
+        if (msg.error.code) { err.code = msg.error.code; }
+        pending.reject(err);
+      } else {
+        pending.resolve(msg.result);
+      }
+    });
+    this._worker.on('error', (err) => {
+      this._closed = true;
+      for (const pending of this._pending.values()) {
+        pending.reject(err);
+      }
+      this._pending.clear();
+    });
+    this._worker.on('exit', (code) => {
+      this._closed = true;
+      if (this._pending.size > 0) {
+        const err = new Error(`Worker exited with code ${code}`);
+        for (const pending of this._pending.values()) {
+          pending.reject(err);
+        }
+        this._pending.clear();
+      }
+    });
+  }
+
+  /**
+   * Send a method call to the worker and return a promise for the result.
+   */
+  private _call(method: string, ...args: any[]): Promise<any> {
+    if (this._closed && method !== 'close') {
+      return Promise.reject(new Error('Database is closed'));
+    }
+    return new Promise((resolve, reject) => {
+      const id = this._nextId++;
+      this._pending.set(id, { resolve, reject });
+      this._worker.postMessage({ id, method, args });
+    });
+  }
+
+  /**
+   * Structured clone across the worker boundary converts Buffer to Uint8Array.
+   * Convert back so callers get the Buffer methods they expect (e.g. toString('utf8')).
+   */
+  private _fixRow(row: any): any {
+    if (!row) { return row; }
+    for (const key of Object.keys(row)) {
+      if (row[key] instanceof Uint8Array && !Buffer.isBuffer(row[key])) {
+        row[key] = Buffer.from(row[key]);
+      }
+    }
+    return row;
+  }
+
+  public async exec(sql: string): Promise<void> {
+    await this._call('exec', sql);
+  }
+
+  public async run(sql: string, ...params: any[]): Promise<MinRunResult> {
+    return this._call('run', sql, ...params);
+  }
+
+  public async get(sql: string, ...params: any[]): Promise<ResultRow | undefined> {
+    const row = await this._call('get', sql, ...params);
+    return this._fixRow(row);
+  }
+
+  public async all(sql: string, ...params: any[]): Promise<ResultRow[]> {
+    const rows = await this._call('all', sql, ...params);
+    return rows.map((r: any) => this._fixRow(r));
+  }
+
+  public async prepare(sql: string): Promise<PreparedStatement> {
+    const { stmtId, columns } = await this._call('stmtPrepare', sql);
+    return new WorkerPreparedStatement(
+      (method: string, ...args: any[]) => this._call(method, ...args),
+      stmtId, columns,
+    );
+  }
+
+  public async runAndGetId(sql: string, ...params: any[]): Promise<number> {
+    return this._call('runAndGetId', sql, ...params);
+  }
+
+  public async allMarshal(sql: string, ...params: any[]): Promise<Buffer> {
+    // Dispatched to the worker as a single call (not via allMarshalQuery)
+    // so the result Buffer can be transferred zero-copy.
+    const result = await this._call('allMarshal', sql, ...params);
+    return Buffer.isBuffer(result) ? result : Buffer.from(result);
+  }
+
+  public async close(): Promise<void> {
+    this._closed = true;
+    await this._call('close');
+    await this._worker.terminate();
+  }
+
+  public async limitAttach(maxAttach: number): Promise<void> {
+    await this._call('limitAttach', maxAttach);
+  }
+
+  // node:sqlite does not expose sqlite3_interrupt().
+  // interrupt is optional in MinDB, so we simply don't provide it.
+
+  public getOptions(): MinDBOptions {
+    return {
+      canInterrupt: false,
+      bindableMethodsProcessOneStatement: true,
+    };
+  }
+
+  /**
+   * Perform a backup using node:sqlite's built-in backup() function.
+   */
+  public async backupTo(
+    destPath: string,
+    options?: { rate?: number }
+  ): Promise<void> {
+    await this._call('backupTo', destPath, options?.rate);
+  }
+
+}
+
+
+class WorkerPreparedStatement implements PreparedStatement {
+  constructor(
+    private _call: (method: string, ...args: any[]) => Promise<any>,
+    private _stmtId: number,
+    private _columns: string[],
+  ) {}
+
+  public async run(...params: any[]): Promise<MinRunResult> {
+    return this._call('stmtRun', this._stmtId, ...params);
+  }
+
+  public async finalize(): Promise<void> {
+    await this._call('stmtFinalize', this._stmtId);
+  }
+
+  public columns(): string[] {
+    return this._columns;
+  }
+}

--- a/app/server/lib/SqliteNativeWorker.ts
+++ b/app/server/lib/SqliteNativeWorker.ts
@@ -1,0 +1,213 @@
+/**
+ * Worker thread script for SqliteNative.
+ *
+ * Owns a DatabaseSync connection and processes requests from the main
+ * thread via parentPort messages. One worker per Grist document.
+ *
+ * Message protocol:
+ *   Main → Worker: { id, method, args }
+ *   Worker → Main: { id, result } | { id, error: { message, code } }
+ *
+ * Special methods:
+ *   open(dbPath, readOnly) — create DatabaseSync, register aggregate, set authorizer
+ *   close() — close the database
+ *   stmtPrepare(sql) — prepare a statement, return { stmtId, columns }
+ *   stmtRun(stmtId, ...params) — run a prepared statement
+ *   stmtFinalize(stmtId) — release a prepared statement
+ *   limitAttach(maxAttach) — allow/deny ATTACH
+ *   backupTo(destPath, rate) — backup via node:sqlite backup()
+ *   exec, run, get, all, runAndGetId, allMarshal — standard MinDB methods
+ */
+
+import { parentPort } from "worker_threads";
+
+const nodeSqlite: any = require("node:sqlite");
+const { DatabaseSync: DatabaseSyncClass, constants: sqliteConstants, backup: sqliteBackup } = nodeSqlite;
+
+// Loaded via require (not import) to work from the compiled _build directory.
+// node:sqlite also uses require because @types/node doesn't include its types.
+const { gristMarshal, fixParameters, quoteLiteral } = require("app/server/lib/SqliteCommon");
+const { quoteIdent } = require("app/server/lib/SQLiteDB");
+
+let db: any = null;
+let attachAllowed = false;
+let nextStmtId = 1;
+const statements = new Map<number, any>();
+
+/**
+ * Map SQLite numeric error codes to string codes matching @gristlabs/sqlite3.
+ */
+const SQLITE_ERRCODE_MAP: Record<number, string> = {
+  1: 'SQLITE_ERROR',
+  5: 'SQLITE_BUSY',
+  8: 'SQLITE_READONLY',
+  9: 'SQLITE_INTERRUPT',
+  14: 'SQLITE_CANTOPEN',
+  19: 'SQLITE_CONSTRAINT',
+  23: 'SQLITE_AUTH',
+};
+
+function translateError(e: any): { message: string; code?: string } {
+  let code = e?.code;
+  let message = e?.message || String(e);
+  if (code === 'ERR_SQLITE_ERROR' && typeof e.errcode === 'number') {
+    const sqliteCode = SQLITE_ERRCODE_MAP[e.errcode]
+      || SQLITE_ERRCODE_MAP[e.errcode & 0xff]
+      || `SQLITE_ERRCODE_${e.errcode}`;
+    code = sqliteCode;
+    if (!message.startsWith(sqliteCode)) {
+      message = `${sqliteCode}: ${message}`;
+    }
+  }
+  return { message, code };
+}
+
+/**
+ * Handle a single request from the main thread.
+ */
+async function handleMessage(msg: { id: number; method: string; args: any[] }) {
+  const { id, method, args } = msg;
+  try {
+    const result = await dispatch(method, args);
+    // For Buffer results (allMarshal), transfer zero-copy when possible.
+    // Large Buffers own their ArrayBuffer; small ones share Node's 8KB pool
+    // and can't be transferred, so fall back to structured clone (cheap copy).
+    if (Buffer.isBuffer(result) &&
+        result.byteOffset === 0 && result.byteLength === result.buffer.byteLength) {
+      parentPort!.postMessage({ id, result }, [result.buffer]);
+    } else {
+      parentPort!.postMessage({ id, result });
+    }
+  } catch (e) {
+    parentPort!.postMessage({ id, error: translateError(e) });
+  }
+}
+
+async function dispatch(method: string, args: any[]): Promise<any> {
+  switch (method) {
+    case 'open': {
+      const [dbPath, readOnly] = args;
+      db = new DatabaseSyncClass(dbPath, { readOnly });
+      // Register grist_marshal aggregate.
+      db.aggregate('grist_marshal', {
+        varargs: true,
+        start: gristMarshal.initialize,
+        step: gristMarshal.step,
+        result: (accum: any) => Buffer.from(gristMarshal.finalize(accum)),
+      });
+      // Block ATTACH by default.
+      db.setAuthorizer((actionCode: number) => {
+        if (actionCode === sqliteConstants.SQLITE_ATTACH && !attachAllowed) {
+          return sqliteConstants.SQLITE_DENY;
+        }
+        return sqliteConstants.SQLITE_OK;
+      });
+      return;
+    }
+
+    case 'close':
+      statements.clear();
+      if (db) { db.close(); db = null; }
+      return;
+
+    case 'exec':
+      db.exec(args[0]);
+      return;
+
+    // Note: run/get/all each call db.prepare() inline without explicit finalization.
+    // This is fine — node:sqlite's DatabaseSync prepared statements are lightweight
+    // synchronous objects that are GC'd automatically (same as better-sqlite3).
+    // The stmtPrepare/stmtFinalize path exists for callers that need to reuse a
+    // statement across multiple calls, not because finalization is required.
+
+    case 'run': {
+      const [sql, ...params] = args;
+      const stmt = db.prepare(sql);
+      const result = stmt.run(...fixParameters(params));
+      return { changes: Number(result.changes) };
+    }
+
+    case 'get': {
+      const [sql, ...params] = args;
+      const stmt = db.prepare(sql);
+      return stmt.get(...fixParameters(params)) ?? undefined;
+    }
+
+    case 'all': {
+      const [sql, ...params] = args;
+      const stmt = db.prepare(sql);
+      return stmt.all(...fixParameters(params));
+    }
+
+    case 'runAndGetId': {
+      const [sql, ...params] = args;
+      const stmt = db.prepare(sql);
+      const result = stmt.run(...fixParameters(params));
+      const rid = result.lastInsertRowid;
+      if (typeof rid === 'bigint') {
+        if (rid > BigInt(Number.MAX_SAFE_INTEGER)) {
+          throw new Error('runAndGetId: lastInsertRowid exceeds safe integer range');
+        }
+        return Number(rid);
+      }
+      return rid;
+    }
+
+    case 'allMarshal': {
+      const [sql, ...params] = args;
+      const probe = db.prepare(sql);
+      const columns: string[] = probe.columns().map((c: any) => c.name);
+      const quotedColumnList = columns.map(quoteIdent).join(",");
+      const nameExprs = columns.map(
+        (c: string) => quoteLiteral(c) + " AS " + quoteIdent(c)
+      ).join(",");
+      const marshalStmt = db.prepare(
+        `SELECT grist_marshal(${quotedColumnList}) AS buf FROM ` +
+        `(SELECT ${nameExprs} UNION ALL SELECT * FROM (${sql}))`
+      );
+      const query = marshalStmt.all(...fixParameters(params));
+      const buf = query[0].buf;
+      return Buffer.isBuffer(buf) ? buf : Buffer.from(buf);
+    }
+
+    case 'stmtPrepare': {
+      const [sql] = args;
+      const stmt = db.prepare(sql);
+      const stmtId = nextStmtId++;
+      statements.set(stmtId, stmt);
+      const columns = stmt.columns().map((c: any) => c.name);
+      return { stmtId, columns };
+    }
+
+    case 'stmtRun': {
+      const [stmtId, ...params] = args;
+      const stmt = statements.get(stmtId);
+      if (!stmt) { throw new Error(`No prepared statement with id ${stmtId}`); }
+      const result = stmt.run(...fixParameters(params));
+      return { changes: Number(result.changes) };
+    }
+
+    case 'stmtFinalize': {
+      const [stmtId] = args;
+      statements.delete(stmtId);
+      return;
+    }
+
+    case 'limitAttach': {
+      attachAllowed = args[0] > 0;
+      return;
+    }
+
+    case 'backupTo': {
+      const [destPath, rate] = args;
+      await sqliteBackup(db, destPath, { rate: rate ?? 100 });
+      return;
+    }
+
+    default:
+      throw new Error(`Unknown method: ${method}`);
+  }
+}
+
+// Listen for messages from main thread.
+parentPort!.on('message', handleMessage);

--- a/test/server/lib/SQLiteDB.ts
+++ b/test/server/lib/SQLiteDB.ts
@@ -79,7 +79,7 @@ describe("SQLiteDB", function() {
       /unable to open database/);
     sdb = await SQLiteDB.openDB(dbPath("test2A"), schemaInfo, OpenMode.OPEN_READONLY);
     assert.sameDeepMembers(await getTableNames(sdb), ["Foo", "Bar"]);
-    await assert.isRejected(sdb.run('INSERT INTO Foo (A) VALUES ("hello")'),
+    await assert.isRejected(sdb.run(`INSERT INTO Foo (A) VALUES ('hello')`),
       /readonly database/);
     await sdb.close();
 
@@ -387,13 +387,13 @@ describe("SQLiteDB", function() {
       const sdb = await SQLiteDB.openDB(dbPath("testTrans1"), schemaInfo, OpenMode.OPEN_CREATE);
 
       // Simple case: just run a statement and it should succeed.
-      await sdb.execTransaction(() => sdb.exec('INSERT INTO Foo (A) VALUES ("hello")'));
+      await sdb.execTransaction(() => sdb.exec(`INSERT INTO Foo (A) VALUES ('hello')`));
       assert.deepEqual(await sdb.all("SELECT A FROM Foo"), [{ A: "hello" }]);
 
       // Now try running one statement that should succeed, and then failing inside the
       // transaction; it should be rolled back along with the first statement.
       await assert.isRejected(sdb.execTransaction(async () => {
-        await sdb.exec('INSERT INTO Foo (A) VALUES ("good bye")');
+        await sdb.exec(`INSERT INTO Foo (A) VALUES ('good bye')`);
         throw new Error("Fake error");
       }), /Fake error/);
       // Ensure that the new value did NOT get added.
@@ -407,16 +407,16 @@ describe("SQLiteDB", function() {
       // see the effects of earlier ones, and should not be affected by earlier failures.
       const sdb = await SQLiteDB.openDB(dbPath("testTrans2"), schemaInfo, OpenMode.OPEN_CREATE);
       const results: any[] = await Promise.all([
-        sdb.execTransaction(() => sdb.exec('INSERT INTO Foo (A) VALUES ("trans1")')),
+        sdb.execTransaction(() => sdb.exec(`INSERT INTO Foo (A) VALUES ('trans1')`)),
         sdb.execTransaction(() => sdb.all("SELECT A FROM Foo")),
-        sdb.execTransaction(() => sdb.exec('INSERT INTO Foo (A) VALUES ("trans2")')),
+        sdb.execTransaction(() => sdb.exec(`INSERT INTO Foo (A) VALUES ('trans2')`)),
         sdb.execTransaction(() => sdb.exec("CREATE TABLE TableNew (foo TEXT)")),
         assert.isRejected(sdb.execTransaction(() => sdb.exec("CREATE TABLE TableNew (foo TEXT)")),
           /TableNew.*already exists/).then(noop),
         sdb.execTransaction(() => sdb.all("SELECT A FROM Foo")),
         sdb.execTransaction(async () => {
           await delay(30);
-          await sdb.exec('INSERT INTO Foo (A) VALUES ("trans3")');
+          await sdb.exec(`INSERT INTO Foo (A) VALUES ('trans3')`);
           await delay(30);
         }),
         sdb.execTransaction(() => sdb.all("SELECT A FROM Foo")),
@@ -437,10 +437,10 @@ describe("SQLiteDB", function() {
     it("should allow nested execTransaction calls", async function() {
       const sdb = await SQLiteDB.openDB(dbPath("testTrans3"), schemaInfo, OpenMode.OPEN_CREATE);
       await sdb.execTransaction(async () => {
-        await sdb.exec('INSERT INTO Foo (A) VALUES ("thing1")');
+        await sdb.exec(`INSERT INTO Foo (A) VALUES ('thing1')`);
         await sdb.execTransaction(async () => {
-          await sdb.exec('INSERT INTO Foo (A) VALUES ("thing2")');
-          await sdb.exec('INSERT INTO Foo (A) VALUES ("thing3")');
+          await sdb.exec(`INSERT INTO Foo (A) VALUES ('thing2')`);
+          await sdb.exec(`INSERT INTO Foo (A) VALUES ('thing3')`);
         });
       });
       assert.lengthOf(await sdb.all("SELECT A FROM Foo"), 3);
@@ -450,10 +450,10 @@ describe("SQLiteDB", function() {
       const sdb = await SQLiteDB.openDB(dbPath("testTrans4"), schemaInfo, OpenMode.OPEN_CREATE);
       await assert.isRejected(
         sdb.execTransaction(async () => {
-          await sdb.exec('INSERT INTO Foo (A) VALUES ("thing1")');
+          await sdb.exec(`INSERT INTO Foo (A) VALUES ('thing1')`);
           await sdb.execTransaction(async () => {
-            await sdb.exec('INSERT INTO Foo (A) VALUES ("thing2")');
-            await sdb.exec('INSERT INTO Foo (A) VALUESBORKBORKBORK ("thing3")');
+            await sdb.exec(`INSERT INTO Foo (A) VALUES ('thing2')`);
+            await sdb.exec(`INSERT INTO Foo (A) VALUESBORKBORKBORK ('thing3')`);
           });
         }),
         /SQLITE_ERROR/);
@@ -463,21 +463,21 @@ describe("SQLiteDB", function() {
 
   it("should nest execTransaction calls robustly regardless of timing", async function() {
     const sdb = await SQLiteDB.openDB(dbPath("testTrans5"), schemaInfo, OpenMode.OPEN_CREATE);
-    await sdb.exec('INSERT INTO Foo (A,B) VALUES ("key", 1)');
+    await sdb.exec(`INSERT INTO Foo (A,B) VALUES ('key', 1)`);
     await Promise.all([
       sdb.execTransaction(async () => {
         // Give an opportunity for another operation to be snuck in.
         await delay(1000);
-        await sdb.exec('UPDATE Foo SET B = 2 WHERE A = "key"');
+        await sdb.exec(`UPDATE Foo SET B = 2 WHERE A = 'key'`);
       }),
       // Wait a little so body of previous transaction has started.
       // This used to be enough to let us sneak an operation into
       // it, potentially in the wrong order.
       delay(100).then(() => sdb.execTransaction(async () => {
-        await sdb.exec('UPDATE Foo SET B = 3 WHERE A = "key"');
+        await sdb.exec(`UPDATE Foo SET B = 3 WHERE A = 'key'`);
       })),
     ]);
-    assert.equal((await sdb.get('SELECT B FROM Foo WHERE A = "key"'))!.B, 3);
+    assert.equal((await sdb.get(`SELECT B FROM Foo WHERE A = 'key'`))!.B, 3);
   });
 
   it("should forbid ATTACHed databases", async function() {
@@ -485,7 +485,7 @@ describe("SQLiteDB", function() {
     await db0.close();
     const db1 = await SQLiteDB.openDB(dbPath("testAttach1"), schemaInfo, OpenMode.OPEN_CREATE);
     await assert.isRejected(db1.exec(`ATTACH '${dbPath("testAttach0")}' AS zing`),
-      /SQLITE_ERROR: too many attached databases - max 0/);
+      /too many attached databases|not authorized/);
     await db1.close();
   });
 

--- a/test/server/lib/SqliteNative.ts
+++ b/test/server/lib/SqliteNative.ts
@@ -1,0 +1,338 @@
+import { assert } from "chai";
+import * as fse from "fs-extra";
+import * as tmp from "tmp-promise";
+
+import { Unmarshaller } from "app/common/marshal";
+import { MinDB, ResultRow } from "app/server/lib/SqliteCommon";
+import { NativeSqliteDatabaseAdapter, NativeSqliteVariant } from "app/server/lib/SqliteNative";
+import { OpenMode } from "app/server/lib/SQLiteDB";
+
+tmp.setGracefulCleanup();
+
+describe("SqliteNative", function() {
+  let tmpDir: string;
+  let cleanup: () => void;
+
+  before(async function() {
+    ({ path: tmpDir, cleanup } = await tmp.dir({ prefix: "grist_test_SqliteNative_", unsafeCleanup: true }));
+  });
+
+  after(function() {
+    cleanup();
+  });
+
+  function dbPath(name: string): string {
+    return `${tmpDir}/${name}.db`;
+  }
+
+  describe("NativeSqliteVariant", function() {
+    const variant = new NativeSqliteVariant();
+
+    it("should open a new database with OPEN_CREATE", async function() {
+      const db = await variant.opener(dbPath("create"), OpenMode.OPEN_CREATE);
+      await db.exec("CREATE TABLE t(x TEXT)");
+      await db.run("INSERT INTO t VALUES(?)", "hello");
+      const row = await db.get("SELECT x FROM t");
+      assert.deepEqual(row, { x: "hello" });
+      await db.close();
+    });
+
+    it("should open an existing database with OPEN_EXISTING", async function() {
+      // Create first.
+      const db1 = await variant.opener(dbPath("existing"), OpenMode.OPEN_CREATE);
+      await db1.exec("CREATE TABLE t(x TEXT)");
+      await db1.run("INSERT INTO t VALUES(?)", "data");
+      await db1.close();
+
+      // Reopen.
+      const db2 = await variant.opener(dbPath("existing"), OpenMode.OPEN_EXISTING);
+      const row = await db2.get("SELECT x FROM t");
+      assert.deepEqual(row, { x: "data" });
+      await db2.close();
+    });
+
+    it("should fail to open non-existent database with OPEN_EXISTING", async function() {
+      await assert.isRejected(
+        variant.opener(dbPath("nonexistent"), OpenMode.OPEN_EXISTING),
+        /unable to open database/
+      );
+    });
+
+    it("should open in read-only mode with OPEN_READONLY", async function() {
+      // Create first.
+      const db1 = await variant.opener(dbPath("readonly"), OpenMode.OPEN_CREATE);
+      await db1.exec("CREATE TABLE t(x TEXT)");
+      await db1.run("INSERT INTO t VALUES(?)", "data");
+      await db1.close();
+
+      // Open readonly.
+      const db2 = await variant.opener(dbPath("readonly"), OpenMode.OPEN_READONLY);
+      const row = await db2.get("SELECT x FROM t");
+      assert.deepEqual(row, { x: "data" });
+
+      // Writes should fail.
+      await assert.isRejected(
+        db2.run("INSERT INTO t VALUES(?)", "more"),
+        /readonly|attempt to write/
+      );
+      await db2.close();
+    });
+  });
+
+  describe("NativeSqliteDatabaseAdapter", function() {
+    let db: MinDB;
+
+    beforeEach(async function() {
+      db = await new NativeSqliteVariant().opener(":memory:", OpenMode.OPEN_CREATE);
+      await db.exec("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT, count INTEGER)");
+    });
+
+    afterEach(async function() {
+      await db.close();
+    });
+
+    describe("exec", function() {
+      it("should execute multiple statements", async function() {
+        await db.exec(`
+          INSERT INTO items(name, count) VALUES('a', 1);
+          INSERT INTO items(name, count) VALUES('b', 2);
+        `);
+        const rows = await db.all("SELECT name FROM items ORDER BY name");
+        assert.deepEqual(rows, [{ name: "a" }, { name: "b" }]);
+      });
+    });
+
+    describe("run", function() {
+      it("should return changes count", async function() {
+        await db.run("INSERT INTO items(name, count) VALUES(?, ?)", "x", 10);
+        const result = await db.run("UPDATE items SET count = ? WHERE name = ?", 20, "x");
+        assert.equal(result.changes, 1);
+      });
+
+      it("should handle boolean parameters", async function() {
+        await db.exec("CREATE TABLE flags(val INTEGER)");
+        await db.run("INSERT INTO flags VALUES(?)", true);
+        await db.run("INSERT INTO flags VALUES(?)", false);
+        const rows = await db.all("SELECT val FROM flags ORDER BY val");
+        assert.deepEqual(rows, [{ val: 0 }, { val: 1 }]);
+      });
+    });
+
+    describe("get", function() {
+      it("should return a single row", async function() {
+        await db.run("INSERT INTO items(name, count) VALUES(?, ?)", "one", 1);
+        await db.run("INSERT INTO items(name, count) VALUES(?, ?)", "two", 2);
+        const row = await db.get("SELECT name, count FROM items WHERE count = ?", 2);
+        assert.deepEqual(row, { name: "two", count: 2 });
+      });
+
+      it("should return undefined for no match", async function() {
+        const row = await db.get("SELECT * FROM items WHERE name = ?", "nope");
+        assert.isUndefined(row);
+      });
+    });
+
+    describe("all", function() {
+      it("should return all matching rows", async function() {
+        await db.exec(`
+          INSERT INTO items(name, count) VALUES('a', 1);
+          INSERT INTO items(name, count) VALUES('b', 2);
+          INSERT INTO items(name, count) VALUES('c', 3);
+        `);
+        const rows = await db.all("SELECT name FROM items WHERE count > ? ORDER BY name", 1);
+        assert.deepEqual(rows, [{ name: "b" }, { name: "c" }]);
+      });
+
+      it("should return empty array for no matches", async function() {
+        const rows = await db.all("SELECT * FROM items WHERE count > ?", 999);
+        assert.deepEqual(rows, []);
+      });
+    });
+
+    describe("prepare", function() {
+      it("should create a reusable prepared statement", async function() {
+        const stmt = await db.prepare("INSERT INTO items(name, count) VALUES(?, ?)");
+        await stmt.run("p1", 10);
+        await stmt.run("p2", 20);
+        await stmt.finalize();
+
+        const rows = await db.all("SELECT name, count FROM items ORDER BY name");
+        assert.deepEqual(rows, [
+          { name: "p1", count: 10 },
+          { name: "p2", count: 20 },
+        ]);
+      });
+
+      it("should report column names", async function() {
+        const stmt = await db.prepare("SELECT id, name, count FROM items");
+        assert.deepEqual(stmt.columns(), ["id", "name", "count"]);
+        await stmt.finalize();
+      });
+    });
+
+    describe("runAndGetId", function() {
+      it("should return the last inserted row id", async function() {
+        const id1 = await db.runAndGetId("INSERT INTO items(name, count) VALUES(?, ?)", "first", 1);
+        const id2 = await db.runAndGetId("INSERT INTO items(name, count) VALUES(?, ?)", "second", 2);
+        assert.equal(id1, 1);
+        assert.equal(id2, 2);
+      });
+    });
+
+    describe("allMarshal", function() {
+      it("should return marshalled data that can be unmarshalled", async function() {
+        await db.exec(`
+          INSERT INTO items(name, count) VALUES('alice', 10);
+          INSERT INTO items(name, count) VALUES('bob', 20);
+        `);
+
+        const buf = await db.allMarshal("SELECT name, count FROM items ORDER BY name");
+
+        // Should be a Buffer (or Uint8Array that we can work with).
+        assert.isTrue(buf instanceof Uint8Array, "result should be a Uint8Array or Buffer");
+        assert.isAbove(buf.length, 0);
+
+        // Unmarshal and verify contents.
+        const unmarshaller = new Unmarshaller();
+        unmarshaller.parse(buf, (value: any) => {
+          // The marshalled data should be a dict of column_name -> [values].
+          assert.deepEqual(value.name, ["alice", "bob"]);
+          assert.deepEqual(value.count, [10, 20]);
+        });
+      });
+
+      it("should handle empty result sets", async function() {
+        const buf = await db.allMarshal("SELECT name, count FROM items WHERE 0");
+        assert.isTrue(buf instanceof Uint8Array);
+
+        const unmarshaller = new Unmarshaller();
+        unmarshaller.parse(buf, (value: any) => {
+          assert.deepEqual(value.name, []);
+          assert.deepEqual(value.count, []);
+        });
+      });
+    });
+
+    describe("limitAttach", function() {
+      it("should block ATTACH by default", async function() {
+        await assert.isRejected(
+          db.exec("ATTACH ':memory:' AS extra"),
+          /not authorized/
+        );
+      });
+
+      it("should allow ATTACH after limitAttach(1)", async function() {
+        await db.limitAttach(1);
+        await db.exec("ATTACH ':memory:' AS extra");
+        // Verify we can use the attached database.
+        await db.exec("CREATE TABLE extra.t2(y TEXT)");
+        await db.run("INSERT INTO extra.t2 VALUES(?)", "attached");
+        const row = await db.get("SELECT y FROM extra.t2");
+        assert.deepEqual(row, { y: "attached" });
+      });
+
+      it("should re-block ATTACH after limitAttach(0)", async function() {
+        await db.limitAttach(1);
+        await db.exec("ATTACH ':memory:' AS extra");
+        await db.exec("DETACH extra");
+        await db.limitAttach(0);
+        await assert.isRejected(
+          db.exec("ATTACH ':memory:' AS extra2"),
+          /not authorized/
+        );
+      });
+    });
+
+    describe("getOptions", function() {
+      it("should report canInterrupt as false", function() {
+        const opts = (db as NativeSqliteDatabaseAdapter).getOptions!();
+        assert.isFalse(opts.canInterrupt);
+        assert.isTrue(opts.bindableMethodsProcessOneStatement);
+      });
+    });
+
+    describe("transactions via exec", function() {
+      it("should support BEGIN/COMMIT transactions", async function() {
+        await db.exec("BEGIN");
+        await db.run("INSERT INTO items(name, count) VALUES(?, ?)", "tx1", 1);
+        await db.run("INSERT INTO items(name, count) VALUES(?, ?)", "tx2", 2);
+        await db.exec("COMMIT");
+
+        const rows = await db.all("SELECT name FROM items ORDER BY name");
+        assert.deepEqual(rows, [{ name: "tx1" }, { name: "tx2" }]);
+      });
+
+      it("should support ROLLBACK", async function() {
+        await db.run("INSERT INTO items(name, count) VALUES(?, ?)", "keep", 1);
+        await db.exec("BEGIN");
+        await db.run("INSERT INTO items(name, count) VALUES(?, ?)", "discard", 2);
+        await db.exec("ROLLBACK");
+
+        const rows = await db.all("SELECT name, count FROM items");
+        assert.deepEqual(rows, [{ name: "keep", count: 1 }]);
+      });
+    });
+
+    describe("data types", function() {
+      it("should handle NULL values", async function() {
+        await db.run("INSERT INTO items(name, count) VALUES(?, ?)", null, null);
+        const row = await db.get("SELECT name, count FROM items WHERE id = last_insert_rowid()");
+        assert.deepEqual(row, { name: null, count: null });
+      });
+
+      it("should handle BLOB values", async function() {
+        await db.exec("CREATE TABLE blobs(data BLOB)");
+        const blob = Buffer.from([0x00, 0x01, 0x02, 0xff]);
+        await db.run("INSERT INTO blobs VALUES(?)", blob);
+        const row = await db.get("SELECT data FROM blobs") as ResultRow;
+        // node:sqlite returns Uint8Array for blobs.
+        assert.isTrue(row.data instanceof Uint8Array);
+        assert.deepEqual(Buffer.from(row.data), blob);
+      });
+
+      it("should handle large integers", async function() {
+        await db.exec("CREATE TABLE big(val INTEGER)");
+        await db.run("INSERT INTO big VALUES(?)", Number.MAX_SAFE_INTEGER);
+        const row = await db.get("SELECT val FROM big") as ResultRow;
+        assert.equal(row.val, Number.MAX_SAFE_INTEGER);
+      });
+    });
+
+    describe("PRAGMA", function() {
+      it("should support PRAGMA queries", async function() {
+        // user_version is used for schema versioning in Grist.
+        await db.exec("PRAGMA user_version = 42");
+        const row = await db.get("PRAGMA user_version") as ResultRow;
+        assert.equal(row.user_version, 42);
+      });
+
+      it("should support table_info", async function() {
+        const cols = await db.all("PRAGMA table_info(items)");
+        const names = cols.map((c: ResultRow) => c.name);
+        assert.deepEqual(names, ["id", "name", "count"]);
+      });
+    });
+  });
+
+  describe("backup", function() {
+    it("should backup a database to a file", async function() {
+      const variant = new NativeSqliteVariant();
+      const db = await variant.opener(":memory:", OpenMode.OPEN_CREATE) as NativeSqliteDatabaseAdapter;
+      await db.exec("CREATE TABLE data(x INTEGER)");
+      for (let i = 0; i < 100; i++) {
+        await db.run("INSERT INTO data VALUES(?)", i);
+      }
+
+      const dest = dbPath("backup_dest");
+      await db.backupTo(dest, { rate: 10 });
+
+      // Verify backup contents.
+      assert.isTrue(await fse.pathExists(dest));
+      const db2 = await variant.opener(dest, OpenMode.OPEN_READONLY);
+      const rows = await db2.all("SELECT count(*) as c FROM data");
+      assert.equal(rows[0].c, 100);
+      await db2.close();
+      await db.close();
+    });
+  });
+});


### PR DESCRIPTION
Prototype SQLite adapter using Node.js built-in node:sqlite module, activated via GRIST_SQLITE_VARIANT=native. Each database connection runs in a dedicated Worker thread to keep the main event loop free.

Key changes:
- SqliteNative.ts: main-thread adapter implementing MinDB via postMessage
- SqliteNativeWorker.ts: worker thread owning the DatabaseSync connection
- Fix allMarshalQuery DQS dependency: use quoteLiteral() instead of relying on double-quoted string literals (a SQLite misfeature)
- Export fixParameters/quoteLiteral from SqliteCommon for reuse
- Fix test SQL to use standard single-quoted string literals
- Zero-copy Buffer transfer for allMarshal results

Bot assisted code.
