### PR TITLE
Bump file-type to version 22.0.0

### DIFF
--- a/app/server/declarations.d.ts
+++ b/app/server/declarations.d.ts
@@ -42,6 +42,10 @@ declare module "winston/lib/winston/common" {
   export function serialize(meta: any): string;
 }
 
+declare module "file-type" {
+  export * from "file-type/source/index";
+}
+
 /**
  * Type definitions for Grist environment variables.
  *

--- a/app/server/lib/guessExt.ts
+++ b/app/server/lib/guessExt.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 
+import { fileTypeFromFile } from "file-type";
 import { extension, lookup } from "mime-types";
 
 /**
@@ -34,7 +35,6 @@ export async function guessExt(filePath: string, fileName: string, mimeType: str
   }
 
   // If not, let's take a look at the file contents.
-  const { fileTypeFromFile } = await import("file-type");
   const detected = await fileTypeFromFile(filePath);
   const detectedExt = detected ? "." + detected.ext : null;
   if (detectedExt) {

--- a/app/server/lib/guessExt.ts
+++ b/app/server/lib/guessExt.ts
@@ -1,6 +1,5 @@
 import * as path from "path";
 
-import { fromFile } from "file-type";
 import { extension, lookup } from "mime-types";
 
 /**
@@ -35,7 +34,8 @@ export async function guessExt(filePath: string, fileName: string, mimeType: str
   }
 
   // If not, let's take a look at the file contents.
-  const detected = await fromFile(filePath);
+  const { fileTypeFromFile } = await import("file-type");
+  const detected = await fileTypeFromFile(filePath);
   const detectedExt = detected ? "." + detected.ext : null;
   if (detectedExt) {
     // For the types for which detection works, we think we should prefer it.

--- a/buildtools/tsconfig-base.json
+++ b/buildtools/tsconfig-base.json
@@ -19,10 +19,6 @@
     "rootDir": "..",
     "outDir": "../_build",
     "paths": {
-      // file-type v17+ is ESM-only. With moduleResolution: "node", TypeScript cannot resolve types
-      // from the "exports" field. This path alias points directly to the type declarations.
-      // Note: if file-type changes its internal layout, this path may need to be updated.
-      "file-type": ["node_modules/file-type/source/index"],
       "*": [
         "*",
         "grist-core/*",

--- a/buildtools/tsconfig-base.json
+++ b/buildtools/tsconfig-base.json
@@ -19,6 +19,10 @@
     "rootDir": "..",
     "outDir": "../_build",
     "paths": {
+      // file-type v17+ is ESM-only. With moduleResolution: "node", TypeScript cannot resolve types
+      // from the "exports" field. This path alias points directly to the type declarations.
+      // Note: if file-type changes its internal layout, this path may need to be updated.
+      "file-type": ["node_modules/file-type/source/index"],
       "*": [
         "*",
         "grist-core/*",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "exceljs": "4.2.1",
     "express": "4.21.2",
     "express-rate-limit": "7.2.0",
-    "file-type": "16.5.4",
+    "file-type": "22.0.0",
     "fs-extra": "7.0.0",
     "grain-rpc": "0.1.7",
     "grainjs": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,6 +190,11 @@
   resolved "https://registry.yarnpkg.com/@bazel/runfiles/-/runfiles-6.5.0.tgz#63cf7b77b91b54873e75f7a08fabec215c6888be"
   integrity sha512-RzahvqTkfpY2jsDxo8YItPX+/iZ6hbiikw1YhE0bA9EKBR5Og8Pa6FHn9PO9M0zaXRVsr0GFQLKbB/0rzy9SzA==
 
+"@borewit/text-codec@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@borewit/text-codec/-/text-codec-0.2.2.tgz#75025f735c0983b3a871668804a57387e3649375"
+  integrity sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -1155,6 +1160,14 @@
     espree "^10.4.0"
     estraverse "^5.3.0"
     picomatch "^4.0.3"
+
+"@tokenizer/inflate@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@tokenizer/inflate/-/inflate-0.4.1.tgz#fa6cdb8366151b3cc8426bf9755c1ea03a2fba08"
+  integrity sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==
+  dependencies:
+    debug "^4.4.3"
+    token-types "^6.1.1"
 
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
@@ -3984,7 +3997,7 @@ debug@^4, debug@^4.3.4, debug@^4.3.5:
   dependencies:
     ms "^2.1.3"
 
-debug@^4.1.0, debug@^4.3.6, debug@^4.4.0, debug@^4.4.1:
+debug@^4.1.0, debug@^4.3.6, debug@^4.4.0, debug@^4.4.1, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -5034,14 +5047,15 @@ file-entry-cache@^8.0.0:
   dependencies:
     flat-cache "^4.0.0"
 
-file-type@16.5.4:
-  version "16.5.4"
-  resolved "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz"
-  integrity sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==
+file-type@22.0.0:
+  version "22.0.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-22.0.0.tgz#437d427c49bdee4d7ecb1e9b70a0e4ab2d8e0b36"
+  integrity sha512-cmBmnYo8Zymabm2+qAP7jTFbKF10bQpYmxoGfuZbRFRcq00BRddJdGNH/P7GA1EMpJy5yQbqa9B7yROb3z8Ziw==
   dependencies:
-    readable-web-to-node-stream "^3.0.0"
-    strtok3 "^6.2.4"
-    token-types "^4.1.1"
+    "@tokenizer/inflate" "^0.4.1"
+    strtok3 "^10.3.5"
+    token-types "^6.1.2"
+    uint8array-extras "^1.5.0"
 
 file-type@^3.8.0:
   version "3.9.0"
@@ -8051,11 +8065,6 @@ pbkdf2@^3.0.3, pbkdf2@^3.1.2:
     sha.js "^2.4.11"
     to-buffer "^1.2.0"
 
-peek-readable@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz"
-  integrity sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==
-
 pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
@@ -8611,13 +8620,6 @@ readable-stream@~2.0.0:
     process-nextick-args "~1.0.6"
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
-
-readable-web-to-node-stream@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz"
-  integrity sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==
-  dependencies:
-    readable-stream "^3.6.0"
 
 readdir-glob@^1.0.0:
   version "1.1.1"
@@ -9607,13 +9609,12 @@ strnum@^1.0.5:
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.1.2.tgz#57bca4fbaa6f271081715dbc9ed7cee5493e28e4"
   integrity sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==
 
-strtok3@^6.2.4:
-  version "6.3.0"
-  resolved "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz"
-  integrity sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==
+strtok3@^10.3.5:
+  version "10.3.5"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-10.3.5.tgz#7213285da0dc3dec0fc8ce5df4b8b7a733f14360"
+  integrity sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==
   dependencies:
     "@tokenizer/token" "^0.3.0"
-    peek-readable "^4.1.0"
 
 style-loader@^3.3.1:
   version "3.3.4"
@@ -9933,11 +9934,12 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-token-types@^4.1.1:
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz"
-  integrity sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==
+token-types@^6.1.1, token-types@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-6.1.2.tgz#18d0fd59b996d421f9f83914d6101c201bd08129"
+  integrity sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==
   dependencies:
+    "@borewit/text-codec" "^0.2.1"
     "@tokenizer/token" "^0.3.0"
     ieee754 "^1.2.1"
 
@@ -10136,6 +10138,11 @@ uid-safe@2.1.5, uid-safe@~2.1.5:
   integrity sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==
   dependencies:
     random-bytes "~1.0.0"
+
+uint8array-extras@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/uint8array-extras/-/uint8array-extras-1.5.0.tgz#10d2a85213de3ada304fea1c454f635c73839e86"
+  integrity sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==
 
 umd@^3.0.0:
   version "3.0.3"


### PR DESCRIPTION
## Context

See https://github.com/gristlabs/grist-core/pull/2191

## Proposed solution

- Bump to latest version of file-type (22.0.0)
- Adapt the code according to the changelog for [version 17](https://github.com/sindresorhus/file-type/releases/tag/v17.0.0).

NB: I used the help of AI (Copilot with Claude Sonnet 4.6)

## Related issues


## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->