### PR TITLE
Fix issue with swiss german numeric formatter

### DIFF
--- a/test/common/ValueFormatter.ts
+++ b/test/common/ValueFormatter.ts
@@ -108,7 +108,10 @@ describe("ValueFormatter", function() {
       // Test currency formatting with custom locales.
       assert.equal(fmt({ numMode: "currency" }, 1000000, { locale: "es-ES" }), "1.000.000,00 €");
       assert.equal(fmt({ numMode: "currency", decimals: 4 }, 1000000, { locale: "en-NZ" }), "$1,000,000.0000");
-      assert.equal(fmt({ numMode: "currency" }, -1234.565, { locale: "de-CH" }), "CHF-1’234.57");
+
+      // NOTE: Maybe a nodejs regression:
+      // https://github.com/nodejs/node/issues/61861#issuecomment-3932974204
+      assert.oneOf(fmt({ numMode: "currency" }, -1234.565, { locale: "de-CH" }), ["CHF-1’234.57", "CHF-1'234.57"]);
       assert.equal(fmt({ numMode: "currency" }, -121e+25, { locale: "es-AR" }),
         "-$ 1.210.000.000.000.000.000.000.000.000,00");
       assert.equal(fmt({ numMode: "currency" }, 0.1234567, { locale: "fr-BE" }), "0,12 €");
@@ -123,7 +126,12 @@ describe("ValueFormatter", function() {
       assert.equal(
         fmt({ numMode: "currency", decimals: 4 }, 1000000, { locale: "en-NZ", currency: "JPY" }),
         "¥1,000,000.0000");
-      assert.equal(fmt({ numMode: "currency" }, -1234.565, { locale: "de-CH", currency: "JMD" }), "$-1’234.57");
+
+      // NOTE: Maybe a nodejs regression:
+      // https://github.com/nodejs/node/issues/61861#issuecomment-3932974204
+      assert.oneOf(fmt({ numMode: "currency" }, -1234.565, { locale: "de-CH", currency: "JMD" }),
+        ["$-1’234.57", "$-1'234.57"]);
+
       assert.equal(
         fmt({ numMode: "currency" }, -121e+25, { locale: "es-AR", currency: "GBP" }),
         "-£ 1.210.000.000.000.000.000.000.000.000,00");


### PR DESCRIPTION
## Context

The CI is failing because of an issue with NodeJS:
https://github.com/gristlabs/grist-core/actions/runs/23158866880/job/67280937328#step:16:1158

## Proposed solution

This is probably a bug in Node / ICU:
https://github.com/nodejs/node/issues/61861

The culprit commit in nodejs:
https://github.com/nodejs/node/commit/1bd7f62d139ceb5c60ba9b198c25434deb7106e7

As it's not a bug on our side, just accept `'` as a thousands separator for Swiss German.



## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->