### PR TITLE
Reduce GRIST_LOG_API_DETAILS logging: omit body and result, add docId

### DIFF
--- a/app/server/lib/requestUtils.ts
+++ b/app/server/lib/requestUtils.ts
@@ -215,7 +215,7 @@ export async function sendReply<T>(
       email: mreq.user?.loginEmail,
       org: mreq.org,
       params: req.params,
-      ...(docId ? {docId} : {}),
+      ...(docId ? { docId } : {}),
     });
   }
   res.status(result.status);


### PR DESCRIPTION
The body and result fields can be very large and are rarely needed for debugging. Drop them from the api call log entry and include `docId` (when available) instead, which is more useful for tracing. Full request/response logging remains available via `GRIST_LOG_HTTP_BODY`.

If anyone complains loudly, these fields may come back, but for now this seems a more useful log generally.
