### PR TITLE
[xs] Form page: apply normal page scrolling behavior

### DIFF
--- a/app/client/ui/FormPage.ts
+++ b/app/client/ui/FormPage.ts
@@ -34,6 +34,8 @@ export class FormPage extends Disposable {
   }
 
   public buildDom() {
+    document.documentElement.classList.add(htmlStyles.className);
+    document.body.classList.add(bodyStyles.className);
     return cssPageContainer(
       dom.domComputed((use) => {
         const error = use(this._model.error);
@@ -137,11 +139,24 @@ export class FormPage extends Disposable {
   }
 }
 
+/**
+ * The `html` and `body` styles below are manually set on form page load.
+ * They are meant to override the default Grist app CSS rules, where height is fixed to 100% of the viewport.
+ * Here, we actually want a usual browser behavior with a normally scrolling page.
+ * We'd rather 'fix' the html and body styles like this, rather than having a child div that scrolls:
+ * this prevents an additional keyboard focus on a scrollable wrapper div when pressing Tab, when using Firefox.
+ */
+const htmlStyles = styled("html", `
+  height: auto;
+  overflow: visible;
+`);
+
+const bodyStyles = styled("body", `
+  height: auto;
+`);
+
 const cssPageContainer = styled("div", `
-  height: 100%;
-  width: 100%;
   padding: 20px;
-  overflow: auto;
 `);
 
 const cssFormBorder = styled("div", `


### PR DESCRIPTION
## Context

As for now, when pressing `Tab` once when arriving on a form page, **with Firefox**, seemingly nothing happens.

It's because Firefox exposes scrollable elements as focusables, and the form page is rendered in a 100% height scrollable div.

So, as a user, while I would think pressing Tab would focus the first visibly focusable thing on the page, I end up wondering why my first Tab press seemingly did nothing, as I'm actually focused on the wrapper div.

## Proposed solution

Make it so that page content overflow is done the usual browser-way on form pages. We have no need for fixed 100% viewport height in that context and it makes more sense to not expose the wrapping div as a scrollable.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

Before:

https://github.com/user-attachments/assets/69c6674c-cc96-4f70-9eb7-bfd42aa6ecd1

After:

https://github.com/user-attachments/assets/4ebb6b64-716c-4652-abec-1efd4767c2f9




