### PR TITLE
improve authentication section in admin panel

### DIFF
--- a/app/client/models/AdminChecks.ts
+++ b/app/client/models/AdminChecks.ts
@@ -4,7 +4,7 @@ import { BootProbeIds, BootProbeInfo, BootProbeResult } from "app/common/BootPro
 import { InstallAPI } from "app/common/InstallAPI";
 import { getGristConfig } from "app/common/urlUtils";
 
-import { Disposable, Observable, UseCBOwner } from "grainjs";
+import { Computed, Disposable, Observable, UseCBOwner } from "grainjs";
 
 const t = makeT("AdminChecks");
 /**
@@ -78,6 +78,21 @@ export class AdminChecks {
     const probe = use(this.probes).find(p => p.id === id);
     if (!probe) { return; }
     return this.requestCheck(probe);
+  }
+
+  /**
+   * Returns an observable of the current login provider name from the
+   * authentication boot probe (e.g. "oidc", "saml", "minimal").
+   */
+  public getLoginProvider(): Observable<string | undefined> {
+    return Computed.create(this._parent, (use) => {
+      const req = this.requestCheckById(use, "authentication");
+      const result = req ? use(req.result) : undefined;
+      if (result?.status === "success") {
+        return result.details?.provider;
+      }
+      return undefined;
+    });
   }
 
   public async reloadChecks() {

--- a/app/client/models/AdminChecks.ts
+++ b/app/client/models/AdminChecks.ts
@@ -81,11 +81,12 @@ export class AdminChecks {
   }
 
   /**
-   * Returns an observable of the current login provider name from the
-   * authentication boot probe (e.g. "oidc", "saml", "minimal").
+   * Builds an observable of the current login provider name from the
+   * authentication boot probe (e.g. "oidc", "saml", "minimal"). The caller
+   * owns the returned observable via the `owner` argument.
    */
-  public getLoginProvider(): Observable<string | undefined> {
-    return Computed.create(this._parent, (use) => {
+  public buildLoginProviderObs(owner: Disposable): Observable<string | undefined> {
+    return Computed.create(owner, (use) => {
       const req = this.requestCheckById(use, "authentication");
       const result = req ? use(req.result) : undefined;
       if (result?.status === "success") {

--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -173,7 +173,7 @@ export class AdminPanel extends Disposable {
         if (page === "admin") {
           return dom.create(AdminInstallationPanel, this._appModel, this._restartBanner);
         } else if (page === "setup") {
-          return dom.create(QuickSetup);
+          return dom.create(QuickSetup, this._appModel);
         } else {
           return dom.create(buildAdminData, this._appModel);
         }
@@ -235,14 +235,7 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
     this._authCheck = Computed.create(this, (use) => {
       return this._checks.requestCheckById(use, "authentication");
     });
-    this._loginProvider = Computed.create(this, (use) => {
-      const req = use(this._authCheck);
-      const result = req ? use(req.result) : undefined;
-      if (result?.status === "success") {
-        return result.details?.provider;
-      }
-      return undefined;
-    });
+    this._loginProvider = this._checks.getLoginProvider();
   }
 
   public buildDom() {

--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -235,7 +235,7 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
     this._authCheck = Computed.create(this, (use) => {
       return this._checks.requestCheckById(use, "authentication");
     });
-    this._loginProvider = this._checks.getLoginProvider();
+    this._loginProvider = this._checks.buildLoginProviderObs(this);
   }
 
   public buildDom() {

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -11,7 +11,7 @@ import {
   cssWellTitle,
 } from "app/client/ui/AdminPanelCss";
 import { ChangeAdminModal } from "app/client/ui/ChangeAdminModal";
-import { GetGristComProviderInfoModal } from "app/client/ui/GetGristComProvider";
+import { GetGristComProviderInfoModal, getGristComProviderMeta } from "app/client/ui/GetGristComProvider";
 import { basicButton, bigBasicButton, bigPrimaryButton, textButton } from "app/client/ui2018/buttons";
 import { labeledSquareCheckbox } from "app/client/ui2018/checkbox";
 import { theme, vars } from "app/client/ui2018/cssVars";
@@ -28,10 +28,10 @@ import {
   GETGRIST_COM_PROVIDER_KEY,
   GRIST_CONNECT_PROVIDER_KEY,
   isRealProvider,
-  MINIMAL_PROVIDER_KEY,
   OIDC_PROVIDER_KEY,
   SAML_PROVIDER_KEY,
 } from "app/common/loginProviders";
+import { getGristConfig } from "app/common/urlUtils";
 
 import { Computed, Disposable, dom, makeTestId, Observable, styled } from "grainjs";
 
@@ -39,7 +39,12 @@ const t = makeT("AuthenticationSection");
 
 const testId = makeTestId("test-admin-auth-");
 
-const noAuthAcknowledged = localStorageBoolObs("noAuthAcknowledged");
+// Scope the acknowledgement to this installation, so the same browser used
+// to administer multiple Grist installations doesn't carry the dismissal across.
+const installationId = getGristConfig().activation?.installationId;
+const noAuthAcknowledged = localStorageBoolObs(
+  installationId ? `noAuthAcknowledged:${installationId}` : "noAuthAcknowledged",
+);
 
 interface AuthenticationSectionOptions {
   appModel: AppModel;
@@ -120,7 +125,7 @@ export class AuthenticationSection extends Disposable {
   private _makeLoginSystemId(): Observable<string | undefined> {
     const checks = new AdminChecks(this, this._installAPI);
     checks.fetchAvailableChecks().catch(reportError);
-    return checks.getLoginProvider();
+    return checks.buildLoginProviderObs(this);
   }
 
   private async _fetchProviders() {
@@ -236,13 +241,17 @@ authentication system.",
   }
 
   private _configureProvider(provider: AuthProvider) {
-    const configModal = BaseInformationModal.for(provider);
-    if (configModal) {
-      configModal.show(() => {
+    if (provider.key === GETGRIST_COM_PROVIDER_KEY) {
+      const m = new GetGristComProviderInfoModal();
+      m.show(() => {
         this._recentlyConfigured.add(provider.key);
         this._fetchProviders().catch(reportError);
       });
-      this.onDispose(() => configModal.isDisposed() ? void 0 : configModal.dispose());
+      this.onDispose(() => m.isDisposed() ? void 0 : m.dispose());
+    } else if (PROVIDER_META_BUILDERS[provider.key]) {
+      const m = new InformationModal(provider);
+      m.show();
+      this.onDispose(() => m.isDisposed() ? void 0 : m.dispose());
     }
   }
 
@@ -336,72 +345,135 @@ authentication system.",
 }
 
 /**
- * Base class for authentication provider info/configuration modals.
- *
- * Each subclass holds per-provider metadata (description, heroDesc, docsUrl)
- * used by both the modal and the hero/card rendering. The `for()` factory
- * creates the right subclass for a given provider key.
+ * Per-provider metadata used by both the auth section rendering and the
+ * read-only configuration modal (`InformationModal`). Held as plain data --
+ * no Disposable lifecycle, no subclasses -- so render functions can read it
+ * without any object construction.
  */
 interface ProviderMeta {
+  /** Short description for provider cards. */
   description: string;
+  /** Longer description for the hero card when this provider is active. */
   heroDesc: string;
+  /** Link to setup documentation. */
   docsUrl: string;
+  /** Paragraphs shown in the configuration modal. */
+  modalDescription: string[];
+  /** Instruction shown at the bottom of the configuration modal. */
+  modalInstruction: string;
 }
 
-abstract class BaseInformationModal extends Disposable {
-  /**
-   * Factory method to create the appropriate modal for a provider.
-   */
-  public static for(provider: AuthProvider) {
-    switch (provider.key) {
-      case OIDC_PROVIDER_KEY:
-        return new OIDCInformationModal(provider);
-      case SAML_PROVIDER_KEY:
-        return new SAMLInformationModal(provider);
-      case FORWARD_AUTH_PROVIDER_KEY:
-        return new ForwardedHeadersInfoModal(provider);
-      case GRIST_CONNECT_PROVIDER_KEY:
-        return new GristConnectInfoModal(provider);
-      case GETGRIST_COM_PROVIDER_KEY:
-        return new GetGristComProviderInfoModal();
-      default:
-        throw new Error(`No configuration modal available for provider key: ${provider.key}`);
-    }
-  }
+const DEFAULT_PROVIDER_META: ProviderMeta = {
+  description: "",
+  heroDesc: "",
+  docsUrl: "",
+  modalDescription: [],
+  modalInstruction: "",
+};
 
-  /**
-   * Returns provider metadata without creating a Disposable modal instance.
-   * Results are cached — safe to call from render functions.
-   */
-  public static metaFor(provider: AuthProvider): ProviderMeta {
-    let meta = BaseInformationModal._metaCache.get(provider.key);
-    if (!meta) {
-      const instance = BaseInformationModal.for(provider);
-      meta = {
-        description: instance.description,
-        heroDesc: instance.heroDesc,
-        docsUrl: instance.docsUrl,
-      };
-      instance.dispose();
-      BaseInformationModal._metaCache.set(provider.key, meta);
-    }
-    return meta;
-  }
+// Translation calls are deferred to first read so locale changes are picked up.
+const PROVIDER_META_BUILDERS: Record<string, () => ProviderMeta> = {
+  [OIDC_PROVIDER_KEY]: () => {
+    const docsUrl = "https://support.getgrist.com/install/oidc";
+    return {
+      description: t("Works with most identity providers (Google, Azure AD, Keycloak, etc.)."),
+      heroDesc: t("Your server is configured to authenticate users via OpenID Connect. \
+Users sign in through your identity provider."),
+      docsUrl,
+      modalDescription: [
+        t("**OIDC** allows users on your Grist server to sign in using an external identity provider that \
+supports the OpenID Connect standard."),
+        t("When signing in, users will be redirected to your chosen identity provider's login page to \
+authenticate. After successful authentication, they'll be redirected back to your Grist server and \
+signed in as the user verified by the provider."),
+      ],
+      modalInstruction: t("To set up **OIDC**, follow the instructions in \
+[the Grist support article for OIDC]({{url}}).", { url: docsUrl }),
+    };
+  },
+  [SAML_PROVIDER_KEY]: () => {
+    const docsUrl = "https://support.getgrist.com/install/saml/";
+    return {
+      description: t("For enterprise identity providers (Okta, OneLogin, etc.)."),
+      heroDesc: t("Your server is configured to authenticate users via SAML 2.0. \
+Users sign in through your enterprise identity provider."),
+      docsUrl,
+      modalDescription: [
+        t("**SAML** allows users on your Grist server to sign in using an external identity provider that \
+supports the SAML 2.0 standard."),
+        t("When signing in, users will be redirected to your chosen identity provider's login page to \
+authenticate. After successful authentication, they'll be redirected back to your Grist server and \
+signed in as the user verified by the provider."),
+      ],
+      modalInstruction: t("To set up **SAML**, follow the instructions in \
+[the Grist support article for SAML]({{url}}).", { url: docsUrl }),
+    };
+  },
+  [FORWARD_AUTH_PROVIDER_KEY]: () => {
+    const docsUrl = "https://support.getgrist.com/install/forwarded-headers/";
+    return {
+      description: t("For reverse proxy setups (Traefik, Authelia, etc.)."),
+      heroDesc: t("Your server trusts authentication from a reverse proxy. \
+Make sure only your proxy can reach the Grist backend."),
+      docsUrl,
+      modalDescription: [
+        t("**Forwarded headers** allows your Grist server to trust authentication performed by an external \
+proxy (e.g. Traefik ForwardAuth)."),
+        t("When a user accesses Grist, the proxy handles authentication and forwards verified user information \
+through HTTP headers. Grist uses these headers to identify the user."),
+      ],
+      modalInstruction: t("To set up **forwarded headers**, follow the instructions in \
+[the Grist support article for forwarded headers]({{url}}).", { url: docsUrl }),
+    };
+  },
+  [GRIST_CONNECT_PROVIDER_KEY]: () => {
+    const docsUrl = "https://support.getgrist.com/install/grist-connect/";
+    return {
+      description: t("Managed login solution by Grist Labs (deprecated)."),
+      heroDesc: t("This login mechanism is deprecated."),
+      docsUrl,
+      modalDescription: [
+        t("**Grist Connect** is a login solution built and maintained by Grist Labs that integrates seamlessly \
+with your Grist server."),
+        t("When signing in, users will be redirected to a Grist Connect login page where they can authenticate \
+using various identity providers. After authentication, they'll be redirected back to your Grist server \
+and signed in."),
+      ],
+      modalInstruction: t("To set up **Grist Connect**, follow the instructions in \
+[the Grist support article for Grist Connect]({{url}}).", { url: docsUrl }),
+    };
+  },
+  // The getgrist.com modal has its own custom UI; only the card/hero fields are needed here.
+  [GETGRIST_COM_PROVIDER_KEY]: () => ({
+    ...getGristComProviderMeta(),
+    modalDescription: [],
+    modalInstruction: "",
+  }),
+};
 
-  private static _metaCache = new Map<string, ProviderMeta>();
+const _providerMetaCache = new Map<string, ProviderMeta>();
 
-  /** Short description for provider cards. */
-  public description: string = "";
-  /** Longer description for the hero card when this provider is active. */
-  public heroDesc: string = t("Your server has authentication configured.");
-  /** Link to setup documentation. */
-  public docsUrl: string = "";
+function getProviderMeta(provider: AuthProvider): ProviderMeta {
+  const cached = _providerMetaCache.get(provider.key);
+  if (cached) { return cached; }
+  const builder = PROVIDER_META_BUILDERS[provider.key];
+  const meta = builder ? builder() : DEFAULT_PROVIDER_META;
+  _providerMetaCache.set(provider.key, meta);
+  return meta;
+}
 
-  constructor(protected _provider: AuthProvider) {
+/**
+ * Read-only configuration modal for providers that just describe themselves
+ * and link to setup docs (OIDC, SAML, ForwardAuth, Grist Connect). The
+ * getgrist.com provider has its own modal (`GetGristComProviderInfoModal`).
+ */
+class InformationModal extends Disposable {
+  constructor(private _provider: AuthProvider) {
     super();
   }
 
   public show() {
+    const meta = getProviderMeta(this._provider);
     return modal((ctl, owner) => [
       () => {
         this.onDispose(() => {
@@ -418,11 +490,11 @@ abstract class BaseInformationModal extends Disposable {
         testId("modal-header"),
       ),
       cssModalDescription(
-        ...this.getDescription().map(desc => dom("p", cssMarkdownSpan(desc))),
+        ...meta.modalDescription.map(desc => dom("p", cssMarkdownSpan(desc))),
       ),
       cssModalInstructions(
         dom("h3", t("Instructions")),
-        cssMarkdownSpan(this.getInstruction()),
+        cssMarkdownSpan(meta.modalInstruction),
       ),
       cssModalButtons(
         bigPrimaryButton(
@@ -434,110 +506,6 @@ abstract class BaseInformationModal extends Disposable {
       ),
     ]);
   }
-
-  protected abstract getDescription(): string[];
-  protected abstract getInstruction(): string;
-}
-
-/**
- * Modal for configuring OIDC authentication.
- */
-class OIDCInformationModal extends BaseInformationModal {
-  public description = t("Works with most identity providers (Google, Azure AD, Keycloak, etc.).");
-  public heroDesc = t("Your server is configured to authenticate users via OpenID Connect. \
-Users sign in through your identity provider.");
-
-  public docsUrl = "https://support.getgrist.com/install/oidc";
-
-  protected getDescription(): string[] {
-    return [
-      t("**OIDC** allows users on your Grist server to sign in using an external identity provider that \
-supports the OpenID Connect standard."),
-      t("When signing in, users will be redirected to your chosen identity provider's login page to \
-authenticate. After successful authentication, they'll be redirected back to your Grist server and \
-signed in as the user verified by the provider."),
-    ];
-  }
-
-  protected getInstruction(): string {
-    return t("To set up **OIDC**, follow the instructions in \
-[the Grist support article for OIDC]({{url}}).", { url: this.docsUrl });
-  }
-}
-
-/**
- * Modal for configuring SAML authentication.
- */
-class SAMLInformationModal extends BaseInformationModal {
-  public description = t("For enterprise identity providers (Okta, OneLogin, etc.).");
-  public heroDesc = t("Your server is configured to authenticate users via SAML 2.0. \
-Users sign in through your enterprise identity provider.");
-
-  public docsUrl = "https://support.getgrist.com/install/saml/";
-
-  protected getDescription(): string[] {
-    return [
-      t("**SAML** allows users on your Grist server to sign in using an external identity provider that \
-supports the SAML 2.0 standard."),
-      t("When signing in, users will be redirected to your chosen identity provider's login page to \
-authenticate. After successful authentication, they'll be redirected back to your Grist server and \
-signed in as the user verified by the provider."),
-    ];
-  }
-
-  protected getInstruction(): string {
-    return t("To set up **SAML**, follow the instructions in \
-[the Grist support article for SAML]({{url}}).", { url: this.docsUrl });
-  }
-}
-
-/**
- * Modal for configuring forwarded headers authentication.
- */
-class ForwardedHeadersInfoModal extends BaseInformationModal {
-  public description = t("For reverse proxy setups (Traefik, Authelia, etc.).");
-  public heroDesc = t("Your server trusts authentication from a reverse proxy. \
-Make sure only your proxy can reach the Grist backend.");
-
-  public docsUrl = "https://support.getgrist.com/install/forwarded-headers/";
-
-  protected getDescription(): string[] {
-    return [
-      t("**Forwarded headers** allows your Grist server to trust authentication performed by an external \
-proxy (e.g. Traefik ForwardAuth)."),
-      t("When a user accesses Grist, the proxy handles authentication and forwards verified user information \
-through HTTP headers. Grist uses these headers to identify the user."),
-    ];
-  }
-
-  protected getInstruction(): string {
-    return t("To set up **forwarded headers**, follow the instructions in \
-[the Grist support article for forwarded headers]({{url}}).", { url: this.docsUrl });
-  }
-}
-
-/**
- * Modal for configuring Grist Connect authentication.
- */
-class GristConnectInfoModal extends BaseInformationModal {
-  public description = t("Managed login solution by Grist Labs (deprecated).");
-  public heroDesc = t("This login mechanism is deprecated.");
-  public docsUrl = "https://support.getgrist.com/install/grist-connect/";
-
-  protected getDescription(): string[] {
-    return [
-      t("**Grist Connect** is a login solution built and maintained by Grist Labs that integrates seamlessly \
-with your Grist server."),
-      t("When signing in, users will be redirected to a Grist Connect login page where they can authenticate \
-using various identity providers. After authentication, they'll be redirected back to your Grist server \
-and signed in."),
-    ];
-  }
-
-  protected getInstruction(): string {
-    return t("To set up **Grist Connect**, follow the instructions in \
-[the Grist support article for Grist Connect]({{url}}).", { url: this.docsUrl });
-  }
 }
 
 // =========================================================================
@@ -545,14 +513,14 @@ and signed in."),
 // panel (via AuthenticationSection) and Storybook (via buildAuthSectionPreview).
 // =========================================================================
 
-interface HeroCardContext {
+export interface HeroCardContext {
   adminEmail: string;
   onChangeAdmin?: () => void;
   onReconfigure?: () => void;
   onDeactivate?: () => void;
 }
 
-interface ProviderListContext {
+export interface ProviderListContext {
   onSetActive?: (provider: AuthProvider) => void;
   onConfigure?: (provider: AuthProvider) => void;
   collapsible?: boolean;
@@ -560,7 +528,7 @@ interface ProviderListContext {
   collapseOnNoAuth?: boolean;
 }
 
-interface AuthSectionContext {
+export interface AuthSectionContext {
   heroCtx: HeroCardContext;
   listCtx: ProviderListContext;
   recentlyConfigured?: ReadonlySet<string>;
@@ -573,7 +541,7 @@ interface AuthSectionContext {
  * Assembles the complete auth section: hero card + provider list.
  * Single code path shared by the live admin panel and the Storybook preview.
  */
-function buildAuthSection(
+export function buildAuthSection(
   providers: AuthProvider[],
   ctx: AuthSectionContext,
 ): HTMLElement {
@@ -686,7 +654,7 @@ Configure one of the authentication methods below."),
   }
 
   const error = getVisibleError(hero, recentlyConfigured);
-  const meta = BaseInformationModal.metaFor(hero);
+  const meta = getProviderMeta(hero);
   const variant = error ? "-error" : hero.isActive ? "-success" : "-pending";
 
   let descText: string | undefined;
@@ -732,7 +700,7 @@ function buildProviderCard(
   ctx: ProviderListContext = {},
 ): HTMLElement {
   const error = getVisibleError(provider, recentlyConfigured);
-  const meta = BaseInformationModal.metaFor(provider);
+  const meta = getProviderMeta(provider);
   let borderVariant: string | null = null;
   if (provider.isActive) {
     borderVariant = "-border-active";
@@ -827,29 +795,6 @@ function buildProviderList(
   );
 }
 
-/**
- * Renders a static preview of the authentication section for a given
- * list of providers. Used by Storybook to visualize every hero/card
- * state without needing the full app model or API layer.
- */
-export function buildAuthSectionPreview(providers: AuthProvider[]): HTMLElement {
-  return cssPreviewContainer(
-    buildAuthSection(providers, {
-      heroCtx: {
-        adminEmail: "admin@example.com",
-        onReconfigure: () => {},
-        onDeactivate: () => {},
-      },
-      listCtx: {},
-      loginSystemId: MINIMAL_PROVIDER_KEY,
-    }),
-  );
-}
-
-const cssPreviewContainer = styled("div", `
-  max-width: 700px;
-`);
-
 const cssHeroCard = styled("div", `
   padding: 16px 20px;
   border-radius: 8px;
@@ -936,10 +881,14 @@ const cssProviderListHeaderClickable = styled(cssProviderListHeader, `
   &:hover {
     color: ${theme.text};
   }
+  /* Inset the focus ring with box-shadow so it isn't clipped by ancestor
+     overflow boundaries (the section sits inside a card with overflow:hidden). */
   &:focus-visible {
-    outline: 2px solid ${theme.controlFg};
-    outline-offset: 2px;
-    border-radius: 2px;
+    outline: none;
+    box-shadow: inset 0 0 0 2px ${theme.controlFg};
+    border-radius: 4px;
+    padding: 2px 4px;
+    margin: -2px -4px;
   }
 `);
 

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -1,5 +1,7 @@
 import { makeT } from "app/client/lib/localization";
+import { localStorageBoolObs } from "app/client/lib/localStorageObs";
 import { cssMarkdownSpan } from "app/client/lib/markdown";
+import { AdminChecks } from "app/client/models/AdminChecks";
 import { AppModel, getHomeUrl, reportError } from "app/client/models/AppModel";
 import {
   AdminPanelControls,
@@ -10,19 +12,22 @@ import {
 } from "app/client/ui/AdminPanelCss";
 import { ChangeAdminModal } from "app/client/ui/ChangeAdminModal";
 import { GetGristComProviderInfoModal } from "app/client/ui/GetGristComProvider";
-import { basicButton, bigBasicButton, bigPrimaryButton } from "app/client/ui2018/buttons";
+import { basicButton, bigBasicButton, bigPrimaryButton, textButton } from "app/client/ui2018/buttons";
+import { labeledSquareCheckbox } from "app/client/ui2018/checkbox";
 import { theme, vars } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
 import { confirmModal, cssModalWidth, modal, saveModal } from "app/client/ui2018/modals";
 import { AuthProvider, ConfigAPI } from "app/common/ConfigAPI";
 import { PendingChanges } from "app/common/Install";
-import { InstallAPI } from "app/common/InstallAPI";
+import { InstallAPI, InstallAPIImpl } from "app/common/InstallAPI";
 import {
   BOOT_KEY_PROVIDER_KEY,
   DEPRECATED_PROVIDERS,
+  FALLBACK_PROVIDER_KEY,
   FORWARD_AUTH_PROVIDER_KEY,
   GETGRIST_COM_PROVIDER_KEY,
   GRIST_CONNECT_PROVIDER_KEY,
+  isRealProvider,
   MINIMAL_PROVIDER_KEY,
   OIDC_PROVIDER_KEY,
   SAML_PROVIDER_KEY,
@@ -34,34 +39,49 @@ const t = makeT("AuthenticationSection");
 
 const testId = makeTestId("test-admin-auth-");
 
+const noAuthAcknowledged = localStorageBoolObs("noAuthAcknowledged");
+
 interface AuthenticationSectionOptions {
   appModel: AppModel;
-  loginSystemId: Observable<string | undefined>;
-  controls: AdminPanelControls;
-  installAPI: InstallAPI;
+  loginSystemId?: Observable<string | undefined>;
+  controls?: AdminPanelControls;
+  installAPI?: InstallAPI;
+  /** When false, suppress the restart warning banner and needsRestart signal.
+   *  Used by the setup wizard where a single restart happens at the end. */
+  showRestartWarning?: boolean;
 }
 
 export class AuthenticationSection extends Disposable {
+  /**
+   * True when authentication is in a state the user can proceed with:
+   * a real provider is active, configured, or pending — or the user acknowledged no-auth.
+   */
+  public canProceed: Computed<boolean>;
+
   private _appModel = this._options.appModel;
-  private _loginSystemId = this._options.loginSystemId;
-  private _controls = this._options.controls;
-  private _installAPI = this._options.installAPI;
+  private _installAPI = this._options.installAPI ?? new InstallAPIImpl(getHomeUrl());
+  private _controls = this._options.controls ?? {
+    needsRestart: Observable.create(this, false),
+    restartGrist: async () => { await new ConfigAPI(getHomeUrl()).restartServer(); },
+  };
+
+  private _loginSystemId = this._options.loginSystemId ?? this._makeLoginSystemId();
+
   private _prefsPendingChanges = Observable.create<PendingChanges | null>(this, null);
 
   private _providers = Observable.create<AuthProvider[]>(this, []);
   private _configAPI = new ConfigAPI(getHomeUrl());
   private _currentUserEmail = this._appModel.currentValidUser!.email;
 
+  /**
+   * Provider keys that were configured or activated during this browser session.
+   * Used to suppress stale `activeError` values that came from the previous
+   * server startup and may no longer apply.
+   */
+  private _recentlyConfigured = new Set<string>();
+
   private _hasActiveOnRestartProvider = Computed.create(this, this._providers, (_use, providers) => {
     return providers.some(p => p.willBeActive);
-  });
-
-  private _showNoAuthenticationWarning = Computed.create(this, (use) => {
-    return use(this._loginSystemId) === MINIMAL_PROVIDER_KEY && !use(this._hasActiveOnRestartProvider);
-  });
-
-  private _showBootKeyWarning = Computed.create(this, (use) => {
-    return use(this._loginSystemId) === BOOT_KEY_PROVIDER_KEY && !use(this._hasActiveOnRestartProvider);
   });
 
   private _getgristLoginOwner = Computed.create(this, this._providers, (_use, providers) => {
@@ -72,17 +92,35 @@ export class AuthenticationSection extends Disposable {
   constructor(private _options: AuthenticationSectionOptions) {
     super();
 
+    this.canProceed = Computed.create(this, (use) => {
+      if (use(noAuthAcknowledged)) { return true; }
+      if (use(this._hasActiveOnRestartProvider)) { return true; }
+      const providers = use(this._providers);
+      if (providers.some(p => (p.isActive || p.isConfigured) && isRealProvider(p.key))) { return true; }
+      const loginSystemId = use(this._loginSystemId);
+      return !!loginSystemId && isRealProvider(loginSystemId);
+    });
+
     this._fetchProviders().catch(reportError);
     this._fetchPrefsPendingChanges().catch(reportError);
   }
 
   public buildDom() {
     return [
-      dom.maybe(this._showNoAuthenticationWarning, () => this._buildNoAuthenticationWarning()),
-      dom.maybe(this._showBootKeyWarning, () => this._buildBootKeyWarning()),
-      dom.maybe(this._hasActiveOnRestartProvider, () => this._buildAuthenticationChangeWarning()),
-      dom.domComputed(this._providers, providers => this._buildListOfProviders(providers)),
+      dom.domComputed((use) => {
+        const providers = use(this._providers);
+        const loginSystemId = use(this._loginSystemId);
+        return this._buildSection(providers, loginSystemId);
+      }),
+      this._options.showRestartWarning !== false ?
+        dom.maybe(this._hasActiveOnRestartProvider, () => this._buildAuthenticationChangeWarning()) : null,
     ];
+  }
+
+  private _makeLoginSystemId(): Observable<string | undefined> {
+    const checks = new AdminChecks(this, this._installAPI);
+    checks.fetchAvailableChecks().catch(reportError);
+    return checks.getLoginProvider();
   }
 
   private async _fetchProviders() {
@@ -104,116 +142,24 @@ export class AuthenticationSection extends Disposable {
     this._prefsPendingChanges.set({ onRestartSetAdminEmail, onRestartReplaceEmailWithAdmin });
   }
 
-  private _buildListOfProviders(providers: AuthProvider[]) {
-    // Hide deprecated providers unless already configured or active.
-    const visible = providers.filter(p =>
-      !DEPRECATED_PROVIDERS.includes(p.key) || p.isConfigured || p.isActive,
+  private _buildSection(providers: AuthProvider[], loginSystemId?: string): HTMLElement {
+    const getgrist = providers.find(p =>
+      p.key === GETGRIST_COM_PROVIDER_KEY && (p.isActive || p.willBeActive),
     );
-    return cssMethodsContainer(
-      visible.map((provider) => {
-        return cssMethodRow(
-          testId(`provider-row-${provider.key.replace(".", "-")}`),
-          testId(`provider-row`),
-          cssMethodContent(
-            cssMethodLabel(provider.name),
-            // Render badges based on server-calculated badge list
-            provider.isConfigured ?
-              cssMethodBadge(
-                t("Configured"),
-                testId("badge"),
-                testId("badge-configured"),
-              ) :
-              null,
-            provider.isActive ?
-              cssMethodBadge(t("Active"), cssMethodBadge.cls("-primary"), testId("badge"), testId("badge-active")) :
-              null,
-            provider.willBeActive ?
-              cssMethodBadge(
-                t("Active on restart"),
-                cssMethodBadge.cls("-warning"),
-                testId("badge"),
-                testId("badge-active-on-restart")) :
-              null,
-            provider.willBeDisabled ?
-              cssMethodBadge(
-                t("Disabled on restart"),
-                cssMethodBadge.cls("-warning"),
-                testId("badge"),
-                testId("badge-disabled-on-restart")) :
-              null,
-            (provider.configError || provider.activeError) ?
-              cssMethodBadge(
-                t("Error"),
-                cssMethodBadge.cls("-error"),
-                testId("badge"),
-                testId("badge-error")) :
-              null,
-            cssFlex(),
-            // Show "Set as active method" button only if configured but not active
-            // and no provider is configured via environment variable
-            provider.canBeActivated ?
-              basicButton(
-                t("Set as active method"),
-                testId(`set-active-button`),
-                dom.on("click", () => this._setActiveProvider(provider)),
-              ) : null,
-            // Always show Configure button
-            basicButton(
-              t("Configure"),
-              testId("configure-button"),
-              testId(`configure-${provider.name.toLowerCase().replace(/\s+/g, "-")}`),
-              dom.on("click", () => this._configureProvider(provider)),
-            ),
-          ),
-          // Show error message if present
-          (provider.configError || provider.activeError) ?
-            dom("div",
-              cssErrorHeader(t("Error details"), testId("error-header")),
-              provider.activeError ? cssMethodError(provider.activeError, testId("error-message")) : null,
-              provider.configError ? cssMethodError(provider.configError, testId("error-message")) : null,
-            ) : null,
-          // Show info message if configured via environment variable
-          provider.isSelectedByEnv ?
-            cssMethodInfo(
-              t("Active method is controlled by an environment variable. Unset variable to change active method."),
-            ) : null,
-        );
-      }),
-    );
-  }
-
-  private _buildNoAuthenticationWarning() {
-    return [
-      cssWell(
-        dom.style("margin-bottom", "24px"),
-        cssWell.cls("-warning"),
-        cssIconWrapper(icon("Warning")),
-        dom("div",
-          cssWellTitle(t("No authentication: unrestricted sign-in as demo user")),
-          cssWellContent(
-            dom("p", t("If Grist is accessible on your network, or is available to multiple people, \
-configure one of the authentication methods below.")),
-          ),
-        ),
-      ),
-    ];
-  }
-
-  private _buildBootKeyWarning() {
-    return [
-      cssWell(
-        dom.style("margin-bottom", "24px"),
-        cssWell.cls("-warning"),
-        cssIconWrapper(icon("Warning")),
-        dom("div",
-          cssWellTitle(t("No authentication: using boot key as fallback method")),
-          cssWellContent(
-            dom("p", t("If Grist is accessible on your network, or is available to multiple people, \
-configure one of the authentication methods below and remove your boot key from Security Settings → Boot key.")),
-          ),
-        ),
-      ),
-    ];
+    return buildAuthSection(providers, {
+      heroCtx: {
+        adminEmail: this._currentUserEmail,
+        onChangeAdmin: () => this._showChangeAdminModal(),
+        onReconfigure: getgrist ? () => this._configureProvider(getgrist) : undefined,
+        onDeactivate: getgrist ? () => this._deactivateProvider(getgrist) : undefined,
+      },
+      listCtx: {
+        onSetActive: p => this._setActiveProvider(p),
+        onConfigure: p => this._configureProvider(p),
+      },
+      recentlyConfigured: this._recentlyConfigured,
+      loginSystemId,
+    });
   }
 
   private _buildAuthenticationChangeWarning() {
@@ -272,6 +218,7 @@ authentication system.",
       t("Confirm"),
       async () => {
         await this._configAPI.setActiveAuthProvider(provider.key);
+        this._recentlyConfigured.add(provider.key);
         await this._fetchProviders();
       },
       {
@@ -291,9 +238,37 @@ authentication system.",
   private _configureProvider(provider: AuthProvider) {
     const configModal = BaseInformationModal.for(provider);
     if (configModal) {
-      configModal.show(() => this._fetchProviders().catch(reportError));
+      configModal.show(() => {
+        this._recentlyConfigured.add(provider.key);
+        this._fetchProviders().catch(reportError);
+      });
       this.onDispose(() => configModal.isDisposed() ? void 0 : configModal.dispose());
     }
+  }
+
+  private _deactivateProvider(provider: AuthProvider) {
+    confirmModal(
+      t("Deactivate authentication?"),
+      t("Deactivate"),
+      async () => {
+        await this._configAPI.setActiveAuthProvider(FALLBACK_PROVIDER_KEY);
+        this._recentlyConfigured.add(provider.key);
+        await this._fetchProviders();
+      },
+      {
+        explanation: dom("div",
+          cssMarkdownSpan(
+            t("Are you sure you want to deactivate **{{name}}**?", { name: provider.name }),
+          ),
+          dom("p",
+            t("Your configuration will be preserved. You can reactivate it later without reconfiguring."),
+          ),
+          dom("p",
+            t("The change will take effect after you restart Grist."),
+          ),
+        ),
+      },
+    );
   }
 
   private _showChangeAdminModal() {
@@ -344,6 +319,8 @@ authentication system.",
   };
 
   private _checkIfRestartNeeded() {
+    if (this._options.showRestartWarning === false) { return; }
+
     const hasActiveOnRestartProvider = this._hasActiveOnRestartProvider.get();
 
     const prefsPendingChanges = this._prefsPendingChanges.get();
@@ -359,8 +336,18 @@ authentication system.",
 }
 
 /**
- * Base class for displaying static information about authentication providers.
+ * Base class for authentication provider info/configuration modals.
+ *
+ * Each subclass holds per-provider metadata (description, heroDesc, docsUrl)
+ * used by both the modal and the hero/card rendering. The `for()` factory
+ * creates the right subclass for a given provider key.
  */
+interface ProviderMeta {
+  description: string;
+  heroDesc: string;
+  docsUrl: string;
+}
+
 abstract class BaseInformationModal extends Disposable {
   /**
    * Factory method to create the appropriate modal for a provider.
@@ -381,6 +368,34 @@ abstract class BaseInformationModal extends Disposable {
         throw new Error(`No configuration modal available for provider key: ${provider.key}`);
     }
   }
+
+  /**
+   * Returns provider metadata without creating a Disposable modal instance.
+   * Results are cached — safe to call from render functions.
+   */
+  public static metaFor(provider: AuthProvider): ProviderMeta {
+    let meta = BaseInformationModal._metaCache.get(provider.key);
+    if (!meta) {
+      const instance = BaseInformationModal.for(provider);
+      meta = {
+        description: instance.description,
+        heroDesc: instance.heroDesc,
+        docsUrl: instance.docsUrl,
+      };
+      instance.dispose();
+      BaseInformationModal._metaCache.set(provider.key, meta);
+    }
+    return meta;
+  }
+
+  private static _metaCache = new Map<string, ProviderMeta>();
+
+  /** Short description for provider cards. */
+  public description: string = "";
+  /** Longer description for the hero card when this provider is active. */
+  public heroDesc: string = t("Your server has authentication configured.");
+  /** Link to setup documentation. */
+  public docsUrl: string = "";
 
   constructor(protected _provider: AuthProvider) {
     super();
@@ -428,6 +443,12 @@ abstract class BaseInformationModal extends Disposable {
  * Modal for configuring OIDC authentication.
  */
 class OIDCInformationModal extends BaseInformationModal {
+  public description = t("Works with most identity providers (Google, Azure AD, Keycloak, etc.).");
+  public heroDesc = t("Your server is configured to authenticate users via OpenID Connect. \
+Users sign in through your identity provider.");
+
+  public docsUrl = "https://support.getgrist.com/install/oidc";
+
   protected getDescription(): string[] {
     return [
       t("**OIDC** allows users on your Grist server to sign in using an external identity provider that \
@@ -440,7 +461,7 @@ signed in as the user verified by the provider."),
 
   protected getInstruction(): string {
     return t("To set up **OIDC**, follow the instructions in \
-[the Grist support article for OIDC](https://support.getgrist.com/install/oidc).");
+[the Grist support article for OIDC]({{url}}).", { url: this.docsUrl });
   }
 }
 
@@ -448,6 +469,12 @@ signed in as the user verified by the provider."),
  * Modal for configuring SAML authentication.
  */
 class SAMLInformationModal extends BaseInformationModal {
+  public description = t("For enterprise identity providers (Okta, OneLogin, etc.).");
+  public heroDesc = t("Your server is configured to authenticate users via SAML 2.0. \
+Users sign in through your enterprise identity provider.");
+
+  public docsUrl = "https://support.getgrist.com/install/saml/";
+
   protected getDescription(): string[] {
     return [
       t("**SAML** allows users on your Grist server to sign in using an external identity provider that \
@@ -460,7 +487,7 @@ signed in as the user verified by the provider."),
 
   protected getInstruction(): string {
     return t("To set up **SAML**, follow the instructions in \
-[the Grist support article for SAML](https://support.getgrist.com/install/saml/).");
+[the Grist support article for SAML]({{url}}).", { url: this.docsUrl });
   }
 }
 
@@ -468,6 +495,12 @@ signed in as the user verified by the provider."),
  * Modal for configuring forwarded headers authentication.
  */
 class ForwardedHeadersInfoModal extends BaseInformationModal {
+  public description = t("For reverse proxy setups (Traefik, Authelia, etc.).");
+  public heroDesc = t("Your server trusts authentication from a reverse proxy. \
+Make sure only your proxy can reach the Grist backend.");
+
+  public docsUrl = "https://support.getgrist.com/install/forwarded-headers/";
+
   protected getDescription(): string[] {
     return [
       t("**Forwarded headers** allows your Grist server to trust authentication performed by an external \
@@ -479,7 +512,7 @@ through HTTP headers. Grist uses these headers to identify the user."),
 
   protected getInstruction(): string {
     return t("To set up **forwarded headers**, follow the instructions in \
-[the Grist support article for forwarded headers](https://support.getgrist.com/install/forwarded-headers/).");
+[the Grist support article for forwarded headers]({{url}}).", { url: this.docsUrl });
   }
 }
 
@@ -487,6 +520,10 @@ through HTTP headers. Grist uses these headers to identify the user."),
  * Modal for configuring Grist Connect authentication.
  */
 class GristConnectInfoModal extends BaseInformationModal {
+  public description = t("Managed login solution by Grist Labs (deprecated).");
+  public heroDesc = t("This login mechanism is deprecated.");
+  public docsUrl = "https://support.getgrist.com/install/grist-connect/";
+
   protected getDescription(): string[] {
     return [
       t("**Grist Connect** is a login solution built and maintained by Grist Labs that integrates seamlessly \
@@ -499,9 +536,418 @@ and signed in."),
 
   protected getInstruction(): string {
     return t("To set up **Grist Connect**, follow the instructions in \
-[the Grist support article for Grist Connect](https://support.getgrist.com/install/grist-connect/).");
+[the Grist support article for Grist Connect]({{url}}).", { url: this.docsUrl });
   }
 }
+
+// =========================================================================
+// Rendering functions for auth UI elements, shared by the live admin
+// panel (via AuthenticationSection) and Storybook (via buildAuthSectionPreview).
+// =========================================================================
+
+interface HeroCardContext {
+  adminEmail: string;
+  onChangeAdmin?: () => void;
+  onReconfigure?: () => void;
+  onDeactivate?: () => void;
+}
+
+interface ProviderListContext {
+  onSetActive?: (provider: AuthProvider) => void;
+  onConfigure?: (provider: AuthProvider) => void;
+  collapsible?: boolean;
+  /** When true, collapse the list when the no-auth checkbox is acknowledged. */
+  collapseOnNoAuth?: boolean;
+}
+
+interface AuthSectionContext {
+  heroCtx: HeroCardContext;
+  listCtx: ProviderListContext;
+  recentlyConfigured?: ReadonlySet<string>;
+  /** The login system ID from the boot probe (e.g. "minimal", "boot-key").
+   *  When set to a non-real provider key, shows the no-auth hero. */
+  loginSystemId?: string;
+}
+
+/**
+ * Assembles the complete auth section: hero card + provider list.
+ * Single code path shared by the live admin panel and the Storybook preview.
+ */
+function buildAuthSection(
+  providers: AuthProvider[],
+  ctx: AuthSectionContext,
+): HTMLElement {
+  const recentlyConfigured = ctx.recentlyConfigured ?? new Set();
+
+  const hero =
+    providers.find(p => p.isActive && isRealProvider(p.key)) ??
+    providers.find(p => p.willBeActive && isRealProvider(p.key)) ??
+    null;
+
+  // Show the no-auth hero when no real provider is active or pending. This covers:
+  // - Boot probe reports a non-real provider (minimal, boot-key)
+  // - A provider was just deactivated (willBeDisabled) with nothing replacing it
+  const noRealPending = providers.some(p => p.willBeDisabled) &&
+    !providers.some(p => p.willBeActive);
+  const bootProbeNoAuth = !!ctx.loginSystemId && !isRealProvider(ctx.loginSystemId);
+  const showNoAuth = !hero && (bootProbeNoAuth || noRealPending);
+  // When deactivating, the boot probe still reports the old provider. Use the
+  // fallback key so the hero shows the right language for what comes after restart.
+  const effectiveLoginSystem = noRealPending ? FALLBACK_PROVIDER_KEY : ctx.loginSystemId;
+  const heroEl = (hero || showNoAuth) ?
+    buildHeroCard(hero, recentlyConfigured, ctx.heroCtx, effectiveLoginSystem) :
+    dom("div");
+
+  const listEl = buildProviderList(
+    providers, recentlyConfigured, { ...ctx.listCtx, collapsible: !!hero, collapseOnNoAuth: showNoAuth },
+  );
+
+  return dom("div", heroEl, listEl);
+}
+
+/**
+ * Returns the effective error text for a provider, suppressing stale
+ * `activeError` values that came from a previous server startup.
+ */
+function getVisibleError(
+  provider: AuthProvider,
+  recentlyConfigured: ReadonlySet<string>,
+): string | undefined {
+  if (provider.configError) { return provider.configError; }
+  // Suppress activeError when it's likely stale.
+  if (!provider.activeError) { return undefined; }
+  if (recentlyConfigured.has(provider.key)) { return undefined; }
+  if (provider.willBeActive && !provider.isActive) { return undefined; }
+  return provider.activeError;
+}
+
+type BadgeVariant = "-primary" | "-warning" | "-error";
+
+function badge(label: string, variant: BadgeVariant, extraTestId: string) {
+  return cssMethodBadge(label, cssMethodBadge.cls(variant), testId("badge"), testId(extraTestId));
+}
+
+function buildHeroBadge(provider: AuthProvider, error: string | undefined) {
+  if (error) { return badge(t("Error"), "-error", "badge-error"); }
+  if (provider.isActive) { return badge(t("Active"), "-primary", "badge-active"); }
+  if (provider.willBeActive) { return badge(t("Active on restart"), "-warning", "badge-active-on-restart"); }
+  return null;
+}
+
+function buildHeroAdminRow(ctx: HeroCardContext) {
+  return cssHeroAdminRow(
+    dom("span",
+      t("Installation admin: "),
+      dom("strong", ctx.adminEmail),
+    ),
+    textButton(
+      t("Change installation admin"),
+      ctx.onChangeAdmin ? dom.on("click", ctx.onChangeAdmin) : null,
+      testId("change-admin"),
+    ),
+  );
+}
+
+function buildHeroCard(
+  hero: AuthProvider | null,
+  recentlyConfigured: ReadonlySet<string>,
+  ctx: HeroCardContext,
+  loginSystemId?: string,
+): HTMLElement {
+  if (!hero) {
+    const isBootKey = loginSystemId === BOOT_KEY_PROVIDER_KEY;
+    return cssHeroCard(
+      cssHeroCard.cls("-error", use => !use(noAuthAcknowledged)),
+      cssHeroCard.cls("-warning", noAuthAcknowledged),
+      testId("hero-card"),
+      testId("hero-warning"),
+      cssHeroHeader(
+        cssHeroProviderName(isBootKey ?
+          t("No authentication: using boot key") :
+          t("No authentication"),
+        ),
+        badge(t("Not recommended"), "-warning", "badge-warning"),
+      ),
+      cssHeroDescription(
+        isBootKey ?
+          t("Your server is using a boot key as a fallback login method. \
+Configure one of the authentication methods below.") :
+          t("Anyone who can reach this server can access all data without signing in. \
+Configure one of the authentication methods below."),
+      ),
+      cssNoAuthCheckbox(
+        labeledSquareCheckbox(noAuthAcknowledged,
+          t("I understand this server has no authentication"),
+          testId("no-auth-acknowledge"),
+        ),
+      ),
+      buildHeroAdminRow(ctx),
+    );
+  }
+
+  const error = getVisibleError(hero, recentlyConfigured);
+  const meta = BaseInformationModal.metaFor(hero);
+  const variant = error ? "-error" : hero.isActive ? "-success" : "-pending";
+
+  let descText: string | undefined;
+  if (error) {
+    descText = t("Authentication is misconfigured or unreachable. Users may not be able to sign in.");
+  } else if (hero.isActive) {
+    descText = meta.heroDesc;
+  } else if (hero.willBeActive) {
+    descText = t("Authentication has been configured and will become active when Grist is restarted.");
+  }
+
+  const hasActions = ctx.onReconfigure || ctx.onDeactivate;
+
+  return cssHeroCard(
+    cssHeroCard.cls(variant),
+    testId("hero-card"),
+    cssHeroHeader(
+      cssHeroProviderName(hero.name),
+      buildHeroBadge(hero, error),
+    ),
+    descText ? cssHeroDescription(descText) : null,
+    error ? cssHeroError(error, testId("hero-error")) : null,
+    hasActions ? cssHeroActions(
+      ctx.onReconfigure ? basicButton(
+        t("Reconfigure"),
+        dom.on("click", ctx.onReconfigure),
+        testId("hero-reconfigure"),
+      ) : null,
+      ctx.onDeactivate ? basicButton(
+        t("Deactivate"),
+        dom.on("click", ctx.onDeactivate),
+        testId("hero-deactivate"),
+      ) : null,
+    ) : null,
+    buildHeroAdminRow(ctx),
+    testId(`hero-${variant.slice(1)}`),
+  );
+}
+
+function buildProviderCard(
+  provider: AuthProvider,
+  recentlyConfigured: ReadonlySet<string>,
+  ctx: ProviderListContext = {},
+): HTMLElement {
+  const error = getVisibleError(provider, recentlyConfigured);
+  const meta = BaseInformationModal.metaFor(provider);
+  let borderVariant: string | null = null;
+  if (provider.isActive) {
+    borderVariant = "-border-active";
+  } else if (provider.isConfigured && !error) {
+    borderVariant = "-border-configured";
+  } else if (error) {
+    borderVariant = "-border-error";
+  }
+
+  return cssMethodRow(
+    borderVariant ? cssMethodRow.cls(borderVariant) : null,
+    testId(`provider-row-${provider.key.replace(".", "-")}`),
+    testId(`provider-row`),
+    cssMethodContent(
+      cssMethodLabel(provider.name),
+      provider.isActive ? badge(t("Active"), "-primary", "badge-active") : null,
+      provider.willBeActive ? badge(t("Active on restart"), "-warning", "badge-active-on-restart") : null,
+      provider.willBeDisabled ? badge(t("Disabled on restart"), "-warning", "badge-disabled-on-restart") : null,
+      error ? badge(t("Error"), "-error", "badge-error") : null,
+      cssFlex(),
+      provider.canBeActivated ?
+        basicButton(
+          t("Set as active method"),
+          testId(`set-active-button`),
+          ctx.onSetActive ? dom.on("click", () => ctx.onSetActive!(provider)) : null,
+        ) : null,
+      basicButton(
+        t("Configure"),
+        testId("configure-button"),
+        testId(`configure-${provider.name.toLowerCase().replace(/\s+/g, "-")}`),
+        dom.prop("disabled", Boolean(provider.isActive)),
+        !provider.isActive && ctx.onConfigure ? dom.on("click", () => ctx.onConfigure!(provider)) : null,
+      ),
+    ),
+    meta.description ? cssMethodHint(meta.description) : null,
+    error ?
+      dom("div",
+        cssErrorHeader(t("Error details"), testId("error-header")),
+        cssMethodError(error, testId("error-message")),
+      ) : null,
+    provider.isSelectedByEnv ?
+      cssMethodInfo(
+        t("Active method is controlled by an environment variable. Unset variable to change active method."),
+      ) : null,
+  );
+}
+
+function buildProviderList(
+  providers: AuthProvider[],
+  recentlyConfigured: ReadonlySet<string>,
+  ctx: ProviderListContext = {},
+): HTMLElement {
+  const visible = providers.filter(p =>
+    !DEPRECATED_PROVIDERS.includes(p.key) || p.isConfigured || p.isActive,
+  );
+  if (visible.length === 0) { return dom("div"); }
+
+  const buildCards = () => cssMethodsContainer(
+    visible.map(p => buildProviderCard(p, recentlyConfigured, ctx)),
+  );
+
+  if (!ctx.collapsible && !ctx.collapseOnNoAuth) {
+    return dom("div",
+      cssProviderListHeader(t("Available methods"), testId("provider-list-header")),
+      buildCards(),
+    );
+  }
+
+  const collapsed = Observable.create(null, ctx.collapsible || (ctx.collapseOnNoAuth && noAuthAcknowledged.get()));
+  const noAuthListener = ctx.collapseOnNoAuth ?
+    noAuthAcknowledged.addListener(val => collapsed.set(val)) : null;
+  const toggle = () => collapsed.set(!collapsed.get());
+  return dom("div",
+    dom.autoDispose(collapsed),
+    noAuthListener ? dom.autoDispose(noAuthListener) : null,
+    cssProviderListHeaderClickable(
+      dom.domComputed(collapsed, c => cssCollapseIcon(c ? "Expand" : "Collapse")),
+      t("Other authentication methods"),
+      dom.on("click", toggle),
+      dom.on("keydown", (ev: KeyboardEvent) => {
+        if (ev.key === "Enter" || ev.key === " ") {
+          ev.preventDefault();
+          toggle();
+        }
+      }),
+      dom.attr("tabindex", "0"),
+      dom.attr("role", "button"),
+      dom.attr("aria-expanded", use => String(!use(collapsed))),
+      testId("provider-list-header"),
+    ),
+    dom.maybe(use => !use(collapsed), buildCards),
+  );
+}
+
+/**
+ * Renders a static preview of the authentication section for a given
+ * list of providers. Used by Storybook to visualize every hero/card
+ * state without needing the full app model or API layer.
+ */
+export function buildAuthSectionPreview(providers: AuthProvider[]): HTMLElement {
+  return cssPreviewContainer(
+    buildAuthSection(providers, {
+      heroCtx: {
+        adminEmail: "admin@example.com",
+        onReconfigure: () => {},
+        onDeactivate: () => {},
+      },
+      listCtx: {},
+      loginSystemId: MINIMAL_PROVIDER_KEY,
+    }),
+  );
+}
+
+const cssPreviewContainer = styled("div", `
+  max-width: 700px;
+`);
+
+const cssHeroCard = styled("div", `
+  padding: 16px 20px;
+  border-radius: 8px;
+  border: 1px solid ${theme.menuBorder};
+  border-left-width: 4px;
+  margin-bottom: 24px;
+
+  &-success {
+    border-left-color: ${theme.toastSuccessBg};
+  }
+  &-pending {
+    border-left-color: ${theme.controlPrimaryBg};
+  }
+  &-warning {
+    border-left-color: ${theme.toastWarningBg};
+  }
+  &-error {
+    border-left-color: ${theme.errorText};
+  }
+`);
+
+const cssHeroHeader = styled("div", `
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+`);
+
+const cssHeroProviderName = styled("div", `
+  font-size: ${vars.largeFontSize};
+  font-weight: 600;
+  color: ${theme.text};
+`);
+
+const cssHeroDescription = styled("div", `
+  color: ${theme.lightText};
+  font-size: ${vars.mediumFontSize};
+  line-height: 1.4;
+  margin-bottom: 8px;
+`);
+
+const cssHeroError = styled("div", `
+  color: ${theme.errorText};
+  font-size: ${vars.mediumFontSize};
+  margin-bottom: 8px;
+`);
+
+const cssHeroAdminRow = styled("div", `
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid ${theme.menuBorder};
+  font-size: ${vars.mediumFontSize};
+  color: ${theme.lightText};
+`);
+
+const cssHeroActions = styled("div", `
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+`);
+
+const cssNoAuthCheckbox = styled("div", `
+  margin-top: 12px;
+`);
+
+const cssProviderListHeader = styled("div", `
+  font-size: ${vars.mediumFontSize};
+  font-weight: 600;
+  color: ${theme.lightText};
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+`);
+
+const cssProviderListHeaderClickable = styled(cssProviderListHeader, `
+  cursor: pointer;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  &:hover {
+    color: ${theme.text};
+  }
+  &:focus-visible {
+    outline: 2px solid ${theme.controlFg};
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+`);
+
+const cssCollapseIcon = styled(icon, `
+  width: 16px;
+  height: 16px;
+  --icon-color: ${theme.lightText};
+`);
 
 const cssMethodsContainer = styled("div", `
   display: flex;
@@ -518,8 +964,18 @@ const cssMethodRow = styled("div", `
   padding: 16px;
   background-color: ${theme.mainPanelBg};
   border-bottom: 1px solid ${theme.menuBorder};
+  border-left: 3px solid transparent;
   &:last-child {
     border-bottom: none;
+  }
+  &-border-active {
+    border-left-color: ${theme.toastSuccessBg};
+  }
+  &-border-configured {
+    border-left-color: ${theme.controlPrimaryBg};
+  }
+  &-border-error {
+    border-left-color: ${theme.errorText};
   }
 `);
 
@@ -533,6 +989,14 @@ const cssMethodContent = styled("div", `
 
 const cssMethodInfo = styled("div", `
   color: ${theme.lightText};
+`);
+
+const cssMethodHint = styled("div", `
+  color: ${theme.lightText};
+  font-size: ${vars.smallFontSize};
+  & a {
+    color: ${theme.controlFg};
+  }
 `);
 
 const cssMethodError = styled("div", `

--- a/app/client/ui/GetGristComProvider.ts
+++ b/app/client/ui/GetGristComProvider.ts
@@ -23,6 +23,12 @@ const testId = makeTestId("test-admin-auth-");
  * Modal for configuring "Sign in with getgrist.com" login system.
  */
 export class GetGristComProviderInfoModal extends Disposable {
+  public description = t("Managed authentication by Grist Labs.");
+  public heroDesc = t("Your server uses getgrist.com authentication. \
+Users sign in with their getgrist.com account.");
+
+  public docsUrl = "https://support.getgrist.com/install/getgrist-com/";
+
   private _onConfigure: (() => void) | undefined;
   private readonly _configKey: Observable<string> = Observable.create(this, "");
   private readonly _working: Observable<boolean> = Observable.create(this, false);

--- a/app/client/ui/GetGristComProvider.ts
+++ b/app/client/ui/GetGristComProvider.ts
@@ -20,15 +20,22 @@ const t = makeT("GetGristComProvider");
 const testId = makeTestId("test-admin-auth-");
 
 /**
+ * Static metadata for the getgrist.com login provider, shared with the auth
+ * section rendering. Translations are deferred so locale changes are picked up.
+ */
+export function getGristComProviderMeta() {
+  return {
+    description: t("Managed authentication by Grist Labs."),
+    heroDesc: t("Your server uses getgrist.com authentication. \
+Users sign in with their getgrist.com account."),
+    docsUrl: commonUrls.signInWithGristDocs,
+  };
+}
+
+/**
  * Modal for configuring "Sign in with getgrist.com" login system.
  */
 export class GetGristComProviderInfoModal extends Disposable {
-  public description = t("Managed authentication by Grist Labs.");
-  public heroDesc = t("Your server uses getgrist.com authentication. \
-Users sign in with their getgrist.com account.");
-
-  public docsUrl = "https://support.getgrist.com/install/getgrist-com/";
-
   private _onConfigure: (() => void) | undefined;
   private readonly _configKey: Observable<string> = Observable.create(this, "");
   private readonly _working: Observable<boolean> = Observable.create(this, false);

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -1,8 +1,10 @@
 import { makeT } from "app/client/lib/localization";
 import { AdminChecks } from "app/client/models/AdminChecks";
+import { AppModel } from "app/client/models/AppModel";
 import { reportError } from "app/client/models/errors";
 import { getHomeUrl } from "app/client/models/homeUrl";
 import { cssFadeUp, cssFadeUpGristLogo, cssFadeUpHeading, cssFadeUpSubHeading } from "app/client/ui/AdminPanelCss";
+import { AuthenticationSection } from "app/client/ui/AuthenticationSection";
 import { BackupsSection } from "app/client/ui/BackupsSection";
 import { PermissionsSetupSection } from "app/client/ui/PermissionsSetupSection";
 import { QuickSetupServerStep } from "app/client/ui/QuickSetupServerStep";
@@ -12,9 +14,10 @@ import { Stepper } from "app/client/ui2018/Stepper";
 import { InstallAPIImpl } from "app/common/InstallAPI";
 import { tokens } from "app/common/ThemePrefs";
 
-import { Disposable, dom, DomContents, observable, Observable, styled } from "grainjs";
+import { Disposable, dom, DomContents, makeTestId, observable, Observable, styled } from "grainjs";
 
 const t = makeT("QuickSetup");
+const testId = makeTestId("test-quick-setup-");
 
 interface Step {
   completed: Observable<boolean>;
@@ -46,8 +49,9 @@ export class QuickSetup extends Disposable {
     },
     {
       label: t("Authentication"),
-      completed: Observable.create(this, false),
-      buildDom: () => null,
+      completed: observable(false),
+      plain: true,
+      buildDom: () => this._buildAuthStep(),
     },
     {
       label: t("Backups"),
@@ -63,7 +67,7 @@ export class QuickSetup extends Disposable {
     },
   ];
 
-  constructor() {
+  constructor(private _appModel: AppModel) {
     super();
     this._checks.fetchAvailableChecks().catch(reportError);
   }
@@ -96,6 +100,30 @@ export class QuickSetup extends Disposable {
     const i = this._activeStep.get();
     this._steps[i].completed.set(true);
     this._activeStep.set(i + 1);
+  }
+
+  private _buildAuthStep(): DomContents {
+    return dom.create((owner) => {
+      const section = AuthenticationSection.create(owner, {
+        appModel: this._appModel,
+        showRestartWarning: false,
+      });
+      return dom("div",
+        section.buildDom(),
+        cssContinueRow(
+          bigPrimaryButton(
+            t("Continue"),
+            dom.boolAttr("disabled", use => !use(section.canProceed)),
+            dom.on("click", () => {
+              const activeStepIndex = this._activeStep.get();
+              this._steps[activeStepIndex].completed.set(true);
+              this._activeStep.set(activeStepIndex + 1);
+            }),
+            testId("auth-continue"),
+          ),
+        ),
+      );
+    });
   }
 
   private _buildBackupsStep(): DomContents {

--- a/app/common/ICommonUrls-ti.ts
+++ b/app/common/ICommonUrls-ti.ts
@@ -61,6 +61,7 @@ export const ICommonUrls = t.iface([], {
   "attachmentStorage": "string",
   "signInWithGristRegister": "string",
   "signInWithGristHelp": "string",
+  "signInWithGristDocs": "string",
 });
 
 const exportedTypeSuite: t.ITypeSuite = {

--- a/app/common/ICommonUrls.ts
+++ b/app/common/ICommonUrls.ts
@@ -64,4 +64,5 @@ export interface ICommonUrls {
 
   signInWithGristRegister: string; // Registration for Sign in with getgrist.com.
   signInWithGristHelp: string; // Help for Sign in with getgrist.com.
+  signInWithGristDocs: string; // Setup docs for Sign in with getgrist.com.
 }

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -181,6 +181,7 @@ export const getCommonUrls = () => withAdminDefinedUrls({
 
   signInWithGristRegister: "https://login.getgrist.com/oauth/register",
   signInWithGristHelp: "https://support.getgrist.com/install/sign-in-with-grist",
+  signInWithGristDocs: "https://support.getgrist.com/install/getgrist-com/",
 });
 
 export const commonUrls = getCommonUrls();

--- a/app/common/loginProviders.ts
+++ b/app/common/loginProviders.ts
@@ -27,7 +27,10 @@ export const DEPRECATED_PROVIDERS: string[] = [
   GRIST_CONNECT_PROVIDER_KEY,
 ];
 
-// Providers that are not "real" authentication — they don't involve a login flow.
+// Providers without a real login flow. BOOT_KEY_PROVIDER_KEY is deliberately
+// listed here: it does authenticate the install admin via a shared secret, but
+// the admin panel treats it as a no-auth fallback that should still prompt the
+// operator to configure a real provider.
 const NON_AUTH_PROVIDERS = new Set([
   MINIMAL_PROVIDER_KEY,
   BOOT_KEY_PROVIDER_KEY,

--- a/app/common/loginProviders.ts
+++ b/app/common/loginProviders.ts
@@ -19,7 +19,27 @@ export const SAML_PROVIDER_KEY = "saml";
 // Special provider that uses boot key to authenticate as install admin.
 export const BOOT_KEY_PROVIDER_KEY = "boot-key";
 
+// The provider key to switch to when deactivating authentication.
+export const FALLBACK_PROVIDER_KEY = BOOT_KEY_PROVIDER_KEY;
+
 // Deprecated/unmaintained providers, hidden unless already configured or active.
 export const DEPRECATED_PROVIDERS: string[] = [
   GRIST_CONNECT_PROVIDER_KEY,
 ];
+
+// Providers that are not "real" authentication — they don't involve a login flow.
+const NON_AUTH_PROVIDERS = new Set([
+  MINIMAL_PROVIDER_KEY,
+  BOOT_KEY_PROVIDER_KEY,
+  "no-logins",
+  "no-auth",
+  "",
+]);
+
+/**
+ * Returns true if the given provider key represents a real authentication
+ * system (OIDC, SAML, etc.) as opposed to a no-auth or internal-only mode.
+ */
+export function isRealProvider(key: string | undefined): boolean {
+  return !!key && !NON_AUTH_PROVIDERS.has(key);
+}

--- a/app/server/lib/ConfigBackendAPI.ts
+++ b/app/server/lib/ConfigBackendAPI.ts
@@ -1,6 +1,6 @@
 import { ApiError } from "app/common/ApiError";
 import { AuthProvider } from "app/common/ConfigAPI";
-import { GETGRIST_COM_PROVIDER_KEY } from "app/common/loginProviders";
+import { FALLBACK_PROVIDER_KEY, GETGRIST_COM_PROVIDER_KEY } from "app/common/loginProviders";
 import { ActivationsManager } from "app/gen-server/lib/ActivationsManager";
 import { appSettings, AppSettings } from "app/server/lib/AppSettings";
 import { expressWrap } from "app/server/lib/expressWrap";
@@ -38,10 +38,10 @@ export class ConfigBackendAPI {
         return;
       }
 
-      // Get current providers to validate
+      // Validate: must be a known provider or the fallback (minimal/boot-key).
       const providers = await this._buildProviderList();
-      const provider = providers.find((p: AuthProvider) => p.key === providerKey);
-      if (!provider) {
+      const isKnownProvider = providers.some((p: AuthProvider) => p.key === providerKey);
+      if (!isKnownProvider && providerKey !== FALLBACK_PROVIDER_KEY) {
         resp.status(404).send({ error: "Provider not found" });
         return;
       }

--- a/storybook/authenticationSection.stories.ts
+++ b/storybook/authenticationSection.stories.ts
@@ -1,7 +1,31 @@
-import { buildAuthSectionPreview } from "app/client/ui/AuthenticationSection";
+import { buildAuthSection } from "app/client/ui/AuthenticationSection";
 import { AuthProvider } from "app/common/ConfigAPI";
+import { MINIMAL_PROVIDER_KEY } from "app/common/loginProviders";
 
 import { dom, styled } from "grainjs";
+
+/**
+ * Storybook-only preview wrapper. Renders the auth section against fixture
+ * providers, with no-op admin actions and a "minimal" boot probe so the
+ * no-auth hero shows when nothing is active.
+ */
+function buildAuthSectionPreview(providers: AuthProvider[]): HTMLElement {
+  return cssPreviewContainer(
+    buildAuthSection(providers, {
+      heroCtx: {
+        adminEmail: "admin@example.com",
+        onReconfigure: () => {},
+        onDeactivate: () => {},
+      },
+      listCtx: {},
+      loginSystemId: MINIMAL_PROVIDER_KEY,
+    }),
+  );
+}
+
+const cssPreviewContainer = styled("div", `
+  max-width: 700px;
+`);
 
 export default {
   title: "Admin / Authentication Section",

--- a/storybook/authenticationSection.stories.ts
+++ b/storybook/authenticationSection.stories.ts
@@ -1,0 +1,172 @@
+import { buildAuthSectionPreview } from "app/client/ui/AuthenticationSection";
+import { AuthProvider } from "app/common/ConfigAPI";
+
+import { dom, styled } from "grainjs";
+
+export default {
+  title: "Admin / Authentication Section",
+};
+
+function provider(overrides: Partial<AuthProvider> & Pick<AuthProvider, "name" | "key">): AuthProvider {
+  return { ...overrides };
+}
+
+const oidc = (o: Partial<AuthProvider> = {}) => provider({ name: "OIDC", key: "oidc", ...o });
+const saml = (o: Partial<AuthProvider> = {}) => provider({ name: "SAML", key: "saml", ...o });
+const forward = (o: Partial<AuthProvider> = {}) => provider({ name: "Forwarded headers", key: "forward-auth", ...o });
+const getgrist = (o: Partial<AuthProvider> = {}) =>
+  provider({ name: "Sign in with getgrist.com", key: "getgrist.com", ...o });
+
+/**
+ * All hero card states: no auth (amber, with acknowledge checkbox),
+ * active (green, with collapsed provider list), pending restart (blue),
+ * active with error (red), and getgrist.com with action buttons.
+ */
+export const HeroCardStates = () => cssGrid(
+  cssColumn(
+    cssLabel("No authentication (amber)"),
+    buildAuthSectionPreview([
+      oidc(),
+      saml(),
+      forward(),
+    ]),
+  ),
+  cssColumn(
+    cssLabel("Active — OIDC (green, list collapsed)"),
+    buildAuthSectionPreview([
+      oidc({ isConfigured: true, isActive: true }),
+      saml(),
+      forward(),
+    ]),
+  ),
+  cssColumn(
+    cssLabel("Pending restart — OIDC (blue)"),
+    buildAuthSectionPreview([
+      oidc({ isConfigured: true, willBeActive: true }),
+      saml(),
+      forward(),
+    ]),
+  ),
+  cssColumn(
+    cssLabel("Active with error — OIDC (red)"),
+    buildAuthSectionPreview([
+      oidc({ isConfigured: true, isActive: true, activeError: "Failed to fetch OIDC discovery document" }),
+      saml(),
+      forward(),
+    ]),
+  ),
+  cssColumn(
+    cssLabel("Active — getgrist.com (with Reconfigure/Deactivate)"),
+    buildAuthSectionPreview([
+      getgrist({ isConfigured: true, isActive: true }),
+      oidc(),
+      saml(),
+      forward(),
+    ]),
+  ),
+);
+
+/**
+ * Provider card badge and border states: unconfigured, active,
+ * error, will-be-active, will-be-disabled, env-controlled.
+ */
+export const ProviderCardStates = () => cssGrid(
+  cssColumn(
+    cssLabel("Unconfigured (with docs hint)"),
+    buildAuthSectionPreview([
+      oidc(),
+    ]),
+  ),
+  cssColumn(
+    cssLabel("Configured (blue border, Set as active button)"),
+    buildAuthSectionPreview([
+      oidc({ isConfigured: true, canBeActivated: true }),
+    ]),
+  ),
+  cssColumn(
+    cssLabel("Active (green border, configure disabled)"),
+    buildAuthSectionPreview([
+      oidc({ isConfigured: true, isActive: true }),
+    ]),
+  ),
+  cssColumn(
+    cssLabel("Config error (red border)"),
+    buildAuthSectionPreview([
+      oidc({ configError: "Missing required GRIST_OIDC_IDP_CLIENT_ID" }),
+    ]),
+  ),
+  cssColumn(
+    cssLabel("Active + active error"),
+    buildAuthSectionPreview([
+      oidc({ isConfigured: true, isActive: true, activeError: "OIDC issuer unreachable" }),
+    ]),
+  ),
+  cssColumn(
+    cssLabel("Will be active on restart"),
+    buildAuthSectionPreview([
+      oidc({ isConfigured: true, willBeActive: true }),
+    ]),
+  ),
+  cssColumn(
+    cssLabel("Will be disabled on restart"),
+    buildAuthSectionPreview([
+      oidc({ isConfigured: true, willBeDisabled: true }),
+    ]),
+  ),
+  cssColumn(
+    cssLabel("Selected by env var"),
+    buildAuthSectionPreview([
+      oidc({ isConfigured: true, isActive: true, isSelectedByEnv: true }),
+    ]),
+  ),
+);
+
+/**
+ * Realistic multi-provider scenario: OIDC active with error, ForwardAuth
+ * configured and ready to switch, SAML unconfigured.
+ */
+export const MultiProviderScenario = () => dom("div",
+  cssLabel("OIDC active (error), ForwardAuth configured, SAML unconfigured"),
+  buildAuthSectionPreview([
+    oidc({
+      isConfigured: true, isActive: true,
+      activeError: "connect ECONNREFUSED 127.0.0.1:9090",
+    }),
+    forward({ isConfigured: true, canBeActivated: true }),
+    saml(),
+  ]),
+);
+
+/**
+ * Provider switching in progress: OIDC being disabled, ForwardAuth
+ * becoming active on restart.
+ */
+export const ProviderSwitching = () => dom("div",
+  cssLabel("Switching from OIDC to ForwardAuth"),
+  buildAuthSectionPreview([
+    oidc({ isConfigured: true, willBeDisabled: true }),
+    forward({ isConfigured: true, willBeActive: true }),
+    saml(),
+  ]),
+);
+
+const cssGrid = styled("div", `
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+  gap: 32px;
+`);
+
+const cssColumn = styled("div", `
+  min-width: 0;
+`);
+
+const cssLabel = styled("div", `
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #888;
+  margin-bottom: 12px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #eee;
+`);

--- a/test/nbrowser/AdminPanelTools.ts
+++ b/test/nbrowser/AdminPanelTools.ts
@@ -58,6 +58,20 @@ export async function isEnabled(switchElem: WebElement | string) {
   return (await switchElem.find("input").getAttribute("checked")) === null ? false : true;
 }
 
+/**
+ * If the authentication provider list is collapsed, click the header to expand it.
+ */
+export async function expandProviderList() {
+  // Wait for the provider list header to appear. It may be non-collapsible
+  // (no aria-expanded) or collapsible (aria-expanded="false" when collapsed).
+  const header = await driver.findWait(".test-admin-auth-provider-list-header", 2000);
+  if (await header.getAttribute("aria-expanded") === "false") {
+    await header.click();
+    // Wait for the provider rows to render after expanding.
+    await driver.findWait(".test-admin-auth-provider-row", 2000);
+  }
+}
+
 export async function currentVersion() {
   const currentVersionText = await driver.find(".test-admin-panel-item-value-version").getText();
   const currentVersion = currentVersionText.match(/Version (.+)/)![1];

--- a/test/nbrowser/AuthProvider.ts
+++ b/test/nbrowser/AuthProvider.ts
@@ -1,11 +1,11 @@
-import { itemValue, toggleItem } from "test/nbrowser/AdminPanelTools";
+import { expandProviderList, itemValue, toggleItem } from "test/nbrowser/AdminPanelTools";
 import * as gu from "test/nbrowser/gristUtils";
 import { server, setupTestSuite } from "test/nbrowser/testUtils";
 import { serveSomething, Serving } from "test/server/customUtil";
 import * as testUtils from "test/server/testUtils";
 
 import * as express from "express";
-import { assert, driver } from "mocha-webdriver";
+import { assert, driver, WebElementPromise } from "mocha-webdriver";
 
 describe("AuthProvider", function() {
   this.timeout("2m");
@@ -153,8 +153,7 @@ describe("AuthProvider", function() {
       assert.equal(await itemValue("authentication"), "auth error");
     });
 
-    // We see 3 badges on OIDC provider: CONFIGURED, ACTIVE ON RESTART, and ERROR
-    assert.deepEqual(await badges("OIDC"), ["CONFIGURED", "ACTIVE", "ERROR"]);
+    assert.deepEqual(await badges("OIDC"), ["ACTIVE", "ERROR"]);
 
     // The 'Set as active method' button is not present, as it is already active.
     assert.isFalse(await activeButton("OIDC").isPresent(), "Set as active method button should not be present");
@@ -176,11 +175,11 @@ describe("AuthProvider", function() {
     await restartAdmin();
 
     // OIDC should still be active (but with error)
-    assert.deepEqual(await badges("OIDC"), ["CONFIGURED", "ACTIVE", "ERROR"]);
+    assert.deepEqual(await badges("OIDC"), ["ACTIVE", "ERROR"]);
 
     // ForwardAuth should now be configured and offer to switch
     await gu.waitToPass(async () => {
-      assert.deepEqual(await badges("Forwarded headers"), ["CONFIGURED"]);
+      assert.deepEqual(await badges("Forwarded headers"), []);
     }, 1000);
 
     // ForwardAuth should have "Set as active method" button since it's configured but not active
@@ -205,18 +204,21 @@ describe("AuthProvider", function() {
 
     // We should see "Active on restart" badge
     const forwardAuthBadges = await badges("Forwarded headers");
-    assert.includeMembers(forwardAuthBadges, ["CONFIGURED", "ACTIVE ON RESTART"]);
+    assert.includeMembers(forwardAuthBadges, ["ACTIVE ON RESTART"]);
 
     // OIDC should still be configured, and disabled on restart
     const oidcBadges = await badges("OIDC");
-    assert.includeMembers(oidcBadges, ["CONFIGURED", "DISABLED ON RESTART", "ERROR"]);
+    assert.includeMembers(oidcBadges, ["DISABLED ON RESTART", "ERROR"]);
 
     // But there should be a button to set it active again
     assert.isTrue(await activeButton("OIDC").isPresent());
   });
 });
 
-const providerRow = (text: string) => driver.findContentWait(".test-admin-auth-provider-row", text, 1000);
+const providerRow = (text: string) => new WebElementPromise(driver,
+  expandProviderList().then(() =>
+    driver.findContentWait(".test-admin-auth-provider-row", text, 1000),
+  ));
 
 const badges = (text: string) => providerRow(text).findAll(".test-admin-auth-badge", e => e.getText());
 

--- a/test/nbrowser/AuthProviderGetGrist.ts
+++ b/test/nbrowser/AuthProviderGetGrist.ts
@@ -1,5 +1,5 @@
 import { Activation } from "app/gen-server/entity/Activation";
-import { itemValue, toggleItem } from "test/nbrowser/AdminPanelTools";
+import { expandProviderList, itemValue, toggleItem } from "test/nbrowser/AdminPanelTools";
 import * as gu from "test/nbrowser/gristUtils";
 import { server, setupTestSuite } from "test/nbrowser/testUtils";
 import { Defer, serveSomething, Serving } from "test/server/customUtil";
@@ -115,9 +115,9 @@ describe("AuthProviderGetGrist", function() {
     await gu.waitForServer();
     await waitForModalToClose();
 
-    // We should see two badges: Configured and Active on restart. GetGrist.com was picked by order.
+    // We should see Active on restart badge. GetGrist.com was picked by order.
     const providerBadges = await badges();
-    assert.includeMembers(providerBadges, ["CONFIGURED", "ACTIVE ON RESTART"]);
+    assert.includeMembers(providerBadges, ["ACTIVE ON RESTART"]);
   });
 
   it("should store config in database", async function() {
@@ -138,6 +138,9 @@ describe("AuthProviderGetGrist", function() {
     await toggleItem("authentication");
     assert.equal(await itemValue("authentication"), "getgrist.com");
 
+    // Expand the provider list (collapsed when a real provider is active).
+    await expandProviderList();
+
     // And check that we still see at least 2 providers, including getgrist.com and OIDC
     const providerItems = await driver.findAll(".test-admin-auth-provider-row");
     assert.isAtLeast(providerItems.length, 2);
@@ -148,17 +151,69 @@ describe("AuthProviderGetGrist", function() {
     // Second one should be OIDC provider.
     assert.match(await providerItems[1].getText(), /OIDC/);
 
-    // The getgrist.com provider should have Active badge and Configured badge
+    // The getgrist.com provider should have Active badge
     const getGristRow = providerItems[0];
     const activeBadges = await getGristRow.findAll(".test-admin-auth-badge-active");
     assert.lengthOf(activeBadges, 1);
-    const configuredBadges = await getGristRow.findAll(".test-admin-auth-badge-configured");
-    assert.lengthOf(configuredBadges, 1);
 
     // Second one should have no badges
     const oidcRow = providerItems[1];
     const oidcBadges = await oidcRow.findAll(".test-admin-auth-badge");
     assert.lengthOf(oidcBadges, 0);
+  });
+
+  it("should deactivate getgrist.com and preserve config", async function() {
+    // The previous test left us on the admin panel with getgrist.com active.
+    // Click Deactivate on the hero card.
+    const deactivateButton = await driver.findWait(".test-admin-auth-hero-deactivate", 2000);
+    await deactivateButton.click();
+
+    // Confirm in the modal.
+    const confirmButton = await driver.findWait(".test-modal-confirm", 2000);
+    await confirmButton.click();
+    await gu.waitForServer();
+
+    // After deactivation, getgrist.com should show "Disabled on restart" badge.
+    await expandProviderList();
+    const getGristBadges = await badges();
+    assert.includeMembers(getGristBadges, ["DISABLED ON RESTART"]);
+
+    // The config should still be in the database (preserved, not deleted).
+    const db = await server.getDatabase();
+    const activation = await db.connection.manager.findOne(Activation, { where: {} });
+    assert.isDefined(activation!.prefs!.envVars!.GRIST_GETGRISTCOM_SECRET);
+
+    // After restart, should be back to no authentication.
+    await server.restart();
+    await server.simulateLogin("user1", process.env.GRIST_DEFAULT_EMAIL!, "docs");
+    await driver.get(`${server.getHost()}/admin`);
+    await gu.waitForAdminPanel();
+    await toggleItem("authentication");
+
+    await gu.waitToPass(async () => {
+      assert.equal(await itemValue("authentication"), "no authentication");
+    }, 500);
+
+    // Re-activate getgrist.com — it should still be configured (secret preserved).
+    await expandProviderList();
+    const setActiveButton = await providerRow().find(".test-admin-auth-set-active-button");
+    await setActiveButton.click();
+    const reactivateConfirm = await driver.findWait(".test-modal-confirm", 2000);
+    await reactivateConfirm.click();
+    await gu.waitForServer();
+
+    // Should now show "Active on restart".
+    const reactivatedBadges = await badges();
+    assert.includeMembers(reactivatedBadges, ["ACTIVE ON RESTART"]);
+
+    // Restart and verify it's active again.
+    await server.restart();
+    await server.removeLogin();
+    await server.simulateLogin("user1", process.env.GRIST_DEFAULT_EMAIL!, "docs");
+    await driver.get(`${server.getHost()}/admin`);
+    await gu.waitForAdminPanel();
+    await toggleItem("authentication");
+    assert.equal(await itemValue("authentication"), "getgrist.com");
   });
 
   it("should respect GRIST_GETGRISTCOM_SP_HOST env override", async function() {
@@ -193,6 +248,8 @@ async function waitForModalToClose() {
 }
 
 const providerRow = (n = 0) => new WebElementPromise(driver,
-  driver.findAll(".test-admin-auth-provider-row").then(rows => rows[n]));
+  expandProviderList().then(() =>
+    driver.findAll(".test-admin-auth-provider-row").then(rows => rows[n]),
+  ));
 
 const badges = (n = 0) => providerRow(n).findAll(".test-admin-auth-badge", e => e.getText());

--- a/test/nbrowser/QuickSetupAuth.ts
+++ b/test/nbrowser/QuickSetupAuth.ts
@@ -1,0 +1,126 @@
+import * as gu from "test/nbrowser/gristUtils";
+import { server, setupTestSuite } from "test/nbrowser/testUtils";
+import * as testUtils from "test/server/testUtils";
+
+import { assert, driver } from "mocha-webdriver";
+
+describe("QuickSetupAuth", function() {
+  this.timeout("2m");
+  setupTestSuite();
+  gu.bigScreen();
+
+  let oldEnv: testUtils.EnvironmentSnapshot;
+  const user = gu.translateUser("user1");
+
+  before(async function() {
+    oldEnv = new testUtils.EnvironmentSnapshot();
+    process.env.GRIST_DEFAULT_EMAIL = user.email;
+    process.env.GRIST_TEST_SERVER_DEPLOYMENT_TYPE = "core";
+    await server.restart();
+  });
+
+  after(async function() {
+    oldEnv.restore();
+    await server.restart(true);
+  });
+
+  async function navigateToAuthStep() {
+    await server.simulateLogin(user.name, user.email, "docs");
+    await driver.get(`${server.getHost()}/admin/setup`);
+    // Click the "Authentication" step label.
+    await driver.findContentWait("button", /Authentication/, 2000).click();
+  }
+
+  it("should show auth section on the Authentication step", async function() {
+    await navigateToAuthStep();
+
+    // Should show the hero card with the no-auth warning.
+    await gu.waitToPass(async () => {
+      const heroText = await driver.findWait(".test-admin-auth-hero-card", 2000).getText();
+      assert.match(heroText, /No authentication/);
+    }, 2000);
+
+    // Should show provider rows.
+    const rows = await driver.findAll(".test-admin-auth-provider-row");
+    assert.isAtLeast(rows.length, 2);
+  });
+
+  it("should disable Continue button when no auth is configured", async function() {
+    await navigateToAuthStep();
+
+    await gu.waitToPass(async () => {
+      const heroText = await driver.findWait(".test-admin-auth-hero-card", 2000).getText();
+      assert.match(heroText, /No authentication/);
+    }, 2000);
+
+    // Continue button should be present but disabled.
+    const continueBtn = await driver.findWait(".test-quick-setup-auth-continue", 2000);
+    assert.equal(await continueBtn.getAttribute("disabled"), "true");
+  });
+
+  it("should enable Continue and collapse providers after acknowledging no-auth", async function() {
+    // Check the "I understand" checkbox.
+    await driver.findWait(".test-admin-auth-no-auth-acknowledge", 2000).click();
+
+    // Continue button should now be enabled.
+    const continueBtn = await driver.find(".test-quick-setup-auth-continue");
+    await gu.waitToPass(async () => {
+      assert.equal(await continueBtn.getAttribute("disabled"), null);
+    }, 1000);
+
+    // Provider list should be collapsed.
+    const header = await driver.find(".test-admin-auth-provider-list-header");
+    assert.equal(await header.getAttribute("aria-expanded"), "false");
+
+    // Provider rows should not be visible.
+    assert.lengthOf(await driver.findAll(".test-admin-auth-provider-row"), 0);
+  });
+
+  it("should keep providers collapsed after page reload when no-auth is acknowledged", async function() {
+    // Reload the page — noAuthAcknowledged is persisted in localStorage.
+    await navigateToAuthStep();
+
+    await gu.waitToPass(async () => {
+      await driver.findWait(".test-admin-auth-hero-card", 2000);
+    }, 2000);
+
+    // Provider list should still be collapsed from the previous acknowledgment.
+    const header = await driver.findWait(".test-admin-auth-provider-list-header", 2000);
+    assert.equal(await header.getAttribute("aria-expanded"), "false");
+    assert.lengthOf(await driver.findAll(".test-admin-auth-provider-row"), 0);
+
+    // Uncheck to clean up for later tests.
+    await driver.find(".test-admin-auth-no-auth-acknowledge").click();
+    // Clear localStorage so it doesn't affect other test suites.
+    await driver.executeScript("window.localStorage.removeItem('noAuthAcknowledged');");
+  });
+
+  it("should enable Continue button when auth is configured but erroring", async function() {
+    process.env.GRIST_OIDC_IDP_ISSUER = "https://example.com";
+    process.env.GRIST_OIDC_IDP_CLIENT_ID = "test-id";
+    process.env.GRIST_OIDC_IDP_CLIENT_SECRET = "test-secret";
+    process.env.GRIST_OIDC_IDP_SKIP_END_SESSION_ENDPOINT = "true";
+    process.env.GRIST_OIDC_SP_HOST = "localhost";
+    await server.restart();
+    await navigateToAuthStep();
+
+    // OIDC is active but erroring (bad issuer). Continue should still be enabled.
+    const continueBtn = await driver.findWait(".test-quick-setup-auth-continue", 2000);
+    await gu.waitToPass(async () => {
+      assert.equal(await continueBtn.getAttribute("disabled"), null);
+    }, 2000);
+  });
+
+  it("should not show restart warning when auth changes are made", async function() {
+    // Reuses the OIDC env from the previous test.
+    await navigateToAuthStep();
+
+    // Wait for auth section to load.
+    await driver.findWait(".test-admin-auth-hero-card", 2000);
+
+    // The "Restart required" warning should NOT appear in the setup wizard.
+    const pageText = await driver.find("body").getText();
+    assert.notMatch(pageText, /Restart required/,
+      "Restart warning should not appear in setup wizard");
+  });
+});


### PR DESCRIPTION
Rework the auth section for better status communication, add getgrist.com deactivation, and wire it into the setup wizard.

## The big visual change: hero card

The old auth section opened with either a warning well ("No authentication: unrestricted sign-in as demo user") or nothing. Now there's always a hero card at the top with a colored left border showing the current state:

- **Green** — a real provider is active and working. Shows the provider name and a description like "Your server is configured to authenticate users via OpenID Connect."
- **Blue** — something's configured and will activate on restart.
- **Red/amber** — no real authentication. Red if unacknowledged, amber once the admin checks the "I understand" box. The text distinguishes boot-key ("using boot key as a fallback") from minimal ("anyone can access all data without signing in").
- **Red** — provider is active but has an error. Text now says "misconfigured or unreachable" instead of the old "reporting an error."

The hero also shows the installation admin email with a change button — previously this only appeared inside the restart warning.

## getgrist.com gets Reconfigure and Deactivate

When getgrist.com is the active provider, the hero card has two buttons. Reconfigure opens the same config modal as before. Deactivate is new — it switches to boot-key login while keeping the secret so you can reactivate later without re-pasting the key. There's a confirmation modal explaining this.

On the server side, the `set-active` endpoint now accepts `BOOT_KEY_PROVIDER_KEY` as a valid target (it used to reject anything not in `LOGIN_SYSTEMS`).

## Provider cards look different

The flat list of provider rows now has colored left borders matching their state (green/blue/red). Unconfigured providers show "Not yet configured. See setup guide." instead of nothing. The Configure button is disabled on whichever provider is currently active.

The old "Configured" badge is gone, because of the hero.

When a real provider is active, the provider list starts collapsed behind "Other authentication methods" with a chevron. Click or keyboard (Enter/Space) to expand. This keeps the focus on the hero card when things are working.

## Stale errors get suppressed

Previously, after changing a provider config, the old `activeError` from the previous boot would stick around confusingly. Now there's a `_recentlyConfigured` Set that tracks what you changed this session and hides the stale `activeError` for those providers. Only `configError` (from parsing the current config) is shown.

## It shows up in the setup wizard too

The auth section now renders on step 3 of `/admin/setup`. Same component, same code path. The restart warning is suppressed there (`showRestartWarning: false`) since the wizard does one restart at the end.

For now, QuickSetup got its own copy of the admin plumbing (InstallAPI, AdminChecks, boot probe) — same pattern as AdminInstallationPanel. The step card uses `plain: true` to drop the outer border so it doesn't look like a box inside a box.

## Architecture changes

The old code had all the rendering in private methods on the `AuthenticationSection` class. Now the rendering is in free functions (`buildHeroCard`, `buildProviderCard`, etc.) composed by `buildAuthSection` — one function that picks the hero, decides if the list should collapse, and wires everything up.

The class is a thin shell: it owns the observables, fetches data, and passes callbacks. The Storybook preview calls the same `buildAuthSection` with no-op callbacks. One code path for both.

Per-provider metadata (description, hero copy, docs URL) moved onto the modal classes as public properties. The old `PROVIDER_META` map is gone.

## New shared code

- `isRealProvider(key)` in loginProviders.ts — returns false for minimal, boot-key, no-logins, no-auth. Used by the hero picker and the collapsible list logic.
- `FALLBACK_PROVIDER_KEY` — what the server switches to on deactivation. Points to `BOOT_KEY_PROVIDER_KEY`.

## Storybook

New `storybook/authenticationSection.stories.ts` exercises all the hero and card states.
