### PR TITLE
Don't create session for anonymous users and api calls

### DIFF
--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -304,7 +304,8 @@ export async function addRequestUser(
     // If we haven't selected a user by other means, and have profiles available in the
     // session, then select a user based on those profiles.
     const session = mreq.session;
-    if (session && !session.altSessionId) {
+    if (session && !session.altSessionId &&
+      !hasApiKey && !isAnonymousUser(mreq)) { // Skip session creation for api calls and anonymous users
       // Create a default alternative session id for use in documents.
       session.altSessionId = makeId();
       forceSessionChange(session);

--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -133,19 +133,26 @@ export function getRequestProfile(req: Request | IncomingMessage,
   return profile;
 }
 
+/**
+ * Expand the user session lifetime if they're just got logged in (as the anonymous session lifetime is shorter).
+ * Therefore it reflect the value set in COOKIE_MAX_AGE.
+ */
+function expandUserSessionIfNewlyLoggedIn(mreq: RequestWithLogin) {
+  const { originalMaxAge, maxAge } = mreq.session.cookie;
+  if (mreq.userIsAuthorized && COOKIE_MAX_AGE !== null && originalMaxAge && originalMaxAge < COOKIE_MAX_AGE) {
+    mreq.session.cookie.originalMaxAge = COOKIE_MAX_AGE;
+    mreq.session.cookie.expires = new Date(Date.now() + COOKIE_MAX_AGE + maxAge - originalMaxAge);
+    forceSessionChange(mreq.session);
+  }
+}
+
 function setRequestUser(mreq: RequestWithLogin, dbManager: HomeDBAuth, user: User) {
   mreq.user = user;
   mreq.userId = user.id;
   mreq.userIsAuthorized = (user.id !== dbManager.getAnonymousUserId());
   const fullUser = dbManager.makeFullUser(user);
 
-  const { originalMaxAge, maxAge } = mreq.session.cookie;
-  // FIXME: If the user got authenticated and the
-  if (mreq.userIsAuthorized && COOKIE_MAX_AGE !== null && originalMaxAge && originalMaxAge < COOKIE_MAX_AGE) {
-    mreq.session.cookie.originalMaxAge = COOKIE_MAX_AGE;
-    mreq.session.cookie.expires = new Date(Date.now() + COOKIE_MAX_AGE - (Math.max(maxAge ?? 0, 0)));
-    forceSessionChange(mreq.session);
-  }
+  expandUserSessionIfNewlyLoggedIn(mreq);
 
   // This is dumb, but historically, we used 'email' field inconsistently; in this Authorizer
   // flow, it was set to the normalized email, rather than the display email. The difference is

--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -14,7 +14,7 @@ import { forceSessionChange, getSessionProfiles, getSessionUser, getSignInStatus
 import { expressWrap } from "app/server/lib/expressWrap";
 import { RequestWithOrg } from "app/server/lib/extractOrg";
 import { GristServer } from "app/server/lib/GristServer";
-import { COOKIE_MAX_AGE,
+import { COOKIE_MAX_AGE, COOKIE_MAX_AGE_ANONYMOUS,
   cookieName as sessionCookieName, getAllowedOrgForSessionID, getCookieDomain } from "app/server/lib/gristSessions";
 import { makeId } from "app/server/lib/idUtils";
 import log from "app/server/lib/log";
@@ -134,11 +134,18 @@ export function getRequestProfile(req: Request | IncomingMessage,
 }
 
 function setRequestUser(mreq: RequestWithLogin, dbManager: HomeDBAuth, user: User) {
+  console.log("🔥 user", mreq.session?.users);
   mreq.user = user;
   mreq.userId = user.id;
   mreq.userIsAuthorized = (user.id !== dbManager.getAnonymousUserId());
-
   const fullUser = dbManager.makeFullUser(user);
+
+  // FIXME: make a comment
+  if (!mreq.session?.users && Number.isInteger(mreq.session?.cookie?.maxAge)) {
+    delete mreq.session.cookie.maxAge;
+    forceSessionChange(mreq.session);
+  }
+
   // This is dumb, but historically, we used 'email' field inconsistently; in this Authorizer
   // flow, it was set to the normalized email, rather than the display email. The difference is
   // visible in the value of the `user.Email` attribute seen by access rules for **API requests**,
@@ -304,8 +311,14 @@ export async function addRequestUser(
     // If we haven't selected a user by other means, and have profiles available in the
     // session, then select a user based on those profiles.
     const session = mreq.session;
+    const genShortLivingSessionID: boolean = isAnonymousUser(mreq) && mreq.xhr;
+    if (genShortLivingSessionID) {
+      session.cookie ||= {};
+      session.cookie.maxAge = COOKIE_MAX_AGE_ANONYMOUS;
+    }
+
     if (session && !session.altSessionId &&
-      !hasApiKey && !isAnonymousUser(mreq)) { // Skip session creation for api calls and anonymous users
+      !hasApiKey) { // Skip session creation for api calls
       // Create a default alternative session id for use in documents.
       session.altSessionId = makeId();
       forceSessionChange(session);

--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -134,15 +134,16 @@ export function getRequestProfile(req: Request | IncomingMessage,
 }
 
 function setRequestUser(mreq: RequestWithLogin, dbManager: HomeDBAuth, user: User) {
-  console.log("🔥 user", mreq.session?.users);
   mreq.user = user;
   mreq.userId = user.id;
   mreq.userIsAuthorized = (user.id !== dbManager.getAnonymousUserId());
   const fullUser = dbManager.makeFullUser(user);
 
-  // FIXME: make a comment
-  if (!mreq.session?.users && Number.isInteger(mreq.session?.cookie?.maxAge)) {
-    delete mreq.session.cookie.maxAge;
+  const { originalMaxAge, maxAge } = mreq.session.cookie;
+  // FIXME: If the user got authenticated and the
+  if (mreq.userIsAuthorized && COOKIE_MAX_AGE !== null && originalMaxAge && originalMaxAge < COOKIE_MAX_AGE) {
+    mreq.session.cookie.originalMaxAge = COOKIE_MAX_AGE;
+    mreq.session.cookie.expires = new Date(Date.now() + COOKIE_MAX_AGE - (Math.max(maxAge ?? 0, 0)));
     forceSessionChange(mreq.session);
   }
 

--- a/app/server/lib/BrowserSession.ts
+++ b/app/server/lib/BrowserSession.ts
@@ -1,6 +1,7 @@
 import { normalizeEmail } from "app/common/emails";
 import { UserProfile } from "app/common/LoginSessionAPI";
 import { SessionStore } from "app/server/lib/gristSessions";
+import { makeId } from "app/server/lib/idUtils";
 import log from "app/server/lib/log";
 import { fromCallback } from "app/server/lib/serverUtils";
 
@@ -90,6 +91,16 @@ export interface SessionOIDCInfo {
 // Make an artificial change to a session to encourage express-session to set a cookie.
 export function forceSessionChange(session: SessionObj) {
   session.alive = Number(session.alive || 0) + 1;
+}
+
+/**
+ * Create a default alternative session id for use in documents.
+ *
+ * This sessionID is also used client side on formulas (like user.SessionIS) when the user is anonymous.
+ */
+export function generateAltSessionID(session: SessionObj) {
+  session.altSessionId = makeId();
+  forceSessionChange(session);
 }
 
 // We expose a sign-in status in a cookie accessible to all subdomains, to assist in auto-signin.

--- a/app/server/lib/gristSessions.ts
+++ b/app/server/lib/gristSessions.ts
@@ -17,10 +17,21 @@ import { createClient } from "redis";
 
 export const cookieName = process.env.GRIST_SESSION_COOKIE || "grist_sid";
 
-export const COOKIE_MAX_AGE =
-  process.env.COOKIE_MAX_AGE === "none" ? null :
-    isNumber(process.env.COOKIE_MAX_AGE || "") ? Number(process.env.COOKIE_MAX_AGE) :
-      90 * 24 * 60 * 60 * 1000;  // 90 days in milliseconds
+function parseMaxAge(val: string | undefined, defaultValue: number): number | null {
+  return val === "none" ? null :
+    isNumber(val || "") ? Number(val) :
+      defaultValue;  // 90 days in milliseconds
+}
+
+export const COOKIE_MAX_AGE = parseMaxAge(
+  process.env.COOKIE_MAX_AGE,
+  90 * 24 * 60 * 60 * 1000, // 90 days in milliseconds
+);
+
+export const COOKIE_MAX_AGE_ANONYMOUS = parseMaxAge(
+  process.env.COOKIE_MAX_AGE_ANONYMOUS,
+  5 * 60 * 1000,
+);
 
 // RedisStore and SqliteStore are expected to provide a set/get interface for sessions.
 export interface SessionStore {

--- a/app/server/lib/gristSessions.ts
+++ b/app/server/lib/gristSessions.ts
@@ -6,6 +6,7 @@ import log from "app/server/lib/log";
 import { fromCallback } from "app/server/lib/serverUtils";
 import { Sessions } from "app/server/lib/Sessions";
 
+import assert from "assert";
 import * as crypto from "crypto";
 import * as path from "path";
 
@@ -32,6 +33,10 @@ export const COOKIE_MAX_AGE_ANONYMOUS = parseMaxAge(
   process.env.COOKIE_MAX_AGE_ANONYMOUS,
   5 * 60 * 1000,
 );
+
+assert.ok((COOKIE_MAX_AGE_ANONYMOUS ?? Infinity) <= (COOKIE_MAX_AGE ?? Infinity),
+  "COOKIE_MAX_AGE_ANONYMOUS cannot be greater than COOKIE_MAX_AGE as anonymous session " +
+  "cannot live longer than regular sessions");
 
 // RedisStore and SqliteStore are expected to provide a set/get interface for sessions.
 export interface SessionStore {

--- a/test/server/lib/Authorizer.ts
+++ b/test/server/lib/Authorizer.ts
@@ -6,7 +6,7 @@ import { TestSession } from "test/gen-server/apiUtils";
 import { createInitialDb, removeConnection, setUpDB } from "test/gen-server/seed";
 import { configForUser, getGristConfig } from "test/gen-server/testUtils";
 import { createDocTools } from "test/server/docTools";
-import { openClient } from "test/server/gristClient";
+import { GristClient, openClient } from "test/server/gristClient";
 import * as testUtils from "test/server/testUtils";
 
 import axios from "axios";
@@ -47,6 +47,10 @@ async function activateServer(home: FlexServer, docManager: DocManager) {
   await home.finalizePlugins(null);
   home.setReady(true);
   serverUrl = home.getOwnUrl();
+}
+
+function countSessions(flexServer: FlexServer = server) {
+  return flexServer.getSessions()["_sessions"].size;
 }
 
 const chimpy = configForUser("Chimpy");
@@ -151,6 +155,15 @@ describe("Authorizer", function() {
     assert.equal(resp.status, 404);
   });
 
+  it("viewer does not generate session when calling the API with an authorization header", async function() {
+    const nbSessionsBefore = countSessions();
+    const docId = docs.Bananas.id;
+    const resp = await axios.get(`${serverUrl}/o/pr/${docId}`, chimpy);
+    const nbSessionsAfter = countSessions();
+    assert.equal(resp.status, 200);
+    assert.equal(nbSessionsBefore, nbSessionsAfter, "No new session should have been created during the API call");
+  });
+
   it("websocket allows openDoc for viewer", async function() {
     const cli = await openClient(server, "chimpy@getgrist.com", "pr");
     cli.ignoreTrivialActions();
@@ -209,6 +222,36 @@ describe("Authorizer", function() {
     assert.equal(fetchTable.error, undefined);
     assert.include(JSON.stringify(fetchTable.data), nonce);
     await cli.close();
+  });
+
+  it("websocket creates a new session except for anonymous users", async function() {
+    const authHeader = "X-email";
+    process.env.GRIST_PROXY_AUTH_HEADER = authHeader;
+    let localServer: FlexServer | null = null;
+    let cli: GristClient | null = null;
+    try {
+      localServer = new FlexServer(0);
+      await activateServer(localServer, docTools.getDocManager());
+
+      const nbSessionBefore = countSessions(localServer);
+      cli = await openClient(localServer, "chimpy@getgrist.com", "nasa", authHeader);
+      const nbSessionAfterChimpyOpenedClient = countSessions(localServer);
+      assert.equal(nbSessionAfterChimpyOpenedClient, nbSessionBefore + 1, "Chimpy should have created a new session");
+
+      // Create another session
+      await cli.close();
+      cli = await openClient(localServer, "anon@getgrist.com", "nasa", authHeader);
+
+      const nbSessionAfterAnonOpenedClient = countSessions(localServer);
+      assert.equal(nbSessionAfterAnonOpenedClient, nbSessionAfterChimpyOpenedClient,
+        "Anon should NOT have created a new session");
+    } finally {
+      await cli?.close();
+      await localServer?.close();
+
+      // Restore previous server
+      await activateServer(server, docTools.getDocManager());
+    }
   });
 
   it("can keep different simultaneous clients of a doc straight", async function() {

--- a/test/server/lib/Authorizer.ts
+++ b/test/server/lib/Authorizer.ts
@@ -155,13 +155,21 @@ describe("Authorizer", function() {
     assert.equal(resp.status, 404);
   });
 
-  it("viewer does not generate session when calling the API with an authorization header", async function() {
+  it("does not generate sessions when calling the API with an authorization header", async function() {
     const nbSessionsBefore = countSessions();
-    const docId = docs.Bananas.id;
-    const resp = await axios.get(`${serverUrl}/o/pr/${docId}`, chimpy);
+    const resp = await axios.get(`${serverUrl}/o/pr`, chimpy);
     const nbSessionsAfter = countSessions();
     assert.equal(resp.status, 200);
-    assert.equal(nbSessionsBefore, nbSessionsAfter, "No new session should have been created during the API call");
+    assert.equal(nbSessionsAfter, nbSessionsBefore, "No new session should have been created during the API call");
+  });
+
+  it("does generate a session when calling the API with a cookie", async function() {
+    const nbSessionsBefore = countSessions();
+    const resp = await axios.get(`${serverUrl}/o/pr`, await getChimpyCookie());
+    const nbSessionsAfter = countSessions();
+    assert.equal(resp.status, 200);
+    assert.equal(nbSessionsAfter, nbSessionsBefore + 1,
+      "A new session should have been created during the API call with cookie");
   });
 
   it("websocket allows openDoc for viewer", async function() {

--- a/test/server/lib/Telemetry.ts
+++ b/test/server/lib/Telemetry.ts
@@ -265,7 +265,6 @@ describe("Telemetry", function() {
                 "eventSource",
                 "watchTimeSeconds",
                 "userId",
-                "altSessionId",
               ]);
               assert.equal(metadata.watchTimeSeconds, 30);
               assert.equal(metadata.userId, 1);
@@ -324,7 +323,6 @@ describe("Telemetry", function() {
               assert.containsAllKeys(metadata, [
                 "watchTimeSeconds",
                 "userId",
-                "altSessionId",
               ]);
               assert.equal(metadata.watchTimeSeconds, 30);
               assert.equal(metadata.userId, 1);


### PR DESCRIPTION
## Context

Making API calls pollutes session store uselessly.

## Proposed solution

Don't set `session.alive` nor `session.altSessionId` so `express-session` does not detect any change and therefore does not persist any key.

## Related issues


## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
