### PR TITLE
Translations: add missing strings in themes selection

### DIFF
--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -1163,7 +1163,9 @@
         "By Name": "By Name",
         "By Date Modified": "By date Modified",
         "Light": "Light",
-        "Custom": "Custom"
+        "Custom": "Custom",
+        "Dark": "Dark",
+        "Light (High Contrast)": "Light (High Contrast)"
     },
     "modals": {
         "Cancel": "Cancel",

--- a/static/locales/fr.client.json
+++ b/static/locales/fr.client.json
@@ -1154,7 +1154,9 @@
         "By Name": "Par Nom",
         "By Date Modified": "Par Date de modification",
         "Light": "Clair",
-        "Custom": "Personnalisé"
+        "Custom": "Personnalisé",
+        "Dark": "Sombre",
+        "Light (High Contrast)": "Clair (contraste élevé)"
     },
     "modals": {
         "Save": "Enregistrer",


### PR DESCRIPTION

## Context

The themes listed in the user profile page were missing a couple translations. The dark and high contrast themes were not part of the translation system.

## Proposed solution

Add the missing translations, and directly translate the French locale.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
