### PR TITLE
make squashed translation PRs, and avoid changes such as yarn.lock

### DIFF
--- a/.github/workflows/translation_keys.yml
+++ b/.github/workflows/translation_keys.yml
@@ -51,7 +51,12 @@ jobs:
       - name: Create PR and merge
         if: env.CHANGED == 'true'
         run: |
-          git commit -m "automated update to translation keys" -a
+          git add static/locales/*.json
+          if git diff --cached --quiet; then
+            echo "No translation file changes to commit"
+            exit 0
+          fi
+          git commit -m "automated update to translation keys"
           git push --set-upstream origin HEAD:translation-keys -f
           num=$(gh pr list --search "automated update to translation keys" --json number -q ".[].number")
           if [[ "$num" != "" ]]; then
@@ -60,6 +65,6 @@ jobs:
           fi
           sed -n '/TRANSLATION_SUMMARY_START/,/TRANSLATION_SUMMARY_END/{//d;p;}' /tmp/scan-output.txt > /tmp/pr-body.txt
           gh pr create --title "automated update to translation keys" --body-file /tmp/pr-body.txt
-          gh pr merge --merge --delete-branch
+          gh pr merge --squash --delete-branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Merge commits aren't allowed on the grist-core repo, and occasionally there are non-translation changes made during builds.

This is a follow-up to https://github.com/gristlabs/grist-core/pull/2185