### PR TITLE
try to fix FormulaAutocomplete flakiness

### DIFF
--- a/test/nbrowser/FormulaAutocomplete.ts
+++ b/test/nbrowser/FormulaAutocomplete.ts
@@ -196,8 +196,7 @@ describe("FormulaAutocomplete", function() {
     // Add a new column 'T' of type Text
     await gu.addColumn("T");
     await gu.getCell({ rowNum: 1, col: "T" }).click();
-    await driver.sendKeys("abc");
-    await driver.sendKeys(Key.ENTER);
+    await gu.enterCell("abc");
 
     // Write a new formula starting with `$Title.` and check that the autocomplete options are correct
     await gu.addColumn("A");
@@ -236,6 +235,8 @@ describe("FormulaAutocomplete", function() {
       // Initially 'A' has no visible column, so these are the only options
       assert.isTrue(completions[0].startsWith("$A"));
       assert.isTrue(completions[1].startsWith("$Release_Date"));
+      // $T appears because ACE fuzzy-matches "$A" against captions including example
+      // values, and $T's example 'abc' (set above) contains 'a'.
       assert.isTrue(completions[2].startsWith("$T"));
     });
     await driver.sendKeys(".");


### PR DESCRIPTION
The test used raw driver.sendKeys("abc") + Key.ENTER to set a cell value, with no wait for the editor or server. On slow CI, the value may not have been saved, leaving the cell empty. A later assertion depends on this value: ACE's fuzzy filter for "$A" only includes $T in the autocomplete results because $T's example value 'abc' contains 'a'. With an empty cell, the example becomes '' and the fuzzy match fails, reducing the count from 3 to 2.

Replace with gu.enterCell which waits for the cell editor and server.

This is somewhat speculative, based on CI logs.
