### PR TITLE
fix TreeViewComponent flakiness from stale element references

### DIFF
--- a/test/projects/TreeViewComponent.ts
+++ b/test/projects/TreeViewComponent.ts
@@ -521,7 +521,7 @@ async function withTreeviewChange(cb: () => WebElementPromise | Promise<void>) {
     try {
       return (await getItemTexts()) !== before;
     } catch (e) {
-      if (e instanceof Error && e.name === 'StaleElementReferenceError') { return false; }
+      if (e instanceof Error && e.name === "StaleElementReferenceError") { return false; }
       throw e;
     }
   });


### PR DESCRIPTION
The withTreeviewChange helper polls element text to detect DOM changes. TreeViewComponent._update is debounced(0), so the DOM rebuild happens asynchronously after the button click. If findAll returns elements just before the rebuild, getText() hits stale references.

Catch StaleElementReferenceError and retry, since it means the DOM is being rebuilt (which is what we're waiting for).

Before fix: 16/20 passes locally. After fix: 20/20.
