### PR TITLE
fix SortFilterSectionOptions flakiness with missing waits

### DIFF
--- a/test/nbrowser/SortFilterSectionOptions.ts
+++ b/test/nbrowser/SortFilterSectionOptions.ts
@@ -480,16 +480,14 @@ describe("SortFilterSectionOptions", function() {
     // click Name
     await driver.findContent(".grist-floating-menu li", /Name/).click();
 
-    // check the filter menu is shown
-    assert.isTrue(
-      await driver.find(".test-filter-menu-wrapper").isPresent(),
-    );
+    // check the filter menu is shown (wait for it to render after clicking Name)
+    await driver.findWait(".test-filter-menu-wrapper", 2000);
 
     // check a filter was added and pinned
     await assertPinnedFilters([{ name: "Name", hasUnsavedChanges: true }]);
 
     // click Apple
-    await driver.findContent(".test-filter-menu-list .test-filter-menu-value", /Apples/).click();
+    await driver.findContentWait(".test-filter-menu-list .test-filter-menu-value", /Apples/, 2000).click();
 
     // click Apply
     await driver.find(".test-filter-menu-apply-btn").click();
@@ -550,7 +548,7 @@ describe("SortFilterSectionOptions", function() {
     // add a filter and check that it's pinned by default
     await driver.find(".test-filter-config-add-filter-btn").click();
     await driver.findContentWait(".grist-floating-menu li", /Name/, 2000).click();
-    await driver.findContent(".test-filter-menu-list .test-filter-menu-value", /Apples/).click();
+    await driver.findContentWait(".test-filter-menu-list .test-filter-menu-value", /Apples/, 2000).click();
     await driver.find(".test-filter-menu-apply-btn").click();
     await assertPinnedFilters([{ name: "Name", hasUnsavedChanges: true }]);
 


### PR DESCRIPTION
Two issues causing cascading failures in "should allow to add filter" and "should allow pinning filters":

1. After clicking a column name to add a filter, the filter menu wrapper was checked with find().isPresent() (instant) instead of findWait(). The menu hadn't rendered yet.

2. After the filter menu appeared, the value list items (e.g. "Apples") were clicked with findContent() (instant) before the list populated.

Fix both with findWait/findContentWait with 2000ms timeout.

Before fix: 14/20 runs pass locally. After fix: 20/20.
