### PR TITLE
Add Record _asdict and to_dict helpers

### DIFF
--- a/sandbox/grist/records.py
+++ b/sandbox/grist/records.py
@@ -114,6 +114,14 @@ class Record(object):
     # non-zero rowId which has just been deleted.
     return self._row_id in self._table.row_ids
 
+  def _asdict(self, dates_as_iso=False, expand_refs=0):
+    # Keep behavior aligned with RECORD(rec, ...), including dependency tracking and cycle guards.
+    from functions.info import RECORD
+    return RECORD(self, dates_as_iso=dates_as_iso, expand_refs=expand_refs)
+
+  def to_dict(self, dates_as_iso=False, expand_refs=0):
+    return self._asdict(dates_as_iso=dates_as_iso, expand_refs=expand_refs)
+
   def _clone_with_relation(self, src_relation):
     return self._table.Record(self._row_id,
                               relation=src_relation.compose(self._source_relation))

--- a/sandbox/grist/test_record_func.py
+++ b/sandbox/grist/test_record_func.py
@@ -46,6 +46,96 @@ class TestRecordFunc(test_engine.EngineTestCase):
       [4,     {'address': RecordStub('Address', 14), 'Bar': 4, 'id': 4, 'name': 'Yale'}],
     ])
 
+  def test_record_methods_match_record(self):
+    self.load_sample(testsamples.sample_students)
+
+    expected = [
+      [1, {'address': RecordStub('Address', 11), 'id': 1, 'name': 'Columbia'}],
+      [2, {'address': RecordStub('Address', 12), 'id': 2, 'name': 'Columbia'}],
+      [3, {'address': RecordStub('Address', 13), 'id': 3, 'name': 'Yale'}],
+      [4, {'address': RecordStub('Address', 14), 'id': 4, 'name': 'Yale'}],
+    ]
+
+    self.add_column("Schools", "Foo", formula='rec._asdict()')
+    self.assertPartialData("Schools", ["id", "Foo"], expected)
+
+    self.modify_column("Schools", "Foo", formula='RECORD(rec)')
+    self.assertPartialData("Schools", ["id", "Foo"], expected)
+
+    self.modify_column("Schools", "Foo", formula='rec.to_dict()')
+    self.assertPartialData("Schools", ["id", "Foo"], expected)
+
+    # Ensure updates continue to work through method-based conversion
+    self.update_record("Schools", 3, name="UConn")
+    self.assertPartialData("Schools", ["id", "Foo"], [
+      [1, {'address': RecordStub('Address', 11), 'id': 1, 'name': 'Columbia'}],
+      [2, {'address': RecordStub('Address', 12), 'id': 2, 'name': 'Columbia'}],
+      [3, {'address': RecordStub('Address', 13), 'id': 3, 'name': 'UConn'}],
+      [4, {'address': RecordStub('Address', 14), 'id': 4, 'name': 'Yale'}],
+    ])
+
+    self.add_column("Schools", "Bar", formula='len($name)')
+    self.assertPartialData("Schools", ["id", "Foo"], [
+      [1, {'address': RecordStub('Address', 11), 'Bar': 8, 'id': 1, 'name': 'Columbia'}],
+      [2, {'address': RecordStub('Address', 12), 'Bar': 8, 'id': 2, 'name': 'Columbia'}],
+      [3, {'address': RecordStub('Address', 13), 'Bar': 5, 'id': 3, 'name': 'UConn'}],
+      [4, {'address': RecordStub('Address', 14), 'Bar': 4, 'id': 4, 'name': 'Yale'}],
+    ])
+
+  def test_record_methods_match_record_options(self):
+    self.load_sample(testsamples.sample_students)
+    self.add_column("Schools", "Foo", formula='rec._asdict(expand_refs=1)')
+    self.add_column("Address", "student", type="Ref:Students")
+    self.update_record("Address", 12, student=6)
+
+    expected_expand_refs = [
+      [1, {'address': {'city': 'New York', 'id': 11, 'student': RecordStub("Students", 0)},
+        'id': 1, 'name': 'Columbia'}],
+      [2, {'address': {'city': 'Colombia', 'id': 12, 'student': RecordStub("Students", 6)},
+        'id': 2, 'name': 'Columbia'}],
+      [3, {'address': {'city': 'New Haven', 'id': 13, 'student': RecordStub("Students", 0)},
+        'id': 3, 'name': 'Yale'}],
+      [4, {'address': {'city': 'West Haven', 'id': 14, 'student': RecordStub("Students", 0)},
+        'id': 4, 'name': 'Yale'}],
+    ]
+
+    self.assertPartialData("Schools", ["id", "Foo"], expected_expand_refs)
+    self.modify_column("Schools", "Foo", formula='RECORD(rec, expand_refs=1)')
+    self.assertPartialData("Schools", ["id", "Foo"], expected_expand_refs)
+    self.modify_column("Schools", "Foo", formula='rec.to_dict(expand_refs=1)')
+    self.assertPartialData("Schools", ["id", "Foo"], expected_expand_refs)
+
+    self.add_column("Address", "DT", type='DateTime')
+    self.add_column("Address", "D", type='Date', formula="$DT and $DT.date()")
+    self.update_records("Address", ['id', 'DT'], [
+      [11, 1600000000],
+      [13, 1500000000],
+    ])
+
+    d1 = datetime.datetime(2020, 9, 13, 8, 26, 40, tzinfo=moment.tzinfo('America/New_York'))
+    d2 = datetime.datetime(2017, 7, 13, 22, 40, tzinfo=moment.tzinfo('America/New_York'))
+    expected_iso_dates = [
+      [1, {'address': {'city': 'New York', 'DT': d1.isoformat(), 'id': 11,
+                       'D': d1.date().isoformat(), 'student': RecordStub("Students", 0)},
+           'id': 1, 'name': 'Columbia'}],
+      [2, {'address': {'city': 'Colombia', 'DT': None, 'id': 12, 'D': None,
+                       'student': RecordStub("Students", 6)},
+           'id': 2, 'name': 'Columbia'}],
+      [3, {'address': {'city': 'New Haven', 'DT': d2.isoformat(), 'id': 13,
+                       'D': d2.date().isoformat(), 'student': RecordStub("Students", 0)},
+           'id': 3, 'name': 'Yale'}],
+      [4, {'address': {'city': 'West Haven', 'DT': None, 'id': 14, 'D': None,
+                       'student': RecordStub("Students", 0)},
+           'id': 4, 'name': 'Yale'}],
+    ]
+
+    self.modify_column("Schools", "Foo", formula='rec._asdict(expand_refs=1, dates_as_iso=True)')
+    self.assertPartialData("Schools", ["id", "Foo"], expected_iso_dates)
+    self.modify_column("Schools", "Foo", formula='RECORD(rec, expand_refs=1, dates_as_iso=True)')
+    self.assertPartialData("Schools", ["id", "Foo"], expected_iso_dates)
+    self.modify_column("Schools", "Foo", formula='rec.to_dict(expand_refs=1, dates_as_iso=True)')
+    self.assertPartialData("Schools", ["id", "Foo"], expected_iso_dates)
+
   def test_reference(self):
     self.load_sample(testsamples.sample_students)
     self.add_column("Schools", "Foo", formula='RECORD($address)')


### PR DESCRIPTION
Implement Record._asdict() and Record.to_dict() as wrappers over RECORD().

Add test coverage for default behavior and options (expand_refs, dates_as_iso).

## Context

<!-- Please include a summary of the change, with motivation and context -->
This issue asks for a more natural way to convert a formula Record into a dictionary, especially for Python users.


<!-- Bonus: if you are comfortable writing one, please insert a user-story https://en.wikipedia.org/wiki/User_story#Common_templates -->

## Proposed solution

<!-- Describe here how you address the issue -->
- Added `Record._asdict(dates_as_iso=False, expand_refs=0)`.
- Added `Record.to_dict(dates_as_iso=False, expand_refs=0)` as an alias.
- Both methods delegate to `RECORD(...)` so that the behavior remains consistent.
- Added tests to validate parity between `rec._asdict()`, `rec.to_dict()`, and `RECORD(rec)`.

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->
Closes #932.

**Scope checklist:**

 - [x] Added explicit Record conversion methods.
 - [x] Added parity tests for default and option behavior.
 - [x] Preserved existing RECORD semantics.
 - [ ] Added dict(rec) support (intentionally not included in this PR).


## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite (actually i just added a test method in [test_record_func.py](https://github.com/gristlabs/grist-core/blob/main/sandbox/grist/test_record_func.py))
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

