### PR TITLE
i18n: add "still working..." to translatable strings

### DIFF
--- a/app/client/models/NotifyModel.ts
+++ b/app/client/models/NotifyModel.ts
@@ -1,3 +1,4 @@
+import { makeT } from "app/client/lib/localization";
 import * as log from "app/client/lib/log";
 import { ConnectState, ConnectStateManager } from "app/client/models/ConnectState";
 import { isNarrowScreenObs, testId } from "app/client/ui2018/cssVars";
@@ -22,6 +23,7 @@ import {
 import clamp from "lodash/clamp";
 import defaults from "lodash/defaults";
 
+const t = makeT("NotifyModel");
 // When rendering app errors, we'll only show the last few.
 const maxAppErrors = 5;
 
@@ -337,7 +339,7 @@ export class Notifier extends Disposable implements INotifier {
     if (await isLongerThan(promise, optTimeout)) {
       if (this._slowNotificationToast.isEmpty()) {
         this._slowNotificationToast.autoDispose(this.createNotification({
-          message: "Still working...",
+          message: t("Still working..."),
           canUserClose: false,
           inToast: true,
           level: "message",


### PR DESCRIPTION
## Context

The slow notification `"Still Working..."` is not translatable.
This PR fixes it.


## Proposed solution

Add a missing `t()` function.

How to test :

* `yarn generate:translation`
* edit the new value in `static/locales/en.client.json`
* test in the front if the new translation applies

A formula like the one bellow is sufficient to make the slow notification appear in the bottom right corner

```python
import time
time.sleep(20)
return "Hello"
```

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
