### PR TITLE
replace a deep link into grist-ee repo in documentation with a public link

### DIFF
--- a/documentation/database.md
+++ b/documentation/database.md
@@ -287,7 +287,7 @@ Stores `users` information.
 | disabled_at | If not null, the date at which the user was disabled |
 | is_first_time_user | Whether the user discovers Grist (used to trigger the Welcome Tour) |
 | options | Serialized options as described in [UserOptions](https://github.com/gristlabs/grist-core/blob/513e13e6ab57c918c0e396b1d56686e45644ee1a/app/common/UserAPI.ts#L169-L179) interface |
-| connect_id | Used by [GristConnect](https://support.getgrist.com/install/grist-connect/) in full Grist edition to identify user in external provider |
+| connect_id | Used by [GristConnect](https://support.getgrist.com/install/grist-connect/) in the full edition of Grist to identify user in external provider |
 | ref | Used to identify a user in the automated tests |
 
 ### `logins` table


### PR DESCRIPTION
The documentation includes mention of an arcane column used by an arcane auth mechanism and links deep into the grist-ee repo. Change the link to the best documentation for the auth mechanism.
