### PR TITLE
Allow to open the row and column menus through keyboard shortcuts when in a grid view

### DIFF
--- a/app/client/components/GridView.ts
+++ b/app/client/components/GridView.ts
@@ -522,6 +522,21 @@ export default class GridView extends BaseView {
 
       this.viewSelectedRecordAsCard();
     },
+    openColumnMenu: function() {
+      const fieldIndex = this.cursor.fieldIndex();
+      this._scrollColumnIntoView(fieldIndex);
+      this.viewPane.querySelector<HTMLElement>(
+        `.column_name.field[data-col-index="${fieldIndex}"] .g-column-menu-btn`,
+      )?.click();
+    },
+    openRowMenu: function() {
+      const rowIndex = this.cursor.rowIndex();
+      if (rowIndex == null) {
+        return;
+      }
+      this.scrolly.scrollRowIntoView(rowIndex);
+      this.viewPane.querySelector<HTMLElement>(`.gridview_row[data-row-index="${rowIndex}"] .menu_toggle`)?.click();
+    },
   };
 
   protected onTableLoaded() {
@@ -1488,6 +1503,7 @@ export default class GridView extends BaseView {
                     dom.cls("font-italic", use => use(field.headerFontItalic) || false),
                     dom.cls("font-underline", use => use(field.headerFontUnderline) || false),
                     dom.cls("font-strikethrough", use => use(field.headerFontStrikethrough) || false),
+                    dom.attr("data-col-index", String(field._index())),
                     kd.style("--frozen-position", () => ko.unwrap(this.frozenPositions.at(field._index()!)!)),
                     kd.toggleClass("frozen", () => ko.unwrap(this.frozenMap.at(field._index()!)!)),
                     dom.autoDispose(isEditingLabel),
@@ -1639,6 +1655,7 @@ export default class GridView extends BaseView {
         dom.autoDispose(fontItalic),
         dom.autoDispose(fontUnderline),
         dom.autoDispose(fontStrikethrough),
+        dom.attr("data-row-index", String(row._index())),
 
         dom.cls("link_selector_row", use => use(this.isLinkSource) && use(isRowActive)),
         dom.cls("highlight_match_row", (use) => {

--- a/app/client/components/commandList.ts
+++ b/app/client/components/commandList.ts
@@ -127,6 +127,8 @@ export type CommandName =
   "activateAssistant" |
   "viewAsCard" |
   "openContextMenu" |
+  "openColumnMenu" |
+  "openRowMenu" |
   "showColumns" |
   "createForm" |
   "insertField" |
@@ -434,6 +436,14 @@ export const groups: CommendGroupDef[] = [{
       name: "openContextMenu",
       keys: [{ default: "Menu", mac: "Ctrl+Enter" }, "Shift+F10"],
       desc: () => t("Open the context menu"),
+    }, {
+      name: "openColumnMenu",
+      keys: [{ default: "Ctrl+Menu", mac: "Ctrl+Shift+Enter" }, "Ctrl+Shift+F10"],
+      desc: () => t("Open the current column menu"),
+    }, {
+      name: "openRowMenu",
+      keys: [{ default: "Alt+Menu", mac: "Ctrl+Alt+Enter" }, "Alt+Shift+F10"],
+      desc: () => t("Open the current row menu"),
     },
   ],
 }, {

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -2622,7 +2622,9 @@
         "showing a behavioral popup": "showing a behavioral popup",
         "Filter this column by just this cell's value": "Filter this column by just this cell's value",
         "Open the context menu": "Open the context menu",
-        "Toggle the screen reader improvements": "Toggle the screen reader improvements"
+        "Toggle the screen reader improvements": "Toggle the screen reader improvements",
+        "Open the current column menu": "Open the current column menu",
+        "Open the current row menu": "Open the current row menu"
     },
     "GridViewMenusDateHelpers": {
         "12-hour format": "12-hour format",

--- a/static/locales/fr.client.json
+++ b/static/locales/fr.client.json
@@ -2617,7 +2617,9 @@
         "showing a behavioral popup": "affichage d'une fenêtre contextuelle comportementale",
         "Filter this column by just this cell's value": "Filtrer cette colonne par la valeur de cette cellule uniquement",
         "Open the context menu": "Ouvrir le menu contextuel",
-        "Toggle the screen reader improvements": "Activer ou désactiver les améliorations pour lecteurs d'écran"
+        "Toggle the screen reader improvements": "Activer ou désactiver les améliorations pour lecteurs d'écran",
+        "Open the current column menu": "Ouvrir le menu de la colonne actuelle",
+        "Open the current row menu": "Ouvrir le menu de la ligne actuelle"
     },
     "GridViewMenusDateHelpers": {
         "12-hour format": "format 12-heures",

--- a/test/nbrowser/ViewContextMenu.ts
+++ b/test/nbrowser/ViewContextMenu.ts
@@ -15,12 +15,12 @@ describe("ViewContextMenu", function() {
   afterEach(() => gu.checkForErrors());
 
   it("should support opening a GridView cell context menu with keyboard", async function() {
-    await assertShiftF10Works();
+    await assertShortcutWorks(Key.chord(Key.SHIFT, Key.F10), "Clear cell");
   });
 
   it("should support opening a RecordView context menu with keyboard", async function() {
     await gu.addNewSection("Card", "Table1");
-    await assertShiftF10Works();
+    await assertShortcutWorks(Key.chord(Key.SHIFT, Key.F10), "Clear field");
   });
 
   it("should not open a context menu twice when opening it with keyboard", async function() {
@@ -41,17 +41,31 @@ describe("ViewContextMenu", function() {
     await gu.selectSectionByTitle("Table1");
     await gu.waitForMenuToClose();
   });
+
+  it("should support opening a GridView column context menu with keyboard", async function() {
+    await assertShortcutWorks(Key.chord(Key.CONTROL, Key.SHIFT, Key.F10), "Column Options");
+  });
+
+  it("should support opening a GridView row context menu with keyboard", async function() {
+    await assertShortcutWorks(Key.chord(Key.ALT, Key.SHIFT, Key.F10), "Duplicate row");
+  });
 });
 
-async function assertShiftF10Works() {
+// Make sure a given keyboard shortcut opens a menu containing a given item.
+async function assertShortcutWorks(shortcut: string, menuItemToTest: string) {
   await gu.waitAppFocus();
-  await pressShiftF10();
+  await pressShortcut(shortcut);
   assert.isTrue(await gu.findOpenMenu().isDisplayed());
+  await gu.findOpenMenuItem("li", menuItemToTest);
   await gu.sendKeys(Key.ESCAPE);
   await gu.waitForMenuToClose();
 }
 
-// Using gu.sendKeys doesn't work with Shift+F10 so we have to deal with the testing environment limitations.
+// Using gu.sendKeys doesn't work with Shift+F10 and similar shortcuts,
+// so we have to deal with the testing environment limitations.
+async function pressShortcut(shortcut: string, inMenu: boolean = false) {
+  await driver.find(inMenu ? ".grist-floating-menu" : ".copypaste").sendKeys(shortcut);
+}
 async function pressShiftF10(inMenu: boolean = false) {
-  return driver.find(inMenu ? ".grist-floating-menu" : ".copypaste").sendKeys(Key.chord(Key.SHIFT, Key.F10));
+  return pressShortcut(Key.chord(Key.SHIFT, Key.F10), inMenu);
 }


### PR DESCRIPTION
> [!WARNING]
> ~This is a follow-up to [an already opened PR](https://github.com/gristlabs/grist-core/pull/2226) and since I can't make PRs to grist-core pointing to branches on my own fork… [You should review this PR by filtering code on the latest commit](https://[github.com/gristlabs/grist-core/pull/2230/changes/cdadf0cd8d573c0f823d639bbfa907b2adf17b1a](https://github.com/gristlabs/grist-core/pull/2230/changes/36e10abb14768f1ec09130b33102fff75ff5893a)).~
> Update: since the first PR got merged, this is now ready.

## Context

For now, in a grid, it's impossible to open the current row menu, or current column menu (the menus appearing when right-cliking the row/col headers, or clicking their down-arrow button).

This adds specific keyboard shortcuts, that somewhat "extend" the default context menu shortcut, to allow that.

## Proposed solution

The proposed solution allows users to : 

- press Ctrl+Menu (or Ctrl+Shift+Enter on mac), or Ctrl+Shift+F10 to open the column menu,
- press Alt+Menu (or Ctrl+Alt+Enter on mac), or Alt+Shift+F10 to open the row menu.

[The implementation](https://github.com/gristlabs/grist-core/pull/2230/changes/36e10abb14768f1ec09130b33102fff75ff5893a) is a bit of a trick, but I allowed myself to code it like that on purpose. Coding things in the more usual "JS way" implied modifying a non-trivial amount of code just for this specific, contained use-case. I quote here what I already wrote in the commit message:

> Since column and row context menus are noticeably tied to the DOM
building, we'd rather just simulate clicks on the correct elements for
this particular kb case, than refactor a whole bunch of code, making the
code more complex for little benefit. This is already the logic followed
for a few cases here and there in the code.

## Related issues

This PR is actually a continuation of [this one](https://github.com/gristlabs/grist-core/pull/2226).

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
