### PR TITLE
fix: show all rows in suggestion mode, not just changed ones

### DIFF
--- a/app/client/components/GristDoc.ts
+++ b/app/client/components/GristDoc.ts
@@ -348,6 +348,7 @@ export class GristDocImpl extends DisposableWithEvents implements GristDoc {
   private _prevSectionId: number | null = null;
   private _assistantPopup = buildAssistantPopup(this);
   private _diffModels: Record<string, DataTableModelWithDiff> = {};
+  private _showAllRowsInComparison: boolean = false;
 
   constructor(
     public readonly app: App,
@@ -359,6 +360,7 @@ export class GristDocImpl extends DisposableWithEvents implements GristDoc {
     options: {
       comparison?: DocStateComparison,  // initial comparison with another document
       compareEmphasis?: CompareEmphasis,
+      showAllRowsInComparison?: boolean, // show all rows in diff view, not just changed ones
     } = {},
   ) {
     super();
@@ -709,6 +711,7 @@ export class GristDocImpl extends DisposableWithEvents implements GristDoc {
 
     this.comparison = options.comparison || null;
     this.compareEmphasis = options.compareEmphasis ?? "remote";
+    this._showAllRowsInComparison = options.showAllRowsInComparison ?? false;
 
     // We need prevent default here to allow drop events to fire.
     this.autoDispose(dom.onElem(window, "dragover", ev => ev.preventDefault()));
@@ -979,7 +982,8 @@ export class GristDocImpl extends DisposableWithEvents implements GristDoc {
       return tableModel;
     }
     if (!this._diffModels[tableId]) {
-      this._diffModels[tableId] = this.autoDispose(new DataTableModelWithDiff(tableModel, this.comparison.details));
+      this._diffModels[tableId] = this.autoDispose(new DataTableModelWithDiff(
+        tableModel, this.comparison.details, { showAllRows: this._showAllRowsInComparison }));
     }
     return this._diffModels[tableId];
   }

--- a/app/client/models/DataTableModelWithDiff.ts
+++ b/app/client/models/DataTableModelWithDiff.ts
@@ -148,7 +148,8 @@ export class DataTableModelWithDiff extends DisposableWithEvents implements Data
    * The _comparison provided to this DataTableModelWithDiff may be mutated. It is used
    * to store and track local changes.
    */
-  public constructor(public core: DataTableModel, private _comparison: DocStateComparisonDetails) {
+  public constructor(public core: DataTableModel, private _comparison: DocStateComparisonDetails,
+    options?: { showAllRows?: boolean }) {
     super();
     this.tableMetaRow = core.tableMetaRow;
     this.tableQuerySets = core.tableQuerySets;
@@ -163,6 +164,7 @@ export class DataTableModelWithDiff extends DisposableWithEvents implements Data
       _comparison.leftChanges.tableDeltas[tableId],
       _comparison.rightChanges.tableDeltas[remoteTableId],
       this.extraRows,
+      { showAllRows: options?.showAllRows },
     ) as any;
     this.tableData = tableDataWithDiff;
     this.isLoaded = core.isLoaded;
@@ -253,7 +255,8 @@ export class TableDataWithDiff {
   private _removedRowValues = new Map<number, Record<string, CellDelta[0]>>();
 
   constructor(public core: TableData, public leftTableDelta: TableDelta,
-    public rightTableDelta: TableDelta, public extraRows: ExtraRows) {
+    public rightTableDelta: TableDelta, public extraRows: ExtraRows,
+    private _options?: { showAllRows?: boolean }) {
     this.dataLoadedEmitter = core.dataLoadedEmitter;
     this.tableActionEmitter = core.tableActionEmitter;
     this.preTableActionEmitter = core.preTableActionEmitter;
@@ -303,6 +306,7 @@ export class TableDataWithDiff {
   }
 
   public getKeepFunc(): undefined | ((rowId: number | "new") => boolean) {
+    if (this._options?.showAllRows) { return undefined; }
     return (rowId: number | "new") => {
       return rowId === "new" || this._updates.has(rowId) || rowId < 0 ||
         this._leftRemovals.has(rowId) || this._rightRemovals.has(rowId);

--- a/app/client/models/DocPageModel.ts
+++ b/app/client/models/DocPageModel.ts
@@ -532,15 +532,18 @@ contact the document owners to attempt a document recovery. [{{error}}]", { erro
     let effectiveCompareEmphasis = compareEmphasis;
 
     // In suggestion mode, automatically set up comparison to highlight changes.
+    let isSuggestionMode = false;
     if (!comparison) {
       const isProposable = Boolean(doc.options?.proposedChanges?.acceptProposals);
       if (isProposable && doc.isFork) {
         // Returning to an existing suggestion fork: fetch comparison against trunk.
         comparison = await this._api.getDocAPI(urlId).compareDoc(
           doc.idParts.trunkId, { detail: true });
+        isSuggestionMode = true;
       } else if (isProposable && doc.isPreFork) {
         // Fresh suggestion session: empty comparison that will track live edits.
         comparison = createEmptyDocStateComparison();
+        isSuggestionMode = true;
       }
       if (comparison) {
         effectiveCompareEmphasis = "local";
@@ -549,7 +552,8 @@ contact the document owners to attempt a document recovery. [{{error}}]", { erro
 
     const gristDoc = gdModule.GristDocImpl.create(flow, this._appObj, this.appModel, docComm, this, openDocResponse,
       this.appModel.topAppModel.plugins,
-      { comparison, compareEmphasis: effectiveCompareEmphasis });
+      { comparison, compareEmphasis: effectiveCompareEmphasis,
+        showAllRowsInComparison: isSuggestionMode });
 
     // Move ownership of docComm to GristDoc.
     gristDoc.autoDispose(flow.release(docComm));

--- a/test/nbrowser/ProposedChangesPage.ts
+++ b/test/nbrowser/ProposedChangesPage.ts
@@ -431,6 +431,35 @@ describe("ProposedChangesPage", function() {
       "Suggest changes (1)");
   });
 
+  it("shows all rows in suggestion mode, not skip rows with ellipses", async function() {
+    const { doc, api } = await makeLifeDoc();
+    const url = await driver.getCurrentUrl();
+
+    // Add enough rows so that a "compare to original" view would
+    // start skipping some.
+    for (let i = 0; i <= 10; i++) {
+      await api.applyUserActions(doc.id, [
+        ["AddRecord", "Life", null, { A: i * 10, B: `Species${i}` }],
+      ]);
+    }
+
+    // Count the rows via the API before entering suggestion mode.
+    const rows = await api.getDocAPI(doc.id).getRows("Life");
+    const expectedRowCount = rows.id.length;
+    assert.isAtLeast(expectedRowCount, 10);
+
+    // Work on a copy (enters suggestion mode with comparison active).
+    await workOnCopy(url);
+
+    // Every row should be visible, no "..." skip rows, no blank rows.
+    const rowNums = Array.from({ length: expectedRowCount }, (_, i) => i + 1);
+    const visibleB = await gu.getVisibleGridCells("B", rowNums);
+    assert.notInclude(visibleB, "...");
+    assert.deepEqual(visibleB, rows.B);
+
+    await returnToTrunk(url);
+  });
+
   it("can make and apply a proposed change affecting two tables", async function() {
     const { api, doc } = await makeLifeDoc();
     const url = await driver.getCurrentUrl();


### PR DESCRIPTION
The compare-to-original diff view helpfully skips unchanged rows and shows "..." placeholders for brevity. But suggestion mode isn't a compact diff view, you're editing a full document that happens to track changes. Collapsing unchanged rows there is confusing, especially for viewers who haven't made any changes yet and just see a mysterious truncated grid.

Add a `showAllRows` flag so that suggestions do not inherit this property of compare-to-original.
