### PR TITLE
Converts field references in Airtable formula columns

### DIFF
--- a/app/client/lib/airtable/AirtableImportUI.ts
+++ b/app/client/lib/airtable/AirtableImportUI.ts
@@ -730,7 +730,8 @@ Your token is never sent to Grist's servers, and is only used to make API calls 
             structureOnly: false,
           }),
         })));
-      } catch {
+      } catch (e) {
+        console.error(e);
         throw new Error(t("Failed to fetch base schema"));
       }
     }, { loading: this._loadingBaseSchema });

--- a/app/client/lib/airtable/AirtableImportUI.ts
+++ b/app/client/lib/airtable/AirtableImportUI.ts
@@ -731,6 +731,7 @@ Your token is never sent to Grist's servers, and is only used to make API calls 
           }),
         })));
       } catch (e) {
+        // Log error to console so the root cause of the issue is available somewhere.
         console.error(e);
         throw new Error(t("Failed to fetch base schema"));
       }

--- a/app/common/airtable/AirtableSchemaImporter.ts
+++ b/app/common/airtable/AirtableSchemaImporter.ts
@@ -589,8 +589,8 @@ function convertFormulaFieldReferences(
   const fieldRefs = Array.from(new Set(formula.match(/{fld[A-Za-z0-9]+}/g) ?? []));
 
   let newFormula = formula;
-  fieldRefs.forEach((fieldId, index) => {
-    newFormula = newFormula.split(fieldId).join(`$[R${index}]`);
+  fieldRefs.forEach((fieldRef, index) => {
+    newFormula = newFormula.split(fieldRef).join(`$[R${index}]`);
   });
 
   const replacements = fieldRefs.map((fieldRef) => {

--- a/app/common/airtable/AirtableSchemaImporter.ts
+++ b/app/common/airtable/AirtableSchemaImporter.ts
@@ -586,11 +586,11 @@ class CountLimitationWarning implements DocSchemaImportWarning {
 function convertFormulaFieldReferences(
   formula: string, getTableIdForField: (fieldId: string) => string,
 ): FormulaTemplate {
-  const fieldRefs = Array.from(new Set(formula.match(/{fld[A-Za-z0-9]+}/g)));
+  const fieldRefs = Array.from(new Set(formula.match(/{fld[A-Za-z0-9]+}/g) ?? []));
 
   let newFormula = formula;
   fieldRefs.forEach((fieldId, index) => {
-    newFormula = newFormula.replace(new RegExp(fieldId, "g"), `$[R${index}]`);
+    newFormula = newFormula.split(fieldId).join(`$[R${index}]`);
   });
 
   const replacements = fieldRefs.map((fieldRef) => {

--- a/app/common/airtable/AirtableSchemaImporter.ts
+++ b/app/common/airtable/AirtableSchemaImporter.ts
@@ -269,7 +269,7 @@ const AirtableFieldMappers: { [type: string]: AirtableFieldMapper } = {
       },
     };
   },
-  formula({ field }) {
+  formula({ field, getTableIdForField }) {
     const formula = typeof field.options?.formula === "string" ? field.options?.formula : "No formula set";
     // Store the formula as a comment to prevent it showing errors.
     const formattedFormula = formula.split("\n").map(line => `#${line.trim()}`).join("\n");
@@ -282,7 +282,7 @@ const AirtableFieldMappers: { [type: string]: AirtableFieldMapper } = {
         // such as field type, options and referenced fields.
         // The logic to implement that however doesn't seem worth the time investment.
         type: "Any",
-        formula: { formula: formattedFormula },
+        formula: convertFormulaFieldReferences(formattedFormula, getTableIdForField),
         isFormula: true,
       },
     };
@@ -581,4 +581,29 @@ class CountLimitationWarning implements DocSchemaImportWarning {
   constructor(fieldName: string, public readonly ref: OriginalTableRef) {
     this.message = `Count field "${fieldName}" may not match Airtable. Filter conditions are not supported.`;
   }
+}
+
+function convertFormulaFieldReferences(
+  formula: string, getTableIdForField: (fieldId: string) => string,
+): FormulaTemplate {
+  const fieldRefs = Array.from(new Set(formula.match(/{fld[A-Za-z0-9]+}/g)));
+
+  let newFormula = formula;
+  fieldRefs.forEach((fieldId, index) => {
+    newFormula = newFormula.replace(new RegExp(fieldId, "g"), `$[R${index}]`);
+  });
+
+  const replacements = fieldRefs.map((fieldRef) => {
+    // Remove the {} brackets from around the ID
+    const fieldId = fieldRef.slice(1, -1);
+    return {
+      originalTableId: getTableIdForField(fieldId),
+      originalColId: fieldId,
+    };
+  });
+
+  return {
+    formula: newFormula,
+    replacements,
+  };
 }

--- a/test/common/airtable/AirtableSchemaImporter.ts
+++ b/test/common/airtable/AirtableSchemaImporter.ts
@@ -306,13 +306,21 @@ describe("AirtableSchemaImporter", function() {
       }),
     ));
 
-    it("correctly converts a formula column", () => basicDeepIncludeFieldTest(
-      {
+    it("correctly converts a formula column", () => {
+      const referencedField = createBasicAirtableField("Referenced field", "checkbox");
+      const referencedField2 = createBasicAirtableField("Referenced field2", "multilineText");
+
+      const fieldDependenciesByTable = {
+        [firstTableId]: [referencedField, referencedField2],
+      };
+
+      const formulaField = {
+        id: fieldNameToId("A formula column"),
         name: "A formula column",
         type: "formula",
         options: {
-          formula: "DATETIME_DIFF({fldBSBtZ30nsLogpl}, TODAY(), 'days')",
-          referencedFieldIds: ["fldBSBtZ30nsLogpl"],
+          formula: `DATETIME_DIFF({${referencedField.id}}, TODAY(), {${referencedField2.id}}) + {${referencedField.id}}`,
+          referencedFieldIds: [referencedField.id, referencedField2.id],
           result: {
             type: "number",
             options: {
@@ -320,16 +328,26 @@ describe("AirtableSchemaImporter", function() {
             },
           },
         },
-      },
-      (testField, testColumn) => ({
-        type: "Any",
-        isFormula: true,
-        formula: {
-          // Expect to find a commented out version of the formula
-          formula: `#${testField.options?.formula}`,
+      };
+
+      const { testField, testColumn } = convertAirtableField({ field: formulaField, fieldDependenciesByTable });
+      runBasicFieldTest(testField, testColumn);
+
+      assert.deepInclude(
+        testColumn,
+        {
+          type: "Any",
+          isFormula: true,
+          formula: {
+            formula: `#DATETIME_DIFF($[R0], TODAY(), $[R1]) + $[R0]`,
+            replacements: [
+              { originalTableId: firstTableId, originalColId: referencedField.id },
+              { originalTableId: firstTableId, originalColId: referencedField2.id },
+            ],
+          },
         },
-      }),
-    ));
+      );
+    });
 
     it("correctly converts a lastModifiedBy column", () => basicDeepIncludeFieldTest(
       { name: "A lastModifiedBy column", type: "lastModifiedBy" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4624,15 +4624,10 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
-
-follow-redirects@^1.15.11:
-  version "1.15.11"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
-  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -4667,10 +4662,10 @@ form-data@^3.0.0:
     hasown "^2.0.2"
     mime-types "^2.1.35"
 
-form-data@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
-  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
+form-data@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
+  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4624,10 +4624,15 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
-follow-redirects@^1.0.0, follow-redirects@^1.15.6:
+follow-redirects@^1.0.0:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+
+follow-redirects@^1.15.11:
+  version "1.15.11"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -4662,10 +4667,10 @@ form-data@^3.0.0:
     hasown "^2.0.2"
     mime-types "^2.1.35"
 
-form-data@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
-  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
+form-data@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
+  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"


### PR DESCRIPTION
## Context

Imported Airtable formula fields currently have field references in that look similar to this: `{fld01230abcdefg}`, which is inconvenient when attempting to convert them to Grist python.

## Proposed solution

This resolves those field IDs to the correct columns in Grist. 

Instead of a formula being:
```
#DATETIME_DIFF({fldBSBtZ30nsLogpl}, TODAY(), 'days')
```
It's now:
```
#DATETIME_DIFF($Due_Date, TODAY(), 'days')
```

## Has this been tested?

- [X] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

