### PR TITLE
Refactor: tighten ISandbox types and resolve SortSpec lint/safety issues

### DIFF
--- a/app/common/SortSpec.ts
+++ b/app/common/SortSpec.ts
@@ -211,10 +211,7 @@ export namespace Sort {
    */
   export function swapColRef(colSpec: ColSpec, colRef: ColRef): ColSpec {
     if (typeof colSpec === "number") {
-      // FIXME: This eslint rule should probably be reenabled. But we need to understand
-      // how this function is expected to be called.
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-unary-minus
-      return colSpec >= 0 ? colRef : -colRef;
+      return createColSpec(colRef, colSpec >= 0 ? ASC : DESC);
     }
     const spec = parseColSpec(colSpec);
     return detailsToSpec({ ...spec, colRef });

--- a/app/server/lib/ISandbox.ts
+++ b/app/server/lib/ISandbox.ts
@@ -23,7 +23,7 @@ export interface ISandboxCreationOptions {
 }
 
 export interface ISandbox {
-  shutdown(): Promise<unknown>;  // TODO: tighten up this type.
+  shutdown(): Promise<void>;
   pyCall(funcName: string, ...varArgs: unknown[]): Promise<any>;
   reportMemoryUsage(): Promise<number>;
   getFlavor(): string;

--- a/app/server/lib/NullSandbox.ts
+++ b/app/server/lib/NullSandbox.ts
@@ -7,7 +7,7 @@ export class UnavailableSandboxMethodError extends Error {
 }
 
 export class NullSandbox implements ISandbox {
-  public async shutdown(): Promise<unknown> {
+  public async shutdown(): Promise<void> {
     throw new UnavailableSandboxMethodError("shutdown is not available");
   }
 


### PR DESCRIPTION
## Context

This PR addresses minor technical debt in the repository by resolving an long-standing `TODO` and a `FIXME`. 

- The `ISandbox` interface had a loose return type for its `shutdown` method, making it difficult to ensure type safety in implementations.
- The `Sort.swapColRef` function was performing unsafe unary operations on potentially string-based column references, which triggered ESLint warnings.

## Proposed solution

1. **Typing Improvement**: Updated the `ISandbox.shutdown()` method signature to return `Promise<void>` instead of `Promise<unknown>`. This matches the actual implementation in `NSandbox.ts` and fulfills the `TODO` in `ISandbox.ts`.
2. **Safety Fix**: Refactored `Sort.swapColRef` in `app/common/SortSpec.ts` to use the `createColSpec` utility. This ensures that column references (whether numeric or string-based) are handled correctly when changing direction, allowing for the removal of the `@typescript-eslint/no-unsafe-unary-minus` override.

## Related issues

Resolves existing TODO in `app/server/lib/ISandbox.ts` and FIXME in `app/common/SortSpec.ts`.
