### PR TITLE
fix DocTutorial flakiness by using gu.enterCell for cell edit

### DIFF
--- a/test/nbrowser/DocTutorial.ts
+++ b/test/nbrowser/DocTutorial.ts
@@ -533,14 +533,12 @@ describe("DocTutorial", function() {
       // Make an edit to one of the tutorial slides.
       await gu.openPage("GristDocTutorial");
       await gu.getCell(1, 1).click();
-      await gu.sendKeys(
+      await gu.enterCell(
         "# Intro",
         Key.chord(Key.SHIFT, Key.ENTER),
         Key.chord(Key.SHIFT, Key.ENTER),
         "Welcome to the Grist Basics tutorial V2.",
-        Key.ENTER,
       );
-      await gu.waitForServer();
 
       // Check that the update is immediately reflected in the tutorial popup.
       assert.equal(


### PR DESCRIPTION
The test used gu.sendKeys to type multi-line tutorial content into a cell. On slow CI, keys could be partially lost, leaving the cell with wrong content. The subsequent assertion on the tutorial popup then found an empty paragraph.

Replace with gu.enterCell which properly opens the editor and waits for the server after committing.

Before fix: 18/20 runs pass locally. After fix: 20/20.
