### PR TITLE
Add eslint rule make t calls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: [3.11]
         node-version: [22.x]
         tests:
-          - ':lint:python:client:common:smoke:stubs:pyodide:'
+          - ':lint:python:client:common:smoke:stubs:pyodide:eslint-unit:'
           - ':server-1-of-2:'
           - ':server-2-of-2:'
           - ':gen-server:'
@@ -206,6 +206,10 @@ jobs:
           MOCHA_WEBDRIVER_LOGDIR: ${{ runner.temp }}/test-logs/webdriver
           TESTDIR: ${{ runner.temp }}/test-logs
           MOCHA_WEBDRIVER_HEADLESS: 1
+
+      - name: Run eslint unit tests for custom rules
+        if: contains(matrix.tests, ':eslint-unit:')
+        run: yarn run test:eslint
 
       - name: Prepare for saving artifact
         if: failure()

--- a/app/client/aclui/ACLUsers.ts
+++ b/app/client/aclui/ACLUsers.ts
@@ -18,7 +18,7 @@ import { Disposable, dom, Observable, styled } from "grainjs";
 import noop from "lodash/noop";
 import { cssMenu, cssMenuWrap, defaultMenuOptions, IMenuOptions, IPopupOptions, setPopupToCreateDom } from "popweasel";
 
-const t = makeT("ViewAsDropdown");
+const t = makeT("ACLUsers");
 const userT = makeT("UserManagerModel");
 
 function isSpecialEmail(email: string) {

--- a/app/client/components/Drafts.ts
+++ b/app/client/components/Drafts.ts
@@ -11,7 +11,7 @@ import {
   IDomArgs, MultiHolder, styled, TagElem,
 } from "grainjs";
 
-const t = makeT("components.Drafts");
+const t = makeT("Drafts");
 
 /**
  * Component that keeps track of editor's state (draft value). If user hits an escape button

--- a/app/client/components/buildViewSectionDom.ts
+++ b/app/client/components/buildViewSectionDom.ts
@@ -17,7 +17,7 @@ import { undef } from "app/common/gutil";
 import { Computed, dom, DomElementArg, Observable, styled } from "grainjs";
 import { defaultMenuOptions } from "popweasel";
 
-const t = makeT("ViewSection");
+const t = makeT("buildViewSectionDom");
 
 export function buildCollapsedSectionDom(options: {
   gristDoc: GristDoc,

--- a/app/client/models/ToggleEnterpriseModel.ts
+++ b/app/client/models/ToggleEnterpriseModel.ts
@@ -9,7 +9,7 @@ import { getGristConfig } from "app/common/urlUtils";
 
 import { Disposable, Observable } from "grainjs";
 
-const t = makeT("ToggleEnterprise");
+const t = makeT("ToggleEnterpriseModel");
 
 export class ToggleEnterpriseModel extends Disposable {
   public readonly edition: Observable<GristDeploymentType | null> = Observable.create(this, null);

--- a/app/client/ui/AdminLeftPanel.ts
+++ b/app/client/ui/AdminLeftPanel.ts
@@ -15,7 +15,7 @@ import { Computed, dom, DomContents, MultiHolder, Observable, styled } from "gra
 
 import type { AppModel } from "app/client/models/AppModel";
 
-const t = makeT("AdminPanel");
+const t = makeT("AdminLeftPanel");
 const testId = makeTestId("test-admin-controls-");
 
 // Check if the AdminControls feature is available, so that we can show it as such in the UI.

--- a/app/client/ui/AdminPanelName.ts
+++ b/app/client/ui/AdminPanelName.ts
@@ -3,7 +3,7 @@
 
 import { makeT } from "app/client/lib/localization";
 
-const t = makeT("AdminPanel");
+const t = makeT("AdminPanelName");
 
 // Translated "Admin Panel" name, made available to other modules.
 export function getAdminPanelName() {

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -30,7 +30,7 @@ import {
 
 import { Computed, Disposable, dom, makeTestId, Observable, styled } from "grainjs";
 
-const t = makeT("AdminPanel");
+const t = makeT("AuthenticationSection");
 
 const testId = makeTestId("test-admin-auth-");
 

--- a/app/client/ui/Automations/TriggersPageUpsell.ts
+++ b/app/client/ui/Automations/TriggersPageUpsell.ts
@@ -12,7 +12,7 @@ import { dom, DomContents, makeTestId, styled } from "grainjs";
 
 const testId = makeTestId("test-automations-");
 
-const t = makeT("TriggersPage");
+const t = makeT("TriggersPageUpsell");
 
 export function buildAutomationsUpsell(appModel: AppModel): DomContents {
   const { deploymentType } = getGristConfig();

--- a/app/client/ui/AutomationsPageEntry.ts
+++ b/app/client/ui/AutomationsPageEntry.ts
@@ -15,7 +15,7 @@ import { isFeatureEnabled } from "app/common/gristUrls";
 import { DomContents, makeTestId, styled } from "grainjs";
 
 const testId = makeTestId("test-tools-");
-const t = makeT("Tools");
+const t = makeT("AutomationsPageEntry");
 
 /**
  * Return the page entry for automations, except when inappliable or explicitly disabled.

--- a/app/client/ui/FilterConfig.ts
+++ b/app/client/ui/FilterConfig.ts
@@ -13,7 +13,7 @@ import { IMenuOptions } from "popweasel";
 
 const testId = makeTestId("test-filter-config-");
 
-const t = makeT("SortConfig");
+const t = makeT("FilterConfig");
 
 export interface FilterConfigOptions {
   /** Options to pass to the menu and popup components. */

--- a/app/client/ui/GetGristComProvider.ts
+++ b/app/client/ui/GetGristComProvider.ts
@@ -15,7 +15,7 @@ import { getGristConfig } from "app/common/urlUtils";
 
 import { Disposable, dom, makeTestId, Observable, styled } from "grainjs";
 
-const t = makeT("AdminPanel");
+const t = makeT("GetGristComProvider");
 
 const testId = makeTestId("test-admin-auth-");
 

--- a/app/client/ui/GridViewMenusDateHelpers.ts
+++ b/app/client/ui/GridViewMenusDateHelpers.ts
@@ -18,7 +18,7 @@ import { dom, styled } from "grainjs";
 import moment from "moment-timezone";
 import * as weasel from "popweasel";
 
-const t = makeT("GridViewMenus");
+const t = makeT("GridViewMenusDateHelpers");
 
 // Formula constants - uses $Column as placeholder for column ID
 const FORMULAS = {

--- a/app/client/ui/RightPanelUtils.ts
+++ b/app/client/ui/RightPanelUtils.ts
@@ -5,7 +5,7 @@ import { IWidgetType } from "app/common/widgetTypes";
 
 import { dom, DomElementArg } from "grainjs";
 
-const t = makeT("RightPanel");
+const t = makeT("RightPanelUtils");
 
 // Returns the icon and label of a type, default to those associate to 'record' type.
 export function getFieldType(widgetType: IWidgetType | null) {

--- a/app/client/ui/RightPanelUtils.ts
+++ b/app/client/ui/RightPanelUtils.ts
@@ -5,18 +5,30 @@ import { IWidgetType } from "app/common/widgetTypes";
 
 import { dom, DomElementArg } from "grainjs";
 
-const t = makeT("RightPanelUtils");
+const rpanelT = makeT("RightPanel");
 
 // Returns the icon and label of a type, default to those associate to 'record' type.
 export function getFieldType(widgetType: IWidgetType | null) {
   // A map of widget type to the icon and label to use for a field of that widget.
   const fieldTypes = new Map<IWidgetType, { label: string; icon: IconName; pluralLabel: string; }>([
-    ["record", { label: t("columns", { count: 1 }), icon: "TypeCell", pluralLabel: t("columns", { count: 2 }) }],
-    ["detail", { label: t("fields", { count: 1 }), icon: "TypeCell", pluralLabel: t("fields", { count: 2 }) }],
-    ["single", { label: t("fields", { count: 1 }), icon: "TypeCell", pluralLabel: t("fields", { count: 2 }) }],
-    ["chart", { label: t("series", { count: 1 }), icon: "ChartLine", pluralLabel: t("series", { count: 2 }) }],
-    ["custom", { label: t("columns", { count: 1 }), icon: "TypeCell", pluralLabel: t("columns", { count: 2 }) }],
-    ["form", { label: t("fields", { count: 1 }), icon: "TypeCell", pluralLabel: t("fields", { count: 2 }) }],
+    ["record", {
+      label: rpanelT("columns", { count: 1 }), icon: "TypeCell", pluralLabel: rpanelT("columns", { count: 2 }),
+    }],
+    ["detail", {
+      label: rpanelT("fields", { count: 1 }), icon: "TypeCell", pluralLabel: rpanelT("fields", { count: 2 }),
+    }],
+    ["single", {
+      label: rpanelT("fields", { count: 1 }), icon: "TypeCell", pluralLabel: rpanelT("fields", { count: 2 }),
+    }],
+    ["chart", {
+      label: rpanelT("series", { count: 1 }), icon: "ChartLine", pluralLabel: rpanelT("series", { count: 2 }),
+    }],
+    ["custom", {
+      label: rpanelT("columns", { count: 1 }), icon: "TypeCell", pluralLabel: rpanelT("columns", { count: 2 }),
+    }],
+    ["form", {
+      label: rpanelT("fields", { count: 1 }), icon: "TypeCell", pluralLabel: rpanelT("fields", { count: 2 }),
+    }],
   ]);
 
   return fieldTypes.get(widgetType || "record") || fieldTypes.get("record")!;

--- a/app/client/ui/SupportGristButton.ts
+++ b/app/client/ui/SupportGristButton.ts
@@ -13,7 +13,7 @@ import { getGristConfig } from "app/common/urlUtils";
 
 import { Computed, Disposable, dom, DomContents, Observable, styled } from "grainjs";
 
-const t = makeT("SupportGristNudge");
+const t = makeT("SupportGristButton");
 
 /**
  * Button that nudges users to support Grist by opting in to telemetry or sponsoring on Github.

--- a/app/client/ui/buildReassignModal.ts
+++ b/app/client/ui/buildReassignModal.ts
@@ -14,7 +14,7 @@ import { decodeObject, encodeObject } from "app/plugin/objtypes";
 import { dom, Observable, styled } from "grainjs";
 import mapValues from "lodash/mapValues";
 
-const t = makeT("ReassignModal");
+const t = makeT("buildReassignModal");
 
 /**
  * Builds a modal that shows the user that they can't reassign records because of uniqueness

--- a/eslint-rules/local-rules.js
+++ b/eslint-rules/local-rules.js
@@ -9,6 +9,7 @@ module.exports = {
           description:
             "Enforce that makeT() is called with the filename (without extension) as its first argument",
         },
+        fixable: "code",
         schema: [],
         messages: {
           mismatch:
@@ -24,7 +25,7 @@ module.exports = {
             if (
               node.callee.type === "Identifier" &&
               node.callee.name === "makeT" &&
-              node.arguments.length > 0 &&
+              node.arguments.length === 1 &&
               node.arguments[0].type === "Literal" &&
               typeof node.arguments[0].value === "string" &&
               node.arguments[0].value !== expected
@@ -36,6 +37,9 @@ module.exports = {
                   actual: node.arguments[0].value,
                   expected,
                 },
+                *fix(fixer) {
+                  yield fixer.replaceText(node.arguments[0], `"${expected}"`);
+                }
               });
             }
           },

--- a/eslint-rules/local-rules.js
+++ b/eslint-rules/local-rules.js
@@ -1,0 +1,46 @@
+const path = require("path");
+
+module.exports = {
+  rules: {
+    "makeT-filename": {
+      meta: {
+        type: "problem",
+        docs: {
+          description:
+            "Enforce that makeT() is called with the filename (without extension) as its first argument",
+        },
+        schema: [],
+        messages: {
+          mismatch:
+            "makeT() argument '{{actual}}' does not match the filename '{{expected}}'",
+        },
+      },
+      create(context) {
+        const filename = context.filename ?? context.getFilename();
+        const expected = path.basename(filename, path.extname(filename));
+
+        return {
+          CallExpression(node) {
+            if (
+              node.callee.type === "Identifier" &&
+              node.callee.name === "makeT" &&
+              node.arguments.length > 0 &&
+              node.arguments[0].type === "Literal" &&
+              typeof node.arguments[0].value === "string" &&
+              node.arguments[0].value !== expected
+            ) {
+              context.report({
+                node: node.arguments[0],
+                messageId: "mismatch",
+                data: {
+                  actual: node.arguments[0].value,
+                  expected,
+                },
+              });
+            }
+          },
+        };
+      },
+    },
+  },
+};

--- a/eslint-rules/local-rules.js
+++ b/eslint-rules/local-rules.js
@@ -7,7 +7,7 @@ module.exports = {
         type: "problem",
         docs: {
           description:
-            "Enforce that makeT() is called with the filename (without extension) as its first argument",
+            "Enforce that `makeT()` is called with the filename (without extension) as its first argument when its results is assigned to `t`",
         },
         fixable: "code",
         schema: [],
@@ -25,6 +25,8 @@ module.exports = {
             if (
               node.callee.type === "Identifier" &&
               node.callee.name === "makeT" &&
+              node.parent.type === "VariableDeclarator" &&
+              node.parent.id.name === "t" &&
               node.arguments.length === 1 &&
               node.arguments[0].type === "Literal" &&
               typeof node.arguments[0].value === "string" &&

--- a/eslint-rules/local-rules.js
+++ b/eslint-rules/local-rules.js
@@ -17,7 +17,7 @@ module.exports = {
         },
       },
       create(context) {
-        const filename = context.filename ?? context.getFilename();
+        const filename = context.filename;
         const expected = path.basename(filename, path.extname(filename));
 
         return {

--- a/eslint-rules/local-rules.js
+++ b/eslint-rules/local-rules.js
@@ -7,7 +7,7 @@ module.exports = {
         type: "problem",
         docs: {
           description:
-            "Enforce that `makeT()` is called with the filename (without extension) as its first argument when its results is assigned to `t`",
+            "Enforce that `makeT()` is called with the filename (without extension) as its first argument when its result is assigned to `t`",
         },
         fixable: "code",
         schema: [],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ const path = require("path");
 
 const babelParser = require("@babel/eslint-parser");
 const js = require("@eslint/js");
+const localRules = require("./eslint-rules/local-rules");
 const stylistic = require("@stylistic/eslint-plugin");
 const tsParser = require("@typescript-eslint/parser");
 const typescriptEslint = require("@typescript-eslint/eslint-plugin");
@@ -107,6 +108,7 @@ module.exports = defineConfig([
       "@typescript-eslint": typescriptEslint,
       "@stylistic": stylistic,
       "@import-x": importX,
+      "local": localRules,
     },
 
     ignores: [
@@ -287,6 +289,8 @@ module.exports = defineConfig([
       "@typescript-eslint/no-unsafe-function-type": "off",
       "@typescript-eslint/no-base-to-string": "off",
       "@typescript-eslint/no-unsafe-enum-comparison": "off",
+
+      "local/makeT-filename": "error",
     },
   },
 ]);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:smoke": "./test/test_env.sh mocha _build/test/nbrowser/Smoke.js",
     "test:docker": "./test/test_under_docker.sh",
     "test:python": "sandbox_venv3/bin/python sandbox/grist/runtests.py ${GREP_TESTS:+discover -p \"test*${GREP_TESTS}*.py\"}",
+    "test:eslint": "NODE_PATH=_build node _build/test/eslint-rules/index.js",
     "cli": "./app/cli.sh",
     "lint": "eslint --max-warnings=0 --cache --cache-strategy content .",
     "lint:fix": "eslint --max-warnings=0 --cache --cache-strategy=content --fix .",

--- a/test/eslint-rules/index.ts
+++ b/test/eslint-rules/index.ts
@@ -1,0 +1,5 @@
+console.info("");
+console.info("Running Eslint custom rules non-regression tests");
+console.info("👉 If you just want to lint your code, please run `yarn lint` instead");
+console.info("");
+export * from "test/eslint-rules/makeT-rule";

--- a/test/eslint-rules/makeT-rule.ts
+++ b/test/eslint-rules/makeT-rule.ts
@@ -1,0 +1,37 @@
+import { RuleTester } from "eslint";
+import localRules from "eslint-rules/local-rules";
+
+const ruleTester = new RuleTester();
+
+// Throws error if the tests in ruleTester.run() do not pass
+ruleTester.run(
+  "makeT-filename", // rule name
+  localRules.rules["makeT-filename"] as any, // rule code.
+  {
+    // 'valid' checks cases that should pass
+    valid: [
+      {
+        name: "passes when makeT() is called with a scope corresponding to the filename",
+        filename: "app/client/ui/App.ts",
+        code: `const t = makeT("App");`,
+      },
+      {
+        name: "passes when makeT() is assigned to a variable not named `t`",
+        filename: "app/client/ui/Foo.ts",
+        code: `const t = makeT("Foo"); const appT = makeT("App");`,
+      },
+    ],
+    // 'invalid' checks cases that should not pass
+    invalid: [
+      {
+        name: "fails when makeT() is called with a scope differing with the filename",
+        filename: "app/client/ui/App.ts",
+        code: `const t = makeT("Foo");`,
+        output: `const t = makeT("App");`,
+        errors: 1,
+      },
+    ],
+  },
+);
+
+console.info("✅ makeT-rule: All tests passed!");

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,6 +3,7 @@
   "include": [
     "*",
     "**/*",
+    "../eslint-rules/**/*.js",
     "../app/client/declarations.d.ts",
     "../app/common/declarations.d.ts",
     "../app/server/declarations.d.ts",


### PR DESCRIPTION
## Context

Some translations are not taken into account. See #2236.

This is due to the fact that the collection of the translation keys ([which scans the call to the `t()` function](https://github.com/gristlabs/grist-core/blob/c6e9ca9f24972dcedaeffc35ecdb275d7b213239/buildtools/generate_translation_keys.js#L59)) assumes that [the scope of the translation key is the filename without the extension](https://github.com/gristlabs/grist-core/blob/c6e9ca9f24972dcedaeffc35ecdb275d7b213239/buildtools/generate_translation_keys.js#L32).

## Proposed solution

I suggest to make an Eslint rule to enforce calls to `makeT` function to have its first argument match the filename without the extension.

I exclude the case where `makeT` is called with a second argument (the instance) and also when it is not assigned to a variable named `t` (some files have two calls to `makeT` to reuse translations of other files).

Also I implement an autofix to ease everyone's life on it, even though translation keys have to be moved in every json when someone rename a code file.

~~This PR does not fix the errors yet, so the CI will fail, I will do that once the PR is approved.~~
This PR also fixes the errors reported by the linter.

PS: The first commit has been implemented by Copilot (Claude Code, sonnet 4.6).

## Related issues

#2236

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->