### PR TITLE
Adapt documentation to run nbrowser tests locally

### DIFF
--- a/documentation/develop.md
+++ b/documentation/develop.md
@@ -186,13 +186,11 @@ for i in {1..20}; do GREP_TESTS="^yourTestSuiteHere\b" systemd-run --scope -p CP
 
 End-to-end tests are run in the GitHub CI with a specific _Chrome_ version that is known to run the tests smoothly.
 
-⚠️ A current issue is that tests don't run properly with _Chrome for Testing_ binaries, or with _Chrome_ starting with version 134.
-
 **If you don't have any tests randomly failing while running them locally: great! You can move on.**
 
-Otherwise, you should make sure that the local test suite uses _Chrome v132_ or _Chrome v133_, and not a _Chrome for Testing_ variant.
+Otherwise, you should make sure that the local test suite uses Chrome with the version expected by the CI (see `buildtools/install_chrome_for_tests.sh`).
 
-In order to do that, you can use an env var to let the script know about a specific chrome binary to use. For example, if your Chrome (v132 or 133) path is `/usr/bin/google-chrome`:
+In order to do that, you can use an env var to let the script know about a specific chrome binary to use. For example, if your Chrome path is `/usr/bin/google-chrome`:
 
 ```
 TEST_CHROME_BINARY_PATH="/usr/bin/google-chrome" yarn run test:nbrowser
@@ -200,9 +198,9 @@ TEST_CHROME_BINARY_PATH="/usr/bin/google-chrome" yarn run test:nbrowser
 
 #### Using an older Chrome version than the one you have already installed
 
-You might already have Chrome v134+ installed and feel stuck!
+You might already have a newer version of Chrome already installed and feel stuck!
 
-One solution is to build yourself a docker container matching what the GitHub actions does. Meaning, with node, python etc, an integrated Chrome v133 binary, and run tests inside that container.
+One solution is to build yourself a docker container matching what the GitHub actions does. Meaning, with node, python etc, an integrated Chrome binary as expected by the CI, and run tests inside that container.
 
 Another solution on Linux, is to just install an old Chrome version on your system directly.
 
@@ -210,10 +208,10 @@ A simple trick is to install an old Chrome _Beta_ binary, in order to not mess w
 
 #### Debian-based distro
 
-You can do the same as the `buildtools/install_chrome_for_tests.sh` script, but target an old version of Chrome _Beta_ like this:
+You can do the same as the `buildtools/install_chrome_for_tests.sh` script, but target an old version of Chrome _Beta_ like this (be sure to have `CHROME_VERSION` set as an env variable):
 
 ```bash
-curl -sS -o /tmp/chrome.deb http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-beta/google-chrome-beta_133.0.6943.35-1_amd64.deb \
+curl -sS -o /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
   && sudo apt-get install --allow-downgrades -y /tmp/chrome.deb \
   && rm /tmp/chrome.deb \
 ```
@@ -223,26 +221,8 @@ Open `google-chrome-beta` one time manually to confirm any first-loads modals th
 Then run tests with:
 
 ```
-SE_BROWSER_VERSION=133.0.6943.35 \
-SE_DRIVER_VERSION=133.0.6943.141 \
-TEST_CHROME_BINARY_PATH="/usr/bin/google-chrome-beta" \
-yarn run test:nbrowser
-```
-
-#### Archlinux
-
-Download the google-chrome-beta aur tarball matching the needed version and manually install it:
-
-- download and extract [this aur tarball](https://aur.archlinux.org/cgit/aur.git/snapshot/aur-56ac6350a4f727c76f7e0c406233e7cad0a45b5f.tar.gz) (matching Chrome Beta [v133](https://aur.archlinux.org/cgit/aur.git/commit/PKGBUILD?h=google-chrome-beta&id=56ac6350a4f727c76f7e0c406233e7cad0a45b5f))
-- `cd` in the extracted directory and `makepkg -si`.
-
-Open `google-chrome-beta` one time manually to confirm any first-loads modals that would prevent tests to run correctly.
-
-Then run tests with:
-
-```
-SE_BROWSER_VERSION=133.0.6943.35 \
-SE_DRIVER_VERSION=133.0.6943.141 \
+SE_BROWSER_VERSION=... \
+SE_DRIVER_VERSION=... \
 TEST_CHROME_BINARY_PATH="/usr/bin/google-chrome-beta" \
 yarn run test:nbrowser
 ```

--- a/documentation/develop.md
+++ b/documentation/develop.md
@@ -198,7 +198,7 @@ TEST_CHROME_BINARY_PATH="/usr/bin/google-chrome" yarn run test:nbrowser
 
 #### Using an older Chrome version than the one you have already installed
 
-You might already have a newer version of Chrome already installed and feel stuck!
+You might already have a newer version of Chrome installed and feel stuck!
 
 One solution is to build yourself a docker container matching what the GitHub actions does. Meaning, with node, python etc, an integrated Chrome binary as expected by the CI, and run tests inside that container.
 
@@ -215,6 +215,26 @@ curl -sS -o /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/g
   && sudo apt-get install --allow-downgrades -y /tmp/chrome.deb \
   && rm /tmp/chrome.deb \
 ```
+
+Open `google-chrome-beta` one time manually to confirm any first-loads modals that would prevent tests to run correctly.
+
+Then run tests with:
+
+```
+SE_BROWSER_VERSION=... \
+SE_DRIVER_VERSION=... \
+TEST_CHROME_BINARY_PATH="/usr/bin/google-chrome-beta" \
+yarn run test:nbrowser
+```
+
+#### Archlinux
+
+Download the google-chrome-beta AUR tarball matching the version you want, and manually install it.
+
+- explore the [google-chrome-beta AUR package history](https://aur.archlinux.org/cgit/aur.git/log/PKGBUILD?h=google-chrome-beta)
+- click on the commit details of the version you are interested in. For example, [this is the latest commit for chrome beta v146](https://aur.archlinux.org/cgit/aur.git/commit/PKGBUILD?h=google-chrome-beta&id=1426cfb8dbd2bac4ed8dcef72856cc18a9654995)
+- download and extract the tarball tied to this commit, which is the "download" link on the commit details page. [Example file for v146](https://aur.archlinux.org/cgit/aur.git/snapshot/aur-1426cfb8dbd2bac4ed8dcef72856cc18a9654995.tar.gz).
+- `cd` in the extracted directory and `makepkg -si`.
 
 Open `google-chrome-beta` one time manually to confirm any first-loads modals that would prevent tests to run correctly.
 


### PR DESCRIPTION
## Context

Previously there existed instruction to run tests with Chrome in version 132.

This is outdated.

## Proposed solution

Adapt the paragraphs where applicable

## Related issues


## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
