### PR TITLE
Hiding admin panel links in grist-desktop

### DIFF
--- a/app/client/ui/AccountWidget.ts
+++ b/app/client/ui/AccountWidget.ts
@@ -236,12 +236,16 @@ export class AccountWidget extends Disposable {
 
   private _maybeBuildAdminPanelMenuItem() {
     // Only show Admin Panel item to the installation admins.
-    if (this._appModel.currentUser?.isInstallAdmin) {
+    // Hide in electron (Grist Desktop) where the admin panel is not useful.
+    const { deploymentType } = getGristConfig();
+    if (this._appModel.currentUser?.isInstallAdmin && deploymentType !== "electron") {
       return menuItemLink(
         getAdminPanelName(),
         urlState().setLinkUrl({ adminPanel: "admin" }),
         testId("usermenu-admin-panel"),
       );
+    } else {
+      return null;
     }
   }
 

--- a/app/client/ui/HomeLeftPane.ts
+++ b/app/client/ui/HomeLeftPane.ts
@@ -45,7 +45,7 @@ export function createHomeLeftPane(leftPanelOpen: Observable<boolean>, home: Hom
   const creating = observable<boolean>(false);
   const renaming = observable<Workspace | null>(null);
   const isAnonymous = !home.app.currentValidUser;
-  const { enableAnonPlayground, templateOrg, onboardingTutorialDocId } = getGristConfig();
+  const { enableAnonPlayground, templateOrg, onboardingTutorialDocId, deploymentType } = getGristConfig();
   const canCreate = !isAnonymous || enableAnonPlayground;
 
   // Show version when hovering over the application icon.
@@ -171,7 +171,7 @@ export function createHomeLeftPane(leftPanelOpen: Observable<boolean>, home: Hom
           ),
         ),
         createVideoTourToolsButton(),
-        (home.app.isInstallAdmin() ?
+        (home.app.isInstallAdmin() && deploymentType !== "electron" ?
           cssPageEntry(
             cssPageLink(cssPageIcon("Settings"), cssLinkText(getAdminPanelName()),
               urlState().setLinkUrl({ adminPanel: "admin" }),


### PR DESCRIPTION
## Context

Admin panel isn't built with grist-desktop in mind and is not useful for desktop users, as most features are server related and requires different setup for desktop build. The sandboxing check is also not needed as by default grist-desktop has sandbox turned on.

This PR hides the links to admin panel on the left and top right menus.

## Has this been tested?

Manually tested by building grist-desktop with and without this change.