### PR TITLE
Fix GranularAccess flakiness

### DIFF
--- a/test/nbrowser/GranularAccess.ts
+++ b/test/nbrowser/GranularAccess.ts
@@ -901,7 +901,7 @@ describe("GranularAccess", function() {
       assert.isFalse(await driver.find(".test-notifier-toast-wrapper").isPresent());
       await cell.click();
       await gu.waitAppFocus();
-      await gu.sendKeys("XYZ");
+      await gu.enterCell(["XYZ"], { validate: false });
       if (save === "enter") {
         await gu.sendKeys(Key.ENTER);
       } else {
@@ -1093,7 +1093,7 @@ describe("GranularAccess", function() {
     // Check anon can create a fork.
     await anon.loadDoc(`/doc/${doc.id}/m/fork?aclUI=1`);
     await gu.getCell({ rowNum: 1, col: 0 }).click();
-    await gu.sendKeys("Testing2", Key.ENTER);
+    await gu.enterCell("Testing2");
     await gu.waitForServer(10000);
     assert.equal(await gu.getCell({ rowNum: 1, col: 0 }).getText(), "Testing2");
     const forkUrl = await driver.getCurrentUrl();


### PR DESCRIPTION
## Context

Some flakiness of GranularAccess fixed again. See this job run for example:
https://github.com/gristlabs/grist-core/actions/runs/23862292280/job/69571941365

## Proposed solution

Use `enterCell` when modifying cell content in this test file.

## Related issues

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
