### PR TITLE
merge translation key updates automatically rather than manually

### DIFF
--- a/.github/workflows/translation_keys.yml
+++ b/.github/workflows/translation_keys.yml
@@ -33,7 +33,7 @@ jobs:
         id: scan-keys
         run: |
           git checkout -b translation-keys
-          yarn run generate:translation
+          yarn run generate:translation 2>&1 | tee /tmp/scan-output.txt
           git status --porcelain
           if [[ $(git status --porcelain | wc -l) -eq "0" ]]; then
             echo "No changes"
@@ -48,14 +48,18 @@ jobs:
           git config user.name "Paul's Grist Bot"
           git config user.email "<paul+bot@getgrist.com>"
 
-      - name: Prepare PR
+      - name: Create PR and merge
         if: env.CHANGED == 'true'
         run: |
           git commit -m "automated update to translation keys" -a
           git push --set-upstream origin HEAD:translation-keys -f
           num=$(gh pr list --search "automated update to translation keys" --json number -q ".[].number")
-          if [[ "$num" = "" ]]; then
-            gh pr create --fill
+          if [[ "$num" != "" ]]; then
+            echo "Existing translation keys PR #$num is open, skipping"
+            exit 0
           fi
+          sed -n '/TRANSLATION_SUMMARY_START/,/TRANSLATION_SUMMARY_END/{//d;p;}' /tmp/scan-output.txt > /tmp/pr-body.txt
+          gh pr create --title "automated update to translation keys" --body-file /tmp/pr-body.txt
+          gh pr merge --merge --delete-branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/buildtools/generate_translation_keys.js
+++ b/buildtools/generate_translation_keys.js
@@ -67,15 +67,16 @@ const getKeysFromFile = (filePath, fileName) => {
 
 // It is highly desirable to retain existing order, to not generate
 // unnecessary merges/conflicts, so we do a specialized merge.
-function merge(target, scanned) {
+function merge(target, scanned, newKeys = []) {
   let merges = 0;
   for (const key of Object.keys(scanned)) {
     if (!(key in target)) {
       console.log("Merging key", {key});
+      newKeys.push(key);
       target[key] = scanned[key];
       merges++;
     } else if (typeof target[key] === "object") {
-      merges += merge(target[key], scanned[key]);
+      merges += merge(target[key], scanned[key], newKeys);
     } else if (scanned[key] !== target[key]) {
       if (!key.endsWith("_one")) {
         console.log("Value difference", {key, value: target[key]});
@@ -114,7 +115,8 @@ async function walkTranslation(dirs) {
   }
   const keys = parser.get({ sort: true });
   const foundKeys = _.cloneDeep(keys.en.translation);
-  const mergeCount = merge(englishKeys, sort(keys.en.translation));
+  const newKeys = [];
+  const mergeCount = merge(englishKeys, sort(keys.en.translation), newKeys);
   await fs.promises.writeFile(
     "static/locales/en.client.json",
     JSON.stringify(englishKeys, null, 4) + "\n",  // match weblate's default
@@ -125,6 +127,18 @@ async function walkTranslation(dirs) {
   const unknownCount = reportUnrecognizedKeys(originalKeys, foundKeys);
   console.log(`Found ${unknownCount} unknown key(s).`);
   console.log(`Make ${mergeCount} merge(s).`);
+  // Print a summary for use in PR descriptions.
+  if (newKeys.length > 0) {
+    console.log("TRANSLATION_SUMMARY_START");
+    console.log(`Added ${newKeys.length} new translation key(s):\n`);
+    for (const key of newKeys.slice(0, 20)) {
+      console.log(`- \`${key}\``);
+    }
+    if (newKeys.length > 20) {
+      console.log(`- ... and ${newKeys.length - 20} more`);
+    }
+    console.log("TRANSLATION_SUMMARY_END");
+  }
 }
 
 walkTranslation(["_build/app/client", ...process.argv.slice(2)]);


### PR DESCRIPTION
Currently, when code adds new keys to translate, an automatic workflow catches that and make a PR, but then the PR sits there waiting for someone to notice. There is almost never an issue with this PR, and even when there is, it would be easy to fix after the fact, so this tweaks the automation to merge automatically.