### PR TITLE
fix Search2 flakiness

### DIFF
--- a/test/nbrowser/Search2.ts
+++ b/test/nbrowser/Search2.ts
@@ -61,7 +61,7 @@ describe("Search2", async function() {
     await gu.getSection("CITY Card List").click();
     await gu.toggleSidePanel("right", "open");
     await driver.findContent(".test-right-panel button", /Change widget/).click();
-    await driver.find(".test-wselect-selectby").doClick();
+    await driver.findWait(".test-wselect-selectby", 1000).doClick();
     await driver.findContent(".test-wselect-selectby option", /CITY/).doClick();
     await driver.find(".test-wselect-addBtn").doClick();
     await gu.waitForServer();


### PR DESCRIPTION
The widget picker popup needs a moment to compute its selectBy options after "Change widget" is clicked. Use findWait instead of find so we don't race the DOM.

Tested locally: 20/20 passes after fix (was 18/20 before).
