### PR TITLE
Add /sql/full endpoint: granular read and write with SQL

### DIFF
--- a/app/client/components/DocComm.ts
+++ b/app/client/components/DocComm.ts
@@ -54,6 +54,7 @@ export class DocComm extends Disposable implements ActiveDocAPI {
   public listActiveUserProfiles = this._wrapMethod("listActiveUserProfiles");
   public applyProposal = this._wrapMethod("applyProposal");
   public getAssistance = this._wrapMethod("getAssistance");
+  public sql = this._wrapMethod("sql");
 
   public changeUrlIdEmitter = this.autoDispose(new Emitter());
 

--- a/app/common/ActiveDocAPI.ts
+++ b/app/common/ActiveDocAPI.ts
@@ -399,6 +399,19 @@ export interface ActiveDocAPI {
   applyUserActions(actions: UserAction[], options?: ApplyUAOptions): Promise<ApplyUAResult>;
 
   /**
+   * Executes a SQL statement against the document. Supports SELECT, INSERT,
+   * UPDATE, DELETE, DDL, and transaction control (BEGIN/COMMIT/ROLLBACK).
+   * Returns a result with command, rowCount, and optionally columns/records.
+   */
+  sql(sql: string): Promise<{
+    statement: string;
+    command: string;
+    rowCount: number;
+    columns?: { id: string, type: string }[];
+    records?: { fields: { [colId: string]: any } }[];
+  }>;
+
+  /**
    * A variant of applyUserActions where actions are passed in by ids (actionNum, actionHash)
    * rather than by value.
    */

--- a/app/common/ActiveDocAPI.ts
+++ b/app/common/ActiveDocAPI.ts
@@ -400,6 +400,19 @@ export interface ActiveDocAPI {
   applyUserActions(actions: UserAction[], options?: ApplyUAOptions): Promise<ApplyUAResult>;
 
   /**
+   * Executes a SQL statement against the document. Supports SELECT, INSERT,
+   * UPDATE, DELETE, DDL, and transaction control (BEGIN/COMMIT/ROLLBACK).
+   * Returns a result with command, rowCount, and optionally columns/records.
+   */
+  sql(sql: string): Promise<{
+    statement: string;
+    command: string;
+    rowCount: number;
+    columns?: { id: string, type: string }[];
+    records?: { fields: { [colId: string]: any } }[];
+  }>;
+
+  /**
    * A variant of applyUserActions where actions are passed in by ids (actionNum, actionHash)
    * rather than by value.
    */

--- a/app/plugin/DocApiTypes-ti.ts
+++ b/app/plugin/DocApiTypes-ti.ts
@@ -111,6 +111,8 @@ export const SqlPost = t.iface([], {
   "sql": "string",
   "args": t.opt(t.union(t.array("any"), "null")),
   "timeout": t.opt("number"),
+  "granular": t.opt("boolean"),
+  "cellFormat": t.opt("string"),
 });
 
 export const SetAttachmentStorePost = t.iface([], {

--- a/app/plugin/DocApiTypes-ti.ts
+++ b/app/plugin/DocApiTypes-ti.ts
@@ -129,6 +129,8 @@ export const SqlPost = t.iface([], {
   "sql": "string",
   "args": t.opt(t.union(t.array("any"), "null")),
   "timeout": t.opt("number"),
+  "granular": t.opt("boolean"),
+  "cellFormat": t.opt("string"),
 });
 
 export const SetAttachmentStorePost = t.iface([], {

--- a/app/plugin/DocApiTypes.ts
+++ b/app/plugin/DocApiTypes.ts
@@ -142,6 +142,9 @@ export interface SqlPost {
   // not increased. Note timeout of a query could affect
   // other queued queries on same document, because of
   // limitations of API node-sqlite3 exposes.
+  granular?: boolean;  // When true: support DML/DDL, decode values,
+  // return column metadata, use granular ACL.
+  cellFormat?: string; // "typed" returns Grist-encoded values (matching REST API cellFormat=typed).
 }
 
 export interface SetAttachmentStorePost {

--- a/app/plugin/DocApiTypes.ts
+++ b/app/plugin/DocApiTypes.ts
@@ -173,6 +173,9 @@ export interface SqlPost {
   // not increased. Note timeout of a query could affect
   // other queued queries on same document, because of
   // limitations of API node-sqlite3 exposes.
+  granular?: boolean;  // When true: support DML/DDL, decode values,
+  // return column metadata, use granular ACL.
+  cellFormat?: string; // "typed" returns Grist-encoded values (matching REST API cellFormat=typed).
 }
 
 export interface SetAttachmentStorePost {

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -167,6 +167,7 @@ import {
 } from "app/server/lib/sessionUtils";
 import { findOrAddAllEnvelope, Sharing } from "app/server/lib/Sharing";
 import { shortDesc } from "app/server/lib/shortDesc";
+import { SqlSession } from "app/server/lib/SqlSession";
 import { TableMetadataLoader } from "app/server/lib/TableMetadataLoader";
 import { DocTriggers } from "app/server/lib/Triggers";
 import { fetchURL, FileUploadInfo, globalUploadSet, UploadInfo } from "app/server/lib/uploads";
@@ -308,6 +309,7 @@ export class ActiveDoc extends EventEmitter {
   /**
    * If set, changes to this document should not propagate to outside world
    */
+  private _sqlSessions = new WeakMap<OptDocSession, SqlSession>();
   private _muted: boolean = false;
   /**
    * If positive, a migration is in progress
@@ -1052,6 +1054,9 @@ export class ActiveDoc extends EventEmitter {
    */
   public async closeDoc(docSession: DocSession): Promise<void> {
     // Note that it's async only to satisfy the Rpc interface that expects a promise.
+    // Clean up any SQL session (releases transaction lock if held).
+    this._sqlSessions.get(docSession)?.endSession();
+    this._sqlSessions.delete(docSession);
     this.docClients.removeClient(docSession);
 
     // If no more clients, schedule a shutdown.
@@ -1352,6 +1357,16 @@ export class ActiveDoc extends EventEmitter {
     return this._granularAccess.canCopyEverything(docSession);
   }
 
+  // Check if user has any read access to a specific table.
+  public async hasTableAccess(docSession: OptDocSession, tableId: string) {
+    return this._granularAccess.hasTableAccess(docSession, tableId);
+  }
+
+  // Get the current ACL rule collection (for SQL ACL translation).
+  public getACLRuleCollection(): ACLRuleCollection {
+    return this._granularAccess.getRuleCollection();
+  }
+
   // Check if it is appropriate for the user to be treated as an owner of
   // the document for granular access purposes when in "prefork" mode
   // (meaning a document has been opened with the intent to fork it, but
@@ -1619,7 +1634,73 @@ export class ActiveDoc extends EventEmitter {
   }
 
   /**
-   * A variant of applyUserActions where actions are passed in by ids (actionNum, actionHash)
+   * Apply user actions built by a `prepare` callback that runs inside the action lock.
+   * The callback receives docStorage for SQLite reads. This eliminates TOCTOU races
+   * between reading row IDs and applying changes — both happen atomically.
+   */
+  public async applyPreparedUserActions(
+    docSession: OptDocSession,
+    prepare: (docStorage: DocStorage) => Promise<UserAction[]>,
+    unsanitizedOptions?: ApplyUAOptions,
+  ): Promise<ApplyUAResult> {
+    await this.waitForInitialization();
+    const release = await this._sharing.acquireUserActionLock();
+    try {
+      const actions = await prepare(this.docStorage);
+      if (actions.length === 0) {
+        return { actionNum: 0, actionHash: null, retValues: [], isModification: false };
+      }
+      return await this.applyUserActionsWithinTransaction(docSession, actions, unsanitizedOptions);
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * Apply user actions while the action lock is held (used by applyPreparedUserActions).
+   */
+  public async applyUserActionsWithinTransaction(
+    docSession: OptDocSession,
+    actions: UserAction[],
+    unsanitizedOptions?: ApplyUAOptions,
+  ): Promise<ApplyUAResult> {
+    const options = sanitizeApplyUAOptions(unsanitizedOptions);
+    await this._granularAccess.checkUserActions(docSession, actions);
+    return this._sharing.applyUserActionsWithinLock(
+      docSession, this._makeInfo(docSession, options), actions, options);
+  }
+
+  /**
+   * Execute a SQL statement. Supports SELECT, DML, DDL, and transactions
+   * (BEGIN/COMMIT/ROLLBACK). Transaction state is per-session. Callable
+   * over WebSocket as the "sql" method.
+   */
+  public async sql(docSession: OptDocSession, sql: string): Promise<any> {
+    let session = this._sqlSessions.get(docSession);
+    if (!session) {
+      session = new SqlSession(this, docSession);
+      this._sqlSessions.set(docSession, session);
+    }
+    return session.exec(sql);
+  }
+
+  /** Acquire the document write lock for a transaction. Returns a release function. */
+  public async acquireTransactionLock(): Promise<() => void> {
+    await this.waitForInitialization();
+    return this._sharing.acquireUserActionLock();
+  }
+
+  /** Get the undo actions for a list of action numbers (used by SqlSession for rollback). */
+  public async getUndoActions(actionNums: number[]): Promise<DocAction[]> {
+    const bundles = await this._actionHistory.getActions(actionNums);
+    const undoActions: DocAction[] = [];
+    for (const bundle of bundles) {
+      if (bundle?.undo) { undoActions.push(...bundle.undo); }
+    }
+    return undoActions;
+  }
+
+  /**
    * rather than by value.
    *
    * @param docSession: The client session originating this action.

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -169,6 +169,7 @@ import {
 } from "app/server/lib/sessionUtils";
 import { findOrAddAllEnvelope, Sharing } from "app/server/lib/Sharing";
 import { shortDesc } from "app/server/lib/shortDesc";
+import { SqlSession } from "app/server/lib/SqlSession";
 import { TableMetadataLoader } from "app/server/lib/TableMetadataLoader";
 import { DocTriggers } from "app/server/lib/Triggers";
 import { fetchURL, FileUploadInfo, globalUploadSet, UploadInfo } from "app/server/lib/uploads";
@@ -313,6 +314,7 @@ export class ActiveDoc extends EventEmitter {
   /**
    * If set, changes to this document should not propagate to outside world
    */
+  private _sqlSessions = new WeakMap<OptDocSession, SqlSession>();
   private _muted: boolean = false;
   /**
    * If positive, a migration is in progress
@@ -1060,6 +1062,9 @@ export class ActiveDoc extends EventEmitter {
    */
   public async closeDoc(docSession: DocSession): Promise<void> {
     // Note that it's async only to satisfy the Rpc interface that expects a promise.
+    // Clean up any SQL session (releases transaction lock if held).
+    this._sqlSessions.get(docSession)?.endSession();
+    this._sqlSessions.delete(docSession);
     this.docClients.removeClient(docSession);
 
     // If no more clients, schedule a shutdown.
@@ -1360,6 +1365,16 @@ export class ActiveDoc extends EventEmitter {
     return this._granularAccess.canCopyEverything(docSession);
   }
 
+  // Check if user has any read access to a specific table.
+  public async hasTableAccess(docSession: OptDocSession, tableId: string) {
+    return this._granularAccess.hasTableAccess(docSession, tableId);
+  }
+
+  // Get the current ACL rule collection (for SQL ACL translation).
+  public getACLRuleCollection(): ACLRuleCollection {
+    return this._granularAccess.getRuleCollection();
+  }
+
   // Check if it is appropriate for the user to be treated as an owner of
   // the document for granular access purposes when in "prefork" mode
   // (meaning a document has been opened with the intent to fork it, but
@@ -1642,6 +1657,73 @@ export class ActiveDoc extends EventEmitter {
       throw new Error("applyWebhookActions only accepts actions on _grist_Triggers");
     }
     return this._applyUserActionsWithExtendedOptions(docSession, actions, { webhook: true });
+  }
+
+  /**
+   * Apply user actions built by a `prepare` callback that runs inside the action lock.
+   * The callback receives docStorage for SQLite reads. This eliminates TOCTOU races
+   * between reading row IDs and applying changes — both happen atomically.
+   */
+  public async applyPreparedUserActions(
+    docSession: OptDocSession,
+    prepare: (docStorage: DocStorage) => Promise<UserAction[]>,
+    unsanitizedOptions?: ApplyUAOptions,
+  ): Promise<ApplyUAResult> {
+    await this.waitForInitialization();
+    const release = await this._sharing.acquireUserActionLock();
+    try {
+      const actions = await prepare(this.docStorage);
+      if (actions.length === 0) {
+        return { actionNum: 0, actionHash: null, retValues: [], isModification: false };
+      }
+      return await this.applyUserActionsWithinTransaction(docSession, actions, unsanitizedOptions);
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * Apply user actions while the action lock is held (used by applyPreparedUserActions).
+   */
+  public async applyUserActionsWithinTransaction(
+    docSession: OptDocSession,
+    actions: UserAction[],
+    unsanitizedOptions?: ApplyUAOptions,
+  ): Promise<ApplyUAResult> {
+    const options = sanitizeApplyUAOptions(unsanitizedOptions);
+    await this._granularAccess.checkUserActions(docSession, actions);
+    return this._sharing.applyUserActionsWithinLock(
+      docSession, this._makeInfo(docSession, options), actions, options);
+  }
+
+  /**
+   * Execute a SQL statement. Supports SELECT, DML, DDL, and transactions
+   * (BEGIN/COMMIT/ROLLBACK). Transaction state is per-session. Callable
+   * over WebSocket as the "sql" method.
+   */
+  public async sql(docSession: OptDocSession, sql: string): Promise<any> {
+    let session = this._sqlSessions.get(docSession);
+    if (!session) {
+      session = new SqlSession(this, docSession);
+      this._sqlSessions.set(docSession, session);
+    }
+    return session.exec(sql);
+  }
+
+  /** Acquire the document write lock for a transaction. Returns a release function. */
+  public async acquireTransactionLock(): Promise<() => void> {
+    await this.waitForInitialization();
+    return this._sharing.acquireUserActionLock();
+  }
+
+  /** Get the undo actions for a list of action numbers (used by SqlSession for rollback). */
+  public async getUndoActions(actionNums: number[]): Promise<DocAction[]> {
+    const bundles = await this._actionHistory.getActions(actionNums);
+    const undoActions: DocAction[] = [];
+    for (const bundle of bundles) {
+      if (bundle?.undo) { undoActions.push(...bundle.undo); }
+    }
+    return undoActions;
   }
 
   /**

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -583,11 +583,22 @@ export class DocWorkerApi {
 
     // A POST /sql endpoint, accepting a body like:
     // { "sql": "select * from Table1 where name = ?", "args": ["Paul"] }
-    // Only SELECT statements are currently supported.
+    // Only SELECT statements are supported on this endpoint.
     this._app.post(
       "/api/docs/:docId/sql", canView, validate(SqlPost),
       withDoc(async (activeDoc, req, res) => {
         await this._runSql(activeDoc, req, res, req.body);
+      }));
+
+    // A POST /sql/full endpoint: supports SELECT, INSERT, UPDATE, DELETE, DDL.
+    // Returns typed/decoded values with column metadata. Uses granular ACL
+    // (row-level filtering for restricted users). See SQL_DESIGN.md.
+    this._app.post(
+      "/api/docs/:docId/sql/full", canView, validate(SqlPost),
+      withDoc(async (activeDoc, req, res) => {
+        await this._runSql(activeDoc, req, res, {
+          ...req.body, granular: true, cellFormat: getCellFormatParameter(req),
+        });
       }));
 
     // Create columns in a table, given as records of the _grist_Tables_column metatable.
@@ -2026,16 +2037,22 @@ export class DocWorkerApi {
     options: Types.SqlPost,
   ) {
     try {
-      const records = await runSQLQuery(req, activeDoc, options);
+      const result = await runSQLQuery(req, activeDoc, options);
       this._logRunSQLQueryEvents(activeDoc, req, options);
-      res.status(200).json({
-        statement: options.sql,
-        records: records.map(
-          rec => ({
-            fields: rec,
-          }),
-        ),
-      });
+      if (options.granular) {
+        // Granular path returns a structured result object directly
+        res.status(200).json(result);
+      } else {
+        // Legacy path returns raw rows
+        res.status(200).json({
+          statement: options.sql,
+          records: (result as any[]).map(
+            rec => ({
+              fields: rec,
+            }),
+          ),
+        });
+      }
     } catch (e) {
       if (e?.code === "SQLITE_INTERRUPT") {
         res.status(400).json({

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -585,11 +585,22 @@ export class DocWorkerApi {
 
     // A POST /sql endpoint, accepting a body like:
     // { "sql": "select * from Table1 where name = ?", "args": ["Paul"] }
-    // Only SELECT statements are currently supported.
+    // Only SELECT statements are supported on this endpoint.
     this._app.post(
       "/api/docs/:docId/sql", canView, validate(SqlPost),
       withDoc(async (activeDoc, req, res) => {
         await this._runSql(activeDoc, req, res, req.body);
+      }));
+
+    // A POST /sql/full endpoint: supports SELECT, INSERT, UPDATE, DELETE, DDL.
+    // Returns typed/decoded values with column metadata. Uses granular ACL
+    // (row-level filtering for restricted users). See SQL_DESIGN.md.
+    this._app.post(
+      "/api/docs/:docId/sql/full", canView, validate(SqlPost),
+      withDoc(async (activeDoc, req, res) => {
+        await this._runSql(activeDoc, req, res, {
+          ...req.body, granular: true, cellFormat: getCellFormatParameter(req),
+        });
       }));
 
     // Create columns in a table, given as records of the _grist_Tables_column metatable.
@@ -1921,16 +1932,22 @@ export class DocWorkerApi {
     options: Types.SqlPost,
   ) {
     try {
-      const records = await runSQLQuery(req, activeDoc, options);
+      const result = await runSQLQuery(req, activeDoc, options);
       this._logRunSQLQueryEvents(activeDoc, req, options);
-      res.status(200).json({
-        statement: options.sql,
-        records: records.map(
-          rec => ({
-            fields: rec,
-          }),
-        ),
-      });
+      if (options.granular) {
+        // Granular path returns a structured result object directly
+        res.status(200).json(result);
+      } else {
+        // Legacy path returns raw rows
+        res.status(200).json({
+          statement: options.sql,
+          records: (result as any[]).map(
+            rec => ({
+              fields: rec,
+            }),
+          ),
+        });
+      }
     } catch (e) {
       if (e?.code === "SQLITE_INTERRUPT") {
         res.status(400).json({

--- a/app/server/lib/DocStorage.ts
+++ b/app/server/lib/DocStorage.ts
@@ -555,27 +555,8 @@ export class DocStorage implements ISQLiteDB, OnDemandStorage {
    * Both Grist and SQL types are expected. Used to interpret Bool/BOOLEANs, and to parse
    * ChoiceList values.
    */
-  private static _decodeValue(val: any, gristType: string, sqlType: string): any {
-    if (val instanceof Uint8Array || Buffer.isBuffer(val)) {
-      val = marshal.loads(val);
-    }
-    if (gristType === "Bool") {
-      if (val === 0 || val === 1) {
-        // Boolean values come in as 0/1. If the column is of type "Bool", interpret those as
-        // true/false (note that the data engine does this too).
-        return Boolean(val);
-      }
-    }
-    if (isListType(gristType)) {
-      if (typeof val === "string" && val.startsWith("[")) {
-        try {
-          return ["L", ...JSON.parse(val)];
-        } catch (e) {
-          // Fall through without parsing
-        }
-      }
-    }
-    return val;
+  private static _decodeValue(val: any, gristType: string, _sqlType?: string): any {
+    return decodeSqliteValue(val, gristType);
   }
 
   /**
@@ -2023,4 +2004,25 @@ export interface FileInfo {
   ident: string;
   storageId: string | null;
   data: Buffer;
+}
+
+/**
+ * Decode a raw SQLite value to a Grist CellValue: unmarshal blobs,
+ * normalize Bool 0/1, restore "L" prefix on list-type JSON strings.
+ * This is the canonical conversion used by both the REST API (via
+ * DocStorage) and the SQL endpoint (via SqlValues).
+ */
+export function decodeSqliteValue(val: any, gristType: string): any {
+  if (val instanceof Uint8Array || Buffer.isBuffer(val)) {
+    try { val = marshal.loads(val); } catch { return null; }
+  }
+  if (gristType === "Bool") {
+    if (val === 0 || val === 1) { return Boolean(val); }
+  }
+  if (isListType(gristType)) {
+    if (typeof val === "string" && val.startsWith("[")) {
+      try { return ["L", ...JSON.parse(val)]; } catch { /* fall through */ }
+    }
+  }
+  return val;
 }

--- a/app/server/lib/DocWorker.ts
+++ b/app/server/lib/DocWorker.ts
@@ -150,6 +150,7 @@ export class DocWorker {
       listActiveUserProfiles: activeDocMethod.bind(null, null, "listActiveUserProfiles"),
       applyProposal: activeDocMethod.bind(null, "owners", "applyProposal"),
       getAssistance: activeDocMethod.bind(null, "viewers", "getAssistance"),
+      sql: activeDocMethod.bind(null, "viewers", "sql"),
     });
   }
 

--- a/app/server/lib/DocWorker.ts
+++ b/app/server/lib/DocWorker.ts
@@ -155,6 +155,7 @@ export class DocWorker {
       listActiveUserProfiles: method(null, "listActiveUserProfiles"),
       applyProposal: method("owners", "applyProposal"),
       getAssistance: method("viewers", "getAssistance"),
+      sql: method("viewers", "sql"),
     });
   }
 

--- a/app/server/lib/GranularAccess.ts
+++ b/app/server/lib/GranularAccess.ts
@@ -460,6 +460,10 @@ export class GranularAccess implements GranularAccessForBundle {
     return this.getReadPermission(pset) !== "deny";
   }
 
+  public getRuleCollection(): ACLRuleCollection {
+    return this._ruler.ruleCollection;
+  }
+
   /**
    * Checks if user has read access to a cell. Optionally takes docData that will be used
    * to retrieve the cell value instead of the current docData.

--- a/app/server/lib/GranularAccess.ts
+++ b/app/server/lib/GranularAccess.ts
@@ -458,6 +458,10 @@ export class GranularAccess implements GranularAccessForBundle {
     return this.getReadPermission(pset) !== "deny";
   }
 
+  public getRuleCollection(): ACLRuleCollection {
+    return this._ruler.ruleCollection;
+  }
+
   /**
    * Checks if user has read access to a cell. Optionally takes docData that will be used
    * to retrieve the cell value instead of the current docData.

--- a/app/server/lib/Sharing.ts
+++ b/app/server/lib/Sharing.ts
@@ -70,6 +70,28 @@ export class Sharing {
     });
   }
 
+  /**
+   * Acquire the user action lock for a transaction. Returns a release function.
+   * While held, no other writes can proceed on this document. The caller MUST
+   * call the release function (in a finally block) or the document will deadlock.
+   */
+  public async acquireUserActionLock(): Promise<() => void> {
+    return this._userActionLock.acquire();
+  }
+
+  /**
+   * Apply user actions while the lock is already held (during a transaction).
+   * The caller must have acquired the lock via acquireUserActionLock().
+   */
+  public async applyUserActionsWithinLock(
+    docSession: OptDocSession,
+    info: ActionInfo,
+    userActions: UserAction[],
+    options: ApplyUAExtendedOptions | null,
+  ): Promise<ApplyUAResult> {
+    return this._doApplyUserActions(info, userActions, docSession, options);
+  }
+
   private async _doApplyUserActions(info: ActionInfo, userActions: UserAction[],
     docSession: OptDocSession,
     options: ApplyUAExtendedOptions | null): Promise<ApplyUAResult> {

--- a/app/server/lib/SqlACL.ts
+++ b/app/server/lib/SqlACL.ts
@@ -1,0 +1,456 @@
+/**
+ * SqlACL: Translates Grist ACL predicate formulas to SQL WHERE clauses,
+ * and provides ACL-filtered SQL execution via CTE wrappers.
+ */
+
+import { ApiError } from "app/common/ApiError";
+import { RulePart } from "app/common/GranularAccessClause";
+import { isMetadataTable } from "app/common/isHiddenTable";
+import { ParsedPredicateFormula } from "app/common/PredicateFormula";
+import { InfoView } from "app/common/RecordView";
+import { ActiveDoc } from "app/server/lib/ActiveDoc";
+import { OptDocSession } from "app/server/lib/DocSession";
+import log from "app/server/lib/log";
+import { quoteIdent } from "app/server/lib/SQLiteDB";
+import { ParsedSQL, sqlifyAST } from "app/server/lib/SqlParser";
+import { ColumnTypeMap } from "app/server/lib/SqlValues";
+
+// Marshal-encoded ["C"] blob (GristObjCode.Censored) for censored cells.
+const CENSORED_BLOB = "X'5b01000000750100000043'";
+
+export function sqlQuote(s: string): string {
+  return "'" + s.replace(/\0/g, "").replace(/'/g, "''") + "'";
+}
+
+// ---- Permission text parsing ----
+
+// ---- Formula-to-SQL compilation ----
+
+/**
+ * Compile a parsed ACL predicate formula into a SQL expression.
+ * Returns null if the formula can't be translated.
+ */
+export function aclFormulaToSQL(
+  parsed: ParsedPredicateFormula,
+  user: Record<string, any>,
+  tableId?: string,
+  columnTypes?: Map<string, ColumnTypeMap>,
+): string | null {
+  try {
+    const colTypes = tableId && columnTypes ? columnTypes.get(tableId) : undefined;
+    return toBool(nodeToSQL(parsed, user, colTypes));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Wrap a SQL expression to match JavaScript truthiness rules.
+ * JS: null, "", 0, false are falsy. SQLite: strings try numeric conversion.
+ */
+function toBool(expr: string): string {
+  return `(${expr} IS NOT NULL AND ${expr} != '' AND ${expr} != 0)`;
+}
+
+function nodeToSQL(
+  node: ParsedPredicateFormula, user: Record<string, any>, colTypes?: ColumnTypeMap,
+): string {
+  const args = node.slice(1) as ParsedPredicateFormula[];
+  const n = (a: ParsedPredicateFormula) => nodeToSQL(a, user, colTypes);
+  switch (node[0]) {
+    case "And":   return "(" + args.map(a => toBool(n(a))).join(" AND ") + ")";
+    case "Or":    return "(" + args.map(a => toBool(n(a))).join(" OR ") + ")";
+    case "Not":   return "(NOT " + toBool(n(args[0])) + ")";
+    case "Eq": case "Is":     return binaryOp(args, user, "=", colTypes);
+    case "NotEq": case "IsNot": return binaryOp(args, user, "!=", colTypes);
+    case "Lt":    return binaryOp(args, user, "<", colTypes);
+    case "LtE":   return binaryOp(args, user, "<=", colTypes);
+    case "Gt":    return binaryOp(args, user, ">", colTypes);
+    case "GtE":   return binaryOp(args, user, ">=", colTypes);
+    case "In":    return n(args[0]) + " IN " + n(args[1]);
+    case "NotIn": return n(args[0]) + " NOT IN " + n(args[1]);
+    case "Add":   return binaryOp(args, user, "+", colTypes);
+    case "Sub":   return binaryOp(args, user, "-", colTypes);
+    case "Mult":  return binaryOp(args, user, "*", colTypes);
+    case "Div":   return binaryOp(args, user, "/", colTypes);
+    case "Mod":   return binaryOp(args, user, "%", colTypes);
+    case "Const": {
+      const val = node[1];
+      if (val === null) { return "NULL"; }
+      if (typeof val === "boolean") { return val ? "1" : "0"; }
+      if (typeof val === "number") { return String(val); }
+      if (typeof val === "string") { return sqlQuote(val); }
+      throw new Error("unsupported const type");
+    }
+    case "List":
+      return "(" + args.map(a => n(a)).join(", ") + ")";
+    case "Name": {
+      const name = node[1] as string;
+      if (name === "EDITOR") { return sqlQuote("editors"); }
+      if (name === "OWNER") { return sqlQuote("owners"); }
+      if (name === "VIEWER") { return sqlQuote("viewers"); }
+      if (name === "True") { return "1"; }
+      if (name === "False") { return "0"; }
+      if (name === "None") { return "NULL"; }
+      throw new Error(`unknown name: ${name}`);
+    }
+    case "Attr":
+      return nodeToSQLAttr(node, user);
+    case "Call":
+      return nodeToSQLCall(node, user, colTypes);
+    case "Comment": return n(args[0]);
+    default: throw new Error(`unsupported node: ${node[0]}`);
+  }
+}
+
+function nodeToSQLAttr(node: ParsedPredicateFormula, user: Record<string, any>): string {
+  const attrName = node[2] as string;
+  const base = node[1] as ParsedPredicateFormula;
+
+  if (base[0] === "Name" && (base[1] === "rec" || base[1] === "newRec")) {
+    return quoteIdent(attrName);
+  }
+
+  if (base[0] === "Name" && base[1] === "user") {
+    return resolveUserValue(user[attrName]);
+  }
+
+  // user.Zone.City — chained attribute access
+  if (base[0] === "Attr") {
+    const baseBase = base[1] as ParsedPredicateFormula;
+    const baseAttr = base[2] as string;
+    if (baseBase[0] === "Name" && baseBase[1] === "user") {
+      const attrValue = user[baseAttr];
+      if (isInfoView(attrValue)) {
+        return resolveUserValue(attrValue.get(attrName));
+      }
+      if (attrValue && typeof attrValue === "object") {
+        return resolveUserValue(attrValue[attrName]);
+      }
+      return "NULL";
+    }
+  }
+
+  throw new Error(`unsupported attr base: ${JSON.stringify(base)}`);
+}
+
+function nodeToSQLCall(
+  node: ParsedPredicateFormula, user: Record<string, any>, colTypes?: ColumnTypeMap,
+): string {
+  const target = node[1] as ParsedPredicateFormula;
+  if (target[0] !== "Attr") { throw new Error("unsupported call target"); }
+  const methodName = target[2] as string;
+  const methodTarget = target[1] as ParsedPredicateFormula;
+  if (methodName === "lower" || methodName === "upper") {
+    return `${methodName === "lower" ? "LOWER" : "UPPER"}(${nodeToSQL(methodTarget, user, colTypes)})`;
+  }
+  throw new Error(`unsupported method: ${methodName}`);
+}
+
+function isInfoView(val: any): val is InfoView {
+  return val && typeof val === "object" && typeof val.get === "function";
+}
+
+function resolveUserValue(val: any): string {
+  if (val === null || val === undefined) { return "NULL"; }
+  if (isInfoView(val)) { return resolveUserValue(val.get("id")); }
+  if (typeof val === "number") { return String(val); }
+  if (typeof val === "boolean") { return val ? "1" : "0"; }
+  return sqlQuote(String(val));
+}
+
+function binaryOp(
+  args: ParsedPredicateFormula[], user: Record<string, any>, op: string, colTypes?: ColumnTypeMap,
+): string {
+  const left = nodeToSQL(args[0], user, colTypes);
+  const right = nodeToSQL(args[1], user, colTypes);
+  if (right === "NULL" && op === "=") { return `(${left} IS NULL)`; }
+  if (right === "NULL" && op === "!=") { return `(${left} IS NOT NULL)`; }
+  if (left === "NULL" && op === "=") { return `(${right} IS NULL)`; }
+  if (left === "NULL" && op === "!=") { return `(${right} IS NOT NULL)`; }
+  if (colTypes && (op === "=" || op === "!=")) {
+    if (isBoolVsNumber(args[0], args[1], colTypes) || isBoolVsNumber(args[1], args[0], colTypes)) {
+      return op === "=" ? "0" : "1";
+    }
+  }
+  return `(${left} ${op} ${right})`;
+}
+
+function isBoolVsNumber(a: ParsedPredicateFormula, b: ParsedPredicateFormula, colTypes: ColumnTypeMap): boolean {
+  if (a[0] !== "Attr" || b[0] !== "Const") { return false; }
+  if (typeof b[1] !== "number") { return false; }
+  const base = a[1] as ParsedPredicateFormula;
+  if (base[0] !== "Name" || (base[1] !== "rec" && base[1] !== "newRec")) { return false; }
+  return colTypes[a[2] as string] === "Bool";
+}
+
+// ---- AST table rewriting ----
+
+function _rewriteTableRefs(node: any, mapping: Map<string, string>): any {
+  if (!node || typeof node !== "object") { return node; }
+  if (Array.isArray(node)) {
+    let changed = false;
+    const result = node.map((n) => {
+      const r = _rewriteTableRefs(n, mapping);
+      if (r !== n) { changed = true; }
+      return r;
+    });
+    return changed ? result : node;
+  }
+  let result: any;
+  for (const key of Object.keys(node)) {
+    const val = node[key];
+    if (key === "table" && typeof val === "string" && mapping.has(val)) {
+      if (!result) { result = { ...node }; }
+      result[key] = mapping.get(val);
+    } else if (typeof val === "object" && val !== null) {
+      const r = _rewriteTableRefs(val, mapping);
+      if (r !== val) {
+        if (!result) { result = { ...node }; }
+        result[key] = r;
+      }
+    }
+  }
+  return result ?? node;
+}
+
+function rewriteAndSqlify(parsed: ParsedSQL, mapping: Map<string, string>): string | null {
+  try {
+    return sqlifyAST(_rewriteTableRefs(parsed.ast, mapping), parsed.dialect);
+  } catch {
+    return null;
+  }
+}
+
+// ---- Helpers for extracting parsed formulas from RuleParts ----
+
+/** Get the parsed formula AST from a RulePart, or null if empty/absent. */
+function getParsedFormula(rule: RulePart): ParsedPredicateFormula | null {
+  if (!rule.aclFormula) { return null; }
+  const raw = rule.origRecord?.aclFormulaParsed;
+  if (!raw || typeof raw !== "string") { return null; }
+  try { return JSON.parse(raw); } catch { return null; }
+}
+
+// ---- Per-table ACL → SQL compilation ----
+
+/** Build a SQL WHERE clause from row-level rules (first-match CASE WHEN). */
+function compileRowFilter(
+  rules: RulePart[], userInfo: Record<string, any>,
+  tableId: string, columnTypes: Map<string, ColumnTypeMap>,
+): string | null {
+  const caseBranches: string[] = [];
+  let defaultAllow = true;
+
+  for (const rule of rules) {
+    const perm = rule.permissions.read;
+    if (!perm) { continue; }
+
+    const formula = getParsedFormula(rule);
+    if (!formula) {
+      defaultAllow = perm === "allow";
+      break;
+    }
+
+    const sqlWhere = aclFormulaToSQL(formula, userInfo, tableId, columnTypes);
+    if (sqlWhere === null) {
+      throw new ApiError("ACL rules for this document cannot be applied to SQL queries", 403);
+    }
+    caseBranches.push(`WHEN ${sqlWhere} THEN ${perm === "allow" ? "1" : "0"}`);
+  }
+
+  if (caseBranches.length > 0) {
+    return `(CASE ${caseBranches.join(" ")} ELSE ${defaultAllow ? "1" : "0"} END = 1)`;
+  }
+  return defaultAllow ? null : "0";
+}
+
+/** Compute column visibility from column-level RuleSets (from ACLRuleCollection). */
+function compileColumnFilter(
+  colRuleSets: import("app/common/GranularAccessClause").RuleSet[],
+  userInfo: Record<string, any>,
+  tableId: string, columnTypes: Map<string, ColumnTypeMap>,
+): { deniedCols: Set<string>, grantedCols: Set<string>, censoredCols: Map<string, string> } {
+  const deniedCols = new Set<string>();
+  const grantedCols = new Set<string>();
+  const colBranches = new Map<string, { cond: string, deny: boolean }[]>();
+  const colDefaults = new Map<string, boolean>();
+
+  for (const ruleSet of colRuleSets) {
+    const cols = ruleSet.colIds === "*" ? [] : ruleSet.colIds;
+    for (const rule of ruleSet.body) {
+      const perm = rule.permissions.read;
+      if (!perm) { continue; }
+      const isDeny = perm === "deny";
+      const formula = getParsedFormula(rule);
+
+      if (!formula) {
+        for (const col of cols) {
+          if (isDeny && !colBranches.has(col)) { deniedCols.add(col); }
+          if (!isDeny) { grantedCols.add(col); }
+          colDefaults.set(col, isDeny);
+        }
+      } else {
+        const sqlCond = aclFormulaToSQL(formula, userInfo, tableId, columnTypes);
+        if (sqlCond === null) {
+          throw new ApiError("ACL rules for this document cannot be applied to SQL queries", 403);
+        }
+        for (const col of cols) {
+          if (!colBranches.has(col)) { colBranches.set(col, []); }
+          colBranches.get(col)!.push({ cond: sqlCond, deny: isDeny });
+        }
+      }
+    }
+  }
+
+  const censoredCols = new Map<string, string>();
+  for (const [col, branches] of colBranches) {
+    if (deniedCols.has(col)) { continue; }
+    const whens = branches.map(b =>
+      `WHEN ${b.cond} THEN ${b.deny ? CENSORED_BLOB : quoteIdent(col)}`,
+    ).join(" ");
+    const defaultDeny = colDefaults.get(col) ?? false;
+    const elseVal = defaultDeny ? CENSORED_BLOB : quoteIdent(col);
+    censoredCols.set(col, `CASE ${whens} ELSE ${elseVal} END`);
+  }
+
+  return { deniedCols, grantedCols, censoredCols };
+}
+
+/** Build a CTE SELECT for a single table with row filter and column visibility. */
+function buildTableCTE(
+  tableId: string,
+  rowFilter: string | null,
+  colFilter: { deniedCols: Set<string>, grantedCols: Set<string>, censoredCols: Map<string, string> },
+  columnTypes: Map<string, ColumnTypeMap>,
+): { sql: string, cteName: string } {
+  const typeMap = columnTypes.get(tableId) || {};
+  const allowedCols = Object.keys(typeMap)
+    .filter(c => c !== "manualSort" && !c.startsWith("gristHelper_") && !colFilter.deniedCols.has(c));
+
+  // When column grants coexist with a conditional row filter, the interaction is:
+  // - Granted columns: always visible (column grant overrides table deny)
+  // - Non-granted columns: censored for rows failing the row filter
+  // - Denied columns: hidden entirely
+  // The row filter becomes per-column censoring, not a WHERE clause,
+  // because granted columns must be visible for ALL rows.
+  // (For unconditional deny "0", non-granted columns are excluded entirely.)
+  if (colFilter.grantedCols.size > 0 && rowFilter && rowFilter !== "0") {
+    const colExprs = allowedCols.map((c) => {
+      if (colFilter.grantedCols.has(c)) {
+        // Granted: always visible
+        const caseExpr = colFilter.censoredCols.get(c);
+        return caseExpr ? `${caseExpr} AS ${quoteIdent(c)}` : quoteIdent(c);
+      }
+      // Non-granted: censor when row filter fails
+      const baseCensor = colFilter.censoredCols.get(c);
+      const colExpr = baseCensor || quoteIdent(c);
+      return `CASE WHEN ${rowFilter} THEN ${colExpr} ELSE ${CENSORED_BLOB} END AS ${quoteIdent(c)}`;
+    });
+    const colList = ["id", ...colExprs].join(", ");
+    const cteName = `_acl_${tableId}`;
+    return {
+      sql: `${quoteIdent(cteName)} AS (SELECT ${colList} FROM ${quoteIdent(tableId)})`,
+      cteName,
+    };
+  }
+
+  // Simple cases: only grants (no row filter), or only row filter (no grants)
+  if (colFilter.grantedCols.size > 0) {
+    // Pure column-grant pattern: only granted columns, no row filter needed
+    const grantedOnly = allowedCols.filter(c => colFilter.grantedCols.has(c));
+    const colExprs = grantedOnly.map((c) => {
+      const caseExpr = colFilter.censoredCols.get(c);
+      return caseExpr ? `${caseExpr} AS ${quoteIdent(c)}` : quoteIdent(c);
+    });
+    const colList = ["id", ...colExprs].join(", ");
+    const cteName = `_acl_${tableId}`;
+    return {
+      sql: `${quoteIdent(cteName)} AS (SELECT ${colList} FROM ${quoteIdent(tableId)})`,
+      cteName,
+    };
+  }
+
+  // No grants: standard path with row filter and column censoring
+  const colExprs = allowedCols.map((c) => {
+    const caseExpr = colFilter.censoredCols.get(c);
+    return caseExpr ? `${caseExpr} AS ${quoteIdent(c)}` : quoteIdent(c);
+  });
+  const colList = ["id", ...colExprs].join(", ");
+  const whereClause = rowFilter ? ` WHERE ${rowFilter}` : "";
+  const cteName = `_acl_${tableId}`;
+  return {
+    sql: `${quoteIdent(cteName)} AS (SELECT ${colList} FROM ${quoteIdent(tableId)}${whereClause})`,
+    cteName,
+  };
+}
+
+// ---- Main entry point ----
+
+function getReferencedTables(parsed: ParsedSQL, columnTypes: Map<string, ColumnTypeMap>): string[] {
+  const knownTables = new Set(columnTypes.keys());
+  if (parsed.tables.length > 0) {
+    return parsed.tables.filter(t => knownTables.has(t) && !isMetadataTable(t));
+  }
+  return [...knownTables].filter(t => !isMetadataTable(t));
+}
+
+/**
+ * Run a query with ACL rules translated to SQL via CTE wrappers.
+ */
+export async function tryRunWithSqlAcl(
+  sql: string,
+  parsed: ParsedSQL,
+  activeDoc: ActiveDoc,
+  docSession: OptDocSession,
+  columnTypes: Map<string, ColumnTypeMap>,
+): Promise<any[]> {
+  const docStorage = activeDoc.docStorage;
+  const userInfo = await activeDoc.getUser(docSession);
+  if (!userInfo) {
+    throw new ApiError("Cannot resolve user for access control", 403);
+  }
+  // Phase 1: Get rules from the existing ACLRuleCollection (shared with GranularAccess).
+  const ruleCollection = activeDoc.getACLRuleCollection();
+  const tableIds = getReferencedTables(parsed, columnTypes);
+
+  // Phase 2: Check table-level access (matches REST API's 403 behavior)
+  for (const tableId of tableIds) {
+    if (!await activeDoc.hasTableAccess(docSession, tableId)) {
+      throw new ApiError(`Access to table "${tableId}" is denied`, 403);
+    }
+  }
+
+  // Phase 3: Compile per-table row and column filters → CTEs
+  const ctes: string[] = [];
+  const tableMapping = new Map<string, string>();
+  const docRuleSet = ruleCollection.getDocDefaultRuleSet();
+
+  for (const tableId of tableIds) {
+    const tableRuleSet = ruleCollection.getTableDefaultRuleSet(tableId);
+    const rowRules = [
+      ...(tableRuleSet?.body || []),
+      ...docRuleSet.body,
+    ];
+    const rowFilter = compileRowFilter(rowRules, userInfo, tableId, columnTypes);
+    const colFilter = compileColumnFilter(
+      ruleCollection.getAllColumnRuleSets(tableId), userInfo, tableId, columnTypes);
+    const { sql: cteSql, cteName } = buildTableCTE(tableId, rowFilter, colFilter, columnTypes);
+    ctes.push(cteSql);
+    tableMapping.set(tableId, cteName);
+  }
+
+  // Phase 4: Rewrite query and execute
+  if (ctes.length === 0) {
+    return docStorage.all(`SELECT * FROM (${sql})`);
+  }
+
+  const filteredSql = rewriteAndSqlify(parsed, tableMapping);
+  if (filteredSql === null) {
+    throw new ApiError("ACL rules for this document cannot be applied to SQL queries", 403);
+  }
+
+  const fullSql = `WITH ${ctes.join(", ")} SELECT * FROM (${filteredSql})`;
+  log.debug("SqlACL: filtered SQL", { sql: fullSql.substring(0, 300) });
+  return docStorage.all(fullSql);
+}

--- a/app/server/lib/SqlParser.ts
+++ b/app/server/lib/SqlParser.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared SQL parser instance for the PgWire/SQL execution pipeline.
+ *
+ * All SQL parsing should go through parseSQL() which tries PostgreSQL mode
+ * first, then falls back to default mode. The returned ParsedSQL carries
+ * the AST and dialect so that sqlify uses the matching mode.
+ */
+import { ApiError } from "app/common/ApiError";
+
+import { AST, Option, Parser } from "node-sql-parser";
+
+export const sqlParser = new Parser();
+export const SQL_PARSE_OPTS = { database: "postgresql" as const };
+
+/** Re-export the parser's AST type for use in entry-point signatures. */
+export type SqlAST = AST;
+
+type Dialect = "postgresql" | "default";
+
+export interface ParsedSQL {
+  ast: AST;
+  dialect: Dialect;
+  tables: string[];
+}
+
+const DML_TYPES = new Set(["insert", "update", "delete", "create", "drop", "alter"]);
+
+/**
+ * Parse a SQL string into an AST. Tries PostgreSQL mode first, falls back
+ * to default mode. This is the single entry point for all SQL parsing —
+ * no other code should call parser.astify directly.
+ *
+ * Why the fallback: node-sql-parser's PostgreSQL mode doesn't support some
+ * valid SQL constructs (e.g., ALTER TABLE RENAME COLUMN). The default mode
+ * (MySQL-like) is more permissive and handles these. The fallback only
+ * triggers when PostgreSQL mode fails to parse entirely — not when it
+ * produces a different AST. The dialect is tracked so that sqlifyAST uses
+ * the matching mode for regeneration.
+ *
+ * Risk: if a query fails in PostgreSQL mode for a non-obvious reason and
+ * default mode parses it with different semantics (e.g., double-quoted
+ * strings vs identifiers), the regenerated SQL could differ from user
+ * intent. In practice this hasn't occurred because the cases triggering
+ * fallback are unsupported DDL syntax, not ambiguous quoting. If this
+ * becomes a concern, the fallback could be restricted to DDL only.
+ */
+export function parseSQL(sql: string): ParsedSQL {
+  let ast: AST | AST[];
+  let dialect: Dialect;
+  let tables: string[];
+
+  try {
+    ast = sqlParser.astify(sql, SQL_PARSE_OPTS);
+    dialect = "postgresql";
+  } catch {
+    // PostgreSQL mode couldn't parse — retry in default mode.
+    // See docstring above for why this is safe in practice.
+    try {
+      ast = sqlParser.astify(sql);
+      dialect = "default";
+    } catch (e: unknown) {
+      throw new ApiError(`SQL parse error: ${e instanceof Error ? e.message : String(e)}`, 400);
+    }
+  }
+
+  if (Array.isArray(ast)) {
+    if (ast.length !== 1) {
+      throw new ApiError("Only single statements are supported", 400);
+    }
+    ast = ast[0];
+  }
+
+  try {
+    const tableList = sqlParser.tableList(sql, dialectOpts(dialect));
+    tables = tableList.map(entry => entry.split("::")[2]);
+  } catch {
+    tables = [];  // Caller should handle empty tables if needed
+  }
+
+  return { ast, dialect, tables };
+}
+
+/** Get parser options for a dialect — PostgreSQL mode or default. */
+function dialectOpts(dialect: Dialect): Option | undefined {
+  return dialect === "postgresql" ? SQL_PARSE_OPTS : undefined;
+}
+
+/** Check whether an AST represents a write (DML/DDL) statement. */
+export function isDMLAst(ast: AST): boolean {
+  return DML_TYPES.has(ast?.type);
+}
+
+/** Regenerate SQL from an AST using the dialect it was parsed with. */
+export function sqlifyAST(ast: AST | AST[], dialect: Dialect): string {
+  return sqlParser.sqlify(ast, dialectOpts(dialect));
+}

--- a/app/server/lib/SqlSession.ts
+++ b/app/server/lib/SqlSession.ts
@@ -1,0 +1,148 @@
+/**
+ * SqlSession: per-connection SQL session with transaction support.
+ *
+ * Handles the stateful parts of SQL execution: transaction lifecycle
+ * (BEGIN/COMMIT/ROLLBACK), write lock management, undo-based rollback,
+ * and routing between the granular SQL pipeline and the transaction DML path.
+ *
+ * ActiveDoc creates one per WebSocket docSession and delegates the "sql"
+ * method to it.
+ */
+import { ApiError } from "app/common/ApiError";
+import { ActiveDoc } from "app/server/lib/ActiveDoc";
+import { OptDocSession } from "app/server/lib/DocSession";
+import {
+  dmlResultToGranular, GranularSqlResult, runSQLQuery, validateForRestrictedUser,
+} from "app/server/lib/runSQLQuery";
+import { executeDMLFromParsed } from "app/server/lib/runSQLWrite";
+import { isDMLAst, ParsedSQL, parseSQL } from "app/server/lib/SqlParser";
+import { loadColumnTypes } from "app/server/lib/SqlValues";
+
+const TXN_TIMEOUT_MS = 30_000;
+
+const TXN_COMMANDS: Record<string, "begin" | "commit" | "rollback"> = {
+  begin: "begin",
+  begin_transaction: "begin",
+  start_transaction: "begin",
+  commit: "commit",
+  end: "commit",
+  end_transaction: "commit",
+  rollback: "rollback",
+  abort: "rollback",
+};
+
+interface Transaction {
+  release: () => void;
+  actionNums: number[];
+  timedOut: boolean;
+  timeout?: ReturnType<typeof setTimeout>;
+}
+
+export class SqlSession {
+  private _txn: Transaction | null = null;
+
+  constructor(
+    private _activeDoc: ActiveDoc,
+    private _docSession: OptDocSession,
+  ) {}
+
+  public async exec(sql: string): Promise<GranularSqlResult> {
+    const trimmed = sql.trim();
+
+    const txnCmd = this._getTransactionCommand(trimmed);
+    if (txnCmd === "begin") { return this._begin(); }
+    if (txnCmd === "commit") { return this._commit(); }
+    if (txnCmd === "rollback") { return this._rollback(); }
+
+    if (this._txn?.timedOut) {
+      await this._doRollback();
+      throw new ApiError("Transaction timed out and was rolled back", 400);
+    }
+
+    // Within a transaction, DML goes through the transaction path.
+    // Parse once here; reuse the AST in _execDmlInTransaction.
+    if (this._txn) {
+      const parsed = parseSQL(trimmed);
+      if (isDMLAst(parsed.ast)) {
+        return this._execDmlInTransaction(trimmed, parsed);
+      }
+    }
+
+    // Regular statement (no transaction, or SELECT within transaction)
+    return await runSQLQuery(
+      this._docSession, this._activeDoc, { sql: trimmed, granular: true },
+    ) as GranularSqlResult;
+  }
+
+  /** Clean up on disconnect — release lock if transaction is open. */
+  public endSession(): void {
+    if (this._txn) { this._endTransaction(); }
+  }
+
+  private _getTransactionCommand(sql: string): "begin" | "commit" | "rollback" | null {
+    // Use a lookup table keyed by normalized SQL. Transaction commands are
+    // always simple one- or two-word statements, so normalization is safe.
+    const key = sql.toLowerCase().replace(/\s+/g, "_").replace(/;$/, "");
+    return TXN_COMMANDS[key] || null;
+  }
+
+  private async _begin(): Promise<GranularSqlResult> {
+    if (this._txn) {
+      throw new ApiError("Already in a transaction", 400);
+    }
+    await this._activeDoc.waitForInitialization();
+    const release = await this._activeDoc.acquireTransactionLock();
+    const txn: Transaction = { release, actionNums: [], timedOut: false };
+    txn.timeout = setTimeout(() => { txn.timedOut = true; }, TXN_TIMEOUT_MS);
+    this._txn = txn;
+    return { statement: "BEGIN", command: "BEGIN", rowCount: 0 };
+  }
+
+  private async _commit(): Promise<GranularSqlResult> {
+    if (this._txn) { this._endTransaction(); }
+    return { statement: "COMMIT", command: "COMMIT", rowCount: 0 };
+  }
+
+  private async _rollback(): Promise<GranularSqlResult> {
+    if (this._txn) { await this._doRollback(); }
+    return { statement: "ROLLBACK", command: "ROLLBACK", rowCount: 0 };
+  }
+
+  private async _execDmlInTransaction(originalSql: string, parsed: ParsedSQL): Promise<GranularSqlResult> {
+    // Validate the SAME parsed result we'll execute — no re-parsing.
+    if (!(await this._activeDoc.canCopyEverything(this._docSession))) {
+      const columnTypes = loadColumnTypes(this._activeDoc.docData!);
+      validateForRestrictedUser(parsed, columnTypes);
+    }
+    const result = await executeDMLFromParsed(
+      parsed, this._activeDoc, this._docSession, { withinTransaction: true });
+    const granular = dmlResultToGranular(originalSql, result);
+    if (granular.actionNum) { this._txn!.actionNums.push(granular.actionNum); }
+    return granular;
+  }
+
+  private async _doRollback(): Promise<void> {
+    const txn = this._txn;
+    if (!txn) { return; }
+    try {
+      if (txn.actionNums.length > 0) {
+        const nums = [...txn.actionNums].reverse();
+        const undoActions = await this._activeDoc.getUndoActions(nums);
+        if (undoActions.length > 0) {
+          await this._activeDoc.applyUserActionsWithinTransaction(
+            this._docSession, [["ApplyUndoActions", undoActions]]);
+        }
+      }
+    } finally {
+      this._endTransaction();
+    }
+  }
+
+  private _endTransaction(): void {
+    const txn = this._txn;
+    if (!txn) { return; }
+    this._txn = null;
+    if (txn.timeout) { clearTimeout(txn.timeout); }
+    txn.release();
+  }
+}

--- a/app/server/lib/SqlValues.ts
+++ b/app/server/lib/SqlValues.ts
@@ -1,0 +1,167 @@
+/**
+ * SqlValues: Decodes raw SQLite values from Grist documents into
+ * human-readable typed values, based on Grist column type metadata.
+ *
+ * Used by the /sql endpoint (with granular flag) to return decoded
+ * values and column metadata.
+ */
+
+import { CellValue } from "app/common/DocActions";
+import { DocData } from "app/common/DocData";
+import { extractTypeFromColType } from "app/common/gristTypes";
+import {
+  CensoredValue, decodeObject, GristDate, GristDateTime,
+  PendingValue, RaisedException, Reference, ReferenceList, SkipValue, UnknownValue,
+} from "app/plugin/objtypes";
+import { decodeSqliteValue } from "app/server/lib/DocStorage";
+
+export interface ColumnTypeMap {
+  [colId: string]: string;  // colId → gristType
+}
+
+/**
+ * Load column type metadata for all tables from the document's docData.
+ */
+export function loadColumnTypes(
+  docData: DocData,
+): Map<string, ColumnTypeMap> {
+  const result = new Map<string, ColumnTypeMap>();
+  const tablesTable = docData.getMetaTable("_grist_Tables");
+  const columnsTable = docData.getMetaTable("_grist_Tables_column");
+  if (!tablesTable || !columnsTable) { return result; }
+
+  const getTableId = tablesTable.getRowPropFunc("tableId");
+  const tableIdById = new Map<number, string>();
+  for (const id of tablesTable.getRowIds()) {
+    tableIdById.set(id, String(getTableId(id) ?? ""));
+  }
+  const getParentId = columnsTable.getRowPropFunc("parentId");
+  const getColId = columnsTable.getRowPropFunc("colId");
+  const getType = columnsTable.getRowPropFunc("type");
+  for (const id of columnsTable.getRowIds()) {
+    const tableId = tableIdById.get(getParentId(id) as number) ?? "";
+    const colId = String(getColId(id) ?? "");
+    const type = String(getType(id) ?? "");
+    if (!tableId || !colId) { continue; }
+    let tableMap = result.get(tableId);
+    if (!tableMap) { tableMap = {}; result.set(tableId, tableMap); }
+    tableMap[colId] = type;
+  }
+  return result;
+}
+
+/**
+ * Resolve Grist types for a list of column names by searching all tables.
+ */
+export function resolveColumnTypes(
+  columns: string[],
+  allColumnTypes: Map<string, ColumnTypeMap>,
+): string[] {
+  return columns.map((col) => {
+    for (const typeMap of allColumnTypes.values()) {
+      if (typeMap[col]) { return typeMap[col]; }
+    }
+    if (col === "id") { return "Int"; }
+    return "";
+  });
+}
+
+/**
+ * Decode a raw SQLite result row into a fields object with decoded values.
+ */
+export function decodeRecord(
+  record: Record<string, CellValue>,
+  columns: string[],
+  colTypes: string[],
+): Record<string, CellValue> {
+  const fields: Record<string, CellValue> = {};
+  for (let i = 0; i < columns.length; i++) {
+    const col = columns[i];
+    const val = record[col];
+    const gristType = colTypes[i];
+    fields[col] = gristType ? decodeValue(val, gristType) : decodeValueFallback(val);
+  }
+  return fields;
+}
+
+/**
+ * Decode a raw SQLite value to a plain value for SQL API responses.
+ * Uses DocStorage.decodeValue for the canonical raw-CellValue normalization
+ * (unmarshal, Bool, list prefix), then applies SQL-specific decoding
+ * (dates to ISO strings, Refs to numbers, Grist objects to plain values).
+ */
+export function decodeValue(val: any, gristType: string): any {
+  if (val === null || val === undefined) { return null; }
+
+  // Canonical raw CellValue normalization (shared with REST API path).
+  val = decodeSqliteValue(val, gristType);
+
+  // Grist-encoded objects (arrays with string code prefix)
+  if (Array.isArray(val) && val.length > 0 && typeof val[0] === "string") {
+    return decodeGristObject(val);
+  }
+
+  // SQL-specific type decoding: convert to plain JSON-safe values
+  const baseType = extractTypeFromColType(gristType);
+  switch (baseType) {
+    case "Bool":
+      // DocStorage.decodeValue already handled 0/1 → true/false
+      return val;
+    case "Date":
+      if (typeof val === "number" && val !== 0) { return GristDate.fromGristValue(val).toString(); }
+      return val === 0 ? null : val;
+    case "DateTime":
+      if (typeof val === "number" && val !== 0) { return new GristDateTime(val * 1000).toISOString(); }
+      return val === 0 ? null : val;
+    case "Int":
+    case "Id":
+      return typeof val === "number" ? Math.round(val) : val;
+    case "Numeric":
+    case "ManualSortPos":
+    case "PositionNumber":
+      return val;
+    case "Ref":
+      return (typeof val === "number" && val === 0) ? null : val;
+    case "ChoiceList":
+    case "Attachments":
+    case "RefList":
+      if (typeof val === "string" && val.startsWith("[")) {
+        try { return JSON.parse(val); } catch { /* fall through */ }
+      }
+      return val;
+    default:
+      if (typeof val === "object") { return JSON.stringify(val); }
+      return val;
+  }
+}
+
+function decodeValueFallback(val: any): any {
+  if (val === null || val === undefined) { return null; }
+  return decodeSqliteValue(val, "Any");
+}
+
+/**
+ * Decode a Grist-encoded value tuple [code, args...] to a plain value
+ * for SQL API responses. Delegates to decodeObject() from objtypes.ts
+ * (the authoritative decoder), then converts class instances to simple
+ * types suitable for JSON API output.
+ */
+function decodeGristObject(val: any[]): any {
+  const obj = decodeObject(val as CellValue);
+  return toPlainValue(obj);
+}
+
+/** Convert a decoded Grist object to a plain JSON-safe value. */
+function toPlainValue(obj: unknown): any {
+  if (obj instanceof GristDateTime) { return obj.toISOString(); }
+  if (obj instanceof GristDate) { return obj.toString(); }  // YYYY-MM-DD
+  if (obj instanceof Reference) { return obj.rowId === 0 ? null : obj.rowId; }
+  if (obj instanceof ReferenceList) { return obj.rowIds; }
+  if (obj instanceof RaisedException) { return `#${obj}`; }
+  if (obj instanceof CensoredValue) { return "#CENSORED"; }
+  if (obj instanceof PendingValue) { return "#PENDING"; }
+  if (obj instanceof SkipValue) { return null; }
+  if (obj instanceof UnknownValue) { return String(obj); }
+  if (Array.isArray(obj)) { return obj.map(toPlainValue); }
+  return obj;
+}

--- a/app/server/lib/runSQLQuery.ts
+++ b/app/server/lib/runSQLQuery.ts
@@ -1,11 +1,21 @@
 import { ApiError } from "app/common/ApiError";
+import { extractInfoFromColType, reencodeAsTypedCellValue } from "app/common/gristTypes";
+import { isMetadataTable } from "app/common/isHiddenTable";
 import * as Types from "app/plugin/DocApiTypes";
 import { ActiveDoc } from "app/server/lib/ActiveDoc";
 import { appSettings } from "app/server/lib/AppSettings";
 import { docSessionFromRequest, OptDocSession } from "app/server/lib/DocSession";
+import { decodeSqliteValue } from "app/server/lib/DocStorage";
 import log from "app/server/lib/log";
 import { optIntegerParam } from "app/server/lib/requestUtils";
+import { DmlResult, executeDMLFromParsed } from "app/server/lib/runSQLWrite";
 import { isRequest, RequestOrSession } from "app/server/lib/sessionUtils";
+import { tryRunWithSqlAcl } from "app/server/lib/SqlACL";
+import { isDMLAst, ParsedSQL, parseSQL, sqlifyAST } from "app/server/lib/SqlParser";
+import { decodeRecord, loadColumnTypes, resolveColumnTypes } from "app/server/lib/SqlValues";
+
+// Limit SQL length to prevent parser bombs (PEG parsers can be slow on pathological input).
+const MAX_SQL_LENGTH = 100_000;
 
 // Maximum duration of a `runSQLQuery` call. Does not apply to internal calls to SQLite.
 const MAX_CUSTOM_SQL_MSEC = appSettings
@@ -17,76 +27,261 @@ const MAX_CUSTOM_SQL_MSEC = appSettings
     defaultValue: 1000,
   });
 
+export function dmlResultToGranular(sql: string, result: DmlResult): GranularSqlResult {
+  const granResult: GranularSqlResult = {
+    statement: sql,
+    rowCount: result.rowCount,
+    command: result.tag.split(" ")[0],
+  };
+  if (result.returning && result.returning.length > 0) {
+    const cols = Object.keys(result.returning[0]);
+    granResult.columns = cols.map(id => ({ id, type: "Any" }));
+    granResult.records = result.returning.map((row) => {
+      const fields: { [colId: string]: any } = {};
+      for (const col of cols) { fields[col] = row[col]; }
+      return { fields };
+    });
+  }
+  if (result.actionNum) { granResult.actionNum = result.actionNum; }
+  return granResult;
+}
+
+export interface GranularSqlResult {
+  statement: string;
+  columns?: { id: string, type: string }[];
+  records?: { fields: { [colId: string]: any } }[];
+  rowCount: number;
+  command: string;
+  actionNum?: number;   // For transaction rollback tracking
+}
+
 /**
- * Executes a SQL SELECT statement on a document and returns the result.
+ * Executes a SQL statement on a document and returns the result.
+ *
+ * Security model (granular path):
+ * - All user SQL is parsed once into an AST, validated, and regenerated.
+ *   Only the regenerated SQL reaches SQLite. This applies to ALL users,
+ *   not just restricted ones — the round-trip is the security boundary.
+ * - Writes: AST is translated to UserActions (BulkAddRecord, etc.) which
+ *   go through applyUserActions with ACL checks. No direct SQLite writes.
+ * - Reads: regenerated SQL is wrapped in `select * from (...)` as
+ *   defense-in-depth. ACL uses CTE wrappers or temp tables for row filtering.
+ * - Restricted users: additionally, table references are checked against an
+ *   allowlist of user tables (no _grist_* or sqlite_master access).
+ *
+ * Without `granular` flag: SELECT-only, requires canCopyEverything, returns raw rows.
+ * With `granular` flag: supports DML/DDL, uses granular ACL, returns decoded values
+ * with column metadata.
  */
 export async function runSQLQuery(
   requestOrSession: NonNullable<RequestOrSession>,
   activeDoc: ActiveDoc,
   options: Types.SqlPost,
-) {
+): Promise<any[] | GranularSqlResult> {
   let docSession: OptDocSession;
   if (isRequest(requestOrSession)) {
     docSession = docSessionFromRequest(requestOrSession);
   } else {
     docSession = requestOrSession;
   }
+
+  const sql = options.sql.replace(/;$/, "").trim();
+
+  if (options.granular) {
+    return _runGranular(docSession, activeDoc, sql, options);
+  }
+
+  // --- Legacy path (unchanged) ---
   if (!(await activeDoc.canCopyEverything(docSession))) {
     throw new ApiError("insufficient document access", 403);
   }
 
-  const statement = options.sql.replace(/;$/, "");
-  // A very loose test, just for early error message
-  if (!statement.toLowerCase().includes("select")) {
+  if (!sql.toLowerCase().includes("select")) {
     throw new ApiError("only select statements are supported", 400);
   }
 
+  return _execSelect(activeDoc, sql, options);
+}
+
+/**
+ * Granular path: parse once, validate, regenerate, then route to DML or SELECT.
+ */
+async function _runGranular(
+  docSession: OptDocSession,
+  activeDoc: ActiveDoc,
+  sql: string,
+  options: Types.SqlPost,
+): Promise<GranularSqlResult> {
+  if (!sql) {
+    return { statement: options.sql, rowCount: 0, command: "EMPTY" };
+  }
+
+  // Limit SQL length to prevent parser bombs (PEG parser can be slow on pathological input)
+  if (sql.length > MAX_SQL_LENGTH) {
+    throw new ApiError("SQL statement too long", 400);
+  }
+
+  // Load column types for table allowlist and value decoding
+  const columnTypes = loadColumnTypes(activeDoc.docData!);
+
+  // Step 1: Parse once. This is the single parse for the entire pipeline.
+  const parsed = parseSQL(sql);
+
+  // Step 2: Validate. Restricted users can only reference user tables.
+  const isRestricted = !(await activeDoc.canCopyEverything(docSession));
+  if (isRestricted) {
+    validateForRestrictedUser(parsed, columnTypes);
+  }
+
+  // Step 3: Regenerate SQL from AST. ALL users get regenerated SQL —
+  // the original user string is never executed.
+  const safeSql = _regenerateSQL(parsed);
+
+  if (isDMLAst(parsed.ast)) {
+    // Write: AST → UserActions → applyUserActions (with ACL checks).
+    const result = await executeDMLFromParsed(parsed, activeDoc, docSession);
+    return dmlResultToGranular(options.sql, result);
+  }
+
+  // Read: execute regenerated SQL with ACL filtering.
+  const records = await _runSelectWithAcl(activeDoc, docSession, safeSql, parsed, columnTypes, options);
+
+  if (!records || records.length === 0) {
+    return { statement: options.sql, columns: [], records: [], rowCount: 0, command: "SELECT" };
+  }
+
+  const columns = Object.keys(records[0]);
+  const colTypes = resolveColumnTypes(columns, columnTypes);
+  const colInfo = columns.map((id, i) => ({ id, type: colTypes[i] || "Text" }));
+
+  const decodedRecords = records.map((rec) => {
+    if (options.cellFormat === "typed") {
+      // cellFormat=typed: unmarshal blobs, then re-encode with type metadata,
+      // matching REST API cellFormat=typed. Uses reencodeAsTypedCellValue
+      // from gristTypes.ts (same function the REST API uses).
+      const fields: { [colId: string]: any } = {};
+      for (let i = 0; i < columns.length; i++) {
+        const col = columns[i];
+        const colType = colTypes[i] || "Text";
+        // Canonical raw CellValue normalization (same as REST API path).
+        const raw = decodeSqliteValue(rec[col], colType);
+        const typeInfo = extractInfoFromColType(colType);
+        fields[col] = reencodeAsTypedCellValue(raw, typeInfo);
+      }
+      return { fields };
+    }
+    // Default: decode to plain values (ISO dates, null for Ref 0, etc.)
+    return { fields: decodeRecord(rec, columns, colTypes) };
+  });
+
+  return {
+    statement: options.sql,
+    columns: colInfo,
+    records: decodedRecords,
+    rowCount: records.length,
+    command: "SELECT",
+  };
+}
+
+/**
+ * Validate a parsed query for restricted users: allowlist tables, reject writable CTEs.
+ */
+export function validateForRestrictedUser(parsed: ParsedSQL, columnTypes: Map<string, any>): void {
+  const allowedTables = new Set(
+    [...columnTypes.keys()].filter(t => !isMetadataTable(t)),
+  );
+
+  // Reject writable CTEs (WITH ... INSERT/UPDATE/DELETE ... RETURNING).
+  // The parser types CTE bodies as Select, but at runtime a writable CTE
+  // would have a different AST type. Check defensively.
+  if (parsed.ast.type === "select" && parsed.ast.with) {
+    for (const cte of parsed.ast.with) {
+      const stmtAst = cte.stmt as { type?: string };
+      if (stmtAst?.type && stmtAst.type !== "select") {
+        throw new ApiError(
+          "Writable CTEs (WITH ... INSERT/UPDATE/DELETE) are not permitted", 403);
+      }
+    }
+  }
+
+  // Allowlist table references
+  for (const table of parsed.tables) {
+    if (!allowedTables.has(table)) {
+      throw new ApiError(
+        `Access to "${table}" is not available. SQL access is limited to document tables.`, 403);
+    }
+  }
+}
+
+/**
+ * Regenerate SQL from AST. This is the security boundary: only SQL constructs
+ * the parser understood and can reproduce will reach SQLite.
+ */
+function _regenerateSQL(parsed: ParsedSQL): string {
+  try {
+    return sqlifyAST(parsed.ast, parsed.dialect);
+  } catch {
+    throw new ApiError("Query could not be regenerated for safe execution", 403);
+  }
+}
+
+/**
+ * For the PgWire transaction path: parse, validate (if restricted), regenerate.
+ * Returns the safe SQL string. Used by execDmlInTransaction.
+ */
+export function sanitizeQuery(sql: string, columnTypes: Map<string, any>): string {
+  if (sql.length > MAX_SQL_LENGTH) {
+    throw new ApiError("SQL statement too long", 400);
+  }
+  const parsed = parseSQL(sql);
+  validateForRestrictedUser(parsed, columnTypes);
+  return _regenerateSQL(parsed);
+}
+
+/**
+ * Run a SELECT with ACL:
+ * 1. canCopyEverything → run directly (fast path)
+ * 2. ACL rules translated to SQL CTE wrappers
+ */
+async function _runSelectWithAcl(
+  activeDoc: ActiveDoc,
+  docSession: OptDocSession,
+  sql: string,
+  parsed: ParsedSQL,
+  columnTypes: Map<string, any>,
+  options: Types.SqlPost,
+): Promise<any[]> {
+  if (await activeDoc.canCopyEverything(docSession)) {
+    return _execSelect(activeDoc, sql, options);
+  }
+
+  return tryRunWithSqlAcl(sql, parsed, activeDoc, docSession, columnTypes);
+}
+
+/**
+ * Execute a SELECT statement against the document's SQLite, with timeout.
+ */
+async function _execSelect(
+  activeDoc: ActiveDoc,
+  sql: string,
+  options: Types.SqlPost,
+): Promise<any[]> {
   const sqlOptions = activeDoc.docStorage.getOptions();
-  if (
-    !sqlOptions?.canInterrupt ||
-    !sqlOptions?.bindableMethodsProcessOneStatement
-  ) {
+  if (!sqlOptions?.canInterrupt || !sqlOptions?.bindableMethodsProcessOneStatement) {
     throw new ApiError("The available SQLite wrapper is not adequate", 500);
   }
-  const timeout = Math.max(
-    0,
-    Math.min(
-      MAX_CUSTOM_SQL_MSEC,
-      optIntegerParam(options.timeout, "timeout") || MAX_CUSTOM_SQL_MSEC,
-    ),
-  );
-  // Wrap in a select to commit to the SELECT branch of SQLite
-  // grammar. Note ; isn't a problem.
-  //
-  // The underlying SQLite functions used will only process the
-  // first statement in the supplied text. For node-sqlite3, the
-  // remainder is placed in a "tail string" ignored by that library.
-  // So a Robert'); DROP TABLE Students;-- style attack isn't applicable.
-  //
-  // Since Grist is used with multiple SQLite wrappers, not just
-  // node-sqlite3, we have added a bindableMethodsProcessOneStatement
-  // flag that will need adding for each wrapper, and this endpoint
-  // will not operate unless that flag is set to true.
-  //
-  // The text is wrapped in select * from (USER SUPPLIED TEXT) which
-  // puts SQLite unconditionally onto the SELECT branch of its
-  // grammar. It is straightforward to break out of such a wrapper
-  // with multiple statements, but again, only the first statement
-  // is processed.
-  const wrappedStatement = `select * from (${statement})`;
+  const timeout = Math.max(0, Math.min(
+    MAX_CUSTOM_SQL_MSEC,
+    optIntegerParam(options.timeout, "timeout") || MAX_CUSTOM_SQL_MSEC,
+  ));
+  const wrappedStatement = `select * from (${sql})`;
   const interrupt = setTimeout(async () => {
-    try {
-      await activeDoc.docStorage.interrupt();
-    } catch (e) {
-      // Should be unreachable, but just in case...
+    try { await activeDoc.docStorage.interrupt(); } catch (e) {
       log.error("runSQL interrupt failed with error ", e);
     }
   }, timeout);
   try {
-    return await activeDoc.docStorage.all(
-      wrappedStatement,
-      ...(options.args || []),
-    );
+    return await activeDoc.docStorage.all(wrappedStatement, ...(options.args || []));
   } finally {
     clearTimeout(interrupt);
   }

--- a/app/server/lib/runSQLWrite.ts
+++ b/app/server/lib/runSQLWrite.ts
@@ -1,0 +1,496 @@
+/**
+ * runSQLWrite: Translates SQL INSERT/UPDATE/DELETE/DDL statements to Grist UserActions.
+ *
+ * Security: the AST is provided by the caller (already parsed and validated by the
+ * pipeline in runSQLQuery). The AST is used to construct UserActions (BulkAddRecord,
+ * etc.) which go through applyUserActions with ACL checks. For UPDATE/DELETE, row-ID
+ * lookup queries are reconstructed from the AST via sqlifyAST() and wrapped in
+ * select * from (...) — they are not raw user input.
+ *
+ * All mutations go through applyUserActions → Python data engine → GranularAccess,
+ * providing formula recalculation, access control, undo, triggers, and client broadcast.
+ */
+
+import { ApplyUAResult } from "app/common/ActiveDocAPI";
+import { ApiError } from "app/common/ApiError";
+import { BulkColValues, CellValue, UserAction } from "app/common/DocActions";
+import { ActiveDoc } from "app/server/lib/ActiveDoc";
+import { OptDocSession } from "app/server/lib/DocSession";
+import { DocStorage } from "app/server/lib/DocStorage";
+import { quoteIdent } from "app/server/lib/SQLiteDB";
+import { ParsedSQL, SqlAST, sqlifyAST } from "app/server/lib/SqlParser";
+
+import type { Alter, Create, Delete, Drop, Insert_Replace, SetList, Update } from "node-sql-parser";
+
+// ---- Types for parser sub-nodes and SQLite results ----
+
+/** A row returned from docStorage.all(). Column values keyed by name. */
+interface SqliteRow { [col: string]: CellValue; }
+
+/** A parsed expression node (WHERE clause, SET value, etc.).
+ *  The parser's own type for these is `any`; we use this to be
+ *  explicit that we're passing an opaque parser expression. */
+type Expr = object | null;
+
+// ---- Helpers ----
+
+/** Extract a column name string from a parser AST node.
+ *  The parser produces column refs in several shapes depending on
+ *  dialect and context. We check each known shape and fall back to
+ *  String() for anything unexpected. */
+function colName(col: unknown): string {
+  if (typeof col === "string") { return col; }
+  if (!col || typeof col !== "object") { return String(col); }
+  const obj = col as Record<string, unknown>;
+  if (typeof obj.value === "string") { return obj.value; }
+  if (obj.expr && typeof obj.expr === "object" && typeof (obj.expr as Record<string, unknown>).value === "string") {
+    return (obj.expr as Record<string, unknown>).value as string;
+  }
+  if (obj.column !== undefined) { return colName(obj.column); }
+  return String(col);
+}
+
+function errMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+export interface DmlResult {
+  tag: string;
+  rowCount: number;
+  returning?: SqliteRow[];
+  actionNum?: number;
+  actionHash?: string | null;
+}
+
+export interface DmlOptions {
+  withinTransaction?: boolean;
+}
+
+interface DmlContext {
+  activeDoc: ActiveDoc;
+  docSession: OptDocSession;
+  opts: DmlOptions;
+  dialect: "postgresql" | "default";
+}
+
+async function applyActions(ctx: DmlContext, actions: UserAction[]): Promise<ApplyUAResult> {
+  if (ctx.opts.withinTransaction) {
+    return ctx.activeDoc.applyUserActionsWithinTransaction(ctx.docSession, actions);
+  }
+  return ctx.activeDoc.applyUserActions(ctx.docSession, actions);
+}
+
+async function applyPrepared(
+  ctx: DmlContext, prepare: (docStorage: DocStorage) => Promise<UserAction[]>,
+): Promise<ApplyUAResult> {
+  if (ctx.opts.withinTransaction) {
+    const actions = await prepare(ctx.activeDoc.docStorage);
+    if (actions.length === 0) {
+      return { actionNum: 0, actionHash: null, retValues: [], isModification: false };
+    }
+    return ctx.activeDoc.applyUserActionsWithinTransaction(ctx.docSession, actions);
+  }
+  return ctx.activeDoc.applyPreparedUserActions(ctx.docSession, prepare);
+}
+
+/**
+ * Execute a DML statement from a pre-parsed result. The caller has already
+ * parsed, validated, and regenerated — this translates the AST to UserActions.
+ */
+export async function executeDMLFromParsed(
+  parsed: ParsedSQL,
+  activeDoc: ActiveDoc,
+  docSession: OptDocSession,
+  options?: DmlOptions,
+): Promise<DmlResult> {
+  const ctx: DmlContext = { activeDoc, docSession, opts: options || {}, dialect: parsed.dialect };
+  switch (parsed.ast.type) {
+    case "insert": case "replace": return executeInsert(parsed.ast, ctx);
+    case "update":  return executeUpdate(parsed.ast, ctx);
+    case "delete":  return executeDelete(parsed.ast, ctx);
+    case "create":  return executeCreate(parsed.ast, ctx);
+    case "drop":    return executeDrop(parsed.ast, ctx);
+    case "alter":   return executeAlter(parsed.ast, ctx);
+    default:
+      throw new ApiError(`Unsupported statement type: ${parsed.ast.type}`, 400);
+  }
+}
+
+// ---- Value extraction ----
+
+interface ValueNode { type: string; value: CellValue; }
+
+function extractValue(node: ValueNode | null | undefined): CellValue {
+  if (node === null || node === undefined) { return null; }
+  switch (node.type) {
+    case "number":
+    case "single_quote_string":
+    case "string":
+    case "double_quote_string":
+      return node.value;
+    case "bool":
+      return node.value === "TRUE" || node.value === true;
+    case "null":
+      return null;
+    case "origin":
+      if (String(node.value).toUpperCase() === "DEFAULT") { return null; }
+      return node.value;
+    default:
+      if (node.value !== undefined) { return node.value; }
+      throw new ApiError(`Unsupported value expression type: ${node.type}`, 400);
+  }
+}
+
+function isLiteralValue(node: ValueNode | null | undefined): boolean {
+  if (!node) { return true; }
+  const t = node.type;
+  return t === "number" || t === "single_quote_string" || t === "string" ||
+    t === "double_quote_string" || t === "bool" || t === "null" || t === "origin";
+}
+
+// ---- Table name extraction ----
+
+function getTableName(ast: Insert_Replace | Update | Delete): string {
+  const refs = ast.type === "delete" ? ast.from : ast.table;
+  if (!refs?.length) {
+    throw new ApiError("No table specified", 400);
+  }
+  return refs[0].table;
+}
+
+// ---- AST construction for SQLite queries ----
+
+/** Build a SELECT that returns matching row IDs for a WHERE clause.
+ *  Constructed from AST (not user input), wrapped for defense-in-depth. */
+function buildIdSelectSql(tableId: string, where: Expr, ctx: DmlContext): string {
+  return buildSelectSql(
+    [{ expr: { type: "column_ref", table: null, column: "id" }, as: null }],
+    [{ db: null, table: tableId, as: null }],
+    where, ctx.dialect, "row ID query",
+  );
+}
+
+function buildSelectSql(
+  columns: object[], from: object[], where: Expr,
+  dialect: "postgresql" | "default", label: string,
+): string {
+  try {
+    const sql = sqlifyAST({ type: "select", columns, from, where: where || null } as SqlAST, dialect);
+    return `select * from (${sql})`;
+  } catch (e) {
+    throw new ApiError(`Failed to build ${label}: ${errMessage(e)}`, 400);
+  }
+}
+
+// ---- INSERT ----
+
+async function executeInsert(
+  ast: Insert_Replace,
+  ctx: DmlContext,
+): Promise<DmlResult> {
+  const tableId = getTableName(ast);
+  const columns: string[] = (ast.columns || []).map(c => colName(c));
+  if (!columns || columns.length === 0) {
+    throw new ApiError("INSERT without column list is not supported", 400);
+  }
+
+  if (ast.values?.type === "select") {
+    return _executeInsertSelect(ast, tableId, columns, ctx);
+  }
+
+  const valueRows = ast.values?.values;
+  if (!valueRows || valueRows.length === 0) {
+    throw new ApiError("INSERT with no values", 400);
+  }
+
+  const idColIdx = columns.indexOf("id");
+  const dataCols = columns.filter(c => c !== "id");
+  const colValues: BulkColValues = {};
+  for (const col of dataCols) { colValues[col] = []; }
+  const rowIds: (number | null)[] = [];
+
+  for (const row of valueRows) {
+    const vals = row.value as ValueNode[];
+    if (vals.length !== columns.length) {
+      throw new ApiError(
+        `INSERT has ${columns.length} columns but ${vals.length} values`, 400,
+      );
+    }
+    if (idColIdx >= 0) {
+      const idVal = extractValue(vals[idColIdx]);
+      rowIds.push(idVal === null ? null : Number(idVal));
+    } else {
+      rowIds.push(null);
+    }
+    for (let i = 0; i < columns.length; i++) {
+      if (i === idColIdx) { continue; }
+      colValues[columns[i]].push(extractValue(vals[i]));
+    }
+  }
+
+  const result = await applyActions(ctx,
+    [["BulkAddRecord", tableId, rowIds, colValues]]);
+  const insertedIds: number[] = result.retValues?.[0] || [];
+  const count = Array.isArray(insertedIds) ? insertedIds.length : valueRows.length;
+  const dmlResult: DmlResult = {
+    tag: `INSERT 0 ${count}`, rowCount: count,
+    actionNum: result.actionNum, actionHash: result.actionHash,
+  };
+  if (ast.returning && Array.isArray(insertedIds) && insertedIds.length > 0) {
+    // Fetch the full inserted rows (including formula columns) from SQLite.
+    const idList = insertedIds.join(",");
+    const rows: SqliteRow[] = await ctx.activeDoc.docStorage.all(
+      `SELECT * FROM ${quoteIdent(tableId)} WHERE id IN (${idList})`);
+    dmlResult.returning = rows;
+  }
+  return dmlResult;
+}
+
+async function _executeInsertSelect(
+  ast: Insert_Replace,
+  tableId: string,
+  columns: string[],
+  ctx: DmlContext,
+): Promise<DmlResult> {
+  let selectSql: string;
+  try {
+    const rawSql = sqlifyAST(ast.values as SqlAST, ctx.dialect);
+    selectSql = `select * from (${rawSql})`;
+  } catch (e) {
+    throw new ApiError(`Failed to build INSERT...SELECT query: ${errMessage(e)}`, 400);
+  }
+
+  const result = await applyPrepared(ctx, async (docStorage) => {
+    const rows: SqliteRow[] = await docStorage.all(selectSql);
+    if (rows.length === 0) { return []; }
+
+    const selectCols = Object.keys(rows[0]);
+    if (selectCols.length !== columns.length) {
+      throw new ApiError(
+        `INSERT has ${columns.length} columns but SELECT returns ${selectCols.length}`, 400,
+      );
+    }
+
+    const colValues: BulkColValues = {};
+    for (const col of columns) { colValues[col] = []; }
+    for (const row of rows) {
+      for (let i = 0; i < columns.length; i++) {
+        colValues[columns[i]].push(row[selectCols[i]]);
+      }
+    }
+    return [["BulkAddRecord", tableId, new Array(rows.length).fill(null), colValues]];
+  });
+
+  const count = result.retValues?.[0]?.length ?? 0;
+  return {
+    tag: `INSERT 0 ${count}`, rowCount: count,
+    actionNum: result.actionNum, actionHash: result.actionHash,
+  };
+}
+
+// ---- UPDATE ----
+
+async function executeUpdate(
+  ast: Update,
+  ctx: DmlContext,
+): Promise<DmlResult> {
+  const tableId = getTableName(ast);
+  const setList: SetList[] = ast.set;
+  if (!setList || setList.length === 0) {
+    throw new ApiError("UPDATE with no SET clause", 400);
+  }
+
+  const hasExpressions = setList.some(item => !isLiteralValue(item.value as ValueNode));
+
+  let selectSql: string;
+  if (hasExpressions) {
+    const selectCols: object[] = [
+      { expr: { type: "column_ref", table: null, column: "id" }, as: null },
+    ];
+    for (let i = 0; i < setList.length; i++) {
+      selectCols.push({ expr: setList[i].value, as: `_set_${i}` });
+    }
+    selectSql = buildSelectSql(selectCols, ast.table || [], ast.where, ctx.dialect, "computed UPDATE query");
+  } else {
+    selectSql = buildIdSelectSql(tableId, ast.where, ctx);
+  }
+
+  const literalValues: Record<string, CellValue> | null = hasExpressions ? null :
+    Object.fromEntries(setList.map(item =>
+      [colName(item.column), extractValue(item.value as ValueNode)]));
+
+  let rowCount = 0;
+  const result = await applyPrepared(ctx, async (docStorage) => {
+    const rows: SqliteRow[] = await docStorage.all(selectSql);
+    if (rows.length === 0) { return []; }
+    rowCount = rows.length;
+
+    const rowIds = rows.map(r => r.id as number);
+    const colValues: BulkColValues = {};
+    if (hasExpressions) {
+      for (let i = 0; i < setList.length; i++) {
+        colValues[colName(setList[i].column)] = rows.map(r => r[`_set_${i}`]);
+      }
+    } else {
+      for (const item of setList) {
+        const name = colName(item.column);
+        colValues[name] = new Array(rowIds.length).fill(literalValues![name]);
+      }
+    }
+    return [["BulkUpdateRecord", tableId, rowIds, colValues]];
+  });
+
+  return { tag: `UPDATE ${rowCount}`, rowCount, actionNum: result.actionNum, actionHash: result.actionHash };
+}
+
+// ---- DELETE ----
+
+async function executeDelete(
+  ast: Delete,
+  ctx: DmlContext,
+): Promise<DmlResult> {
+  const tableId = getTableName(ast);
+  const selectSql = buildIdSelectSql(tableId, ast.where, ctx);
+
+  let rowCount = 0;
+  const result = await applyPrepared(ctx, async (docStorage) => {
+    const rows: SqliteRow[] = await docStorage.all(selectSql);
+    if (rows.length === 0) { return []; }
+    rowCount = rows.length;
+    return [["BulkRemoveRecord", tableId, rows.map(r => r.id as number)]];
+  });
+
+  return { tag: `DELETE ${rowCount}`, rowCount, actionNum: result.actionNum, actionHash: result.actionHash };
+}
+
+// ---- CREATE TABLE ----
+
+function sqlTypeToGrist(sqlType: string): string {
+  const t = sqlType.toUpperCase();
+  if (t.startsWith("INT") || t === "SERIAL" || t === "BIGINT" || t === "SMALLINT") { return "Int"; }
+  if (t.startsWith("FLOAT") || t.startsWith("DOUBLE") || t === "REAL" || t === "DECIMAL" ||
+    t === "NUMERIC" || t === "MONEY") { return "Numeric"; }
+  if (t === "BOOLEAN" || t === "BOOL") { return "Bool"; }
+  if (t === "DATE") { return "Date"; }
+  if (t.startsWith("TIMESTAMP")) { return "DateTime"; }
+  if (t.startsWith("VARCHAR") || t.startsWith("CHAR") || t === "TEXT" || t === "CLOB" ||
+    t === "UUID" || t === "JSON" || t === "JSONB") { return "Text"; }
+  return "Text";
+}
+
+async function executeCreate(
+  ast: Create,
+  ctx: DmlContext,
+): Promise<DmlResult> {
+  if (ast.keyword !== "table") {
+    throw new ApiError(`CREATE ${ast.keyword} is not supported`, 400);
+  }
+
+  const tableRef = Array.isArray(ast.table) ? ast.table[0] : ast.table;
+  const tableId = tableRef?.table;
+  if (!tableId) {
+    throw new ApiError("No table specified", 400);
+  }
+
+  const defs = ast.create_definitions;
+  if (!defs || defs.length === 0) {
+    throw new ApiError("CREATE TABLE with no columns", 400);
+  }
+
+  const columns: { id: string, type: string }[] = [];
+  for (const def of defs) {
+    if (def.resource !== "column") { continue; }
+    const cname = colName(def.column);
+    if (!cname) { continue; }
+    const sqlType = def.definition?.dataType || "TEXT";
+    columns.push({ id: cname, type: sqlTypeToGrist(sqlType) });
+  }
+
+  if (columns.length === 0) {
+    throw new ApiError("CREATE TABLE with no columns", 400);
+  }
+
+  const result = await applyActions(ctx, [["AddTable", tableId, columns]]);
+  return { tag: "CREATE TABLE", rowCount: 0, actionNum: result.actionNum, actionHash: result.actionHash };
+}
+
+// ---- DROP TABLE ----
+
+async function executeDrop(
+  ast: Drop,
+  ctx: DmlContext,
+): Promise<DmlResult> {
+  if (ast.keyword !== "table") {
+    throw new ApiError(`DROP ${ast.keyword} is not supported`, 400);
+  }
+
+  const tableId = ast.name?.[0]?.table;
+  if (!tableId) {
+    throw new ApiError("No table specified", 400);
+  }
+
+  const result = await applyActions(ctx, [["RemoveTable", tableId]]);
+  return { tag: "DROP TABLE", rowCount: 0, actionNum: result.actionNum, actionHash: result.actionHash };
+}
+
+// ---- ALTER TABLE ----
+
+async function executeAlter(
+  ast: Alter,
+  ctx: DmlContext,
+): Promise<DmlResult> {
+  const firstTable = ast.table?.[0];
+  const tableId = firstTable && "table" in firstTable ? firstTable.table : undefined;
+  if (!tableId) {
+    throw new ApiError("No table specified", 400);
+  }
+
+  const exprs: { action: string; [k: string]: unknown }[] = ast.expr;
+  if (!exprs || exprs.length === 0) {
+    throw new ApiError("ALTER TABLE with no operations", 400);
+  }
+
+  const actions: UserAction[] = [];
+  for (const expr of exprs) {
+    switch (expr.action) {
+      case "add": {
+        const cname = colName((expr.column));
+        const sqlType = (expr.definition as { dataType?: string })?.dataType || "TEXT";
+        if (!cname) { throw new ApiError("ADD COLUMN with no column name", 400); }
+        actions.push(["AddColumn", tableId, cname, { type: sqlTypeToGrist(sqlType) }]);
+        break;
+      }
+      case "drop": {
+        const cname = colName((expr.column));
+        if (!cname) { throw new ApiError("DROP COLUMN with no column name", 400); }
+        actions.push(["RemoveColumn", tableId, cname]);
+        break;
+      }
+      case "rename": {
+        if (expr.resource === "column") {
+          const oldName = colName((expr.old_column));
+          const newName = colName((expr.column));
+          if (!oldName || !newName) { throw new ApiError("RENAME COLUMN missing names", 400); }
+          actions.push(["RenameColumn", tableId, oldName, newName]);
+        } else if (expr.resource === "table") {
+          const newName = expr.table as string;
+          if (!newName) { throw new ApiError("RENAME TO missing new name", 400); }
+          actions.push(["RenameTable", tableId, newName]);
+        } else {
+          throw new ApiError(`Unsupported ALTER RENAME resource: ${expr.resource}`, 400);
+        }
+        break;
+      }
+      default:
+        throw new ApiError(`Unsupported ALTER TABLE action: ${expr.action}`, 400);
+    }
+  }
+
+  let resultInfo: { actionNum?: number, actionHash?: string | null } = {};
+  if (actions.length > 0) {
+    const result = await applyActions(ctx, actions);
+    resultInfo = { actionNum: result.actionNum, actionHash: result.actionHash };
+  }
+
+  return { tag: "ALTER TABLE", rowCount: 0, ...resultInfo };
+}

--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
     "multiparty": "4.2.2",
     "node-abort-controller": "3.0.1",
     "node-fetch": "2.6.7",
+    "node-sql-parser": "5.4.0",
     "openid-client": "5.6.1",
     "p-limit": "7.3.0",
     "pg": "8.6.0",

--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
     "multiparty": "4.3.0",
     "node-abort-controller": "3.0.1",
     "node-fetch": "2.6.7",
+    "node-sql-parser": "5.4.0",
     "openid-client": "5.6.1",
     "p-limit": "7.3.0",
     "pg": "8.6.0",

--- a/test/server/lib/DocApiSql.ts
+++ b/test/server/lib/DocApiSql.ts
@@ -1,0 +1,1734 @@
+/**
+ * Tests for the /sql/full endpoint.
+ * Tests DML, DDL, ACL filtering, value decoding, and formula recalculation.
+ * These test the business logic in runSQLQuery/runSQLWrite/SqlACL/SqlValues
+ * and do NOT depend on the PG wire protocol.
+ */
+import { UserAPIImpl } from "app/common/UserAPI";
+import { prepareDatabase } from "test/server/lib/helpers/PrepareDatabase";
+import { TestServer } from "test/server/lib/helpers/TestServer";
+import { createTestDir, EnvironmentSnapshot, setTmpLogLevel } from "test/server/testUtils";
+
+import { assert } from "chai";
+import fetch from "node-fetch";
+
+describe("DocApiSql-full", function() {
+  this.timeout(60000);
+
+  setTmpLogLevel("error");
+
+  let server: TestServer;
+  let oldEnv: EnvironmentSnapshot;
+  let userApi: UserAPIImpl;
+  let homeUrl: string;
+
+  before(async function() {
+    oldEnv = new EnvironmentSnapshot();
+    const testDir = await createTestDir("DocApiSqlGranular");
+    await prepareDatabase(testDir);
+    server = await TestServer.startServer("home,docs", testDir, "DocApiSqlGranular");
+    homeUrl = server.serverUrl;
+    userApi = server.makeUserApi("docs", "chimpy");
+  });
+
+  after(async function() {
+    if (server) { await server.stop(); }
+    oldEnv?.restore();
+  });
+
+  let docId: string;
+
+  beforeEach(async function() {
+    const workspaces = await userApi.getOrgWorkspaces("current");
+    const wsId = workspaces[0].id;
+    docId = await userApi.newDoc({ name: "SqlTest" }, wsId);
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "People", [
+        { id: "Name", type: "Text" },
+        { id: "Age", type: "Int" },
+        { id: "Score", type: "Numeric" },
+      ]],
+      ["BulkAddRecord", "People", [null, null, null], {
+        Name: ["Alice", "Bob", "Charlie"],
+        Age: [30, 25, 35],
+        Score: [95.5, 87.3, 92.1],
+      }],
+    ]);
+  });
+
+  /** Set up ACL: give kiwi a role and add rule groups. Each group creates one resource
+   *  with one or more rules. A rule with no formula is the default (must be last). */
+  async function addAclRules(
+    kiwiRole: "viewers" | "editors",
+    ...groups: {
+      table: string, cols?: string,
+      rules: { formula?: string, perms: string }[],
+      userAttr?: { name: string, tableId: string, lookupColId: string, charId: string },
+    }[]
+  ) {
+    await userApi.updateDocPermissions(docId, {
+      users: { "kiwi@getgrist.com": kiwiRole },
+    });
+    const actions: any[] = [];
+    let resId = -1;
+    for (const group of groups) {
+      actions.push(["AddRecord", "_grist_ACLResources", resId,
+        { tableId: group.table, colIds: group.cols || "*" }]);
+      if (group.userAttr) {
+        actions.push(["AddRecord", "_grist_ACLRules", null, {
+          resource: resId,
+          userAttributes: JSON.stringify(group.userAttr),
+        }]);
+      }
+      for (const rule of group.rules) {
+        actions.push(["AddRecord", "_grist_ACLRules", null, {
+          resource: resId,
+          aclFormula: rule.formula || "",
+          permissionsText: rule.perms,
+        }]);
+      }
+      resId--;
+    }
+    await userApi.applyUserActions(docId, actions);
+  }
+
+  async function sqlPost(sql: string, args?: any[]) {
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_chimpy",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql, args }),
+    });
+    const body = await resp.json();
+    if (!resp.ok) { throw new Error(body.error || `HTTP ${resp.status}`); }
+    return body;
+  }
+
+  // ---- SELECT ----
+
+  it("should return decoded values and column metadata", async function() {
+    const result = await sqlPost("SELECT Name, Age, Score FROM People ORDER BY Age");
+    assert.equal(result.command, "SELECT");
+    assert.equal(result.rowCount, 3);
+    assert.isArray(result.columns);
+    assert.deepEqual(result.columns.map((c: any) => c.id), ["Name", "Age", "Score"]);
+
+    assert.equal(result.records[0].fields.Name, "Bob");
+    assert.equal(result.records[0].fields.Age, 25);
+  });
+
+  it("should handle JOIN", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Departments", [{ id: "DeptName", type: "Text" }]],
+      ["BulkAddRecord", "Departments", [null, null], { DeptName: ["Engineering", "Sales"] }],
+      ["AddColumn", "People", "Dept", { type: "Ref:Departments" }],
+      ["BulkUpdateRecord", "People", [1, 2], { Dept: [1, 2] }],
+    ]);
+    const result = await sqlPost(
+      "SELECT p.Name, d.DeptName FROM People p JOIN Departments d ON p.Dept = d.id ORDER BY p.Name",
+    );
+    assert.equal(result.rowCount, 2);
+    assert.equal(result.records[0].fields.Name, "Alice");
+    assert.equal(result.records[0].fields.DeptName, "Engineering");
+  });
+
+  it("should decode Bool values", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Active", { type: "Bool" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Active: [true, false, true] }],
+    ]);
+    const result = await sqlPost("SELECT Name, Active FROM People ORDER BY Name");
+    assert.strictEqual(result.records[0].fields.Active, true);
+    assert.strictEqual(result.records[1].fields.Active, false);
+  });
+
+  it("should decode Ref 0 as null", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Departments", [{ id: "Name", type: "Text" }]],
+      ["BulkAddRecord", "Departments", [null], { Name: ["Engineering"] }],
+      ["AddColumn", "People", "Dept", { type: "Ref:Departments" }],
+      ["BulkUpdateRecord", "People", [1], { Dept: [1] }],
+    ]);
+    const result = await sqlPost("SELECT Name, Dept FROM People ORDER BY Name");
+    assert.equal(result.records[0].fields.Dept, 1);    // Alice has dept
+    assert.equal(result.records[1].fields.Dept, null);  // Bob has 0 → null
+  });
+
+  // ---- DML ----
+
+  it("should INSERT and return row count", async function() {
+    const result = await sqlPost("INSERT INTO People (Name, Age, Score) VALUES ('Diana', 28, 91.0)");
+    assert.equal(result.command, "INSERT");
+    assert.equal(result.rowCount, 1);
+
+    const sel = await sqlPost("SELECT Name FROM People WHERE Name = 'Diana'");
+    assert.equal(sel.rowCount, 1);
+  });
+
+  it("should UPDATE with WHERE", async function() {
+    const result = await sqlPost("UPDATE People SET Age = 99 WHERE Name = 'Alice'");
+    assert.equal(result.command, "UPDATE");
+    assert.equal(result.rowCount, 1);
+
+    const sel = await sqlPost("SELECT Age FROM People WHERE Name = 'Alice'");
+    assert.equal(sel.records[0].fields.Age, 99);
+  });
+
+  it("should UPDATE with expressions", async function() {
+    await sqlPost("UPDATE People SET Age = Age + 10 WHERE Name = 'Alice'");
+    const sel = await sqlPost("SELECT Age FROM People WHERE Name = 'Alice'");
+    assert.equal(sel.records[0].fields.Age, 40);
+  });
+
+  it("should DELETE with WHERE", async function() {
+    const result = await sqlPost("DELETE FROM People WHERE Name = 'Bob'");
+    assert.equal(result.command, "DELETE");
+    assert.equal(result.rowCount, 1);
+
+    const sel = await sqlPost("SELECT Name FROM People ORDER BY Name");
+    assert.deepEqual(sel.records.map((r: any) => r.fields.Name), ["Alice", "Charlie"]);
+  });
+
+  it("should INSERT ... SELECT", async function() {
+    await sqlPost("CREATE TABLE Archive (Name TEXT, Age INT)");
+    await sqlPost("INSERT INTO Archive (Name, Age) SELECT Name, Age FROM People WHERE Age > 28");
+    const sel = await sqlPost("SELECT Name FROM Archive ORDER BY Name");
+    assert.deepEqual(sel.records.map((r: any) => r.fields.Name), ["Alice", "Charlie"]);
+  });
+
+  it("should INSERT ... RETURNING with formula columns", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Summary", {
+        type: "Text", isFormula: true,
+        formula: "$Name + ' (age ' + str($Age) + ')'",
+      }],
+    ]);
+    const result = await sqlPost(
+      "INSERT INTO People (Name, Age, Score) VALUES ('Diana', 28, 91.0) RETURNING *");
+    assert.equal(result.command, "INSERT");
+    assert.equal(result.rowCount, 1);
+    // RETURNING should include the formula column with computed value
+    assert.isArray(result.records);
+    assert.equal(result.records.length, 1);
+    const row = result.records[0].fields;
+    assert.equal(row.Name, "Diana");
+    assert.equal(row.Age, 28);
+    assert.equal(row.Summary, "Diana (age 28)");
+  });
+
+  // ---- DDL ----
+
+  it("should CREATE TABLE", async function() {
+    const result = await sqlPost("CREATE TABLE Projects (Title TEXT, Budget NUMERIC)");
+    assert.equal(result.command, "CREATE");
+
+    await sqlPost("INSERT INTO Projects (Title, Budget) VALUES ('Alpha', 1000)");
+    const sel = await sqlPost("SELECT Title FROM Projects");
+    assert.equal(sel.records[0].fields.Title, "Alpha");
+  });
+
+  it("should DROP TABLE", async function() {
+    await sqlPost("CREATE TABLE TempTable (x TEXT)");
+    await sqlPost("DROP TABLE TempTable");
+    const tables = await sqlPost("SELECT tableId FROM _grist_Tables");
+    assert.notInclude(tables.records.map((r: any) => r.fields.tableId), "TempTable");
+  });
+
+  // ---- Formula recalculation ----
+
+  it("should trigger formula recalculation on write", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Summary", {
+        type: "Text", isFormula: true,
+        formula: "$Name + ' (age ' + str($Age) + ')'",
+      }],
+    ]);
+
+    await sqlPost("INSERT INTO People (Name, Age, Score) VALUES ('Diana', 28, 91.0)");
+    const sel = await sqlPost("SELECT Summary FROM People WHERE Name = 'Diana'");
+    assert.equal(sel.records[0].fields.Summary, "Diana (age 28)");
+  });
+
+  // ---- ACL ----
+
+  it("should filter rows based on access rules", async function() {
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age > 30", perms: "-R" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_kiwi",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT Name FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    const names = result.records.map((r: any) => r.fields.Name);
+    assert.include(names, "Alice");
+    assert.include(names, "Bob");
+    assert.notInclude(names, "Charlie");
+  });
+
+  it("should hide denied columns and expand SELECT * without them", async function() {
+    await addAclRules("viewers",
+      { table: "People", cols: "Score", rules: [{ perms: "-R" }] });
+
+    // SELECT * should return Name and Age but not Score
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_kiwi",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT * FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    const colIds = result.columns.map((c: any) => c.id);
+    assert.include(colIds, "Name");
+    assert.include(colIds, "Age");
+    assert.notInclude(colIds, "Score");
+    assert.equal(result.records[0].fields.Name, "Alice");
+
+    // Explicitly naming denied column should error (no such column)
+    const resp2 = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_kiwi",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT Score FROM People" }),
+    });
+    assert.notEqual(resp2.status, 200);
+  });
+
+  it("should filter rows using user.Email in access rules", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Owner", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Owner: ["kiwi@getgrist.com", "chimpy@getgrist.com", "kiwi@getgrist.com"],
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Owner == user.Email", perms: "+R" }, { perms: "-R" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_kiwi",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT Name FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    const names = result.records.map((r: any) => r.fields.Name);
+    assert.deepEqual(names, ["Alice", "Charlie"]);
+  });
+
+  // ---- ACL with user attribute tables ----
+
+  it("should filter rows using user attribute table lookup", async function() {
+    // Set up a Time Sheets-style pattern:
+    // - People table with Email column
+    // - Tasks table with Employee (Ref:People) column
+    // - User attribute rule: "Person" looks up People by Email
+    // - ACL rule: user.Person.id == rec.Employee → +R, else -R
+    // This is the most common real-world pattern for multi-tenant row filtering.
+
+    await userApi.applyUserActions(docId, [
+      // Add an Employee ref column and a Tasks table
+      ["AddTable", "Tasks", [
+        { id: "TaskName", type: "Text" },
+        { id: "Employee", type: "Ref:People" },
+      ]],
+      // Update People to have email addresses
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Name: ["Kiwi User", "Chimpy User", "Other User"],
+      }],
+      ["AddColumn", "People", "Email", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Email: ["kiwi@getgrist.com", "chimpy@getgrist.com", "other@getgrist.com"],
+      }],
+      // Add tasks assigned to different people
+      ["BulkAddRecord", "Tasks", [null, null, null], {
+        TaskName: ["Task A", "Task B", "Task C"],
+        Employee: [1, 2, 1],  // Kiwi, Chimpy, Kiwi
+      }],
+    ]);
+
+    // Give kiwi access and set up user attribute rule: "Person" looks up People by Email
+    await addAclRules("editors",
+      { table: "*", rules: [], userAttr: { name: "Person", tableId: "People", lookupColId: "Email", charId: "Email" } },
+      { table: "Tasks", rules: [{ formula: "user.Person.id == rec.Employee", perms: "+R" }, { perms: "-R" }] });
+
+    // Query as kiwi — should only see tasks assigned to kiwi (Employee=1)
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_kiwi",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT TaskName FROM Tasks ORDER BY TaskName" }),
+    });
+    const result = await resp.json();
+    const names = result.records.map((r: any) => r.fields.TaskName);
+    assert.deepEqual(names, ["Task A", "Task C"]);
+    assert.notInclude(names, "Task B");
+  });
+
+  it("should filter using user attribute field other than id", async function() {
+    // user.Person.Name (a text field on the looked-up record) == rec.AssignedTo
+    // This tests that chained attribute access resolves actual field values,
+    // not just the row id.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Email", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Email: ["kiwi@getgrist.com", "chimpy@getgrist.com", "other@getgrist.com"],
+      }],
+      ["AddTable", "Projects", [
+        { id: "Title", type: "Text" },
+        { id: "AssignedTo", type: "Text" },
+      ]],
+      ["BulkAddRecord", "Projects", [null, null, null], {
+        Title: ["Proj X", "Proj Y", "Proj Z"],
+        AssignedTo: ["Alice", "Bob", "Alice"],
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "*", rules: [], userAttr: { name: "Person", tableId: "People", lookupColId: "Email", charId: "Email" } },
+      { table: "Projects", rules: [{ formula: "user.Person.Name == rec.AssignedTo", perms: "+R" }, { perms: "-R" }] });
+
+    // Kiwi's Person record is row 1 (Alice). Should only see projects assigned to "Alice".
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_kiwi",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT Title FROM Projects ORDER BY Title" }),
+    });
+    const result = await resp.json();
+    const titles = result.records.map((r: any) => r.fields.Title);
+    assert.deepEqual(titles, ["Proj X", "Proj Z"]);
+  });
+
+  it("should handle ACL rules with .lower() and .upper() string methods", async function() {
+    await addAclRules("viewers",
+      { table: "People", rules: [
+        { formula: "rec.Name.upper() == 'ALICE' or rec.Name.lower() == 'bob'", perms: "+R" },
+        { perms: "-R" },
+      ] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_kiwi",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT Name FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    const names = result.records.map((r: any) => r.fields.Name);
+    assert.deepEqual(names, ["Alice", "Bob"]);
+  });
+
+  // ---- ACL parity: SQL WHERE must match JS predicate evaluation ----
+  // These tests verify that /sql/full returns the same rows as the REST API
+  // for tricky ACL patterns where JS and SQL semantics could diverge.
+
+  async function sqlNames(table: string, col: string, apiKey: string = "api_key_for_kiwi") {
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": `Bearer ${apiKey}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: `SELECT ${col} FROM ${table} ORDER BY ${col}` }),
+    });
+    const result = await resp.json();
+    if (!resp.ok) { throw new Error(`SQL query failed: ${result.error || resp.status}`); }
+    return (result.records || []).map((r: any) => r.fields[col]).sort();
+  }
+
+  async function restNames(table: string, col: string, apiKey: string = "api_key_for_kiwi") {
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/tables/${table}/records`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    const result = await resp.json();
+    return (result.records || []).map((r: any) => r.fields[col]).sort();
+  }
+
+  it("should match REST API for truthy check on empty string", async function() {
+    // rec.Tag as a truthy condition: JS treats "" as falsy, SQL treats "" as truthy.
+    // Grist ACL evaluator (JS) excludes rows with empty string.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Tag", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Tag: ["active", "", "active"],  // Bob has empty string
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Tag", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult,
+      "SQL and REST should agree on which rows pass the truthy check");
+    // Both should exclude Bob (empty Tag)
+    assert.notInclude(sqlResult, "Bob");
+    assert.include(sqlResult, "Alice");
+  });
+
+  it("should match REST API for numeric comparison with zero", async function() {
+    // rec.Score != 0: Bob's score set to 0, others nonzero.
+    await userApi.applyUserActions(docId, [
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Score: [95.5, 0, 92.1],
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Score != 0", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    assert.notInclude(sqlResult, "Bob");
+  });
+
+  it("should match REST API for first-match rule ordering", async function() {
+    // Multiple rules: allow if Age > 30, deny if Age > 25, allow by default.
+    // First-match: Alice (30) → fails rule 1, matches rule 2 (denied).
+    // Bob (25) → fails both, hits default (allowed).
+    // Charlie (35) → matches rule 1 (allowed).
+    await addAclRules("viewers", { table: "People", rules: [
+      { formula: "rec.Age > 30", perms: "+R" },
+      { formula: "rec.Age > 25", perms: "-R" },
+      { perms: "+R" },
+    ] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult,
+      "SQL CASE WHEN must match JS first-match semantics");
+    assert.include(sqlResult, "Charlie");  // Age 35 > 30 → allowed by rule 1
+    assert.include(sqlResult, "Bob");      // Age 25, misses both rules → default allow
+    assert.notInclude(sqlResult, "Alice");  // Age 30 > 25 → denied by rule 2
+  });
+
+  it("should match REST API for Bool column as condition", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Active", { type: "Bool" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Active: [true, false, true] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Active", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    assert.include(sqlResult, "Alice");
+    assert.notInclude(sqlResult, "Bob");
+  });
+
+  it("should match REST API for Ref column as condition", async function() {
+    // Ref 0 is "no reference" — should be falsy in both JS and SQL.
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Depts", [{ id: "DName", type: "Text" }]],
+      ["BulkAddRecord", "Depts", [null], { DName: ["Eng"] }],
+      ["AddColumn", "People", "Dept", { type: "Ref:Depts" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Dept: [1, 0, 1] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Dept", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    assert.include(sqlResult, "Alice");
+    assert.notInclude(sqlResult, "Bob");  // Dept is 0 → falsy
+  });
+
+  it("should match REST API for combined And/Or conditions", async function() {
+    await addAclRules("viewers",
+      { table: "People", rules: [
+        // Allow if (Age >= 30 and Score > 90) or Name == "Bob"
+        { formula: "(rec.Age >= 30 and rec.Score > 90) or rec.Name == 'Bob'", perms: "+R" },
+        { perms: "-R" },
+      ] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    // Alice: 30, 95.5 → passes first branch
+    // Bob: 25, 87.3 → passes second branch
+    // Charlie: 35, 92.1 → passes first branch
+    assert.deepEqual(sqlResult, ["Alice", "Bob", "Charlie"]);
+  });
+
+  it("should match REST API for Not on a string column", async function() {
+    // `not rec.Name` — JS: !"Alice" is false, !"" is true.
+    // Need truthiness wrapper to propagate inside Not.
+    await userApi.applyUserActions(docId, [
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Name: ["Alice", "", "Charlie"],  // Bob has empty name
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "not rec.Name", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Age");
+    const restResult = await restNames("People", "Age");
+    assert.deepEqual(sqlResult, restResult,
+      "Not on string column must use JS truthiness (empty string is falsy)");
+    // Only Bob (empty name) should pass `not rec.Name`
+    assert.equal(sqlResult.length, 1);
+  });
+
+  it("should match REST API for Bool column negation", async function() {
+    // `not rec.Active` is the idiomatic way to check for false Bool values.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Active", { type: "Bool" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Active: [true, false, true] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "not rec.Active", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    // Only Bob (Active=false) should pass `not rec.Active`
+    assert.deepEqual(sqlResult, ["Bob"]);
+  });
+
+  it("should match REST API for Bool compared to number literal", async function() {
+    // rec.Active == 0: JS false === 0 is false (type mismatch).
+    // SQL would say 0 = 0 is true without the Bool-vs-number fix.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Active", { type: "Bool" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Active: [true, false, true] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Active == 0", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult,
+      "Bool == 0 is always false in JS (type mismatch) — SQL must match");
+  });
+
+  it("should match REST API for Bool equality with False", async function() {
+    // `rec.Active == False` is the explicit way to check for false.
+    // In Python False==0 is True, but Grist's JS evaluator uses ===
+    // where false===0 is false. This tests that SQL matches JS.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Active", { type: "Bool" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Active: [true, false, true] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Active == False", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+  });
+
+  it("should match REST API for In membership check", async function() {
+    // rec.Age in [30, 35]: Alice (30) and Charlie (35) match, Bob (25) doesn't.
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age in [30, 35]", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    assert.include(sqlResult, "Alice");    // Age 30
+    assert.include(sqlResult, "Charlie");  // Age 35
+    assert.notInclude(sqlResult, "Bob");   // Age 25
+  });
+
+  it("should match REST API for Not with comparison", async function() {
+    // not (rec.Age > 30): straightforward logical negation
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "not (rec.Age > 30)", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    assert.include(sqlResult, "Alice");    // 30 > 30 is false, negated → true
+    assert.include(sqlResult, "Bob");      // 25 > 30 is false, negated → true
+    assert.notInclude(sqlResult, "Charlie"); // 35 > 30 is true, negated → false
+  });
+
+  it("should match REST API for Is comparison with None", async function() {
+    // rec.Score is None: tests null identity
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Note", { type: "Text" }],
+      // Only set Alice's note; Bob and Charlie stay null
+      ["BulkUpdateRecord", "People", [1], { Note: ["has note"] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Note is not None", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+  });
+
+  it("should match REST API for arithmetic in condition", async function() {
+    // rec.Age + rec.Score > 120
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age + rec.Score > 120", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    // Alice: 30 + 95.5 = 125.5 > 120 → allowed
+    // Bob: 25 + 87.3 = 112.3 → denied
+    // Charlie: 35 + 92.1 = 127.1 > 120 → allowed
+    assert.deepEqual(sqlResult, ["Alice", "Charlie"]);
+  });
+
+  it("should match REST API for >= comparison with null values", async function() {
+    // rec.Score >= 0 where Score is null:
+    // JS: null >= 0 → true (null coerces to 0, 0 >= 0 is true)
+    // SQL: NULL >= 0 → NULL (falsy)
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Rating", { type: "Numeric" }],
+      // Alice has rating, Bob has 0, Charlie has no rating (null)
+      ["BulkUpdateRecord", "People", [1, 2], { Rating: [4.5, 0] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Rating >= 0", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult,
+      "NULL >= 0 must match JS semantics (null coerces to 0)");
+  });
+
+  it("should match REST API for arithmetic with null column", async function() {
+    // rec.Rating + rec.Age > 30 where Rating is null:
+    // JS: null + 30 = 30 > 30 → false (null coerces to 0)
+    // SQL: NULL + 30 = NULL > 30 → NULL (falsy)
+    // Both say false for this case, but they'd diverge at threshold
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Bonus", { type: "Int" }],
+      // Alice has bonus 10, Bob has no bonus (null), Charlie has bonus 5
+      ["BulkUpdateRecord", "People", [1, 3], { Bonus: [10, 5] }],
+    ]);
+    // Allow if Age + Bonus > 25.
+    // Alice: 30+10=40>25 → allowed. Bob: 25+null: JS 25>25 false, SQL NULL. Charlie: 35+5=40>25 → allowed.
+    // Bob: JS says 25+0=25>25 is false. SQL says NULL+25=NULL>25 is false. Both false — match.
+    // But change threshold to 24: JS 25+0=25>24 true, SQL NULL>24 false — diverge.
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age + rec.Bonus > 24", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult,
+      "Arithmetic with null column must match JS null-coercion semantics");
+  });
+
+  it("should match REST API for Not of a comparison involving null", async function() {
+    // not (rec.Rating > 5) where Rating is null:
+    // JS: not (null > 5) → not false → true
+    // SQL: NOT (NULL > 5) → NOT NULL → NULL (falsy)
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Level", { type: "Int" }],
+      // Alice has Level 10, Bob has no level (null), Charlie has Level 3
+      ["BulkUpdateRecord", "People", [1, 3], { Level: [10, 3] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "not (rec.Level > 5)", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult,
+      "NOT (NULL > 5) must match JS: not false → true");
+  });
+
+  // ---- ACL rule combination tests ----
+  // These test the rule system itself, not individual formula evaluation.
+
+  it("should match REST API for column deny + row filter combined", async function() {
+    // Row rule: only Age > 25. Column rule: deny Score.
+    // Result: Alice and Charlie visible, Score hidden on both.
+    await addAclRules("viewers",
+      // Row filter
+      { table: "People", rules: [{ formula: "rec.Age > 25", perms: "+R" }, { perms: "-R" }] },
+      // Column deny
+      { table: "People", cols: "Score", rules: [{ perms: "-R" }] });
+
+    // Check rows filtered
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    assert.notInclude(sqlResult, "Bob");  // Age 25, fails > 25
+
+    // Check column hidden: SELECT * should not include Score
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    const colIds = result.columns.map((c: any) => c.id);
+    assert.notInclude(colIds, "Score");
+    assert.include(colIds, "Name");
+  });
+
+  it("should match REST API for multiple column deny groups", async function() {
+    // Deny Score in one rule, deny Age in another.
+    await addAclRules("viewers",
+      { table: "People", cols: "Score", rules: [{ perms: "-R" }] },
+      { table: "People", cols: "Age", rules: [{ perms: "-R" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    const colIds = result.columns.map((c: any) => c.id);
+    assert.notInclude(colIds, "Score");
+    assert.notInclude(colIds, "Age");
+    assert.include(colIds, "Name");
+
+    // REST should agree
+    const restResp = await fetch(`${homeUrl}/api/docs/${docId}/tables/People/records`, {
+      headers: { Authorization: "Bearer api_key_for_kiwi" },
+    });
+    const restResult = await restResp.json();
+    const restCols = Object.keys(restResult.records[0].fields);
+    assert.notInclude(restCols, "Score");
+    assert.notInclude(restCols, "Age");
+  });
+
+  it("should match REST API for owner bypassing all rules", async function() {
+    // Set up restrictive rules, then query as owner (chimpy) — should see everything.
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age > 100", perms: "+R" }, { perms: "-R" }] },
+      { table: "People", cols: "Score", rules: [{ perms: "-R" }] });
+
+    // Owner should see all rows and all columns
+    const sqlResult = await sqlNames("People", "Name", "api_key_for_chimpy");
+    assert.deepEqual(sqlResult, ["Alice", "Bob", "Charlie"]);
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_chimpy", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM People LIMIT 1" }),
+    });
+    const result = await resp.json();
+    const colIds = result.columns.map((c: any) => c.id);
+    assert.include(colIds, "Score");
+  });
+
+  it("should match REST API for table with global deny but no table rules", async function() {
+    // Global rule denies non-owners. Table-specific allow overrides for People.
+    // A second table with no specific rules should be denied.
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Secret", [{ id: "Data", type: "Text" }]],
+      ["BulkAddRecord", "Secret", [null], { Data: ["hidden"] }],
+    ]);
+    await addAclRules("editors",
+      // Table-specific: allow People
+      { table: "People", rules: [{ perms: "+R" }] },
+      // Global: deny non-owners
+      { table: "*", rules: [{ formula: "user.Access not in [OWNER]", perms: "none" }] });
+
+    // People should be readable
+    const sqlPeople = await sqlNames("People", "Name");
+    assert.equal(sqlPeople.length, 3);
+
+    // Secret should be denied — query should fail or return empty
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Data FROM Secret" }),
+    });
+    // Should get an error (table not accessible) matching REST behavior
+    const restResp = await fetch(`${homeUrl}/api/docs/${docId}/tables/Secret/records`, {
+      headers: { Authorization: "Bearer api_key_for_kiwi" },
+    });
+    // Both should deny access with non-200 status
+    assert.equal(resp.status, 403, "SQL should return 403 for denied table");
+    assert.include([403, 404], restResp.status, "REST should deny access to Secret table");
+  });
+
+  it("should match REST API for JOIN across tables with different ACL", async function() {
+    // People has row filter (Age > 25), Departments has no filter.
+    // JOIN should only return People rows that pass the filter.
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Departments", [{ id: "DeptName", type: "Text" }]],
+      ["BulkAddRecord", "Departments", [null, null], { DeptName: ["Eng", "Sales"] }],
+      ["AddColumn", "People", "Dept", { type: "Ref:Departments" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Dept: [1, 2, 1] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age > 25", perms: "+R" }, { perms: "-R" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sql: "SELECT p.Name, d.DeptName FROM People p JOIN Departments d ON p.Dept = d.id ORDER BY p.Name",
+      }),
+    });
+    const result = await resp.json();
+    const names = result.records.map((r: any) => r.fields.Name);
+    // Bob (Age 25) should be filtered out even in the JOIN
+    assert.notInclude(names, "Bob");
+    assert.include(names, "Alice");
+    assert.include(names, "Charlie");
+  });
+
+  // ---- Structural edge cases ----
+
+  it("should fail closed when ACL rule uses rec.Ref.Column pattern", async function() {
+    // Grist ACL doesn't follow Ref columns — rec.Dept.DeptName evaluates
+    // to undefined (Ref value is a row ID, not a record). The SQL path
+    // fails closed with an error; REST silently treats the condition as false.
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Departments", [{ id: "DeptName", type: "Text" }]],
+      ["BulkAddRecord", "Departments", [null], { DeptName: ["Eng"] }],
+      ["AddColumn", "People", "Dept", { type: "Ref:Departments" }],
+      ["BulkUpdateRecord", "People", [1], { Dept: [1] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [
+        { formula: "rec.Dept.DeptName == 'Eng'", perms: "+R" },
+        { perms: "-R" },
+      ] });
+
+    // SQL path: fails closed (can't compile chained rec attribute to SQL)
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Name FROM People" }),
+    });
+    assert.notEqual(resp.status, 200, "Unsupported ACL pattern must not return unfiltered data");
+
+    // REST path: doesn't crash, but the rule evaluates to undefined == 'Eng'
+    // which is always false, so no rows are visible.
+    const restResp = await fetch(`${homeUrl}/api/docs/${docId}/tables/People/records`, {
+      headers: { Authorization: "Bearer api_key_for_kiwi" },
+    });
+    assert.equal(restResp.status, 200, "REST should not crash on this pattern");
+  });
+
+  it("should not leak data when user query references denied table in subquery", async function() {
+    // SELECT * FROM AllowedTable WHERE id IN (SELECT ref FROM DeniedTable)
+    // Should fail because DeniedTable is in the query's referenced tables.
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Secret", [{ id: "PersonRef", type: "Ref:People" }]],
+      ["BulkAddRecord", "Secret", [null], { PersonRef: [1] }],
+    ]);
+    await addAclRules("viewers",
+      // Deny Secret table
+      { table: "Secret", rules: [{ perms: "-R" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sql: "SELECT Name FROM People WHERE id IN (SELECT PersonRef FROM Secret)",
+      }),
+    });
+    assert.equal(resp.status, 403, "Subquery against denied table must be rejected");
+  });
+
+  it("should match REST API when all columns are denied but table is allowed", async function() {
+    // Table has +R for rows, but every data column has -R.
+    // CTE becomes SELECT id FROM People WHERE ... — only id visible.
+    await addAclRules("viewers",
+      { table: "People", cols: "Name", rules: [{ perms: "-R" }] },
+      { table: "People", cols: "Age", rules: [{ perms: "-R" }] },
+      { table: "People", cols: "Score", rules: [{ perms: "-R" }] });
+
+    // SQL: SELECT * should succeed but only return id (no data columns)
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM People" }),
+    });
+    assert.equal(resp.status, 200, "Query should succeed even with all data columns denied");
+    const result = await resp.json();
+    const colIds = (result.columns || []).map((c: any) => c.id);
+    assert.notInclude(colIds, "Name");
+    assert.notInclude(colIds, "Age");
+    assert.notInclude(colIds, "Score");
+
+    // REST: should return records with no data fields
+    const restResp = await fetch(`${homeUrl}/api/docs/${docId}/tables/People/records`, {
+      headers: { Authorization: "Bearer api_key_for_kiwi" },
+    });
+    assert.equal(restResp.status, 200);
+    const restResult = await restResp.json();
+    const restFields = Object.keys(restResult.records[0].fields);
+    assert.notInclude(restFields, "Name");
+    assert.notInclude(restFields, "Age");
+    assert.notInclude(restFields, "Score");
+  });
+
+  it("should work with no ACL rules at all", async function() {
+    // Baseline: a viewer with no ACL rules should see everything
+    // (default behavior is allow-all).
+    await userApi.updateDocPermissions(docId, {
+      users: { "kiwi@getgrist.com": "viewers" },
+    });
+    // No ACL rules added — just the default
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    assert.deepEqual(sqlResult, ["Alice", "Bob", "Charlie"]);
+  });
+
+  it("should not show denied column even via ORDER BY", async function() {
+    // ORDER BY Score where Score is denied — should error, not leak ordering info
+    await addAclRules("viewers",
+      { table: "People", cols: "Score", rules: [{ perms: "-R" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Name FROM People ORDER BY Score" }),
+    });
+    // Should error — Score is not in the CTE
+    assert.notEqual(resp.status, 200,
+      "ORDER BY on denied column should fail, not leak ordering info");
+  });
+
+  it("should match REST API for conditional column censoring", async function() {
+    // Rule: -R on Secret when rec.Age < 30. Secret should be NULL for Bob (Age 25)
+    // but visible for Alice (30) and Charlie (35). This uses CASE WHEN in the CTE.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Secret", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Secret: ["s1", "s2", "s3"],
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", cols: "Secret", rules: [{ formula: "rec.Age < 30", perms: "-R" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Name, Secret FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    assert.equal(resp.status, 200);
+    const records = result.records.map((r: any) => r.fields);
+    // Alice (30): visible. Bob (25): censored. Charlie (35): visible.
+    assert.equal(records[0].Name, "Alice");
+    assert.equal(records[0].Secret, "s1");
+    assert.equal(records[1].Name, "Bob");
+    assert.equal(records[1].Secret, "#CENSORED", "Censored cell should show #CENSORED");
+    assert.equal(records[2].Name, "Charlie");
+    assert.equal(records[2].Secret, "s3");
+
+    // Verify REST censors the same cells
+    const restResp = await fetch(`${homeUrl}/api/docs/${docId}/tables/People/records`, {
+      headers: { Authorization: "Bearer api_key_for_kiwi" },
+    });
+    const restResult = await restResp.json();
+    const restBob = restResult.records.find((r: any) => r.fields.Name === "Bob");
+    const restAlice = restResult.records.find((r: any) => r.fields.Name === "Alice");
+    assert.notEqual(restBob.fields.Secret, "s2", "REST should censor Bob's Secret too");
+    assert.equal(restAlice.fields.Secret, "s1");
+  });
+
+  it("should match REST API for user.UserID rule", async function() {
+    // Private table accessible only to a specific user by UserID.
+    const profile = await userApi.getUserProfile();
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "OwnerOnly", [{ id: "Data", type: "Text" }]],
+      ["BulkAddRecord", "OwnerOnly", [null], { Data: ["secret"] }],
+    ]);
+    await addAclRules("editors",
+      { table: "OwnerOnly", rules: [{ formula: `user.UserID == ${profile.id}`, perms: "+R" }, { perms: "-R" }] });
+
+    // Kiwi should be denied
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Data FROM OwnerOnly" }),
+    });
+    assert.equal(resp.status, 403);
+
+    // Owner should see it
+    const ownerResult = await sqlNames("OwnerOnly", "Data", "api_key_for_chimpy");
+    assert.deepEqual(ownerResult, ["secret"]);
+  });
+
+  it("should handle column-grant pattern (grant specific, deny rest)", async function() {
+    // Pattern: grant "all" on columns B,D; deny "none" on * for non-owners.
+    // REST API shows only B,D to editor. SQL path should match or fail closed.
+    // This is a complex GranularAccess pattern; the SQL path may not fully
+    // support it yet, but must not leak denied column data.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Secret", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Secret: ["x", "y", "z"] }],
+    ]);
+    await addAclRules("editors",
+      // Grant Name,Age to everyone
+      { table: "People", cols: "Name,Age", rules: [{ perms: "all" }] },
+      // Deny everything else for non-owners
+      { table: "People", rules: [{ formula: 'user.Access != "owners"', perms: "none" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM People ORDER BY Name" }),
+    });
+    assert.equal(resp.status, 200);
+    const result = await resp.json();
+    const colIds = (result.columns || []).map((c: any) => c.id);
+    // Granted columns should be visible with real values
+    assert.include(colIds, "Name");
+    assert.include(colIds, "Age");
+    // All rows visible (column grant makes rows accessible)
+    assert.equal(result.rowCount, 3);
+    // Non-granted columns: every value censored (user-only deny always matches)
+    const records = result.records.map((r: any) => r.fields);
+    assert.equal(records[0].Name, "Alice", "Granted column has real value");
+    for (const rec of records) {
+      if (colIds.includes("Score")) {
+        assert.equal(rec.Score, "#CENSORED", "Non-granted column censored for denied rows");
+      }
+      if (colIds.includes("Secret")) {
+        assert.equal(rec.Secret, "#CENSORED", "Non-granted column censored for denied rows");
+      }
+    }
+  });
+
+  it("should match REST API for ACL rule based on formula column", async function() {
+    // rec.Public where Public is a formula column ($B == "clear").
+    // The SQL CTE reads the cached formula value from SQLite.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Tag", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Tag: ["clear", "secret", "clear"] }],
+      ["AddColumn", "People", "Public", {
+        type: "Bool", isFormula: true, formula: '$Tag == "clear"',
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "not rec.Public", perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    // Bob (Tag "secret", Public false) should be hidden
+    assert.include(sqlResult, "Alice");
+    assert.notInclude(sqlResult, "Bob");
+    assert.include(sqlResult, "Charlie");
+  });
+
+  it("should match REST API for multiple conditional column rules (first-match)", async function() {
+    // Two conditional deny rules on the same column: first-match should win.
+    // Rule 1: deny Secret when rec.Age < 30
+    // Rule 2: deny Secret when rec.Name == 'Charlie'
+    // Alice (30): both conditions false → visible
+    // Bob (25): rule 1 matches (Age < 30) → censored (first match wins)
+    // Charlie (35): rule 1 false, rule 2 matches → censored
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Secret", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Secret: ["s1", "s2", "s3"] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", cols: "Secret", rules: [
+        { formula: "rec.Age < 30", perms: "-R" },
+        { formula: "rec.Name == 'Charlie'", perms: "-R" },
+      ] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Name, Secret FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    assert.equal(resp.status, 200);
+    const records = result.records.map((r: any) => r.fields);
+    assert.equal(records[0].Secret, "s1", "Alice: both conditions false → visible");
+    assert.equal(records[1].Secret, "#CENSORED", "Bob: Age < 30 → censored");
+    assert.equal(records[2].Secret, "#CENSORED", "Charlie: Name match → censored");
+  });
+
+  it("should match REST API for conditional column grant", async function() {
+    // Grant Secret only when rec.Age >= 30. Otherwise censored.
+    // This is the inverse of conditional deny — conditional visibility.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Secret", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Secret: ["s1", "s2", "s3"] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", cols: "Secret", rules: [
+        // Grant when Age >= 30, deny by default
+        { formula: "rec.Age >= 30", perms: "+R" },
+        { perms: "-R" },
+      ] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Name, Secret FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    assert.equal(resp.status, 200);
+    const records = result.records.map((r: any) => r.fields);
+    assert.equal(records[0].Secret, "s1", "Alice (30): granted → visible");
+    assert.equal(records[1].Secret, "#CENSORED", "Bob (25): default deny → censored");
+    assert.equal(records[2].Secret, "s3", "Charlie (35): granted → visible");
+  });
+
+  it("should handle column grant + row filter interaction", async function() {
+    // Column grant on Name,Age + row filter on Status.
+    // Name,Age: visible for ALL rows (grant overrides row filter).
+    // Score: visible only for public rows, censored otherwise.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Status", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Status: ["public", "private", "public"],
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", cols: "Name,Age", rules: [{ perms: "all" }] },
+      { table: "People", rules: [
+        { formula: "rec.Status == 'public'", perms: "+R" },
+        { perms: "-R" },
+      ] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM People ORDER BY Name" }),
+    });
+    assert.equal(resp.status, 200);
+    const result = await resp.json();
+    const records = result.records.map((r: any) => r.fields);
+    // All 3 rows visible (because Name,Age grant makes rows accessible)
+    assert.equal(records.length, 3);
+    // Name always visible (granted)
+    assert.equal(records[0].Name, "Alice");
+    assert.equal(records[1].Name, "Bob");
+    assert.equal(records[2].Name, "Charlie");
+    // Score: visible for public rows, censored for private
+    assert.notEqual(records[0].Score, "#CENSORED", "Alice (public): Score visible");
+    assert.equal(records[1].Score, "#CENSORED", "Bob (private): Score censored");
+    assert.notEqual(records[2].Score, "#CENSORED", "Charlie (public): Score visible");
+  });
+
+  it("should handle column grant + column censoring + row filter together", async function() {
+    // Three ACL mechanisms at once:
+    // - Column grant: Name always visible
+    // - Conditional column deny: Secret censored when Age < 30
+    // - Row filter: only public rows for non-granted, non-censored columns
+    //
+    // Expected per cell:
+    // Alice  (30, public):  Name=Alice, Score=95.5, Secret=s1
+    // Bob    (25, private): Name=Bob,   Score=#C,   Secret=#C (both: row deny AND col deny)
+    // Charlie(35, public):  Name=Charlie, Score=92.1, Secret=s3
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Status", { type: "Text" }],
+      ["AddColumn", "People", "Secret", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Status: ["public", "private", "public"],
+        Secret: ["s1", "s2", "s3"],
+      }],
+    ]);
+    await addAclRules("viewers",
+      // Column grant: Name always visible
+      { table: "People", cols: "Name", rules: [{ perms: "all" }] },
+      // Conditional column deny: Secret censored when Age < 30
+      { table: "People", cols: "Secret", rules: [
+        { formula: "rec.Age < 30", perms: "-R" },
+      ] },
+      // Row filter: only public rows
+      { table: "People", rules: [
+        { formula: "rec.Status == 'public'", perms: "+R" },
+        { perms: "-R" },
+      ] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Name, Score, Secret FROM People ORDER BY Name" }),
+    });
+    assert.equal(resp.status, 200);
+    const result = await resp.json();
+    const records = result.records.map((r: any) => r.fields);
+    assert.equal(records.length, 3, "All rows visible because Name is granted");
+
+    // Alice (public, Age 30): Name granted, Score passes row filter, Secret passes col rule
+    assert.equal(records[0].Name, "Alice");
+    assert.notEqual(records[0].Score, "#CENSORED", "Alice: Score visible (public)");
+    assert.equal(records[0].Secret, "s1", "Alice: Secret visible (Age >= 30 and public)");
+
+    // Bob (private, Age 25): Name granted, Score fails row filter, Secret fails BOTH
+    assert.equal(records[1].Name, "Bob");
+    assert.equal(records[1].Score, "#CENSORED", "Bob: Score censored (private)");
+    assert.equal(records[1].Secret, "#CENSORED", "Bob: Secret censored (Age < 30 AND private)");
+
+    // Charlie (public, Age 35): all visible
+    assert.equal(records[2].Name, "Charlie");
+    assert.notEqual(records[2].Score, "#CENSORED", "Charlie: Score visible (public)");
+    assert.equal(records[2].Secret, "s3", "Charlie: Secret visible (Age >= 30 and public)");
+  });
+
+  it("should handle gnarly multi-rule interaction", async function() {
+    // The kitchen sink: multiple column groups, conditional grants and denies,
+    // user attributes, row filtering, and cell censoring all at once.
+    //
+    // Table: Staff with columns Name, Dept, Salary, Rating, Notes, Status
+    //
+    // Rules:
+    //   Column grant on Name,Dept — always visible
+    //   Column deny on Salary when rec.Dept != user.Team.Dept — only see your dept's salaries
+    //   Column conditional grant on Rating: +R when rec.Status == 'published', default -R
+    //   Column deny on Notes — always hidden
+    //   Row filter: rec.Status != 'fired' → +R, default -R
+    //   User attribute: Team looks up Teams table by email
+    //
+    // Data:
+    //   Alice: Eng, 100k, 5, "note1", published  → visible (not fired, published)
+    //   Bob:   Sales, 90k, 4, "note2", published  → visible, salary censored (wrong dept)
+    //   Charlie: Eng, 110k, 3, "note3", draft     → visible, rating censored (not published)
+    //   Diana: Eng, 95k, 2, "note4", fired        → row hidden (fired)
+    //
+    // Expected for kiwi (Eng team):
+    //   Name    Dept   Salary  Rating  Notes  Status
+    //   Alice   Eng    100000  5       hidden published  ← salary visible (same dept), rating visible (published)
+    //   Bob     Sales  #C      4       hidden published  ← salary censored (wrong dept), rating visible (published)
+    //   Charlie Eng    110000  #C      hidden draft      ← salary visible (same dept), rating censored (not published)
+    //   (Diana hidden — fired)
+
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Teams", [
+        { id: "Email", type: "Text" },
+        { id: "Dept", type: "Text" },
+      ]],
+      ["BulkAddRecord", "Teams", [null, null], {
+        Email: ["kiwi@getgrist.com", "chimpy@getgrist.com"],
+        Dept: ["Eng", "Sales"],
+      }],
+      ["AddTable", "Staff", [
+        { id: "Name", type: "Text" },
+        { id: "Dept", type: "Text" },
+        { id: "Salary", type: "Int" },
+        { id: "Rating", type: "Int" },
+        { id: "Notes", type: "Text" },
+        { id: "Status", type: "Text" },
+      ]],
+      ["BulkAddRecord", "Staff", [null, null, null, null], {
+        Name: ["Alice", "Bob", "Charlie", "Diana"],
+        Dept: ["Eng", "Sales", "Eng", "Eng"],
+        Salary: [100000, 90000, 110000, 95000],
+        Rating: [5, 4, 3, 2],
+        Notes: ["note1", "note2", "note3", "note4"],
+        Status: ["published", "published", "draft", "fired"],
+      }],
+    ]);
+
+    await addAclRules("viewers",
+      // User attribute: Team lookup by email
+      { table: "*", rules: [],
+        userAttr: { name: "Team", tableId: "Teams", lookupColId: "Email", charId: "Email" } },
+      // Column grant: Name, Dept always visible
+      { table: "Staff", cols: "Name,Dept", rules: [{ perms: "all" }] },
+      // Column deny: Salary censored when wrong department
+      { table: "Staff", cols: "Salary", rules: [
+        { formula: "rec.Dept != user.Team.Dept", perms: "-R" },
+      ] },
+      // Column conditional grant: Rating visible when published, default deny
+      { table: "Staff", cols: "Rating", rules: [
+        { formula: "rec.Status == 'published'", perms: "+R" },
+        { perms: "-R" },
+      ] },
+      // Column deny: Notes always hidden
+      { table: "Staff", cols: "Notes", rules: [{ perms: "-R" }] },
+      // Row filter: hide fired employees
+      { table: "Staff", rules: [
+        { formula: "rec.Status != 'fired'", perms: "+R" },
+        { perms: "-R" },
+      ] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM Staff ORDER BY Name" }),
+    });
+    assert.equal(resp.status, 200);
+    const result = await resp.json();
+    const colIds = result.columns.map((c: any) => c.id);
+    const records = result.records.map((r: any) => r.fields);
+
+    // All 4 rows visible — column grants make rows accessible even when
+    // the row filter would deny. Diana (fired) appears with granted columns
+    // visible and everything else censored.
+    assert.equal(records.length, 4);
+
+    // Notes always hidden
+    assert.notInclude(colIds, "Notes", "Notes column should be completely hidden");
+
+    // Granted columns always visible with real values (all 4 rows)
+    assert.include(colIds, "Name");
+    assert.include(colIds, "Dept");
+    assert.equal(records[0].Name, "Alice");
+    assert.equal(records[1].Name, "Bob");
+    assert.equal(records[2].Name, "Charlie");
+    assert.equal(records[3].Name, "Diana");
+    assert.equal(records[0].Dept, "Eng");
+    assert.equal(records[1].Dept, "Sales");
+    assert.equal(records[2].Dept, "Eng");
+    assert.equal(records[3].Dept, "Eng");
+
+    // Salary: visible for Eng AND not fired, censored otherwise.
+    // Alice (Eng, not fired): visible. Bob (Sales): censored (wrong dept).
+    // Charlie (Eng, not fired): visible. Diana (Eng, fired): censored (row filter).
+    assert.equal(records[0].Salary, 100000, "Alice (Eng, not fired): salary visible");
+    assert.equal(records[1].Salary, "#CENSORED", "Bob (Sales): salary censored (wrong dept)");
+    assert.equal(records[2].Salary, 110000, "Charlie (Eng, not fired): salary visible");
+    assert.equal(records[3].Salary, "#CENSORED", "Diana (fired): salary censored (row filter)");
+
+    // Rating: visible when published AND row filter passes, censored otherwise.
+    assert.equal(records[0].Rating, 5, "Alice (published, not fired): rating visible");
+    assert.equal(records[1].Rating, 4, "Bob (published, not fired): rating visible");
+    assert.equal(records[2].Rating, "#CENSORED", "Charlie (draft): rating censored");
+    assert.equal(records[3].Rating, "#CENSORED", "Diana (fired): rating censored");
+
+    // Status: not granted, not denied, subject to row filter only.
+    if (colIds.includes("Status")) {
+      assert.notEqual(records[0].Status, "#CENSORED", "Alice (not fired): Status visible");
+      assert.equal(records[3].Status, "#CENSORED", "Diana (fired): Status censored");
+    }
+
+    // Cross-check against REST API: same rows, same censoring pattern.
+    const restResp = await fetch(`${homeUrl}/api/docs/${docId}/tables/Staff/records`, {
+      headers: { Authorization: "Bearer api_key_for_kiwi" },
+    });
+    assert.equal(restResp.status, 200);
+    const restResult = await restResp.json();
+    const restRecords = restResult.records;
+    // REST should return same number of rows
+    assert.equal(restRecords.length, records.length,
+      "REST and SQL should return same number of rows");
+    // Compare per-row: granted columns must match, censored cells must both be hidden
+    for (const sqlRec of records) {
+      const restRec = restRecords.find((r: any) => r.fields.Name === sqlRec.Name);
+      assert.ok(restRec, `REST should have row for ${sqlRec.Name}`);
+      // Granted columns: exact match
+      assert.equal(restRec.fields.Name, sqlRec.Name, `Name match for ${sqlRec.Name}`);
+      assert.equal(restRec.fields.Dept, sqlRec.Dept, `Dept match for ${sqlRec.Name}`);
+      // Salary: if SQL says censored, REST should also censor (not show real value)
+      if (sqlRec.Salary === "#CENSORED") {
+        assert.notEqual(restRec.fields.Salary, sqlRec.Name === "Bob" ? 90000 :
+          sqlRec.Name === "Diana" ? 95000 : -1,
+        `REST should censor Salary for ${sqlRec.Name}`);
+      } else {
+        assert.equal(restRec.fields.Salary, sqlRec.Salary,
+          `Salary should match for ${sqlRec.Name}`);
+      }
+      // Rating: if SQL says censored, REST should also censor
+      if (sqlRec.Rating === "#CENSORED") {
+        const realRating = sqlRec.Name === "Charlie" ? 3 : sqlRec.Name === "Diana" ? 2 : -1;
+        assert.notEqual(restRec.fields.Rating, realRating,
+          `REST should censor Rating for ${sqlRec.Name}`);
+      } else {
+        assert.equal(restRec.fields.Rating, sqlRec.Rating,
+          `Rating should match for ${sqlRec.Name}`);
+      }
+    }
+  });
+
+  it("should handle column grant with unconditional table deny", async function() {
+    // Pure column-grant pattern: table denies everything, columns grant Name,Age.
+    // Non-granted columns should be completely hidden (not just censored).
+    await addAclRules("viewers",
+      { table: "People", cols: "Name,Age", rules: [{ perms: "all" }] },
+      { table: "People", rules: [{ perms: "none" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM People ORDER BY Name" }),
+    });
+    assert.equal(resp.status, 200);
+    const result = await resp.json();
+    const colIds = result.columns.map((c: any) => c.id);
+    assert.include(colIds, "Name");
+    assert.include(colIds, "Age");
+    assert.notInclude(colIds, "Score", "Non-granted column should be hidden with unconditional deny");
+    assert.equal(result.rowCount, 3, "All rows visible via granted columns");
+  });
+
+  // ---- Backwards compatibility ----
+
+  it("should return legacy format without granular flag", async function() {
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_chimpy",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT Name FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    // Legacy format: {statement, records: [{fields: {...}}]}
+    assert.property(result, "statement");
+    assert.property(result, "records");
+    assert.notProperty(result, "columns");
+    assert.notProperty(result, "command");
+    assert.equal(result.records[0].fields.Name, "Alice");
+  });
+
+  it("should support cellFormat=typed for self-describing values", async function() {
+    // Set up columns covering Date, Ref, RefList, ChoiceList, DateTime, Bool, plain Text/Int
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Birthday", { type: "Date" }],
+      ["AddColumn", "People", "Updated", { type: "DateTime:UTC" }],
+      ["AddColumn", "People", "Active", { type: "Bool" }],
+      ["AddColumn", "People", "Tags", { type: "ChoiceList" }],
+      ["AddTable", "Departments", [{ id: "DeptName", type: "Text" }]],
+      ["BulkAddRecord", "Departments", [null, null], { DeptName: ["Eng", "Sales"] }],
+      ["AddColumn", "People", "Dept", { type: "Ref:Departments" }],
+      ["AddColumn", "People", "Depts", { type: "RefList:Departments" }],
+      ["BulkUpdateRecord", "People", [1], {
+        Birthday: [1710460800],
+        Updated: [1710460800],
+        Active: [true],
+        Tags: [["L", "fast", "smart"]],
+        Dept: [1],
+        Depts: [["L", 1, 2]],
+      }],
+    ]);
+
+    // Default format: decoded plain values
+    const normalResp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_chimpy", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sql: "SELECT Name, Birthday, Updated, Active, Tags, Dept, Depts FROM People WHERE Name = 'Alice'",
+      }),
+    });
+    const normalResult = await normalResp.json();
+    assert.equal(normalResp.status, 200);
+    const n = normalResult.records[0].fields;
+    assert.equal(typeof n.Birthday, "string", "Normal: Date as ISO string");
+    assert.equal(typeof n.Dept, "number", "Normal: Ref as plain number");
+    assert.equal(n.Active, true, "Normal: Bool as boolean");
+    assert.equal(n.Name, "Alice", "Normal: Text as string");
+
+    // Typed format: Grist-encoded tuples
+    const typedResp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full?cellFormat=typed`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_chimpy", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sql: "SELECT Name, Birthday, Updated, Active, Tags, Dept, Depts FROM People WHERE Name = 'Alice'",
+      }),
+    });
+    const typedResult = await typedResp.json();
+    assert.equal(typedResp.status, 200);
+    const t = typedResult.records[0].fields;
+
+    // Text and Bool stay as-is (no type tuple needed)
+    assert.equal(t.Name, "Alice");
+    assert.equal(t.Active, true);
+
+    // Date → ["d", epoch]
+    assert.isArray(t.Birthday, "Typed: Date should be tuple");
+    assert.equal(t.Birthday[0], "d");
+    assert.equal(t.Birthday[1], 1710460800);
+
+    // DateTime → ["D", epoch, timezone]
+    assert.isArray(t.Updated, "Typed: DateTime should be tuple");
+    assert.equal(t.Updated[0], "D");
+    assert.equal(t.Updated[1], 1710460800);
+    assert.equal(t.Updated[2], "UTC");
+
+    // Ref → ["R", tableId, rowId]
+    assert.isArray(t.Dept, "Typed: Ref should be tuple");
+    assert.equal(t.Dept[0], "R");
+    assert.equal(t.Dept[1], "Departments");
+    assert.equal(t.Dept[2], 1);
+
+    // RefList → ["r", tableId, [rowIds]]
+    assert.isArray(t.Depts, "Typed: RefList should be tuple");
+    assert.equal(t.Depts[0], "r");
+    assert.equal(t.Depts[1], "Departments");
+    assert.isArray(t.Depts[2]);
+    assert.deepEqual(t.Depts[2], [1, 2]);
+
+    // ChoiceList → ["L", ...choices]
+    assert.isArray(t.Tags, "Typed: ChoiceList should be tuple");
+    assert.equal(t.Tags[0], "L");
+    assert.include(t.Tags, "fast");
+    assert.include(t.Tags, "smart");
+  });
+
+  // ---- Security ----
+
+  it("should deny writes from a viewer", async function() {
+    await userApi.updateDocPermissions(docId, {
+      users: { "kiwi@getgrist.com": "viewers" },
+    });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "INSERT INTO People (Name, Age, Score) VALUES ('Eve', 22, 88)" }),
+    });
+    assert.notEqual(resp.status, 200, "Viewer should not be able to INSERT");
+
+    const resp2 = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "DELETE FROM People WHERE Name = 'Alice'" }),
+    });
+    assert.notEqual(resp2.status, 200, "Viewer should not be able to DELETE");
+
+    // Verify data unchanged
+    const sel = await sqlNames("People", "Name", "api_key_for_chimpy");
+    assert.deepEqual(sel, ["Alice", "Bob", "Charlie"]);
+  });
+
+  it("should not execute raw SQL injection attempts", async function() {
+    const attacks = [
+      "SELECT * FROM People; DROP TABLE People",
+      "SELECT * FROM People WHERE Name = '' OR 1=1 --",
+      "SELECT * FROM _grist_ACLRules",
+    ];
+    for (const sql of attacks) {
+      const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+        method: "POST",
+        headers: { "Authorization": "Bearer api_key_for_chimpy", "Content-Type": "application/json" },
+        body: JSON.stringify({ sql }),
+      });
+      if (resp.ok) {
+        const result = await resp.json();
+        assert.notEqual(result.command, "DROP");
+      }
+    }
+    const sel = await sqlPost("SELECT Name FROM People ORDER BY Name");
+    assert.deepEqual(sel.records.map((r: any) => r.fields.Name), ["Alice", "Bob", "Charlie"]);
+  });
+
+  // ---- Black-hat attack tests ----
+  // These attempt to bypass ACL filtering as a restricted user.
+
+  async function kiwiSql(sql: string): Promise<{ status: number, body: any }> {
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql }),
+    });
+    return { status: resp.status, body: await resp.json() };
+  }
+
+  it("ATTACK: schema prefix main.Table to bypass CTE", async function() {
+    // The CTE rewrites "People" → "_acl_People". But "main.People"
+    // is a different AST reference that might not get rewritten,
+    // letting the attacker read the unfiltered table.
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age > 100", perms: "+R" }, { perms: "-R" }] });
+
+    // Normal query — should return no rows (nobody has Age > 100)
+    const normal = await kiwiSql("SELECT Name FROM People");
+    if (normal.status === 200) {
+      assert.equal(normal.body.rowCount, 0, "Normal query should return no rows");
+    }
+
+    // Attack: try schema-qualified name to bypass CTE
+    const attack = await kiwiSql("SELECT Name FROM main.People");
+    const leaked = attack.status === 200 ?
+      (attack.body.records || []).map((r: any) => r.fields.Name) : [];
+    assert.notInclude(leaked, "Alice", "main.People must not bypass CTE");
+    assert.notInclude(leaked, "Bob", "main.People must not bypass CTE");
+    assert.notInclude(leaked, "Charlie", "main.People must not bypass CTE");
+  });
+
+  it("ATTACK: read _grist_ACLRules to see access control configuration", async function() {
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age > 30", perms: "-R" }] });
+
+    // Try to read the ACL rules directly
+    const r1 = await kiwiSql("SELECT * FROM _grist_ACLRules");
+    assert.notEqual(r1.status, 200, "Should not be able to read _grist_ACLRules");
+
+    // Try to read schema
+    const r2 = await kiwiSql("SELECT * FROM sqlite_master");
+    assert.notEqual(r2.status, 200, "Should not be able to read sqlite_master");
+
+    // Try pragma
+    const r3 = await kiwiSql("PRAGMA table_info('People')");
+    assert.notEqual(r3.status, 200, "Should not be able to run PRAGMA");
+  });
+
+  it("ATTACK: UNION to exfiltrate data from denied table", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Secret", [{ id: "Data", type: "Text" }]],
+      ["BulkAddRecord", "Secret", [null], { Data: ["top-secret"] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "Secret", rules: [{ perms: "-R" }] });
+
+    // Try UNION with denied table
+    const r = await kiwiSql("SELECT Name FROM People UNION SELECT Data FROM Secret");
+    assert.notEqual(r.status, 200,
+      "UNION referencing denied table should fail, not return data");
+  });
+
+  it("ATTACK: subquery in SELECT list to read hidden column", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Secret", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Secret: ["s1", "s2", "s3"] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", cols: "Secret", rules: [{ perms: "-R" }] });
+
+    // Try to read denied column via subquery in SELECT expression.
+    // The CTE excludes Secret, so the subquery should fail (column not found).
+    const r = await kiwiSql(
+      "SELECT Name, (SELECT Secret FROM People p2 WHERE p2.id = People.id) AS leak FROM People",
+    );
+    if (r.status === 200) {
+      // If it somehow succeeded, verify no secret values leaked
+      for (const rec of r.body.records) {
+        assert.notInclude(["s1", "s2", "s3"], rec.fields.leak,
+          "VULNERABILITY: subquery leaked denied column value");
+      }
+    }
+    // Expected: error because Secret column doesn't exist in the CTE
+  });
+
+  it("ATTACK: correlated subquery to probe hidden row existence", async function() {
+    // Even if a row is hidden, can we detect its existence via a correlated subquery?
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Name == 'Alice'", perms: "+R" }, { perms: "-R" }] });
+
+    // Kiwi can only see Alice. Try to detect Bob exists via EXISTS subquery.
+    // Both "People" references get rewritten to _acl_People (which has only Alice),
+    // so EXISTS should find no Bob rows.
+    const r = await kiwiSql(
+      "SELECT Name, EXISTS(SELECT 1 FROM People p2 WHERE p2.Name = 'Bob') AS bob_exists FROM People",
+    );
+    if (r.status === 200) {
+      for (const rec of r.body.records) {
+        const exists = rec.fields.bob_exists;
+        assert.include([0, false, "0", null], exists,
+          "VULNERABILITY: EXISTS detected hidden row Bob (got " + exists + ")");
+      }
+    }
+  });
+
+  it("ATTACK: COUNT(*) to detect hidden row count", async function() {
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Name == 'Alice'", perms: "+R" }, { perms: "-R" }] });
+
+    // Kiwi can only see Alice. COUNT(*) should report 1, not 3.
+    const r = await kiwiSql("SELECT COUNT(*) as n FROM People");
+    if (r.status === 200) {
+      const count = r.body.records[0].fields.n;
+      assert.equal(count, 1,
+        "VULNERABILITY: COUNT(*) revealed hidden row count (expected 1, got " + count + ")");
+    }
+  });
+});

--- a/test/server/lib/DocApiSql.ts
+++ b/test/server/lib/DocApiSql.ts
@@ -1,0 +1,1734 @@
+/**
+ * Tests for the /sql/full endpoint.
+ * Tests DML, DDL, ACL filtering, value decoding, and formula recalculation.
+ * These test the business logic in runSQLQuery/runSQLWrite/SqlACL/SqlValues
+ * and do NOT depend on the PG wire protocol.
+ */
+import { UserAPIImpl } from "app/common/UserAPI";
+import { prepareDatabase } from "test/server/lib/helpers/PrepareDatabase";
+import { TestServer } from "test/server/lib/helpers/TestServer";
+import { createTestDir, EnvironmentSnapshot, setTmpLogLevel } from "test/server/testUtils";
+
+import { assert } from "chai";
+import fetch from "node-fetch";
+
+describe("DocApiSql-full", function() {
+  this.timeout(60000);
+
+  setTmpLogLevel("error");
+
+  let server: TestServer;
+  let oldEnv: EnvironmentSnapshot;
+  let userApi: UserAPIImpl;
+  let homeUrl: string;
+
+  before(async function() {
+    oldEnv = new EnvironmentSnapshot();
+    const testDir = await createTestDir("DocApiSqlGranular");
+    await prepareDatabase(testDir, oldEnv);
+    server = await TestServer.startServer("home,docs", testDir, "DocApiSqlGranular");
+    homeUrl = server.serverUrl;
+    userApi = server.makeUserApi("docs", "chimpy");
+  });
+
+  after(async function() {
+    if (server) { await server.stop(); }
+    oldEnv?.restore();
+  });
+
+  let docId: string;
+
+  beforeEach(async function() {
+    const workspaces = await userApi.getOrgWorkspaces("current");
+    const wsId = workspaces[0].id;
+    docId = await userApi.newDoc({ name: "SqlTest" }, wsId);
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "People", [
+        { id: "Name", type: "Text" },
+        { id: "Age", type: "Int" },
+        { id: "Score", type: "Numeric" },
+      ]],
+      ["BulkAddRecord", "People", [null, null, null], {
+        Name: ["Alice", "Bob", "Charlie"],
+        Age: [30, 25, 35],
+        Score: [95.5, 87.3, 92.1],
+      }],
+    ]);
+  });
+
+  /** Set up ACL: give kiwi a role and add rule groups. Each group creates one resource
+   *  with one or more rules. A rule with no formula is the default (must be last). */
+  async function addAclRules(
+    kiwiRole: "viewers" | "editors",
+    ...groups: {
+      table: string, cols?: string,
+      rules: { formula?: string, perms: string }[],
+      userAttr?: { name: string, tableId: string, lookupColId: string, charId: string },
+    }[]
+  ) {
+    await userApi.updateDocPermissions(docId, {
+      users: { "kiwi@getgrist.com": kiwiRole },
+    });
+    const actions: any[] = [];
+    let resId = -1;
+    for (const group of groups) {
+      actions.push(["AddRecord", "_grist_ACLResources", resId,
+        { tableId: group.table, colIds: group.cols || "*" }]);
+      if (group.userAttr) {
+        actions.push(["AddRecord", "_grist_ACLRules", null, {
+          resource: resId,
+          userAttributes: JSON.stringify(group.userAttr),
+        }]);
+      }
+      for (const rule of group.rules) {
+        actions.push(["AddRecord", "_grist_ACLRules", null, {
+          resource: resId,
+          aclFormula: rule.formula || "",
+          permissionsText: rule.perms,
+        }]);
+      }
+      resId--;
+    }
+    await userApi.applyUserActions(docId, actions);
+  }
+
+  async function sqlPost(sql: string, args?: any[]) {
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_chimpy",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql, args }),
+    });
+    const body = await resp.json();
+    if (!resp.ok) { throw new Error(body.error || `HTTP ${resp.status}`); }
+    return body;
+  }
+
+  // ---- SELECT ----
+
+  it("should return decoded values and column metadata", async function() {
+    const result = await sqlPost("SELECT Name, Age, Score FROM People ORDER BY Age");
+    assert.equal(result.command, "SELECT");
+    assert.equal(result.rowCount, 3);
+    assert.isArray(result.columns);
+    assert.deepEqual(result.columns.map((c: any) => c.id), ["Name", "Age", "Score"]);
+
+    assert.equal(result.records[0].fields.Name, "Bob");
+    assert.equal(result.records[0].fields.Age, 25);
+  });
+
+  it("should handle JOIN", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Departments", [{ id: "DeptName", type: "Text" }]],
+      ["BulkAddRecord", "Departments", [null, null], { DeptName: ["Engineering", "Sales"] }],
+      ["AddColumn", "People", "Dept", { type: "Ref:Departments" }],
+      ["BulkUpdateRecord", "People", [1, 2], { Dept: [1, 2] }],
+    ]);
+    const result = await sqlPost(
+      "SELECT p.Name, d.DeptName FROM People p JOIN Departments d ON p.Dept = d.id ORDER BY p.Name",
+    );
+    assert.equal(result.rowCount, 2);
+    assert.equal(result.records[0].fields.Name, "Alice");
+    assert.equal(result.records[0].fields.DeptName, "Engineering");
+  });
+
+  it("should decode Bool values", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Active", { type: "Bool" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Active: [true, false, true] }],
+    ]);
+    const result = await sqlPost("SELECT Name, Active FROM People ORDER BY Name");
+    assert.strictEqual(result.records[0].fields.Active, true);
+    assert.strictEqual(result.records[1].fields.Active, false);
+  });
+
+  it("should decode Ref 0 as null", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Departments", [{ id: "Name", type: "Text" }]],
+      ["BulkAddRecord", "Departments", [null], { Name: ["Engineering"] }],
+      ["AddColumn", "People", "Dept", { type: "Ref:Departments" }],
+      ["BulkUpdateRecord", "People", [1], { Dept: [1] }],
+    ]);
+    const result = await sqlPost("SELECT Name, Dept FROM People ORDER BY Name");
+    assert.equal(result.records[0].fields.Dept, 1);    // Alice has dept
+    assert.equal(result.records[1].fields.Dept, null);  // Bob has 0 → null
+  });
+
+  // ---- DML ----
+
+  it("should INSERT and return row count", async function() {
+    const result = await sqlPost("INSERT INTO People (Name, Age, Score) VALUES ('Diana', 28, 91.0)");
+    assert.equal(result.command, "INSERT");
+    assert.equal(result.rowCount, 1);
+
+    const sel = await sqlPost("SELECT Name FROM People WHERE Name = 'Diana'");
+    assert.equal(sel.rowCount, 1);
+  });
+
+  it("should UPDATE with WHERE", async function() {
+    const result = await sqlPost("UPDATE People SET Age = 99 WHERE Name = 'Alice'");
+    assert.equal(result.command, "UPDATE");
+    assert.equal(result.rowCount, 1);
+
+    const sel = await sqlPost("SELECT Age FROM People WHERE Name = 'Alice'");
+    assert.equal(sel.records[0].fields.Age, 99);
+  });
+
+  it("should UPDATE with expressions", async function() {
+    await sqlPost("UPDATE People SET Age = Age + 10 WHERE Name = 'Alice'");
+    const sel = await sqlPost("SELECT Age FROM People WHERE Name = 'Alice'");
+    assert.equal(sel.records[0].fields.Age, 40);
+  });
+
+  it("should DELETE with WHERE", async function() {
+    const result = await sqlPost("DELETE FROM People WHERE Name = 'Bob'");
+    assert.equal(result.command, "DELETE");
+    assert.equal(result.rowCount, 1);
+
+    const sel = await sqlPost("SELECT Name FROM People ORDER BY Name");
+    assert.deepEqual(sel.records.map((r: any) => r.fields.Name), ["Alice", "Charlie"]);
+  });
+
+  it("should INSERT ... SELECT", async function() {
+    await sqlPost("CREATE TABLE Archive (Name TEXT, Age INT)");
+    await sqlPost("INSERT INTO Archive (Name, Age) SELECT Name, Age FROM People WHERE Age > 28");
+    const sel = await sqlPost("SELECT Name FROM Archive ORDER BY Name");
+    assert.deepEqual(sel.records.map((r: any) => r.fields.Name), ["Alice", "Charlie"]);
+  });
+
+  it("should INSERT ... RETURNING with formula columns", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Summary", {
+        type: "Text", isFormula: true,
+        formula: "$Name + ' (age ' + str($Age) + ')'",
+      }],
+    ]);
+    const result = await sqlPost(
+      "INSERT INTO People (Name, Age, Score) VALUES ('Diana', 28, 91.0) RETURNING *");
+    assert.equal(result.command, "INSERT");
+    assert.equal(result.rowCount, 1);
+    // RETURNING should include the formula column with computed value
+    assert.isArray(result.records);
+    assert.equal(result.records.length, 1);
+    const row = result.records[0].fields;
+    assert.equal(row.Name, "Diana");
+    assert.equal(row.Age, 28);
+    assert.equal(row.Summary, "Diana (age 28)");
+  });
+
+  // ---- DDL ----
+
+  it("should CREATE TABLE", async function() {
+    const result = await sqlPost("CREATE TABLE Projects (Title TEXT, Budget NUMERIC)");
+    assert.equal(result.command, "CREATE");
+
+    await sqlPost("INSERT INTO Projects (Title, Budget) VALUES ('Alpha', 1000)");
+    const sel = await sqlPost("SELECT Title FROM Projects");
+    assert.equal(sel.records[0].fields.Title, "Alpha");
+  });
+
+  it("should DROP TABLE", async function() {
+    await sqlPost("CREATE TABLE TempTable (x TEXT)");
+    await sqlPost("DROP TABLE TempTable");
+    const tables = await sqlPost("SELECT tableId FROM _grist_Tables");
+    assert.notInclude(tables.records.map((r: any) => r.fields.tableId), "TempTable");
+  });
+
+  // ---- Formula recalculation ----
+
+  it("should trigger formula recalculation on write", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Summary", {
+        type: "Text", isFormula: true,
+        formula: "$Name + ' (age ' + str($Age) + ')'",
+      }],
+    ]);
+
+    await sqlPost("INSERT INTO People (Name, Age, Score) VALUES ('Diana', 28, 91.0)");
+    const sel = await sqlPost("SELECT Summary FROM People WHERE Name = 'Diana'");
+    assert.equal(sel.records[0].fields.Summary, "Diana (age 28)");
+  });
+
+  // ---- ACL ----
+
+  it("should filter rows based on access rules", async function() {
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age > 30", perms: "-R" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_kiwi",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT Name FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    const names = result.records.map((r: any) => r.fields.Name);
+    assert.include(names, "Alice");
+    assert.include(names, "Bob");
+    assert.notInclude(names, "Charlie");
+  });
+
+  it("should hide denied columns and expand SELECT * without them", async function() {
+    await addAclRules("viewers",
+      { table: "People", cols: "Score", rules: [{ perms: "-R" }] });
+
+    // SELECT * should return Name and Age but not Score
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_kiwi",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT * FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    const colIds = result.columns.map((c: any) => c.id);
+    assert.include(colIds, "Name");
+    assert.include(colIds, "Age");
+    assert.notInclude(colIds, "Score");
+    assert.equal(result.records[0].fields.Name, "Alice");
+
+    // Explicitly naming denied column should error (no such column)
+    const resp2 = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_kiwi",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT Score FROM People" }),
+    });
+    assert.notEqual(resp2.status, 200);
+  });
+
+  it("should filter rows using user.Email in access rules", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Owner", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Owner: ["kiwi@getgrist.com", "chimpy@getgrist.com", "kiwi@getgrist.com"],
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Owner == user.Email", perms: "+R" }, { perms: "-R" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_kiwi",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT Name FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    const names = result.records.map((r: any) => r.fields.Name);
+    assert.deepEqual(names, ["Alice", "Charlie"]);
+  });
+
+  // ---- ACL with user attribute tables ----
+
+  it("should filter rows using user attribute table lookup", async function() {
+    // Set up a Time Sheets-style pattern:
+    // - People table with Email column
+    // - Tasks table with Employee (Ref:People) column
+    // - User attribute rule: "Person" looks up People by Email
+    // - ACL rule: user.Person.id == rec.Employee → +R, else -R
+    // This is the most common real-world pattern for multi-tenant row filtering.
+
+    await userApi.applyUserActions(docId, [
+      // Add an Employee ref column and a Tasks table
+      ["AddTable", "Tasks", [
+        { id: "TaskName", type: "Text" },
+        { id: "Employee", type: "Ref:People" },
+      ]],
+      // Update People to have email addresses
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Name: ["Kiwi User", "Chimpy User", "Other User"],
+      }],
+      ["AddColumn", "People", "Email", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Email: ["kiwi@getgrist.com", "chimpy@getgrist.com", "other@getgrist.com"],
+      }],
+      // Add tasks assigned to different people
+      ["BulkAddRecord", "Tasks", [null, null, null], {
+        TaskName: ["Task A", "Task B", "Task C"],
+        Employee: [1, 2, 1],  // Kiwi, Chimpy, Kiwi
+      }],
+    ]);
+
+    // Give kiwi access and set up user attribute rule: "Person" looks up People by Email
+    await addAclRules("editors",
+      { table: "*", rules: [], userAttr: { name: "Person", tableId: "People", lookupColId: "Email", charId: "Email" } },
+      { table: "Tasks", rules: [{ formula: "user.Person.id == rec.Employee", perms: "+R" }, { perms: "-R" }] });
+
+    // Query as kiwi — should only see tasks assigned to kiwi (Employee=1)
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_kiwi",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT TaskName FROM Tasks ORDER BY TaskName" }),
+    });
+    const result = await resp.json();
+    const names = result.records.map((r: any) => r.fields.TaskName);
+    assert.deepEqual(names, ["Task A", "Task C"]);
+    assert.notInclude(names, "Task B");
+  });
+
+  it("should filter using user attribute field other than id", async function() {
+    // user.Person.Name (a text field on the looked-up record) == rec.AssignedTo
+    // This tests that chained attribute access resolves actual field values,
+    // not just the row id.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Email", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Email: ["kiwi@getgrist.com", "chimpy@getgrist.com", "other@getgrist.com"],
+      }],
+      ["AddTable", "Projects", [
+        { id: "Title", type: "Text" },
+        { id: "AssignedTo", type: "Text" },
+      ]],
+      ["BulkAddRecord", "Projects", [null, null, null], {
+        Title: ["Proj X", "Proj Y", "Proj Z"],
+        AssignedTo: ["Alice", "Bob", "Alice"],
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "*", rules: [], userAttr: { name: "Person", tableId: "People", lookupColId: "Email", charId: "Email" } },
+      { table: "Projects", rules: [{ formula: "user.Person.Name == rec.AssignedTo", perms: "+R" }, { perms: "-R" }] });
+
+    // Kiwi's Person record is row 1 (Alice). Should only see projects assigned to "Alice".
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_kiwi",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT Title FROM Projects ORDER BY Title" }),
+    });
+    const result = await resp.json();
+    const titles = result.records.map((r: any) => r.fields.Title);
+    assert.deepEqual(titles, ["Proj X", "Proj Z"]);
+  });
+
+  it("should handle ACL rules with .lower() and .upper() string methods", async function() {
+    await addAclRules("viewers",
+      { table: "People", rules: [
+        { formula: "rec.Name.upper() == 'ALICE' or rec.Name.lower() == 'bob'", perms: "+R" },
+        { perms: "-R" },
+      ] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_kiwi",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT Name FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    const names = result.records.map((r: any) => r.fields.Name);
+    assert.deepEqual(names, ["Alice", "Bob"]);
+  });
+
+  // ---- ACL parity: SQL WHERE must match JS predicate evaluation ----
+  // These tests verify that /sql/full returns the same rows as the REST API
+  // for tricky ACL patterns where JS and SQL semantics could diverge.
+
+  async function sqlNames(table: string, col: string, apiKey: string = "api_key_for_kiwi") {
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": `Bearer ${apiKey}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: `SELECT ${col} FROM ${table} ORDER BY ${col}` }),
+    });
+    const result = await resp.json();
+    if (!resp.ok) { throw new Error(`SQL query failed: ${result.error || resp.status}`); }
+    return (result.records || []).map((r: any) => r.fields[col]).sort();
+  }
+
+  async function restNames(table: string, col: string, apiKey: string = "api_key_for_kiwi") {
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/tables/${table}/records`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    const result = await resp.json();
+    return (result.records || []).map((r: any) => r.fields[col]).sort();
+  }
+
+  it("should match REST API for truthy check on empty string", async function() {
+    // rec.Tag as a truthy condition: JS treats "" as falsy, SQL treats "" as truthy.
+    // Grist ACL evaluator (JS) excludes rows with empty string.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Tag", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Tag: ["active", "", "active"],  // Bob has empty string
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Tag", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult,
+      "SQL and REST should agree on which rows pass the truthy check");
+    // Both should exclude Bob (empty Tag)
+    assert.notInclude(sqlResult, "Bob");
+    assert.include(sqlResult, "Alice");
+  });
+
+  it("should match REST API for numeric comparison with zero", async function() {
+    // rec.Score != 0: Bob's score set to 0, others nonzero.
+    await userApi.applyUserActions(docId, [
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Score: [95.5, 0, 92.1],
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Score != 0", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    assert.notInclude(sqlResult, "Bob");
+  });
+
+  it("should match REST API for first-match rule ordering", async function() {
+    // Multiple rules: allow if Age > 30, deny if Age > 25, allow by default.
+    // First-match: Alice (30) → fails rule 1, matches rule 2 (denied).
+    // Bob (25) → fails both, hits default (allowed).
+    // Charlie (35) → matches rule 1 (allowed).
+    await addAclRules("viewers", { table: "People", rules: [
+      { formula: "rec.Age > 30", perms: "+R" },
+      { formula: "rec.Age > 25", perms: "-R" },
+      { perms: "+R" },
+    ] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult,
+      "SQL CASE WHEN must match JS first-match semantics");
+    assert.include(sqlResult, "Charlie");  // Age 35 > 30 → allowed by rule 1
+    assert.include(sqlResult, "Bob");      // Age 25, misses both rules → default allow
+    assert.notInclude(sqlResult, "Alice");  // Age 30 > 25 → denied by rule 2
+  });
+
+  it("should match REST API for Bool column as condition", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Active", { type: "Bool" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Active: [true, false, true] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Active", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    assert.include(sqlResult, "Alice");
+    assert.notInclude(sqlResult, "Bob");
+  });
+
+  it("should match REST API for Ref column as condition", async function() {
+    // Ref 0 is "no reference" — should be falsy in both JS and SQL.
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Depts", [{ id: "DName", type: "Text" }]],
+      ["BulkAddRecord", "Depts", [null], { DName: ["Eng"] }],
+      ["AddColumn", "People", "Dept", { type: "Ref:Depts" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Dept: [1, 0, 1] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Dept", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    assert.include(sqlResult, "Alice");
+    assert.notInclude(sqlResult, "Bob");  // Dept is 0 → falsy
+  });
+
+  it("should match REST API for combined And/Or conditions", async function() {
+    await addAclRules("viewers",
+      { table: "People", rules: [
+        // Allow if (Age >= 30 and Score > 90) or Name == "Bob"
+        { formula: "(rec.Age >= 30 and rec.Score > 90) or rec.Name == 'Bob'", perms: "+R" },
+        { perms: "-R" },
+      ] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    // Alice: 30, 95.5 → passes first branch
+    // Bob: 25, 87.3 → passes second branch
+    // Charlie: 35, 92.1 → passes first branch
+    assert.deepEqual(sqlResult, ["Alice", "Bob", "Charlie"]);
+  });
+
+  it("should match REST API for Not on a string column", async function() {
+    // `not rec.Name` — JS: !"Alice" is false, !"" is true.
+    // Need truthiness wrapper to propagate inside Not.
+    await userApi.applyUserActions(docId, [
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Name: ["Alice", "", "Charlie"],  // Bob has empty name
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "not rec.Name", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Age");
+    const restResult = await restNames("People", "Age");
+    assert.deepEqual(sqlResult, restResult,
+      "Not on string column must use JS truthiness (empty string is falsy)");
+    // Only Bob (empty name) should pass `not rec.Name`
+    assert.equal(sqlResult.length, 1);
+  });
+
+  it("should match REST API for Bool column negation", async function() {
+    // `not rec.Active` is the idiomatic way to check for false Bool values.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Active", { type: "Bool" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Active: [true, false, true] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "not rec.Active", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    // Only Bob (Active=false) should pass `not rec.Active`
+    assert.deepEqual(sqlResult, ["Bob"]);
+  });
+
+  it("should match REST API for Bool compared to number literal", async function() {
+    // rec.Active == 0: JS false === 0 is false (type mismatch).
+    // SQL would say 0 = 0 is true without the Bool-vs-number fix.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Active", { type: "Bool" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Active: [true, false, true] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Active == 0", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult,
+      "Bool == 0 is always false in JS (type mismatch) — SQL must match");
+  });
+
+  it("should match REST API for Bool equality with False", async function() {
+    // `rec.Active == False` is the explicit way to check for false.
+    // In Python False==0 is True, but Grist's JS evaluator uses ===
+    // where false===0 is false. This tests that SQL matches JS.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Active", { type: "Bool" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Active: [true, false, true] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Active == False", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+  });
+
+  it("should match REST API for In membership check", async function() {
+    // rec.Age in [30, 35]: Alice (30) and Charlie (35) match, Bob (25) doesn't.
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age in [30, 35]", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    assert.include(sqlResult, "Alice");    // Age 30
+    assert.include(sqlResult, "Charlie");  // Age 35
+    assert.notInclude(sqlResult, "Bob");   // Age 25
+  });
+
+  it("should match REST API for Not with comparison", async function() {
+    // not (rec.Age > 30): straightforward logical negation
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "not (rec.Age > 30)", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    assert.include(sqlResult, "Alice");    // 30 > 30 is false, negated → true
+    assert.include(sqlResult, "Bob");      // 25 > 30 is false, negated → true
+    assert.notInclude(sqlResult, "Charlie"); // 35 > 30 is true, negated → false
+  });
+
+  it("should match REST API for Is comparison with None", async function() {
+    // rec.Score is None: tests null identity
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Note", { type: "Text" }],
+      // Only set Alice's note; Bob and Charlie stay null
+      ["BulkUpdateRecord", "People", [1], { Note: ["has note"] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Note is not None", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+  });
+
+  it("should match REST API for arithmetic in condition", async function() {
+    // rec.Age + rec.Score > 120
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age + rec.Score > 120", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    // Alice: 30 + 95.5 = 125.5 > 120 → allowed
+    // Bob: 25 + 87.3 = 112.3 → denied
+    // Charlie: 35 + 92.1 = 127.1 > 120 → allowed
+    assert.deepEqual(sqlResult, ["Alice", "Charlie"]);
+  });
+
+  it("should match REST API for >= comparison with null values", async function() {
+    // rec.Score >= 0 where Score is null:
+    // JS: null >= 0 → true (null coerces to 0, 0 >= 0 is true)
+    // SQL: NULL >= 0 → NULL (falsy)
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Rating", { type: "Numeric" }],
+      // Alice has rating, Bob has 0, Charlie has no rating (null)
+      ["BulkUpdateRecord", "People", [1, 2], { Rating: [4.5, 0] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Rating >= 0", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult,
+      "NULL >= 0 must match JS semantics (null coerces to 0)");
+  });
+
+  it("should match REST API for arithmetic with null column", async function() {
+    // rec.Rating + rec.Age > 30 where Rating is null:
+    // JS: null + 30 = 30 > 30 → false (null coerces to 0)
+    // SQL: NULL + 30 = NULL > 30 → NULL (falsy)
+    // Both say false for this case, but they'd diverge at threshold
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Bonus", { type: "Int" }],
+      // Alice has bonus 10, Bob has no bonus (null), Charlie has bonus 5
+      ["BulkUpdateRecord", "People", [1, 3], { Bonus: [10, 5] }],
+    ]);
+    // Allow if Age + Bonus > 25.
+    // Alice: 30+10=40>25 → allowed. Bob: 25+null: JS 25>25 false, SQL NULL. Charlie: 35+5=40>25 → allowed.
+    // Bob: JS says 25+0=25>25 is false. SQL says NULL+25=NULL>25 is false. Both false — match.
+    // But change threshold to 24: JS 25+0=25>24 true, SQL NULL>24 false — diverge.
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age + rec.Bonus > 24", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult,
+      "Arithmetic with null column must match JS null-coercion semantics");
+  });
+
+  it("should match REST API for Not of a comparison involving null", async function() {
+    // not (rec.Rating > 5) where Rating is null:
+    // JS: not (null > 5) → not false → true
+    // SQL: NOT (NULL > 5) → NOT NULL → NULL (falsy)
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Level", { type: "Int" }],
+      // Alice has Level 10, Bob has no level (null), Charlie has Level 3
+      ["BulkUpdateRecord", "People", [1, 3], { Level: [10, 3] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "not (rec.Level > 5)", perms: "+R" }, { perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult,
+      "NOT (NULL > 5) must match JS: not false → true");
+  });
+
+  // ---- ACL rule combination tests ----
+  // These test the rule system itself, not individual formula evaluation.
+
+  it("should match REST API for column deny + row filter combined", async function() {
+    // Row rule: only Age > 25. Column rule: deny Score.
+    // Result: Alice and Charlie visible, Score hidden on both.
+    await addAclRules("viewers",
+      // Row filter
+      { table: "People", rules: [{ formula: "rec.Age > 25", perms: "+R" }, { perms: "-R" }] },
+      // Column deny
+      { table: "People", cols: "Score", rules: [{ perms: "-R" }] });
+
+    // Check rows filtered
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    assert.notInclude(sqlResult, "Bob");  // Age 25, fails > 25
+
+    // Check column hidden: SELECT * should not include Score
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    const colIds = result.columns.map((c: any) => c.id);
+    assert.notInclude(colIds, "Score");
+    assert.include(colIds, "Name");
+  });
+
+  it("should match REST API for multiple column deny groups", async function() {
+    // Deny Score in one rule, deny Age in another.
+    await addAclRules("viewers",
+      { table: "People", cols: "Score", rules: [{ perms: "-R" }] },
+      { table: "People", cols: "Age", rules: [{ perms: "-R" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    const colIds = result.columns.map((c: any) => c.id);
+    assert.notInclude(colIds, "Score");
+    assert.notInclude(colIds, "Age");
+    assert.include(colIds, "Name");
+
+    // REST should agree
+    const restResp = await fetch(`${homeUrl}/api/docs/${docId}/tables/People/records`, {
+      headers: { Authorization: "Bearer api_key_for_kiwi" },
+    });
+    const restResult = await restResp.json();
+    const restCols = Object.keys(restResult.records[0].fields);
+    assert.notInclude(restCols, "Score");
+    assert.notInclude(restCols, "Age");
+  });
+
+  it("should match REST API for owner bypassing all rules", async function() {
+    // Set up restrictive rules, then query as owner (chimpy) — should see everything.
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age > 100", perms: "+R" }, { perms: "-R" }] },
+      { table: "People", cols: "Score", rules: [{ perms: "-R" }] });
+
+    // Owner should see all rows and all columns
+    const sqlResult = await sqlNames("People", "Name", "api_key_for_chimpy");
+    assert.deepEqual(sqlResult, ["Alice", "Bob", "Charlie"]);
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_chimpy", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM People LIMIT 1" }),
+    });
+    const result = await resp.json();
+    const colIds = result.columns.map((c: any) => c.id);
+    assert.include(colIds, "Score");
+  });
+
+  it("should match REST API for table with global deny but no table rules", async function() {
+    // Global rule denies non-owners. Table-specific allow overrides for People.
+    // A second table with no specific rules should be denied.
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Secret", [{ id: "Data", type: "Text" }]],
+      ["BulkAddRecord", "Secret", [null], { Data: ["hidden"] }],
+    ]);
+    await addAclRules("editors",
+      // Table-specific: allow People
+      { table: "People", rules: [{ perms: "+R" }] },
+      // Global: deny non-owners
+      { table: "*", rules: [{ formula: "user.Access not in [OWNER]", perms: "none" }] });
+
+    // People should be readable
+    const sqlPeople = await sqlNames("People", "Name");
+    assert.equal(sqlPeople.length, 3);
+
+    // Secret should be denied — query should fail or return empty
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Data FROM Secret" }),
+    });
+    // Should get an error (table not accessible) matching REST behavior
+    const restResp = await fetch(`${homeUrl}/api/docs/${docId}/tables/Secret/records`, {
+      headers: { Authorization: "Bearer api_key_for_kiwi" },
+    });
+    // Both should deny access with non-200 status
+    assert.equal(resp.status, 403, "SQL should return 403 for denied table");
+    assert.include([403, 404], restResp.status, "REST should deny access to Secret table");
+  });
+
+  it("should match REST API for JOIN across tables with different ACL", async function() {
+    // People has row filter (Age > 25), Departments has no filter.
+    // JOIN should only return People rows that pass the filter.
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Departments", [{ id: "DeptName", type: "Text" }]],
+      ["BulkAddRecord", "Departments", [null, null], { DeptName: ["Eng", "Sales"] }],
+      ["AddColumn", "People", "Dept", { type: "Ref:Departments" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Dept: [1, 2, 1] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age > 25", perms: "+R" }, { perms: "-R" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sql: "SELECT p.Name, d.DeptName FROM People p JOIN Departments d ON p.Dept = d.id ORDER BY p.Name",
+      }),
+    });
+    const result = await resp.json();
+    const names = result.records.map((r: any) => r.fields.Name);
+    // Bob (Age 25) should be filtered out even in the JOIN
+    assert.notInclude(names, "Bob");
+    assert.include(names, "Alice");
+    assert.include(names, "Charlie");
+  });
+
+  // ---- Structural edge cases ----
+
+  it("should fail closed when ACL rule uses rec.Ref.Column pattern", async function() {
+    // Grist ACL doesn't follow Ref columns — rec.Dept.DeptName evaluates
+    // to undefined (Ref value is a row ID, not a record). The SQL path
+    // fails closed with an error; REST silently treats the condition as false.
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Departments", [{ id: "DeptName", type: "Text" }]],
+      ["BulkAddRecord", "Departments", [null], { DeptName: ["Eng"] }],
+      ["AddColumn", "People", "Dept", { type: "Ref:Departments" }],
+      ["BulkUpdateRecord", "People", [1], { Dept: [1] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [
+        { formula: "rec.Dept.DeptName == 'Eng'", perms: "+R" },
+        { perms: "-R" },
+      ] });
+
+    // SQL path: fails closed (can't compile chained rec attribute to SQL)
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Name FROM People" }),
+    });
+    assert.notEqual(resp.status, 200, "Unsupported ACL pattern must not return unfiltered data");
+
+    // REST path: doesn't crash, but the rule evaluates to undefined == 'Eng'
+    // which is always false, so no rows are visible.
+    const restResp = await fetch(`${homeUrl}/api/docs/${docId}/tables/People/records`, {
+      headers: { Authorization: "Bearer api_key_for_kiwi" },
+    });
+    assert.equal(restResp.status, 200, "REST should not crash on this pattern");
+  });
+
+  it("should not leak data when user query references denied table in subquery", async function() {
+    // SELECT * FROM AllowedTable WHERE id IN (SELECT ref FROM DeniedTable)
+    // Should fail because DeniedTable is in the query's referenced tables.
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Secret", [{ id: "PersonRef", type: "Ref:People" }]],
+      ["BulkAddRecord", "Secret", [null], { PersonRef: [1] }],
+    ]);
+    await addAclRules("viewers",
+      // Deny Secret table
+      { table: "Secret", rules: [{ perms: "-R" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sql: "SELECT Name FROM People WHERE id IN (SELECT PersonRef FROM Secret)",
+      }),
+    });
+    assert.equal(resp.status, 403, "Subquery against denied table must be rejected");
+  });
+
+  it("should match REST API when all columns are denied but table is allowed", async function() {
+    // Table has +R for rows, but every data column has -R.
+    // CTE becomes SELECT id FROM People WHERE ... — only id visible.
+    await addAclRules("viewers",
+      { table: "People", cols: "Name", rules: [{ perms: "-R" }] },
+      { table: "People", cols: "Age", rules: [{ perms: "-R" }] },
+      { table: "People", cols: "Score", rules: [{ perms: "-R" }] });
+
+    // SQL: SELECT * should succeed but only return id (no data columns)
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM People" }),
+    });
+    assert.equal(resp.status, 200, "Query should succeed even with all data columns denied");
+    const result = await resp.json();
+    const colIds = (result.columns || []).map((c: any) => c.id);
+    assert.notInclude(colIds, "Name");
+    assert.notInclude(colIds, "Age");
+    assert.notInclude(colIds, "Score");
+
+    // REST: should return records with no data fields
+    const restResp = await fetch(`${homeUrl}/api/docs/${docId}/tables/People/records`, {
+      headers: { Authorization: "Bearer api_key_for_kiwi" },
+    });
+    assert.equal(restResp.status, 200);
+    const restResult = await restResp.json();
+    const restFields = Object.keys(restResult.records[0].fields);
+    assert.notInclude(restFields, "Name");
+    assert.notInclude(restFields, "Age");
+    assert.notInclude(restFields, "Score");
+  });
+
+  it("should work with no ACL rules at all", async function() {
+    // Baseline: a viewer with no ACL rules should see everything
+    // (default behavior is allow-all).
+    await userApi.updateDocPermissions(docId, {
+      users: { "kiwi@getgrist.com": "viewers" },
+    });
+    // No ACL rules added — just the default
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    assert.deepEqual(sqlResult, ["Alice", "Bob", "Charlie"]);
+  });
+
+  it("should not show denied column even via ORDER BY", async function() {
+    // ORDER BY Score where Score is denied — should error, not leak ordering info
+    await addAclRules("viewers",
+      { table: "People", cols: "Score", rules: [{ perms: "-R" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Name FROM People ORDER BY Score" }),
+    });
+    // Should error — Score is not in the CTE
+    assert.notEqual(resp.status, 200,
+      "ORDER BY on denied column should fail, not leak ordering info");
+  });
+
+  it("should match REST API for conditional column censoring", async function() {
+    // Rule: -R on Secret when rec.Age < 30. Secret should be NULL for Bob (Age 25)
+    // but visible for Alice (30) and Charlie (35). This uses CASE WHEN in the CTE.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Secret", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Secret: ["s1", "s2", "s3"],
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", cols: "Secret", rules: [{ formula: "rec.Age < 30", perms: "-R" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Name, Secret FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    assert.equal(resp.status, 200);
+    const records = result.records.map((r: any) => r.fields);
+    // Alice (30): visible. Bob (25): censored. Charlie (35): visible.
+    assert.equal(records[0].Name, "Alice");
+    assert.equal(records[0].Secret, "s1");
+    assert.equal(records[1].Name, "Bob");
+    assert.equal(records[1].Secret, "#CENSORED", "Censored cell should show #CENSORED");
+    assert.equal(records[2].Name, "Charlie");
+    assert.equal(records[2].Secret, "s3");
+
+    // Verify REST censors the same cells
+    const restResp = await fetch(`${homeUrl}/api/docs/${docId}/tables/People/records`, {
+      headers: { Authorization: "Bearer api_key_for_kiwi" },
+    });
+    const restResult = await restResp.json();
+    const restBob = restResult.records.find((r: any) => r.fields.Name === "Bob");
+    const restAlice = restResult.records.find((r: any) => r.fields.Name === "Alice");
+    assert.notEqual(restBob.fields.Secret, "s2", "REST should censor Bob's Secret too");
+    assert.equal(restAlice.fields.Secret, "s1");
+  });
+
+  it("should match REST API for user.UserID rule", async function() {
+    // Private table accessible only to a specific user by UserID.
+    const profile = await userApi.getUserProfile();
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "OwnerOnly", [{ id: "Data", type: "Text" }]],
+      ["BulkAddRecord", "OwnerOnly", [null], { Data: ["secret"] }],
+    ]);
+    await addAclRules("editors",
+      { table: "OwnerOnly", rules: [{ formula: `user.UserID == ${profile.id}`, perms: "+R" }, { perms: "-R" }] });
+
+    // Kiwi should be denied
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Data FROM OwnerOnly" }),
+    });
+    assert.equal(resp.status, 403);
+
+    // Owner should see it
+    const ownerResult = await sqlNames("OwnerOnly", "Data", "api_key_for_chimpy");
+    assert.deepEqual(ownerResult, ["secret"]);
+  });
+
+  it("should handle column-grant pattern (grant specific, deny rest)", async function() {
+    // Pattern: grant "all" on columns B,D; deny "none" on * for non-owners.
+    // REST API shows only B,D to editor. SQL path should match or fail closed.
+    // This is a complex GranularAccess pattern; the SQL path may not fully
+    // support it yet, but must not leak denied column data.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Secret", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Secret: ["x", "y", "z"] }],
+    ]);
+    await addAclRules("editors",
+      // Grant Name,Age to everyone
+      { table: "People", cols: "Name,Age", rules: [{ perms: "all" }] },
+      // Deny everything else for non-owners
+      { table: "People", rules: [{ formula: 'user.Access != "owners"', perms: "none" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM People ORDER BY Name" }),
+    });
+    assert.equal(resp.status, 200);
+    const result = await resp.json();
+    const colIds = (result.columns || []).map((c: any) => c.id);
+    // Granted columns should be visible with real values
+    assert.include(colIds, "Name");
+    assert.include(colIds, "Age");
+    // All rows visible (column grant makes rows accessible)
+    assert.equal(result.rowCount, 3);
+    // Non-granted columns: every value censored (user-only deny always matches)
+    const records = result.records.map((r: any) => r.fields);
+    assert.equal(records[0].Name, "Alice", "Granted column has real value");
+    for (const rec of records) {
+      if (colIds.includes("Score")) {
+        assert.equal(rec.Score, "#CENSORED", "Non-granted column censored for denied rows");
+      }
+      if (colIds.includes("Secret")) {
+        assert.equal(rec.Secret, "#CENSORED", "Non-granted column censored for denied rows");
+      }
+    }
+  });
+
+  it("should match REST API for ACL rule based on formula column", async function() {
+    // rec.Public where Public is a formula column ($B == "clear").
+    // The SQL CTE reads the cached formula value from SQLite.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Tag", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Tag: ["clear", "secret", "clear"] }],
+      ["AddColumn", "People", "Public", {
+        type: "Bool", isFormula: true, formula: '$Tag == "clear"',
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "not rec.Public", perms: "-R" }] });
+
+    const sqlResult = await sqlNames("People", "Name");
+    const restResult = await restNames("People", "Name");
+    assert.deepEqual(sqlResult, restResult);
+    // Bob (Tag "secret", Public false) should be hidden
+    assert.include(sqlResult, "Alice");
+    assert.notInclude(sqlResult, "Bob");
+    assert.include(sqlResult, "Charlie");
+  });
+
+  it("should match REST API for multiple conditional column rules (first-match)", async function() {
+    // Two conditional deny rules on the same column: first-match should win.
+    // Rule 1: deny Secret when rec.Age < 30
+    // Rule 2: deny Secret when rec.Name == 'Charlie'
+    // Alice (30): both conditions false → visible
+    // Bob (25): rule 1 matches (Age < 30) → censored (first match wins)
+    // Charlie (35): rule 1 false, rule 2 matches → censored
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Secret", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Secret: ["s1", "s2", "s3"] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", cols: "Secret", rules: [
+        { formula: "rec.Age < 30", perms: "-R" },
+        { formula: "rec.Name == 'Charlie'", perms: "-R" },
+      ] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Name, Secret FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    assert.equal(resp.status, 200);
+    const records = result.records.map((r: any) => r.fields);
+    assert.equal(records[0].Secret, "s1", "Alice: both conditions false → visible");
+    assert.equal(records[1].Secret, "#CENSORED", "Bob: Age < 30 → censored");
+    assert.equal(records[2].Secret, "#CENSORED", "Charlie: Name match → censored");
+  });
+
+  it("should match REST API for conditional column grant", async function() {
+    // Grant Secret only when rec.Age >= 30. Otherwise censored.
+    // This is the inverse of conditional deny — conditional visibility.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Secret", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Secret: ["s1", "s2", "s3"] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", cols: "Secret", rules: [
+        // Grant when Age >= 30, deny by default
+        { formula: "rec.Age >= 30", perms: "+R" },
+        { perms: "-R" },
+      ] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Name, Secret FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    assert.equal(resp.status, 200);
+    const records = result.records.map((r: any) => r.fields);
+    assert.equal(records[0].Secret, "s1", "Alice (30): granted → visible");
+    assert.equal(records[1].Secret, "#CENSORED", "Bob (25): default deny → censored");
+    assert.equal(records[2].Secret, "s3", "Charlie (35): granted → visible");
+  });
+
+  it("should handle column grant + row filter interaction", async function() {
+    // Column grant on Name,Age + row filter on Status.
+    // Name,Age: visible for ALL rows (grant overrides row filter).
+    // Score: visible only for public rows, censored otherwise.
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Status", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Status: ["public", "private", "public"],
+      }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", cols: "Name,Age", rules: [{ perms: "all" }] },
+      { table: "People", rules: [
+        { formula: "rec.Status == 'public'", perms: "+R" },
+        { perms: "-R" },
+      ] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM People ORDER BY Name" }),
+    });
+    assert.equal(resp.status, 200);
+    const result = await resp.json();
+    const records = result.records.map((r: any) => r.fields);
+    // All 3 rows visible (because Name,Age grant makes rows accessible)
+    assert.equal(records.length, 3);
+    // Name always visible (granted)
+    assert.equal(records[0].Name, "Alice");
+    assert.equal(records[1].Name, "Bob");
+    assert.equal(records[2].Name, "Charlie");
+    // Score: visible for public rows, censored for private
+    assert.notEqual(records[0].Score, "#CENSORED", "Alice (public): Score visible");
+    assert.equal(records[1].Score, "#CENSORED", "Bob (private): Score censored");
+    assert.notEqual(records[2].Score, "#CENSORED", "Charlie (public): Score visible");
+  });
+
+  it("should handle column grant + column censoring + row filter together", async function() {
+    // Three ACL mechanisms at once:
+    // - Column grant: Name always visible
+    // - Conditional column deny: Secret censored when Age < 30
+    // - Row filter: only public rows for non-granted, non-censored columns
+    //
+    // Expected per cell:
+    // Alice  (30, public):  Name=Alice, Score=95.5, Secret=s1
+    // Bob    (25, private): Name=Bob,   Score=#C,   Secret=#C (both: row deny AND col deny)
+    // Charlie(35, public):  Name=Charlie, Score=92.1, Secret=s3
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Status", { type: "Text" }],
+      ["AddColumn", "People", "Secret", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], {
+        Status: ["public", "private", "public"],
+        Secret: ["s1", "s2", "s3"],
+      }],
+    ]);
+    await addAclRules("viewers",
+      // Column grant: Name always visible
+      { table: "People", cols: "Name", rules: [{ perms: "all" }] },
+      // Conditional column deny: Secret censored when Age < 30
+      { table: "People", cols: "Secret", rules: [
+        { formula: "rec.Age < 30", perms: "-R" },
+      ] },
+      // Row filter: only public rows
+      { table: "People", rules: [
+        { formula: "rec.Status == 'public'", perms: "+R" },
+        { perms: "-R" },
+      ] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT Name, Score, Secret FROM People ORDER BY Name" }),
+    });
+    assert.equal(resp.status, 200);
+    const result = await resp.json();
+    const records = result.records.map((r: any) => r.fields);
+    assert.equal(records.length, 3, "All rows visible because Name is granted");
+
+    // Alice (public, Age 30): Name granted, Score passes row filter, Secret passes col rule
+    assert.equal(records[0].Name, "Alice");
+    assert.notEqual(records[0].Score, "#CENSORED", "Alice: Score visible (public)");
+    assert.equal(records[0].Secret, "s1", "Alice: Secret visible (Age >= 30 and public)");
+
+    // Bob (private, Age 25): Name granted, Score fails row filter, Secret fails BOTH
+    assert.equal(records[1].Name, "Bob");
+    assert.equal(records[1].Score, "#CENSORED", "Bob: Score censored (private)");
+    assert.equal(records[1].Secret, "#CENSORED", "Bob: Secret censored (Age < 30 AND private)");
+
+    // Charlie (public, Age 35): all visible
+    assert.equal(records[2].Name, "Charlie");
+    assert.notEqual(records[2].Score, "#CENSORED", "Charlie: Score visible (public)");
+    assert.equal(records[2].Secret, "s3", "Charlie: Secret visible (Age >= 30 and public)");
+  });
+
+  it("should handle gnarly multi-rule interaction", async function() {
+    // The kitchen sink: multiple column groups, conditional grants and denies,
+    // user attributes, row filtering, and cell censoring all at once.
+    //
+    // Table: Staff with columns Name, Dept, Salary, Rating, Notes, Status
+    //
+    // Rules:
+    //   Column grant on Name,Dept — always visible
+    //   Column deny on Salary when rec.Dept != user.Team.Dept — only see your dept's salaries
+    //   Column conditional grant on Rating: +R when rec.Status == 'published', default -R
+    //   Column deny on Notes — always hidden
+    //   Row filter: rec.Status != 'fired' → +R, default -R
+    //   User attribute: Team looks up Teams table by email
+    //
+    // Data:
+    //   Alice: Eng, 100k, 5, "note1", published  → visible (not fired, published)
+    //   Bob:   Sales, 90k, 4, "note2", published  → visible, salary censored (wrong dept)
+    //   Charlie: Eng, 110k, 3, "note3", draft     → visible, rating censored (not published)
+    //   Diana: Eng, 95k, 2, "note4", fired        → row hidden (fired)
+    //
+    // Expected for kiwi (Eng team):
+    //   Name    Dept   Salary  Rating  Notes  Status
+    //   Alice   Eng    100000  5       hidden published  ← salary visible (same dept), rating visible (published)
+    //   Bob     Sales  #C      4       hidden published  ← salary censored (wrong dept), rating visible (published)
+    //   Charlie Eng    110000  #C      hidden draft      ← salary visible (same dept), rating censored (not published)
+    //   (Diana hidden — fired)
+
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Teams", [
+        { id: "Email", type: "Text" },
+        { id: "Dept", type: "Text" },
+      ]],
+      ["BulkAddRecord", "Teams", [null, null], {
+        Email: ["kiwi@getgrist.com", "chimpy@getgrist.com"],
+        Dept: ["Eng", "Sales"],
+      }],
+      ["AddTable", "Staff", [
+        { id: "Name", type: "Text" },
+        { id: "Dept", type: "Text" },
+        { id: "Salary", type: "Int" },
+        { id: "Rating", type: "Int" },
+        { id: "Notes", type: "Text" },
+        { id: "Status", type: "Text" },
+      ]],
+      ["BulkAddRecord", "Staff", [null, null, null, null], {
+        Name: ["Alice", "Bob", "Charlie", "Diana"],
+        Dept: ["Eng", "Sales", "Eng", "Eng"],
+        Salary: [100000, 90000, 110000, 95000],
+        Rating: [5, 4, 3, 2],
+        Notes: ["note1", "note2", "note3", "note4"],
+        Status: ["published", "published", "draft", "fired"],
+      }],
+    ]);
+
+    await addAclRules("viewers",
+      // User attribute: Team lookup by email
+      { table: "*", rules: [],
+        userAttr: { name: "Team", tableId: "Teams", lookupColId: "Email", charId: "Email" } },
+      // Column grant: Name, Dept always visible
+      { table: "Staff", cols: "Name,Dept", rules: [{ perms: "all" }] },
+      // Column deny: Salary censored when wrong department
+      { table: "Staff", cols: "Salary", rules: [
+        { formula: "rec.Dept != user.Team.Dept", perms: "-R" },
+      ] },
+      // Column conditional grant: Rating visible when published, default deny
+      { table: "Staff", cols: "Rating", rules: [
+        { formula: "rec.Status == 'published'", perms: "+R" },
+        { perms: "-R" },
+      ] },
+      // Column deny: Notes always hidden
+      { table: "Staff", cols: "Notes", rules: [{ perms: "-R" }] },
+      // Row filter: hide fired employees
+      { table: "Staff", rules: [
+        { formula: "rec.Status != 'fired'", perms: "+R" },
+        { perms: "-R" },
+      ] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM Staff ORDER BY Name" }),
+    });
+    assert.equal(resp.status, 200);
+    const result = await resp.json();
+    const colIds = result.columns.map((c: any) => c.id);
+    const records = result.records.map((r: any) => r.fields);
+
+    // All 4 rows visible — column grants make rows accessible even when
+    // the row filter would deny. Diana (fired) appears with granted columns
+    // visible and everything else censored.
+    assert.equal(records.length, 4);
+
+    // Notes always hidden
+    assert.notInclude(colIds, "Notes", "Notes column should be completely hidden");
+
+    // Granted columns always visible with real values (all 4 rows)
+    assert.include(colIds, "Name");
+    assert.include(colIds, "Dept");
+    assert.equal(records[0].Name, "Alice");
+    assert.equal(records[1].Name, "Bob");
+    assert.equal(records[2].Name, "Charlie");
+    assert.equal(records[3].Name, "Diana");
+    assert.equal(records[0].Dept, "Eng");
+    assert.equal(records[1].Dept, "Sales");
+    assert.equal(records[2].Dept, "Eng");
+    assert.equal(records[3].Dept, "Eng");
+
+    // Salary: visible for Eng AND not fired, censored otherwise.
+    // Alice (Eng, not fired): visible. Bob (Sales): censored (wrong dept).
+    // Charlie (Eng, not fired): visible. Diana (Eng, fired): censored (row filter).
+    assert.equal(records[0].Salary, 100000, "Alice (Eng, not fired): salary visible");
+    assert.equal(records[1].Salary, "#CENSORED", "Bob (Sales): salary censored (wrong dept)");
+    assert.equal(records[2].Salary, 110000, "Charlie (Eng, not fired): salary visible");
+    assert.equal(records[3].Salary, "#CENSORED", "Diana (fired): salary censored (row filter)");
+
+    // Rating: visible when published AND row filter passes, censored otherwise.
+    assert.equal(records[0].Rating, 5, "Alice (published, not fired): rating visible");
+    assert.equal(records[1].Rating, 4, "Bob (published, not fired): rating visible");
+    assert.equal(records[2].Rating, "#CENSORED", "Charlie (draft): rating censored");
+    assert.equal(records[3].Rating, "#CENSORED", "Diana (fired): rating censored");
+
+    // Status: not granted, not denied, subject to row filter only.
+    if (colIds.includes("Status")) {
+      assert.notEqual(records[0].Status, "#CENSORED", "Alice (not fired): Status visible");
+      assert.equal(records[3].Status, "#CENSORED", "Diana (fired): Status censored");
+    }
+
+    // Cross-check against REST API: same rows, same censoring pattern.
+    const restResp = await fetch(`${homeUrl}/api/docs/${docId}/tables/Staff/records`, {
+      headers: { Authorization: "Bearer api_key_for_kiwi" },
+    });
+    assert.equal(restResp.status, 200);
+    const restResult = await restResp.json();
+    const restRecords = restResult.records;
+    // REST should return same number of rows
+    assert.equal(restRecords.length, records.length,
+      "REST and SQL should return same number of rows");
+    // Compare per-row: granted columns must match, censored cells must both be hidden
+    for (const sqlRec of records) {
+      const restRec = restRecords.find((r: any) => r.fields.Name === sqlRec.Name);
+      assert.ok(restRec, `REST should have row for ${sqlRec.Name}`);
+      // Granted columns: exact match
+      assert.equal(restRec.fields.Name, sqlRec.Name, `Name match for ${sqlRec.Name}`);
+      assert.equal(restRec.fields.Dept, sqlRec.Dept, `Dept match for ${sqlRec.Name}`);
+      // Salary: if SQL says censored, REST should also censor (not show real value)
+      if (sqlRec.Salary === "#CENSORED") {
+        assert.notEqual(restRec.fields.Salary, sqlRec.Name === "Bob" ? 90000 :
+          sqlRec.Name === "Diana" ? 95000 : -1,
+        `REST should censor Salary for ${sqlRec.Name}`);
+      } else {
+        assert.equal(restRec.fields.Salary, sqlRec.Salary,
+          `Salary should match for ${sqlRec.Name}`);
+      }
+      // Rating: if SQL says censored, REST should also censor
+      if (sqlRec.Rating === "#CENSORED") {
+        const realRating = sqlRec.Name === "Charlie" ? 3 : sqlRec.Name === "Diana" ? 2 : -1;
+        assert.notEqual(restRec.fields.Rating, realRating,
+          `REST should censor Rating for ${sqlRec.Name}`);
+      } else {
+        assert.equal(restRec.fields.Rating, sqlRec.Rating,
+          `Rating should match for ${sqlRec.Name}`);
+      }
+    }
+  });
+
+  it("should handle column grant with unconditional table deny", async function() {
+    // Pure column-grant pattern: table denies everything, columns grant Name,Age.
+    // Non-granted columns should be completely hidden (not just censored).
+    await addAclRules("viewers",
+      { table: "People", cols: "Name,Age", rules: [{ perms: "all" }] },
+      { table: "People", rules: [{ perms: "none" }] });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "SELECT * FROM People ORDER BY Name" }),
+    });
+    assert.equal(resp.status, 200);
+    const result = await resp.json();
+    const colIds = result.columns.map((c: any) => c.id);
+    assert.include(colIds, "Name");
+    assert.include(colIds, "Age");
+    assert.notInclude(colIds, "Score", "Non-granted column should be hidden with unconditional deny");
+    assert.equal(result.rowCount, 3, "All rows visible via granted columns");
+  });
+
+  // ---- Backwards compatibility ----
+
+  it("should return legacy format without granular flag", async function() {
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql`, {
+      method: "POST",
+      headers: {
+        "Authorization": "Bearer api_key_for_chimpy",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ sql: "SELECT Name FROM People ORDER BY Name" }),
+    });
+    const result = await resp.json();
+    // Legacy format: {statement, records: [{fields: {...}}]}
+    assert.property(result, "statement");
+    assert.property(result, "records");
+    assert.notProperty(result, "columns");
+    assert.notProperty(result, "command");
+    assert.equal(result.records[0].fields.Name, "Alice");
+  });
+
+  it("should support cellFormat=typed for self-describing values", async function() {
+    // Set up columns covering Date, Ref, RefList, ChoiceList, DateTime, Bool, plain Text/Int
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Birthday", { type: "Date" }],
+      ["AddColumn", "People", "Updated", { type: "DateTime:UTC" }],
+      ["AddColumn", "People", "Active", { type: "Bool" }],
+      ["AddColumn", "People", "Tags", { type: "ChoiceList" }],
+      ["AddTable", "Departments", [{ id: "DeptName", type: "Text" }]],
+      ["BulkAddRecord", "Departments", [null, null], { DeptName: ["Eng", "Sales"] }],
+      ["AddColumn", "People", "Dept", { type: "Ref:Departments" }],
+      ["AddColumn", "People", "Depts", { type: "RefList:Departments" }],
+      ["BulkUpdateRecord", "People", [1], {
+        Birthday: [1710460800],
+        Updated: [1710460800],
+        Active: [true],
+        Tags: [["L", "fast", "smart"]],
+        Dept: [1],
+        Depts: [["L", 1, 2]],
+      }],
+    ]);
+
+    // Default format: decoded plain values
+    const normalResp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_chimpy", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sql: "SELECT Name, Birthday, Updated, Active, Tags, Dept, Depts FROM People WHERE Name = 'Alice'",
+      }),
+    });
+    const normalResult = await normalResp.json();
+    assert.equal(normalResp.status, 200);
+    const n = normalResult.records[0].fields;
+    assert.equal(typeof n.Birthday, "string", "Normal: Date as ISO string");
+    assert.equal(typeof n.Dept, "number", "Normal: Ref as plain number");
+    assert.equal(n.Active, true, "Normal: Bool as boolean");
+    assert.equal(n.Name, "Alice", "Normal: Text as string");
+
+    // Typed format: Grist-encoded tuples
+    const typedResp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full?cellFormat=typed`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_chimpy", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sql: "SELECT Name, Birthday, Updated, Active, Tags, Dept, Depts FROM People WHERE Name = 'Alice'",
+      }),
+    });
+    const typedResult = await typedResp.json();
+    assert.equal(typedResp.status, 200);
+    const t = typedResult.records[0].fields;
+
+    // Text and Bool stay as-is (no type tuple needed)
+    assert.equal(t.Name, "Alice");
+    assert.equal(t.Active, true);
+
+    // Date → ["d", epoch]
+    assert.isArray(t.Birthday, "Typed: Date should be tuple");
+    assert.equal(t.Birthday[0], "d");
+    assert.equal(t.Birthday[1], 1710460800);
+
+    // DateTime → ["D", epoch, timezone]
+    assert.isArray(t.Updated, "Typed: DateTime should be tuple");
+    assert.equal(t.Updated[0], "D");
+    assert.equal(t.Updated[1], 1710460800);
+    assert.equal(t.Updated[2], "UTC");
+
+    // Ref → ["R", tableId, rowId]
+    assert.isArray(t.Dept, "Typed: Ref should be tuple");
+    assert.equal(t.Dept[0], "R");
+    assert.equal(t.Dept[1], "Departments");
+    assert.equal(t.Dept[2], 1);
+
+    // RefList → ["r", tableId, [rowIds]]
+    assert.isArray(t.Depts, "Typed: RefList should be tuple");
+    assert.equal(t.Depts[0], "r");
+    assert.equal(t.Depts[1], "Departments");
+    assert.isArray(t.Depts[2]);
+    assert.deepEqual(t.Depts[2], [1, 2]);
+
+    // ChoiceList → ["L", ...choices]
+    assert.isArray(t.Tags, "Typed: ChoiceList should be tuple");
+    assert.equal(t.Tags[0], "L");
+    assert.include(t.Tags, "fast");
+    assert.include(t.Tags, "smart");
+  });
+
+  // ---- Security ----
+
+  it("should deny writes from a viewer", async function() {
+    await userApi.updateDocPermissions(docId, {
+      users: { "kiwi@getgrist.com": "viewers" },
+    });
+
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "INSERT INTO People (Name, Age, Score) VALUES ('Eve', 22, 88)" }),
+    });
+    assert.notEqual(resp.status, 200, "Viewer should not be able to INSERT");
+
+    const resp2 = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql: "DELETE FROM People WHERE Name = 'Alice'" }),
+    });
+    assert.notEqual(resp2.status, 200, "Viewer should not be able to DELETE");
+
+    // Verify data unchanged
+    const sel = await sqlNames("People", "Name", "api_key_for_chimpy");
+    assert.deepEqual(sel, ["Alice", "Bob", "Charlie"]);
+  });
+
+  it("should not execute raw SQL injection attempts", async function() {
+    const attacks = [
+      "SELECT * FROM People; DROP TABLE People",
+      "SELECT * FROM People WHERE Name = '' OR 1=1 --",
+      "SELECT * FROM _grist_ACLRules",
+    ];
+    for (const sql of attacks) {
+      const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+        method: "POST",
+        headers: { "Authorization": "Bearer api_key_for_chimpy", "Content-Type": "application/json" },
+        body: JSON.stringify({ sql }),
+      });
+      if (resp.ok) {
+        const result = await resp.json();
+        assert.notEqual(result.command, "DROP");
+      }
+    }
+    const sel = await sqlPost("SELECT Name FROM People ORDER BY Name");
+    assert.deepEqual(sel.records.map((r: any) => r.fields.Name), ["Alice", "Bob", "Charlie"]);
+  });
+
+  // ---- Black-hat attack tests ----
+  // These attempt to bypass ACL filtering as a restricted user.
+
+  async function kiwiSql(sql: string): Promise<{ status: number, body: any }> {
+    const resp = await fetch(`${homeUrl}/api/docs/${docId}/sql/full`, {
+      method: "POST",
+      headers: { "Authorization": "Bearer api_key_for_kiwi", "Content-Type": "application/json" },
+      body: JSON.stringify({ sql }),
+    });
+    return { status: resp.status, body: await resp.json() };
+  }
+
+  it("ATTACK: schema prefix main.Table to bypass CTE", async function() {
+    // The CTE rewrites "People" → "_acl_People". But "main.People"
+    // is a different AST reference that might not get rewritten,
+    // letting the attacker read the unfiltered table.
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age > 100", perms: "+R" }, { perms: "-R" }] });
+
+    // Normal query — should return no rows (nobody has Age > 100)
+    const normal = await kiwiSql("SELECT Name FROM People");
+    if (normal.status === 200) {
+      assert.equal(normal.body.rowCount, 0, "Normal query should return no rows");
+    }
+
+    // Attack: try schema-qualified name to bypass CTE
+    const attack = await kiwiSql("SELECT Name FROM main.People");
+    const leaked = attack.status === 200 ?
+      (attack.body.records || []).map((r: any) => r.fields.Name) : [];
+    assert.notInclude(leaked, "Alice", "main.People must not bypass CTE");
+    assert.notInclude(leaked, "Bob", "main.People must not bypass CTE");
+    assert.notInclude(leaked, "Charlie", "main.People must not bypass CTE");
+  });
+
+  it("ATTACK: read _grist_ACLRules to see access control configuration", async function() {
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Age > 30", perms: "-R" }] });
+
+    // Try to read the ACL rules directly
+    const r1 = await kiwiSql("SELECT * FROM _grist_ACLRules");
+    assert.notEqual(r1.status, 200, "Should not be able to read _grist_ACLRules");
+
+    // Try to read schema
+    const r2 = await kiwiSql("SELECT * FROM sqlite_master");
+    assert.notEqual(r2.status, 200, "Should not be able to read sqlite_master");
+
+    // Try pragma
+    const r3 = await kiwiSql("PRAGMA table_info('People')");
+    assert.notEqual(r3.status, 200, "Should not be able to run PRAGMA");
+  });
+
+  it("ATTACK: UNION to exfiltrate data from denied table", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddTable", "Secret", [{ id: "Data", type: "Text" }]],
+      ["BulkAddRecord", "Secret", [null], { Data: ["top-secret"] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "Secret", rules: [{ perms: "-R" }] });
+
+    // Try UNION with denied table
+    const r = await kiwiSql("SELECT Name FROM People UNION SELECT Data FROM Secret");
+    assert.notEqual(r.status, 200,
+      "UNION referencing denied table should fail, not return data");
+  });
+
+  it("ATTACK: subquery in SELECT list to read hidden column", async function() {
+    await userApi.applyUserActions(docId, [
+      ["AddColumn", "People", "Secret", { type: "Text" }],
+      ["BulkUpdateRecord", "People", [1, 2, 3], { Secret: ["s1", "s2", "s3"] }],
+    ]);
+    await addAclRules("viewers",
+      { table: "People", cols: "Secret", rules: [{ perms: "-R" }] });
+
+    // Try to read denied column via subquery in SELECT expression.
+    // The CTE excludes Secret, so the subquery should fail (column not found).
+    const r = await kiwiSql(
+      "SELECT Name, (SELECT Secret FROM People p2 WHERE p2.id = People.id) AS leak FROM People",
+    );
+    if (r.status === 200) {
+      // If it somehow succeeded, verify no secret values leaked
+      for (const rec of r.body.records) {
+        assert.notInclude(["s1", "s2", "s3"], rec.fields.leak,
+          "VULNERABILITY: subquery leaked denied column value");
+      }
+    }
+    // Expected: error because Secret column doesn't exist in the CTE
+  });
+
+  it("ATTACK: correlated subquery to probe hidden row existence", async function() {
+    // Even if a row is hidden, can we detect its existence via a correlated subquery?
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Name == 'Alice'", perms: "+R" }, { perms: "-R" }] });
+
+    // Kiwi can only see Alice. Try to detect Bob exists via EXISTS subquery.
+    // Both "People" references get rewritten to _acl_People (which has only Alice),
+    // so EXISTS should find no Bob rows.
+    const r = await kiwiSql(
+      "SELECT Name, EXISTS(SELECT 1 FROM People p2 WHERE p2.Name = 'Bob') AS bob_exists FROM People",
+    );
+    if (r.status === 200) {
+      for (const rec of r.body.records) {
+        const exists = rec.fields.bob_exists;
+        assert.include([0, false, "0", null], exists,
+          "VULNERABILITY: EXISTS detected hidden row Bob (got " + exists + ")");
+      }
+    }
+  });
+
+  it("ATTACK: COUNT(*) to detect hidden row count", async function() {
+    await addAclRules("viewers",
+      { table: "People", rules: [{ formula: "rec.Name == 'Alice'", perms: "+R" }, { perms: "-R" }] });
+
+    // Kiwi can only see Alice. COUNT(*) should report 1, not 3.
+    const r = await kiwiSql("SELECT COUNT(*) as n FROM People");
+    if (r.status === 200) {
+      const count = r.body.records[0].fields.n;
+      assert.equal(count, 1,
+        "VULNERABILITY: COUNT(*) revealed hidden row count (expected 1, got " + count + ")");
+    }
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1602,6 +1602,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"
   integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
 
+"@types/pegjs@^0.10.0":
+  version "0.10.6"
+  resolved "https://registry.yarnpkg.com/@types/pegjs/-/pegjs-0.10.6.tgz#bc20fc4809fed4cddab8d0dbee0e568803741a82"
+  integrity sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==
+
 "@types/pidusage@2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@types/pidusage/-/pidusage-2.0.5.tgz#ec8477720e390b78e3d88b7b522d9e2d4c7995a8"
@@ -2676,6 +2681,11 @@ big-integer@^1.6.17:
   resolved "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz"
   integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
 
+big-integer@^1.6.48:
+  version "1.6.52"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.52.tgz#60a887f3047614a8e1bffe5d7173490a97dc8c85"
+  integrity sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz"
@@ -2821,9 +2831,9 @@ brace-expansion@^2.0.1:
     balanced-match "^1.0.0"
 
 brace-expansion@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
-  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.3.tgz#0493338bdd58e319b1039c67cf7ee439892c01d9"
+  integrity sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==
   dependencies:
     balanced-match "^1.0.0"
 
@@ -7481,6 +7491,14 @@ node-releases@^2.0.27:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
   integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
 
+node-sql-parser@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/node-sql-parser/-/node-sql-parser-5.4.0.tgz#acf876755eb0de8c81b76577be1a673f9b902518"
+  integrity sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==
+  dependencies:
+    "@types/pegjs" "^0.10.0"
+    big-integer "^1.6.48"
+
 nodemon@^3.1.9:
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-3.1.9.tgz#df502cdc3b120e1c3c0c6e4152349019efa7387b"
@@ -9576,9 +9594,9 @@ tar@^6.1.11:
     yallist "^4.0.0"
 
 tar@^7.4.3:
-  version "7.5.11"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.11.tgz#1250fae45d98806b36d703b30973fa8e0a6d8868"
-  integrity sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==
+  version "7.5.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.13.tgz#0d214ed56781a26edc313581c0e2d929ceeb866d"
+  integrity sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"
@@ -10707,12 +10725,7 @@ ws@8.18.0, ws@^8.18.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
-ws@^8.19.0:
-  version "8.19.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.19.0.tgz#ddc2bdfa5b9ad860204f5a72a4863a8895fd8c8b"
-  integrity sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==
-
-ws@^8.2.3:
+ws@^8.19.0, ws@^8.2.3:
   version "8.20.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.0.tgz#4cd9532358eba60bc863aad1623dfb045a4d4af8"
   integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1784,6 +1784,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"
   integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
 
+"@types/pegjs@^0.10.0":
+  version "0.10.6"
+  resolved "https://registry.yarnpkg.com/@types/pegjs/-/pegjs-0.10.6.tgz#bc20fc4809fed4cddab8d0dbee0e568803741a82"
+  integrity sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==
+
 "@types/pidusage@2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@types/pidusage/-/pidusage-2.0.5.tgz#ec8477720e390b78e3d88b7b522d9e2d4c7995a8"
@@ -2866,6 +2871,11 @@ big-integer@^1.6.17:
   version "1.6.48"
   resolved "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz"
   integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
+big-integer@^1.6.48:
+  version "1.6.52"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.52.tgz#60a887f3047614a8e1bffe5d7173490a97dc8c85"
+  integrity sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==
 
 big.js@^5.2.2:
   version "5.2.2"
@@ -7632,6 +7642,14 @@ node-releases@^2.0.27:
   version "2.0.27"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.27.tgz#eedca519205cf20f650f61d56b070db111231e4e"
   integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
+
+node-sql-parser@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/node-sql-parser/-/node-sql-parser-5.4.0.tgz#acf876755eb0de8c81b76577be1a673f9b902518"
+  integrity sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==
+  dependencies:
+    "@types/pegjs" "^0.10.0"
+    big-integer "^1.6.48"
 
 nodemon@^3.1.9:
   version "3.1.9"


### PR DESCRIPTION
Adds a far more feature-rich SQL endpoint for Grist documents. Unlike the existing endpoint, this one is compatible with granular access control, and supports writes.

```
POST /api/docs/:docId/sql/full
{ "sql": "SELECT Name, Age FROM People WHERE Age > 30" }
```

Returns typed results with column metadata. Also supports INSERT, UPDATE, DELETE, CREATE TABLE, DROP TABLE, ALTER TABLE, and (when used over a WebSocket) transactions.

The challenge: Grist is a spreadsheet, not a database. Writes must go through applyUserActions so formulas recalculate, access control is checked, undo history is recorded, and connected clients are notified. Reads must respect row-level and column-level ACL rules. Raw SQL can't be executed directly against SQLite.

The approach: a three-step pipeline.

  1. Parse the user's SQL into an AST (node-sql-parser).
  2. Validate and regenerate SQL from the AST. The original user string is discarded — only parser-understood SQL reaches SQLite.
  3. Route: SELECTs run against SQLite with ACL enforced via CTE wrappers. Writes are translated from the AST into UserActions (BulkAddRecord, BulkUpdateRecord, etc.) and applied normally.

Access control reuses Grist's existing ACLRuleCollection (same data structures as GranularAccess). Row rules become CASE WHEN clauses in CTE WHERE filters. Column rules hide, censor, or grant columns. Cell-level censoring uses CASE WHEN with a marshal-encoded censored marker. User attribute tables, .lower()/.upper(), and all formula operators are supported.

Value decoding uses the shared decodeSqliteValue function (extracted from DocStorage) and decodeObject from objtypes.ts. Supports cellFormat=typed (matching the REST API) for self-describing values.

The existing /sql endpoint is unchanged.

Heavily bot assisted code.