### PR TITLE
Enables Airtable to update existing rows during import

### DIFF
--- a/app/client/lib/airtable/AirtableImporter.ts
+++ b/app/client/lib/airtable/AirtableImporter.ts
@@ -128,6 +128,7 @@ export async function applyAirtableImportSchemaAndImportData(params: {
   await importDataFromAirtableBase({
     listRecords: tableId => listRecords(api.base(baseId), tableId, {}),
     addRows: docApi.addRows.bind(docApi),
+    addOrUpdateRows: docApi.addOrUpdateRows.bind(docApi),
     updateRows: docApi.updateRows.bind(docApi),
     uploadAttachment: docApi.uploadAttachment.bind(docApi),
     schemaCrosswalk,

--- a/app/common/UserAPI.ts
+++ b/app/common/UserAPI.ts
@@ -30,7 +30,7 @@ import {
 } from "app/common/Triggers";
 import { addCurrentOrgToPath, getGristConfig } from "app/common/urlUtils";
 import { AttachmentStore, AttachmentStoreDesc,  Record as ApiRecord, TablesGet } from "app/plugin/DocApiTypes";
-import { AddOrUpdateRecord } from "app/plugin/DocApiTypes";
+import { AddOrUpdateRecord, BulkAddOrUpdateRecordResult } from "app/plugin/DocApiTypes";
 
 import { AxiosProgressEvent } from "axios";
 import omitBy from "lodash/omitBy";
@@ -554,8 +554,9 @@ export interface DocAPI {
   sql(sql: string, args?: any[]): Promise<SqlResult>;
   updateRows(tableId: string, changes: TableColValues): Promise<number[]>;
   addRows(tableId: string, additions: BulkColValues): Promise<number[]>;
-  addOrUpdateRows(tableId: string, records: AddOrUpdateRecord[],
-    options?: AddOrUpdateRowsOptions): Promise<void>;
+  addOrUpdateRows(
+    tableId: string, records: AddOrUpdateRecord[], options?: AddOrUpdateRowsOptions
+  ): Promise<BulkAddOrUpdateRecordResult>;
   removeRows(tableId: string, removals: number[]): Promise<number[]>;
   fork(): Promise<ForkResult>;
   replace(source: DocReplacementOptions): Promise<void>;
@@ -1171,14 +1172,14 @@ export class DocAPIImpl extends BaseAPI implements DocAPI {
 
   public async addOrUpdateRows(
     tableId: string, records: AddOrUpdateRecord[], options: AddOrUpdateRowsOptions = {},
-  ): Promise<void> {
+  ): Promise<BulkAddOrUpdateRecordResult> {
     const params = new URLSearchParams();
     if (options.add === false) { params.set("noadd", "1"); }
     if (options.update === false) { params.set("noupdate", "1"); }
     if (options.onMany !== undefined) { params.set("onmany", options.onMany); }
     if (options.allowEmptyRequire) { params.set("allow_empty_require", "1"); }
     const query = params.toString() ? `?${params.toString()}` : "";
-    await this.requestJson(`${this._url}/tables/${tableId}/records${query}`, {
+    return this.requestJson(`${this._url}/tables/${tableId}/records${query}`, {
       body: JSON.stringify({ records }),
       method: "PUT",
     });

--- a/app/common/UserAPI.ts
+++ b/app/common/UserAPI.ts
@@ -30,6 +30,7 @@ import {
 } from "app/common/Triggers";
 import { addCurrentOrgToPath, getGristConfig } from "app/common/urlUtils";
 import { AttachmentStore, AttachmentStoreDesc,  Record as ApiRecord, TablesGet } from "app/plugin/DocApiTypes";
+import { AddOrUpdateRecord } from "app/plugin/DocApiTypes";
 
 import { AxiosProgressEvent } from "axios";
 import omitBy from "lodash/omitBy";
@@ -351,6 +352,17 @@ export interface OrgError {
   status: number;
 }
 
+export interface AddOrUpdateRowsOptions {
+  /** Permit inserting a record. Defaults to true. */
+  add?: boolean;
+  /** Permit updating a record. Defaults to true. */
+  update?: boolean;
+  /** Whether to update none, one, or all matching records. Defaults to "first". */
+  onMany?: "none" | "first" | "all";
+  /** Allow "wildcard" operation where empty `require` matches all records. Defaults to false. */
+  allowEmptyRequire?: boolean;
+}
+
 /**
  * Options to control the source of a document being replaced.  For
  * example, a document could be initialized from another document
@@ -542,6 +554,8 @@ export interface DocAPI {
   sql(sql: string, args?: any[]): Promise<SqlResult>;
   updateRows(tableId: string, changes: TableColValues): Promise<number[]>;
   addRows(tableId: string, additions: BulkColValues): Promise<number[]>;
+  addOrUpdateRows(tableId: string, records: AddOrUpdateRecord[],
+    options?: AddOrUpdateRowsOptions): Promise<void>;
   removeRows(tableId: string, removals: number[]): Promise<number[]>;
   fork(): Promise<ForkResult>;
   replace(source: DocReplacementOptions): Promise<void>;
@@ -1152,6 +1166,21 @@ export class DocAPIImpl extends BaseAPI implements DocAPI {
     return this.requestJson(`${this._url}/tables/${tableId}/data`, {
       body: JSON.stringify(additions),
       method: "POST",
+    });
+  }
+
+  public async addOrUpdateRows(
+    tableId: string, records: AddOrUpdateRecord[], options: AddOrUpdateRowsOptions = {},
+  ): Promise<void> {
+    const params = new URLSearchParams();
+    if (options.add === false) { params.set("noadd", "1"); }
+    if (options.update === false) { params.set("noupdate", "1"); }
+    if (options.onMany !== undefined) { params.set("onmany", options.onMany); }
+    if (options.allowEmptyRequire) { params.set("allow_empty_require", "1"); }
+    const query = params.toString() ? `?${params.toString()}` : "";
+    await this.requestJson(`${this._url}/tables/${tableId}/records${query}`, {
+      body: JSON.stringify({ records }),
+      method: "PUT",
     });
   }
 

--- a/app/common/airtable/AirtableDataImporter.ts
+++ b/app/common/airtable/AirtableDataImporter.ts
@@ -8,15 +8,15 @@ import {
 } from "app/common/airtable/AirtableAttachmentTracker";
 import { AirtableDataImportParams } from "app/common/airtable/AirtableDataImporterTypes";
 import {
-  createEmptyBulkColValues,
   extractRefFromRecordField,
   isRefField,
   ReferenceTracker,
   RefValuesByColumnId,
   TableReferenceTracker,
 } from "app/common/airtable/AirtableReferenceTracker";
-import { BulkColValues, CellValue, GristObjCode } from "app/plugin/GristData";
 import { AirtableIdColumnLabel } from "app/common/airtable/AirtableSchemaImporter";
+import { AddOrUpdateRecord } from "app/plugin/DocApiTypes";
+import { CellValue, GristObjCode } from "app/plugin/GristData";
 
 export async function importDataFromAirtableBase(
   { listRecords, addOrUpdateRows, updateRows, uploadAttachment, schemaCrosswalk, onProgress }: AirtableDataImportParams,
@@ -24,7 +24,7 @@ export async function importDataFromAirtableBase(
   const referenceTracker = new ReferenceTracker();
   const attachmentTracker = new AttachmentTracker();
 
-  const addRowsPromises: Promise<any>[] = [];
+  const addOrUpdateRowsPromises: Promise<any>[] = [];
 
   // Verify every table has an airtable ID column.
   let missingIdColumnCount = 0;
@@ -36,7 +36,7 @@ export async function importDataFromAirtableBase(
   if (missingIdColumnCount > 0) {
     // TODO - Raise this issue with the user in a more helpful way. This is just for testing purposes.
     throw new Error(
-      `${missingIdColumnCount} tables are missing an Airtable ID column (labelled ${AirtableIdColumnLabel}`
+      `${missingIdColumnCount} tables are missing an Airtable ID column (labelled ${AirtableIdColumnLabel})`,
     );
   }
 
@@ -76,12 +76,13 @@ export async function importDataFromAirtableBase(
     while (listRecordsResult.records.length > 0) {
       const { records } = listRecordsResult;
 
-      const colValues: BulkColValues = createEmptyBulkColValues(gristColumnIds);
       const airtableRecordIds: string[] = [];
+      const addOrUpdateRecords: AddOrUpdateRecord[] = [];
       const refsByColumnIdForRecords: RefValuesByColumnId[] = [];
       const attachmentsByColumnIdForRecords: AttachmentsByColumnId[] = [];
 
       for (const record of records) {
+        const addOrUpdateRecord: Required<AddOrUpdateRecord> = { require: {}, fields: {} };
         const refsByColumnId: RefValuesByColumnId = {};
         const attachmentsByColumnId: AttachmentsByColumnId = {};
 
@@ -100,7 +101,7 @@ export async function importDataFromAirtableBase(
 
           if (isRefField(airtableField) || isAttachmentField(airtableField)) {
             // Column should remain blank until it's filled in by a later step.
-            colValues[gristColumn.id].push(null);
+            addOrUpdateRecord.fields[gristColumn.id] = null;
             continue;
           }
 
@@ -109,14 +110,14 @@ export async function importDataFromAirtableBase(
 
           const value = converter(fieldMapping.airtableField, record.fields[fieldMapping.airtableField.name]);
 
-          // Always push, even if the value is undefined, so that row values are always at the right index.
-          colValues[fieldMapping.gristColumn.id].push(value ?? null);
+          addOrUpdateRecord.fields[fieldMapping.gristColumn.id] = value ?? null;
         }
 
         if (tableCrosswalk.airtableIdColumn) {
-          colValues[tableCrosswalk.airtableIdColumn.id].push(record.id);
+          addOrUpdateRecord.require[tableCrosswalk.airtableIdColumn.id] = record.id;
         }
 
+        addOrUpdateRecords.push(addOrUpdateRecord);
         refsByColumnIdForRecords.push(refsByColumnId);
         attachmentsByColumnIdForRecords.push(attachmentsByColumnId);
       }
@@ -124,23 +125,25 @@ export async function importDataFromAirtableBase(
       // Need to check if addOrUpdateRows can handle just adding.
       // If so - let's move everything over to record syntax? Maybe Claude can help.
 
-      const addRowsPromise = addOrUpdateRows(tableCrosswalk.gristTable.id, colValues)
-        .then(() => {
-          airtableRecordIds.forEach((airtableRecordId, index) => {
-            // Only add entries to the reference and attachment trackers once we know they're added to the table.
-            referenceTracker.addRecordIdMapping(airtableRecordId, gristRowIds[index]);
-            tableReferenceTracker?.addUnresolvedRecord({
-              gristRecordId: gristRowIds[index],
-              refsByColumnId: refsByColumnIdForRecords[index],
-            });
-            tableAttachmentTracker?.addRecord({
-              gristRecordId: gristRowIds[index],
-              attachmentsByColumnId: attachmentsByColumnIdForRecords[index],
-            });
+      const addOrUpdateRowsPromise = addOrUpdateRows(
+        tableCrosswalk.gristTable.id, addOrUpdateRecords, { onMany: "first" },
+      ).then((result) => {
+        airtableRecordIds.forEach((airtableRecordId, index) => {
+          const gristRecordId = result.recordIds[index][0];
+          // Only add entries to the reference and attachment trackers once we know they're added to the table.
+          referenceTracker.addRecordIdMapping(airtableRecordId, gristRecordId);
+          tableReferenceTracker?.addUnresolvedRecord({
+            gristRecordId,
+            refsByColumnId: refsByColumnIdForRecords[index],
+          });
+          tableAttachmentTracker?.addRecord({
+            gristRecordId,
+            attachmentsByColumnId: attachmentsByColumnIdForRecords[index],
           });
         });
+      });
 
-      addRowsPromises.push(addRowsPromise);
+      addOrUpdateRowsPromises.push(addOrUpdateRowsPromise);
 
       listRecordsResult = await listRecordsResult.fetchNextPage();
     }
@@ -148,7 +151,7 @@ export async function importDataFromAirtableBase(
 
   // Future improvement - report all errors here using Promise.allSettled, or continue even if
   //                      a few sets of rows throw errors
-  await Promise.all(addRowsPromises);
+  await Promise.all(addOrUpdateRowsPromises);
 
   for (const tableReferenceTracker of referenceTracker.getTables()) {
     await tableReferenceTracker.bulkUpdateRowsWithUnresolvedReferences(updateRows);

--- a/app/common/airtable/AirtableDataImporter.ts
+++ b/app/common/airtable/AirtableDataImporter.ts
@@ -53,7 +53,11 @@ export async function importDataFromAirtableBase(
 
     let tableReferenceTracker: TableReferenceTracker | undefined;
     if (referenceColumnIds.length > 0) {
-      tableReferenceTracker = referenceTracker.addTable(tableCrosswalk.gristTable.id, referenceColumnIds);
+      tableReferenceTracker = referenceTracker.addTable(
+        tableCrosswalk.gristTable.id,
+        referenceColumnIds,
+        { airtableIdColumnId: tableCrosswalk.airtableIdColumn?.id },
+      );
     }
 
     const attachmentColumnIds = Array.from(tableCrosswalk.fields.values())
@@ -109,8 +113,6 @@ export async function importDataFromAirtableBase(
 
         if (tableCrosswalk.airtableIdColumn) {
           addOrUpdateRecord.require[tableCrosswalk.airtableIdColumn.id] = record.id;
-          // Simplifies bulk-column conversion to have all fields in one object.
-          addOrUpdateRecord.fields[tableCrosswalk.airtableIdColumn.id] = record.id;
         }
 
         addOrUpdateRecords.push(addOrUpdateRecord);

--- a/app/common/airtable/AirtableDataImporter.ts
+++ b/app/common/airtable/AirtableDataImporter.ts
@@ -6,9 +6,11 @@ import {
   isAttachmentField,
   TableAttachmentTracker,
 } from "app/common/airtable/AirtableAttachmentTracker";
+import { AirtableBaseSchemaCrosswalk } from "app/common/airtable/AirtableCrosswalk";
 import { AirtableDataImportParams } from "app/common/airtable/AirtableDataImporterTypes";
 import {
   extractRefFromRecordField,
+  getRefFieldLinkedTableId,
   isRefField,
   ReferenceTracker,
   RefValuesByColumnId,
@@ -47,15 +49,18 @@ export async function importDataFromAirtableBase(
       gristColumnIds.push(tableCrosswalk.airtableIdColumn.id);
     }
 
-    const referenceColumnIds = Array.from(tableCrosswalk.fields.values())
+    const referenceColumns = Array.from(tableCrosswalk.fields.values())
       .filter(mapping => isRefField(mapping.airtableField))
-      .map(mapping => mapping.gristColumn.id);
+      .map(mapping => ({
+        id: mapping.gristColumn.id,
+        tableId: resolveLinkedTableId(schemaCrosswalk, mapping.airtableField),
+      }));
 
     let tableReferenceTracker: TableReferenceTracker | undefined;
-    if (referenceColumnIds.length > 0) {
+    if (referenceColumns.length > 0) {
       tableReferenceTracker = referenceTracker.addTable(
         tableCrosswalk.gristTable.id,
-        referenceColumnIds,
+        referenceColumns,
         { airtableIdColumnId: tableCrosswalk.airtableIdColumn?.id },
       );
     }
@@ -226,3 +231,11 @@ const AirtableFieldValueConverters: Record<string, AirtableFieldValueConverter> 
 };
 
 const formatCollaborator = (collaborator: any) => collaborator?.name;
+
+const resolveTableId = (schemaCrosswalk: AirtableBaseSchemaCrosswalk, airtableTableId: string) =>
+  schemaCrosswalk.tables.get(airtableTableId)?.gristTable.id;
+
+function resolveLinkedTableId(schemaCrosswalk: AirtableBaseSchemaCrosswalk, field: AirtableFieldSchema) {
+  const linkedTableId = getRefFieldLinkedTableId(field);
+  return linkedTableId && resolveTableId(schemaCrosswalk, linkedTableId);
+}

--- a/app/common/airtable/AirtableDataImporter.ts
+++ b/app/common/airtable/AirtableDataImporter.ts
@@ -14,31 +14,25 @@ import {
   RefValuesByColumnId,
   TableReferenceTracker,
 } from "app/common/airtable/AirtableReferenceTracker";
-import { AirtableIdColumnLabel } from "app/common/airtable/AirtableSchemaImporter";
 import { AddOrUpdateRecord } from "app/plugin/DocApiTypes";
 import { CellValue, GristObjCode } from "app/plugin/GristData";
+import { convertToBulkColValues } from "app/plugin/TableOperationsImpl";
 
 export async function importDataFromAirtableBase(
-  { listRecords, addOrUpdateRows, updateRows, uploadAttachment, schemaCrosswalk, onProgress }: AirtableDataImportParams,
+  {
+    listRecords,
+    addRows,
+    addOrUpdateRows,
+    updateRows,
+    uploadAttachment,
+    schemaCrosswalk,
+    onProgress,
+  }: AirtableDataImportParams,
 ) {
   const referenceTracker = new ReferenceTracker();
   const attachmentTracker = new AttachmentTracker();
 
   const addOrUpdateRowsPromises: Promise<any>[] = [];
-
-  // Verify every table has an airtable ID column.
-  let missingIdColumnCount = 0;
-  for (const table of schemaCrosswalk.tables.values()) {
-    if (table.airtableIdColumn === undefined) {
-      missingIdColumnCount += 1;
-    }
-  }
-  if (missingIdColumnCount > 0) {
-    // TODO - Raise this issue with the user in a more helpful way. This is just for testing purposes.
-    throw new Error(
-      `${missingIdColumnCount} tables are missing an Airtable ID column (labelled ${AirtableIdColumnLabel})`,
-    );
-  }
 
   // TODO: Strings passed to onProgress calls in common code aren't translatable.
   onProgress?.({ percent: 0, status: "Importing records from Airtable..." });
@@ -77,7 +71,7 @@ export async function importDataFromAirtableBase(
       const { records } = listRecordsResult;
 
       const airtableRecordIds: string[] = [];
-      const addOrUpdateRecords: AddOrUpdateRecord[] = [];
+      const addOrUpdateRecords: Required<AddOrUpdateRecord>[] = [];
       const refsByColumnIdForRecords: RefValuesByColumnId[] = [];
       const attachmentsByColumnIdForRecords: AttachmentsByColumnId[] = [];
 
@@ -115,6 +109,8 @@ export async function importDataFromAirtableBase(
 
         if (tableCrosswalk.airtableIdColumn) {
           addOrUpdateRecord.require[tableCrosswalk.airtableIdColumn.id] = record.id;
+          // Simplifies bulk-column conversion to have all fields in one object.
+          addOrUpdateRecord.fields[tableCrosswalk.airtableIdColumn.id] = record.id;
         }
 
         addOrUpdateRecords.push(addOrUpdateRecord);
@@ -122,14 +118,21 @@ export async function importDataFromAirtableBase(
         attachmentsByColumnIdForRecords.push(attachmentsByColumnId);
       }
 
-      // Need to check if addOrUpdateRows can handle just adding.
-      // If so - let's move everything over to record syntax? Maybe Claude can help.
+      let addOrUpdateRowsPromise: Promise<number[]> = Promise.resolve([]);
 
-      const addOrUpdateRowsPromise = addOrUpdateRows(
-        tableCrosswalk.gristTable.id, addOrUpdateRecords, { onMany: "first" },
-      ).then((result) => {
+      if (tableCrosswalk.airtableIdColumn) {
+        addOrUpdateRowsPromise =
+          addOrUpdateRows(tableCrosswalk.gristTable.id, addOrUpdateRecords, { onMany: "first" })
+            .then(result => result.recordIds.map(ids => ids[0]));
+      } else {
+        addOrUpdateRowsPromise = addRows(
+          tableCrosswalk.gristTable.id, convertToBulkColValues(addOrUpdateRecords),
+        );
+      }
+
+      const finishedProcessingPromise = addOrUpdateRowsPromise.then((recordIds) => {
         airtableRecordIds.forEach((airtableRecordId, index) => {
-          const gristRecordId = result.recordIds[index][0];
+          const gristRecordId = recordIds[index];
           // Only add entries to the reference and attachment trackers once we know they're added to the table.
           referenceTracker.addRecordIdMapping(airtableRecordId, gristRecordId);
           tableReferenceTracker?.addUnresolvedRecord({
@@ -143,7 +146,7 @@ export async function importDataFromAirtableBase(
         });
       });
 
-      addOrUpdateRowsPromises.push(addOrUpdateRowsPromise);
+      addOrUpdateRowsPromises.push(finishedProcessingPromise);
 
       listRecordsResult = await listRecordsResult.fetchNextPage();
     }

--- a/app/common/airtable/AirtableDataImporter.ts
+++ b/app/common/airtable/AirtableDataImporter.ts
@@ -16,6 +16,7 @@ import {
   TableReferenceTracker,
 } from "app/common/airtable/AirtableReferenceTracker";
 import { BulkColValues, CellValue, GristObjCode } from "app/plugin/GristData";
+import { AirtableIdColumnLabel } from "app/common/airtable/AirtableSchemaImporter";
 
 export async function importDataFromAirtableBase(
   { listRecords, addOrUpdateRows, updateRows, uploadAttachment, schemaCrosswalk, onProgress }: AirtableDataImportParams,
@@ -24,6 +25,20 @@ export async function importDataFromAirtableBase(
   const attachmentTracker = new AttachmentTracker();
 
   const addRowsPromises: Promise<any>[] = [];
+
+  // Verify every table has an airtable ID column.
+  let missingIdColumnCount = 0;
+  for (const table of schemaCrosswalk.tables.values()) {
+    if (table.airtableIdColumn === undefined) {
+      missingIdColumnCount += 1;
+    }
+  }
+  if (missingIdColumnCount > 0) {
+    // TODO - Raise this issue with the user in a more helpful way. This is just for testing purposes.
+    throw new Error(
+      `${missingIdColumnCount} tables are missing an Airtable ID column (labelled ${AirtableIdColumnLabel}`
+    );
+  }
 
   // TODO: Strings passed to onProgress calls in common code aren't translatable.
   onProgress?.({ percent: 0, status: "Importing records from Airtable..." });

--- a/app/common/airtable/AirtableDataImporter.ts
+++ b/app/common/airtable/AirtableDataImporter.ts
@@ -18,7 +18,7 @@ import {
 import { BulkColValues, CellValue, GristObjCode } from "app/plugin/GristData";
 
 export async function importDataFromAirtableBase(
-  { listRecords, addRows, updateRows, uploadAttachment, schemaCrosswalk, onProgress }: AirtableDataImportParams,
+  { listRecords, addOrUpdateRows, updateRows, uploadAttachment, schemaCrosswalk, onProgress }: AirtableDataImportParams,
 ) {
   const referenceTracker = new ReferenceTracker();
   const attachmentTracker = new AttachmentTracker();
@@ -106,8 +106,11 @@ export async function importDataFromAirtableBase(
         attachmentsByColumnIdForRecords.push(attachmentsByColumnId);
       }
 
-      const addRowsPromise = addRows(tableCrosswalk.gristTable.id, colValues)
-        .then((gristRowIds) => {
+      // Need to check if addOrUpdateRows can handle just adding.
+      // If so - let's move everything over to record syntax? Maybe Claude can help.
+
+      const addRowsPromise = addOrUpdateRows(tableCrosswalk.gristTable.id, colValues)
+        .then(() => {
           airtableRecordIds.forEach((airtableRecordId, index) => {
             // Only add entries to the reference and attachment trackers once we know they're added to the table.
             referenceTracker.addRecordIdMapping(airtableRecordId, gristRowIds[index]);

--- a/app/common/airtable/AirtableDataImporterTypes.ts
+++ b/app/common/airtable/AirtableDataImporterTypes.ts
@@ -3,7 +3,7 @@ import { AirtableTableId } from "app/common/airtable/AirtableAPITypes";
 import { AirtableBaseSchemaCrosswalk, GristTableId } from "app/common/airtable/AirtableCrosswalk";
 import { BulkColValues, TableColValues } from "app/common/DocActions";
 import { AddOrUpdateRowsOptions } from "app/common/UserAPI";
-import { AddOrUpdateRecord } from "app/plugin/DocApiTypes";
+import { AddOrUpdateRecord, BulkAddOrUpdateRecordResult } from "app/plugin/DocApiTypes";
 
 /**
  * Parameters for importing data from Airtable into Grist.
@@ -45,8 +45,9 @@ export type ListRecordsFunc = (tableId: AirtableTableId) => Promise<ListAirtable
  */
 type AddRowsFunc = (tableId: GristTableId, rows: BulkColValues) => Promise<number[]>;
 
-type AddOrUpdateRowsFunc =
-  (tableId: GristTableId, records: AddOrUpdateRecord[], options: AddOrUpdateRowsOptions) => Promise<void>;
+type AddOrUpdateRowsFunc = (
+  tableId: GristTableId, records: AddOrUpdateRecord[], options: AddOrUpdateRowsOptions,
+) => Promise<BulkAddOrUpdateRecordResult>;
 
 /**
  * Function that updates the column value(s) of a set of rows in a Grist table.

--- a/app/common/airtable/AirtableDataImporterTypes.ts
+++ b/app/common/airtable/AirtableDataImporterTypes.ts
@@ -2,6 +2,8 @@ import { ListAirtableRecordsResult } from "app/common/airtable/AirtableAPI";
 import { AirtableTableId } from "app/common/airtable/AirtableAPITypes";
 import { AirtableBaseSchemaCrosswalk, GristTableId } from "app/common/airtable/AirtableCrosswalk";
 import { BulkColValues, TableColValues } from "app/common/DocActions";
+import { AddOrUpdateRowsOptions } from "app/common/UserAPI";
+import { AddOrUpdateRecord } from "app/plugin/DocApiTypes";
 
 /**
  * Parameters for importing data from Airtable into Grist.
@@ -12,6 +14,7 @@ export interface AirtableDataImportParams {
 
   // Grist data API operations. Used to import data into Grist.
   addRows: AddRowsFunc,
+  addOrUpdateRows: AddOrUpdateRowsFunc,
   updateRows: UpdateRowsFunc,
   uploadAttachment: UploadAttachmentFunc,
 
@@ -41,6 +44,9 @@ export type ListRecordsFunc = (tableId: AirtableTableId) => Promise<ListAirtable
  * Function that adds rows to a Grist table.
  */
 type AddRowsFunc = (tableId: GristTableId, rows: BulkColValues) => Promise<number[]>;
+
+type AddOrUpdateRowsFunc =
+  (tableId: GristTableId, records: AddOrUpdateRecord[], options: AddOrUpdateRowsOptions) => Promise<void>;
 
 /**
  * Function that updates the column value(s) of a set of rows in a Grist table.

--- a/app/common/airtable/AirtableReferenceTracker.ts
+++ b/app/common/airtable/AirtableReferenceTracker.ts
@@ -27,8 +27,8 @@ export class ReferenceTracker {
     return this._rowIdLookup.get(originalRecordId);
   }
 
-  public addTable(gristTableId: string, columnIdsToUpdate: string[]) {
-    const tableTracker = new TableReferenceTracker(this, gristTableId, columnIdsToUpdate);
+  public addTable(gristTableId: string, columnIdsToUpdate: string[], options: { airtableIdColumnId?: string } = {}) {
+    const tableTracker = new TableReferenceTracker(this, gristTableId, columnIdsToUpdate, options);
     this._tableReferenceTrackers.set(gristTableId, tableTracker);
     return tableTracker;
   }
@@ -41,10 +41,16 @@ export class ReferenceTracker {
 // Store and resolve references per-table to enable bulk updates.
 export class TableReferenceTracker {
   private _unresolvedRefsForRecords: UnresolvedRefsForRecord[] = [];
+  private _airtableIdColumnId?: string;
 
   // To perform bulk updates, all reference columns need updating at the same time.
   // Enforce this by explicitly listing the column ids to use during instantiation.
-  public constructor(private _parent: ReferenceTracker, private _tableId: string, private _columnIds: string[]) {
+  public constructor(
+    private _parent: ReferenceTracker,
+    private _tableId: string,
+    private _columnIds: string[],
+    _options: { airtableIdColumnId?: string } = {}) {
+    this._airtableIdColumnId = _options.airtableIdColumnId;
   }
 
   public addUnresolvedRecord(unresolvedRefsForRecord: UnresolvedRefsForRecord) {
@@ -68,8 +74,22 @@ export class TableReferenceTracker {
         const references = unresolvedRefsForRecord.refsByColumnId[columnId];
         // TODO - Unresolvable references are currently just skipped silently. Find a way to display
         //        them in the cell / UI.
-        const resolvedReferences = references ?
-          references.map(originalRecordId => this._parent.resolve(originalRecordId)).filter(isNonNullish) : [];
+        if (!references) {
+          pendingUpdate[columnId].push([GristObjCode.List]);
+          continue;
+        }
+
+        // If there's an Airtable ID column, the sandbox can perform the lookup for us.
+        if (this._airtableIdColumnId) {
+          pendingUpdate[columnId].push(
+            [GristObjCode.LookUp, references, { column: this._airtableIdColumnId }],
+          );
+          continue;
+        }
+
+        const resolvedReferences =
+          references.map(originalRecordId => this._parent.resolve(originalRecordId)).filter(isNonNullish);
+
         pendingUpdate[columnId].push(
           [GristObjCode.List, ...resolvedReferences],
         );

--- a/app/common/airtable/AirtableReferenceTracker.ts
+++ b/app/common/airtable/AirtableReferenceTracker.ts
@@ -1,7 +1,7 @@
 import { AirtableFieldSchema } from "app/common/airtable/AirtableAPITypes";
 import { AirtableFieldMappingInfo } from "app/common/airtable/AirtableCrosswalk";
 import { UpdateRowsFunc } from "app/common/airtable/AirtableDataImporterTypes";
-import { TableColValues } from "app/common/DocActions";
+import { CellValue, TableColValues } from "app/common/DocActions";
 import { isNonNullish } from "app/common/gutil";
 import { BulkColValues, GristObjCode } from "app/plugin/GristData";
 
@@ -28,8 +28,27 @@ export class ReferenceTracker {
     this._rowIdLookup.set(originalRecordId, gristRecordId);
   }
 
-  public resolve(originalRecordId: string): number | undefined {
+  public lookupRowIdForRecord(originalRecordId: string): number | undefined {
     return this._rowIdLookup.get(originalRecordId);
+  }
+
+  public resolveCellValue(column: RefColumn, originalRecordIds: string[] | undefined): CellValue {
+    if (!originalRecordIds) {
+      return [GristObjCode.List];
+    }
+
+    // If there's an Airtable ID column, the sandbox can perform the lookup for us.
+    const otherTableAirtableIdColumnId =
+      column.tableId && this.getTable(column.tableId)?.airtableIdColumnId;
+
+    if (otherTableAirtableIdColumnId) {
+      return [GristObjCode.LookUp, originalRecordIds, { column: otherTableAirtableIdColumnId }];
+    }
+
+    const internallyKnownRowIds =
+      originalRecordIds.map(originalRecordId => this.lookupRowIdForRecord(originalRecordId)).filter(isNonNullish);
+
+    return [GristObjCode.List, ...internallyKnownRowIds];
   }
 
   public addTable(gristTableId: string, columnIdsToUpdate: RefColumn[], options: { airtableIdColumnId?: string } = {}) {
@@ -84,28 +103,7 @@ export class TableReferenceTracker {
         const references = unresolvedRefsForRecord.refsByColumnId[column.id];
         // TODO - Unresolvable references are currently just skipped silently. Find a way to display
         //        them in the cell / UI.
-        if (!references) {
-          pendingUpdate[column.id].push([GristObjCode.List]);
-          continue;
-        }
-
-        // If there's an Airtable ID column, the sandbox can perform the lookup for us.
-        const otherTableAirtableIdColumnId =
-          column.tableId && this._parent.getTable(column.tableId)?.airtableIdColumnId;
-
-        if (otherTableAirtableIdColumnId) {
-          pendingUpdate[column.id].push(
-            [GristObjCode.LookUp, references, { column: otherTableAirtableIdColumnId }],
-          );
-          continue;
-        }
-
-        const resolvedReferences =
-          references.map(originalRecordId => this._parent.resolve(originalRecordId)).filter(isNonNullish);
-
-        pendingUpdate[column.id].push(
-          [GristObjCode.List, ...resolvedReferences],
-        );
+        pendingUpdate[column.id].push(this._parent.resolveCellValue(column, references));
       }
 
       if (pendingUpdate.id.length >= batchSize) {

--- a/app/common/airtable/AirtableReferenceTracker.ts
+++ b/app/common/airtable/AirtableReferenceTracker.ts
@@ -12,6 +12,11 @@ interface UnresolvedRefsForRecord {
   refsByColumnId: RefValuesByColumnId;
 }
 
+interface RefColumn {
+  tableId?: string;
+  id: string;
+}
+
 export class ReferenceTracker {
   // Maps known airtable ids to their grist row ids to enable reference resolution.
   // Airtable row ids are guaranteed unique within a base.
@@ -27,10 +32,14 @@ export class ReferenceTracker {
     return this._rowIdLookup.get(originalRecordId);
   }
 
-  public addTable(gristTableId: string, columnIdsToUpdate: string[], options: { airtableIdColumnId?: string } = {}) {
+  public addTable(gristTableId: string, columnIdsToUpdate: RefColumn[], options: { airtableIdColumnId?: string } = {}) {
     const tableTracker = new TableReferenceTracker(this, gristTableId, columnIdsToUpdate, options);
     this._tableReferenceTrackers.set(gristTableId, tableTracker);
     return tableTracker;
+  }
+
+  public getTable(gristTableId: string): TableReferenceTracker | undefined {
+    return this._tableReferenceTrackers.get(gristTableId);
   }
 
   public getTables(): TableReferenceTracker[] {
@@ -40,17 +49,17 @@ export class ReferenceTracker {
 
 // Store and resolve references per-table to enable bulk updates.
 export class TableReferenceTracker {
+  public readonly airtableIdColumnId?: string;
   private _unresolvedRefsForRecords: UnresolvedRefsForRecord[] = [];
-  private _airtableIdColumnId?: string;
 
   // To perform bulk updates, all reference columns need updating at the same time.
   // Enforce this by explicitly listing the column ids to use during instantiation.
   public constructor(
     private _parent: ReferenceTracker,
     private _tableId: string,
-    private _columnIds: string[],
+    private _refColumns: RefColumn[],
     _options: { airtableIdColumnId?: string } = {}) {
-    this._airtableIdColumnId = _options.airtableIdColumnId;
+    this.airtableIdColumnId = _options.airtableIdColumnId;
   }
 
   public addUnresolvedRecord(unresolvedRefsForRecord: UnresolvedRefsForRecord) {
@@ -62,27 +71,31 @@ export class TableReferenceTracker {
     options?: { batchSize?: number },
   ) {
     const batchSize = options?.batchSize ?? 100;
+    const refColumnIds = this._refColumns.map(col => col.id);
 
-    let pendingUpdate: TableColValues = { id: [], ...createEmptyBulkColValues(this._columnIds) };
+    let pendingUpdate: TableColValues = { id: [], ...createEmptyBulkColValues(refColumnIds) };
 
     for (const unresolvedRefsForRecord of this._unresolvedRefsForRecords) {
       pendingUpdate.id.push(unresolvedRefsForRecord.gristRecordId);
 
       // Every row needs an entry in its respective column in the bulk update, so always loop through
       // the same columns for every row.
-      for (const columnId of this._columnIds) {
-        const references = unresolvedRefsForRecord.refsByColumnId[columnId];
+      for (const column of this._refColumns) {
+        const references = unresolvedRefsForRecord.refsByColumnId[column.id];
         // TODO - Unresolvable references are currently just skipped silently. Find a way to display
         //        them in the cell / UI.
         if (!references) {
-          pendingUpdate[columnId].push([GristObjCode.List]);
+          pendingUpdate[column.id].push([GristObjCode.List]);
           continue;
         }
 
         // If there's an Airtable ID column, the sandbox can perform the lookup for us.
-        if (this._airtableIdColumnId) {
-          pendingUpdate[columnId].push(
-            [GristObjCode.LookUp, references, { column: this._airtableIdColumnId }],
+        const otherTableAirtableIdColumnId =
+          column.tableId && this._parent.getTable(column.tableId)?.airtableIdColumnId;
+
+        if (otherTableAirtableIdColumnId) {
+          pendingUpdate[column.id].push(
+            [GristObjCode.LookUp, references, { column: otherTableAirtableIdColumnId }],
           );
           continue;
         }
@@ -90,14 +103,14 @@ export class TableReferenceTracker {
         const resolvedReferences =
           references.map(originalRecordId => this._parent.resolve(originalRecordId)).filter(isNonNullish);
 
-        pendingUpdate[columnId].push(
+        pendingUpdate[column.id].push(
           [GristObjCode.List, ...resolvedReferences],
         );
       }
 
       if (pendingUpdate.id.length >= batchSize) {
         await updateRows(this._tableId, pendingUpdate);
-        pendingUpdate = { id: [], ...createEmptyBulkColValues(this._columnIds) };
+        pendingUpdate = { id: [], ...createEmptyBulkColValues(refColumnIds) };
       }
     }
 
@@ -109,6 +122,10 @@ export class TableReferenceTracker {
 
 export function isRefField(field: AirtableFieldSchema) {
   return field.type === "multipleRecordLinks";
+}
+
+export function getRefFieldLinkedTableId(field: AirtableFieldSchema): string | undefined {
+  return field.options?.linkedTableId;
 }
 
 export function extractRefFromRecordField(

--- a/app/plugin/DocApiTypes.ts
+++ b/app/plugin/DocApiTypes.ts
@@ -123,6 +123,7 @@ export interface ColumnMetadata {
     colRef: number;
     label: string;
     isFormula: boolean;
+    type: string;
     [colId: string]: CellValue;
   };
 }

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -3628,8 +3628,9 @@ export class ActiveDoc extends EventEmitter {
         colRef: colRefs[index],
         label: String(columnData.label?.[index] ?? ""),
         isFormula: Boolean(columnData.isFormula?.[index]),
+        type: String(columnData.type?.[index] ?? ""),
       } };
-      const otherFieldNames = without(fieldNames, "label", "isFormula");
+      const otherFieldNames = without(fieldNames, "label", "isFormula", "type");
       for (const key of otherFieldNames) {
         column.fields[key] = columnData[key][index];
       }

--- a/test/client/lib/DocSchemaImport.ts
+++ b/test/client/lib/DocSchemaImport.ts
@@ -24,6 +24,7 @@ describe("DocSchemaImport", function() {
                 colRef: 1,
                 label: "Column 1",
                 isFormula: false,
+                type: "Text",
               },
             },
             {
@@ -32,6 +33,7 @@ describe("DocSchemaImport", function() {
                 colRef: 2,
                 label: "Column 2",
                 isFormula: true,
+                type: "Text",
               },
             },
           ],
@@ -48,6 +50,7 @@ describe("DocSchemaImport", function() {
                 colRef: 3,
                 label: "Column 3",
                 isFormula: false,
+                type: "Text",
               },
             },
           ],

--- a/test/common/airtable/AirtableDataImporter.ts
+++ b/test/common/airtable/AirtableDataImporter.ts
@@ -1,13 +1,15 @@
 import { AirtableTableId } from "app/common/airtable/AirtableAPITypes";
 import {
   AirtableBaseSchemaCrosswalk,
-  AirtableTableCrosswalk, GristTableId,
+  AirtableTableCrosswalk,
+  GristTableId,
 } from "app/common/airtable/AirtableCrosswalk";
 import { importDataFromAirtableBase } from "app/common/airtable/AirtableDataImporter";
 import { AirtableDataImportParams } from "app/common/airtable/AirtableDataImporterTypes";
 import { ReferenceTracker } from "app/common/airtable/AirtableReferenceTracker";
 import { AirtableIdColumnLabel } from "app/common/airtable/AirtableSchemaImporter";
 import { ExistingColumnSchema } from "app/common/DocSchemaImportTypes";
+import { AddOrUpdateRecord, BulkAddOrUpdateRecordResult } from "app/plugin/DocApiTypes";
 import { BulkColValues, GristObjCode } from "app/plugin/GristData";
 
 import Airtable from "airtable";
@@ -18,6 +20,7 @@ import fetch from "node-fetch";
 import * as sinon from "sinon";
 
 describe("AirtableDataImporter", function() {
+  const AirtableIdColumnId = "Airtable_Id";
   const basicCrosswalkFields = [
     {
       airtableField: { id: "fld0", name: "Name", type: "singleLineText" as const, options: {} },
@@ -84,7 +87,7 @@ describe("AirtableDataImporter", function() {
       fields.set(fieldPair.airtableField.name, fieldPair);
     }
 
-    const airtableIdColumn = { id: "Airtable_Id", ref: 111, label: AirtableIdColumnLabel, isFormula: false };
+    const airtableIdColumn = { id: AirtableIdColumnId, ref: 111, label: AirtableIdColumnLabel, isFormula: false };
     gristColumns.push(airtableIdColumn);
 
     return {
@@ -120,6 +123,35 @@ describe("AirtableDataImporter", function() {
       return Promise.resolve(newIds);
     }) satisfies AirtableDataImportParams["addRows"];
 
+  let nextRowId = 1;
+  const knownRows = new Map<string, number>();
+  const addOrUpdateRowsMock = sinon.fake(async (tableId, records, options) => {
+    const result: BulkAddOrUpdateRecordResult = {
+      recordIds: [],
+      createdRecordIds: [],
+      updatedRecordIds: [],
+    };
+
+    for (const record of records) {
+      // Sorted keys array as replacer ensures consistent serialization regardless of property order.
+      const requireKeys = Object.keys(record.require).sort();
+      const key = `${tableId}:${JSON.stringify(record.require, requireKeys)}`;
+      const existing = knownRows.get(key);
+
+      if (existing != null) {
+        result.recordIds.push([existing]);
+        result.updatedRecordIds.push([existing]);
+      } else {
+        const id = nextRowId++;
+        knownRows.set(key, id);
+        result.recordIds.push([id]);
+        result.createdRecordIds.push(id);
+      }
+    }
+
+    return result;
+  }) satisfies AirtableDataImportParams["addOrUpdateRows"];
+
   const updateRowsMock =
     sinon.fake((tableId, rows) => Promise.resolve(rows.id)) satisfies AirtableDataImportParams["updateRows"];
 
@@ -145,6 +177,8 @@ describe("AirtableDataImporter", function() {
     nock.cleanAll();
     nock.enableNetConnect();
     sinon.reset();
+    nextRowId = 1;
+    knownRows.clear();
   });
 
   describe("ReferenceTracker", () => {
@@ -300,7 +334,7 @@ describe("AirtableDataImporter", function() {
   });
 
   describe("importDataFromAirtableBase", () => {
-    it("calls addRows for each table with converted field values", async () => {
+    it("calls addOrUpdateRows for each table with converted field values", async () => {
       const mockRecord = {
         id: "rec123",
         fields: {
@@ -316,17 +350,18 @@ describe("AirtableDataImporter", function() {
       await importDataFromAirtableBase({
         listRecords,
         addRows: addRowsMock,
+        addOrUpdateRows: addOrUpdateRowsMock,
         updateRows: updateRowsMock,
         uploadAttachment: uploadAttachmentMock,
         schemaCrosswalk,
       });
 
-      assert.isTrue(addRowsMock.called);
-      const call = addRowsMock.getCall(0);
+      assert.isTrue(addOrUpdateRowsMock.called);
+      const call = addOrUpdateRowsMock.getCall(0);
       assert.equal(call.args[0], "Main");
       assert.deepEqual(
         call.args[1],
-        getBulkColSyntaxForRecords(schemaCrosswalk.tables.get("tblMain")!, [mockRecord]));
+        getAddOrUpdateSyntaxForRecords(schemaCrosswalk.tables.get("tblMain")!, [mockRecord]));
     });
 
     it("excludes formula columns from import", async () => {
@@ -348,18 +383,20 @@ describe("AirtableDataImporter", function() {
       await importDataFromAirtableBase({
         listRecords,
         addRows: addRowsMock,
+        addOrUpdateRows: addOrUpdateRowsMock,
         updateRows: updateRowsMock,
         uploadAttachment: uploadAttachmentMock,
         schemaCrosswalk,
       });
 
-      const call = addRowsMock.getCall(0);
-      const bulkColValues = call.args[1];
-      assert.notProperty(bulkColValues, "Formula");
-      assert.notProperty(bulkColValues, "Count");
-      assert.notProperty(bulkColValues, "Rollup");
-      assert.notProperty(bulkColValues, "Lookup");
-      assert.property(bulkColValues, "Name");
+      const call = addOrUpdateRowsMock.getCall(0);
+      const records: AddOrUpdateRecord[] = call.args[1];
+      const fields = records[0].fields!;
+      assert.notProperty(fields, "Formula");
+      assert.notProperty(fields, "Count");
+      assert.notProperty(fields, "Rollup");
+      assert.notProperty(fields, "Lookup");
+      assert.property(fields, "Name");
     });
 
     async function testAirtableIdColumn(params = { omitAirtableId: false }) {
@@ -380,23 +417,25 @@ describe("AirtableDataImporter", function() {
       await importDataFromAirtableBase({
         listRecords,
         addRows: addRowsMock,
+        addOrUpdateRows: addOrUpdateRowsMock,
         updateRows: updateRowsMock,
         uploadAttachment: uploadAttachmentMock,
         schemaCrosswalk,
       });
 
-      const call = addRowsMock.getCall(0);
-      return call.args[1];
+      const call = addOrUpdateRowsMock.getCall(0);
+      const records: AddOrUpdateRecord[] = call.args[1];
+      return records[0];
     }
 
     it("stores airtable id when airtableIdColumn is configured", async () => {
-      const bulkColValues = await testAirtableIdColumn({ omitAirtableId: false });
-      assert.deepEqual(bulkColValues.Airtable_Id, ["rec999"], "Airtable ID column data missing");
+      const record = await testAirtableIdColumn({ omitAirtableId: false });
+      assert.equal(record.require.Airtable_Id, "rec999", "Airtable ID column data missing");
     });
 
     it("skips airtable id when airtableIdColumn is missing", async () => {
-      const bulkColValues = await testAirtableIdColumn({ omitAirtableId: true });
-      assert.isUndefined(bulkColValues.Airtable_Id, "Airtable ID column present when it shouldn't be");
+      const record = await testAirtableIdColumn({ omitAirtableId: true });
+      assert.isUndefined(record.require.Airtable_Id, "Airtable ID column present when it shouldn't be");
     });
 
     it("handles multipleRecordLinks references and defers resolution", async () => {
@@ -425,15 +464,16 @@ describe("AirtableDataImporter", function() {
       await importDataFromAirtableBase({
         listRecords,
         addRows: addRowsMock,
+        addOrUpdateRows: addOrUpdateRowsMock,
         updateRows: updateRowsMock,
         uploadAttachment: uploadAttachmentMock,
         schemaCrosswalk,
       });
 
       // First add rows with links as null
-      const addRowsCall = addRowsMock.getCall(0);
-      const initialBulkValues = addRowsCall.args[1];
-      assert.deepEqual(initialBulkValues.Links, [null, null, null]);
+      const addOrUpdateCall = addOrUpdateRowsMock.getCall(0);
+      const records: AddOrUpdateRecord[] = addOrUpdateCall.args[1];
+      assert.deepEqual(records.map(r => r.fields!.Links), [null, null, null]);
 
       // Update rows with resolved links
       assert.isTrue(updateRowsMock.called);
@@ -464,14 +504,15 @@ describe("AirtableDataImporter", function() {
       await importDataFromAirtableBase({
         listRecords,
         addRows: addRowsMock,
+        addOrUpdateRows: addOrUpdateRowsMock,
         updateRows: updateRowsMock,
         uploadAttachment: uploadAttachmentMock,
         schemaCrosswalk,
       });
 
       // Expect 4 pages - 3 pages of 3, and 1 of 1.
-      assert.equal(addRowsMock.callCount, 4);
-      const totalRows = sum(addRowsMock.getCalls().map(call => call.args[1].Name.length));
+      assert.equal(addOrUpdateRowsMock.callCount, 4);
+      const totalRows = sum(addOrUpdateRowsMock.getCalls().map(call => call.args[1].length));
       // Expect all rows to have been added.
       assert.equal(totalRows, 10);
     });
@@ -492,31 +533,29 @@ describe("AirtableDataImporter", function() {
       await importDataFromAirtableBase({
         listRecords,
         addRows: addRowsMock,
+        addOrUpdateRows: addOrUpdateRowsMock,
         updateRows: updateRowsMock,
         uploadAttachment: uploadAttachmentMock,
         schemaCrosswalk,
       });
 
-      let bulkColValues: BulkColValues;
-      let colId: string;
+      const colId = schemaCrosswalk.tables.get("tblMain")!.fields.get(fieldName)!.gristColumn.id;
       if (fieldName === "Attachments") {
         const call = updateRowsMock.getCall(1);
-        bulkColValues = call.args[1];
-        colId = schemaCrosswalk.tables.get("tblMain")!.fields.get(fieldName)!.gristColumn.id;
+        const bulkColValues: BulkColValues = call.args[1];
         if (bulkColValues[colId] === undefined) {
           throw new Error("Expected column not in updateRows call");
         }
         return bulkColValues[colId][0];
       } else {
-        const call = addRowsMock.getCall(0);
-        bulkColValues = call.args[1];
-        colId = schemaCrosswalk.tables.get("tblMain")!.fields.get(fieldName)!.gristColumn.id;
-        if (bulkColValues[colId] === undefined) {
-          throw new Error("Expected column not in addRows call");
+        const call = addOrUpdateRowsMock.getCall(0);
+        const records: AddOrUpdateRecord[] = call.args[1];
+        const fields = records[0].fields!;
+        if (!(colId in fields)) {
+          throw new Error("Expected column not in addOrUpdateRows call");
         }
+        return fields[colId];
       }
-
-      return bulkColValues[colId][0];
     }
 
     it("converts aiText fields correctly", async () => {
@@ -636,28 +675,28 @@ describe("AirtableDataImporter", function() {
     it("skips count field data conversion because it's a formula column", async () => {
       await assert.isRejected(
         testFieldValueConversion("Count", 42),
-        "Expected column not in addRows call",
+        "Expected column not in addOrUpdateRows call",
       );
     });
 
     it("skips formula field data conversion because it's a formula column", async () => {
       await assert.isRejected(
         testFieldValueConversion("Formula", "computed result"),
-        "Expected column not in addRows call",
+        "Expected column not in addOrUpdateRows call",
       );
     });
 
     it("skips lookup field data conversion because it's a formula column", async () => {
       await assert.isRejected(
         testFieldValueConversion("Lookup", ["value1", "value2"]),
-        "Expected column not in addRows call",
+        "Expected column not in addOrUpdateRows call",
       );
     });
 
     it("skips rollup field data conversion because it's a formula column", async () => {
       await assert.isRejected(
         testFieldValueConversion("Rollup", {}),
-        "Expected column not in addRows call",
+        "Expected column not in addOrUpdateRows call",
       );
     });
 
@@ -689,15 +728,17 @@ describe("AirtableDataImporter", function() {
       await importDataFromAirtableBase({
         listRecords,
         addRows: addRowsMock,
+        addOrUpdateRows: addOrUpdateRowsMock,
         updateRows: updateRowsMock,
         uploadAttachment: uploadAttachmentMock,
         schemaCrosswalk,
       });
 
-      const call = addRowsMock.getCall(0);
-      const bulkColValues = call.args[1];
-      assert.deepEqual(bulkColValues.Name, [null]);
-      assert.deepEqual(bulkColValues.CreatedBy, [null]);
+      const call = addOrUpdateRowsMock.getCall(0);
+      const records: AddOrUpdateRecord[] = call.args[1];
+      const fields = records[0].fields!;
+      assert.deepEqual(fields.Name, null);
+      assert.deepEqual(fields.CreatedBy, null);
     });
 
     it("propagates errors thrown from listRecords", async () => {
@@ -711,6 +752,7 @@ describe("AirtableDataImporter", function() {
         await importDataFromAirtableBase({
           listRecords,
           addRows: addRowsMock,
+          addOrUpdateRows: addOrUpdateRowsMock,
           updateRows: updateRowsMock,
           uploadAttachment: uploadAttachmentMock,
           schemaCrosswalk,
@@ -736,6 +778,7 @@ describe("AirtableDataImporter", function() {
       await importDataFromAirtableBase({
         listRecords: listEmptyResult,
         addRows: addRowsMock,
+        addOrUpdateRows: addOrUpdateRowsMock,
         updateRows: updateRowsMock,
         uploadAttachment: uploadAttachmentMock,
         schemaCrosswalk,
@@ -749,6 +792,7 @@ describe("AirtableDataImporter", function() {
 
 type AirtableRecordKeyFieldsOnly = Pick<Airtable.Record<any>, "id" | "fields">;
 
+/*
 // Converts Airtable records into the expected bulk-column syntax
 function getBulkColSyntaxForRecords(tableCrosswalk: AirtableTableCrosswalk, records: AirtableRecordKeyFieldsOnly[]) {
   const fieldMappings = Array.from(tableCrosswalk.fields.values()).filter(mapping => !mapping.gristColumn.isFormula);
@@ -774,6 +818,29 @@ function getBulkColSyntaxForRecords(tableCrosswalk: AirtableTableCrosswalk, reco
     }
   }
   return bulkCol;
+}
+*/
+
+// Converts Airtable records into the expected bulk-column syntax
+function getAddOrUpdateSyntaxForRecords(
+  tableCrosswalk: AirtableTableCrosswalk, records: AirtableRecordKeyFieldsOnly[],
+) {
+  const fieldMappings = Array.from(tableCrosswalk.fields.values()).filter(mapping => !mapping.gristColumn.isFormula);
+
+  const addOrUpdateRecords: AddOrUpdateRecord[] = records.map((record) => {
+    const addOrUpdate: Required<AddOrUpdateRecord> = { require: {}, fields: {} };
+    for (const fieldMapping of fieldMappings) {
+      addOrUpdate.fields[fieldMapping.gristColumn.id] = record.fields[fieldMapping.airtableField.name] ?? null;
+    }
+
+    if (tableCrosswalk.airtableIdColumn) {
+      addOrUpdate.require[tableCrosswalk.airtableIdColumn.id] = record.id;
+    }
+
+    return addOrUpdate;
+  });
+
+  return addOrUpdateRecords;
 }
 
 function createListRecordsFake(

--- a/test/common/airtable/AirtableDataImporter.ts
+++ b/test/common/airtable/AirtableDataImporter.ts
@@ -209,13 +209,21 @@ describe("AirtableDataImporter", function() {
       tracker.addRecordIdMapping("airtable-food-1", 101);
       tracker.addRecordIdMapping("airtable-food-2", 102);
 
-      const tableTracker = tracker.addTable("country", ["cities", "foods"]);
+      // Provide airtableIdColumnId so the tracker asks the sandbox to find the right row
+      tracker.addTable("cities", [], { airtableIdColumnId: "Airtable_Id" });
+      // Omit airtableIdColumnId to so the tracker looks at its known rows for the right row
+      tracker.addTable("foods", [], { airtableIdColumnId: undefined });
+
+      const tableTracker = tracker.addTable("country", [
+        { id: "cities", tableId: "cities" },
+        { id: "local_foods", tableId: "foods" },
+      ]);
 
       tableTracker.addUnresolvedRecord({
         gristRecordId: 1,
         refsByColumnId: {
           cities: ["airtable-rec-1", "airtable-rec-2"],
-          foods: ["airtable-food-1", "airtable-food-2"],
+          local_foods: ["airtable-food-1", "airtable-food-2"],
         },
       });
 
@@ -236,10 +244,10 @@ describe("AirtableDataImporter", function() {
       assert.deepEqual(updates, {
         id: [1, 2],
         cities: [
-          [GristObjCode.List, 10, 20],
-          [GristObjCode.List, 30],
+          [GristObjCode.LookUp, ["airtable-rec-1", "airtable-rec-2"], { column: "Airtable_Id" }],
+          [GristObjCode.LookUp, ["airtable-rec-3"], { column: "Airtable_Id" }],
         ],
-        foods: [
+        local_foods: [
           [GristObjCode.List, 101, 102],
           [GristObjCode.List],
         ],
@@ -251,13 +259,17 @@ describe("AirtableDataImporter", function() {
 
       tracker.addRecordIdMapping("airtable-rec-1", 10);
 
-      const tableTracker = tracker.addTable("users", ["friends"]);
+      const tableTracker = tracker.addTable("users", [
+        { id: "friends", tableId: "people" },
+        { id: "email", tableId: "emails" },
+      ]);
 
       // Reference to an unmapped record
       tableTracker.addUnresolvedRecord({
         gristRecordId: 1,
         refsByColumnId: {
           friends: ["airtable-rec-1", "airtable-rec-unknown"],
+          emails: ["airtable-rec-unknown-email"],
         },
       });
 
@@ -268,13 +280,16 @@ describe("AirtableDataImporter", function() {
 
       // Only the resolvable reference should be included
       assert.deepEqual(updates.friends, [[GristObjCode.List, 10]]);
+      // TODO - Got to here
     });
 
     it("handles batch updates with default batch size", async () => {
       const tracker = new ReferenceTracker();
 
       tracker.addRecordIdMapping("airtable-rec-1", 10);
-      const tableTracker = tracker.addTable("users", ["col1"]);
+      const tableTracker = tracker.addTable("users", [{
+        id: "col1", tableId: "users",
+      }]);
 
       // Add more than default batch size (100) records
       for (let i = 0; i < 150; i++) {
@@ -302,7 +317,7 @@ describe("AirtableDataImporter", function() {
       const tracker = new ReferenceTracker();
 
       tracker.addRecordIdMapping("airtable-rec-1", 10);
-      const tableTracker = tracker.addTable("users", ["col1"]);
+      const tableTracker = tracker.addTable("users", [{ id: "col1", tableId: "users" }]);
 
       // Add 25 records
       for (let i = 0; i < 25; i++) {
@@ -323,7 +338,7 @@ describe("AirtableDataImporter", function() {
 
     it("does not update if there are no unresolved records", async () => {
       const tracker = new ReferenceTracker();
-      const tableTracker = tracker.addTable("users", ["friends"]);
+      const tableTracker = tracker.addTable("users", [{ id: "friends", tableId: "users" }]);
 
       const updateRowsMock = sinon.stub().resolves([]);
 

--- a/test/common/airtable/AirtableDataImporter.ts
+++ b/test/common/airtable/AirtableDataImporter.ts
@@ -379,6 +379,41 @@ describe("AirtableDataImporter", function() {
         getAddOrUpdateSyntaxForRecords(schemaCrosswalk.tables.get("tblMain")!, [mockRecord]));
     });
 
+    it("calls addRows for tables which don't have an Airtable ID column", async () => {
+      const mockRecord = {
+        id: "rec123",
+        fields: {
+          Name: "Test Name",
+          Count: 42,
+        },
+      };
+
+      const listRecords = createListRecordsFake(new Map([["tblMain", [mockRecord]]]));
+
+      const schemaCrosswalk = createBasicSchemaCrosswalk([["tblMain", "Main"]]);
+
+      // Remove the airtable ID column from the mapping, so the importer doesn't know it exists.
+      schemaCrosswalk.tables.forEach((tableMapping) => {
+        tableMapping.airtableIdColumn = undefined;
+      });
+
+      await importDataFromAirtableBase({
+        listRecords,
+        addRows: addRowsMock,
+        addOrUpdateRows: addOrUpdateRowsMock,
+        updateRows: updateRowsMock,
+        uploadAttachment: uploadAttachmentMock,
+        schemaCrosswalk,
+      });
+
+      assert.isTrue(addRowsMock.called);
+      const call = addRowsMock.getCall(0);
+      assert.equal(call.args[0], "Main");
+      assert.deepEqual(
+        call.args[1],
+        getBulkColSyntaxForRecords(schemaCrosswalk.tables.get("tblMain")!, [mockRecord]));
+    });
+
     it("excludes formula columns from import", async () => {
       const mockRecord = {
         id: "rec123",
@@ -438,19 +473,24 @@ describe("AirtableDataImporter", function() {
         schemaCrosswalk,
       });
 
+      if (params.omitAirtableId) {
+        const call = addRowsMock.getCall(0);
+        return call.args[1];
+      }
+
       const call = addOrUpdateRowsMock.getCall(0);
       const records: AddOrUpdateRecord[] = call.args[1];
       return records[0];
     }
 
     it("stores airtable id when airtableIdColumn is configured", async () => {
-      const record = await testAirtableIdColumn({ omitAirtableId: false });
+      const record = await testAirtableIdColumn({ omitAirtableId: false }) as AddOrUpdateRecord;
       assert.equal(record.require.Airtable_Id, "rec999", "Airtable ID column data missing");
     });
 
     it("skips airtable id when airtableIdColumn is missing", async () => {
-      const record = await testAirtableIdColumn({ omitAirtableId: true });
-      assert.isUndefined(record.require.Airtable_Id, "Airtable ID column present when it shouldn't be");
+      const bulkValues = await testAirtableIdColumn({ omitAirtableId: true }) as BulkColValues;
+      assert.isUndefined(bulkValues.Airtable_Id, "Airtable ID column present when it shouldn't be");
     });
 
     it("handles multipleRecordLinks references and defers resolution", async () => {
@@ -807,7 +847,6 @@ describe("AirtableDataImporter", function() {
 
 type AirtableRecordKeyFieldsOnly = Pick<Airtable.Record<any>, "id" | "fields">;
 
-/*
 // Converts Airtable records into the expected bulk-column syntax
 function getBulkColSyntaxForRecords(tableCrosswalk: AirtableTableCrosswalk, records: AirtableRecordKeyFieldsOnly[]) {
   const fieldMappings = Array.from(tableCrosswalk.fields.values()).filter(mapping => !mapping.gristColumn.isFormula);
@@ -834,7 +873,6 @@ function getBulkColSyntaxForRecords(tableCrosswalk: AirtableTableCrosswalk, reco
   }
   return bulkCol;
 }
-*/
 
 // Converts Airtable records into the expected bulk-column syntax
 function getAddOrUpdateSyntaxForRecords(

--- a/test/common/airtable/AirtableDataImporter.ts
+++ b/test/common/airtable/AirtableDataImporter.ts
@@ -128,8 +128,8 @@ describe("AirtableDataImporter", function() {
   const addOrUpdateRowsMock = sinon.fake(async (tableId, records, options) => {
     const result: BulkAddOrUpdateRecordResult = {
       recordIds: [],
-      createdRecordIds: [],
-      updatedRecordIds: [],
+      addRecordIds: [],
+      updateRecordIds: [],
     };
 
     for (const record of records) {
@@ -140,12 +140,12 @@ describe("AirtableDataImporter", function() {
 
       if (existing != null) {
         result.recordIds.push([existing]);
-        result.updatedRecordIds.push([existing]);
+        result.updateRecordIds.push([existing]);
       } else {
         const id = nextRowId++;
         knownRows.set(key, id);
         result.recordIds.push([id]);
-        result.createdRecordIds.push(id);
+        result.addRecordIds.push(id);
       }
     }
 

--- a/test/common/airtable/AirtableDataImporter.ts
+++ b/test/common/airtable/AirtableDataImporter.ts
@@ -188,14 +188,14 @@ describe("AirtableDataImporter", function() {
       tracker.addRecordIdMapping("airtable-rec-1", 42);
       tracker.addRecordIdMapping("airtable-rec-2", 99);
 
-      assert.equal(tracker.resolve("airtable-rec-1"), 42);
-      assert.equal(tracker.resolve("airtable-rec-2"), 99);
+      assert.equal(tracker.lookupRowIdForRecord("airtable-rec-1"), 42);
+      assert.equal(tracker.lookupRowIdForRecord("airtable-rec-2"), 99);
     });
 
     it("returns undefined for unknown record ids", () => {
       const tracker = new ReferenceTracker();
 
-      assert.isUndefined(tracker.resolve("unknown-rec-id"));
+      assert.isUndefined(tracker.lookupRowIdForRecord("unknown-rec-id"));
     });
   });
 

--- a/test/common/airtable/AirtableDataImporter.ts
+++ b/test/common/airtable/AirtableDataImporter.ts
@@ -280,7 +280,6 @@ describe("AirtableDataImporter", function() {
 
       // Only the resolvable reference should be included
       assert.deepEqual(updates.friends, [[GristObjCode.List, 10]]);
-      // TODO - Got to here
     });
 
     it("handles batch updates with default batch size", async () => {


### PR DESCRIPTION
## Context

Currently, Airtable imports onto existing documents will always insert new rows. However, updating is usually preferable to bring the document into consistency with Airtable.

## Proposed solution

This makes the default behaviour of Airtable import be to update rows, if there's an Airtable ID column present in the table. 

It also enables new rows to lookup existing rows for the purposes of reference resolution, so newly updated references will be referentially intact. 

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [X] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

