### PR TITLE
Fix typo in floating menu selector

### DIFF
--- a/test/projects/filterUtils.ts
+++ b/test/projects/filterUtils.ts
@@ -3,7 +3,7 @@ import * as gu from "test/nbrowser/gristUtils";
 import { addToRepl, driver, WebElementPromise } from "mocha-webdriver";
 
 export async function openRelativeOptionsMenu(minMax: "min" | "max") {
-  if (!await driver.find(".grist-floatin-menu").isPresent()) {
+  if (!await driver.find(".grist-floating-menu").isPresent()) {
     await driver.find(`.test-filter-menu-${minMax}`).click();
   }
 }


### PR DESCRIPTION
## Context

I found a typo in selector of `test/projects/filterUtils.ts`.

## Proposed solution

Fix the typo and look at the test results.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
