### PR TITLE
fix PageWidgetPicker flakiness by waiting for picker to render

### DIFF
--- a/test/projects/PageWidgetPicker.ts
+++ b/test/projects/PageWidgetPicker.ts
@@ -35,7 +35,7 @@ describe("PageWidgetPicker", () => {
   it("should reflect `.value` on open", async function() {
     // set value option to [`Card List`, 'Companies', ['company_id', 'city']]
     await driver.find(".test-option-value").click();
-    await driver.findContent(".test-wselect-type", /Card List/).click();
+    await driver.findContentWait(".test-wselect-type", /Card List/, 500).click();
     await driver.findContent(".test-wselect-table", /History/).click();
     await driver.findContent(".test-wselect-table", /History/).find(".test-wselect-pivot").click();
     await driver.findContent(".test-wselect-column", /company_id/).doClick();


### PR DESCRIPTION
The first test clicks .test-option-value to open the picker, then immediately tries to find "Card List" in the widget type list. Unlike openPicker() which waits for .test-wselect-container, this code path had no wait, so the findContent could fire before the picker rendered.

Use findContentWait to wait for element.

Before fix: 16/20 runs pass locally. After fix: 20/20.
