### PR TITLE
Fixing flaky tests

### DIFF
--- a/test/nbrowser/AccessRules1.ts
+++ b/test/nbrowser/AccessRules1.ts
@@ -91,6 +91,7 @@ describe("AccessRules1", function() {
     await gu.openPage("ClientsTable");
     await gu.waitForServer();
     await gu.getCell(0, 1).click();
+    await gu.waitAppFocus();
     await gu.sendKeys("Will it work?", Key.ENTER);
     await gu.waitForServer();
     if (memo === "") {

--- a/test/nbrowser/AccessRules2.ts
+++ b/test/nbrowser/AccessRules2.ts
@@ -63,11 +63,13 @@ describe("AccessRules2", function() {
 
     const [email1, email2, email3] = ["user1", "user2", "user3"].map(u => gu.translateUser(u as any).email);
     // All users the doc is shared with should be listed, with correct Access.
-    assert.equal(await driver.findContent(".test-acl-user-item", email1).isPresent(), false);
-    assert.equal(await driver.findContent(".test-acl-user-item", email2)
-      .find(".test-acl-user-access").getText(), "(Owner)");
-    assert.equal(await driver.findContent(".test-acl-user-item", email3)
-      .find(".test-acl-user-access").getText(), "(Editor)");
+    await gu.waitToPass(async () => {
+      assert.equal(await driver.findContent(".test-acl-user-item", email1).isPresent(), false);
+      assert.equal(await driver.findContent(".test-acl-user-item", email2)
+        .find(".test-acl-user-access").getText(), "(Owner)");
+      assert.equal(await driver.findContent(".test-acl-user-item", email3)
+        .find(".test-acl-user-access").getText(), "(Editor)");
+    });
 
     // Check examples are present.
     assert.deepEqual(
@@ -414,14 +416,16 @@ describe("AccessRules2", function() {
     await gu.undo();
     await driver.findWait(".test-rule-set", 2000);
 
-    ruleSet = findDefaultRuleSet(/ClientsTable/);
-    assert.lengthOf(await ruleSet.findAll(".test-rule-part"), 2);
-    assert.lengthOf(await ruleSet.findAll(".test-rule-add"), 2);
-    assert.equal(
-      await ruleSet.find(".test-rule-part-and-memo:nth-child(2) .test-rule-acl-formula").getText(),
-      "Everyone Else",
-    );
-    assert.equal(await ruleSet.find(".test-rule-extra-add").isPresent(), false);
+    await gu.waitToPass(async () => {
+      ruleSet = findDefaultRuleSet(/ClientsTable/);
+      assert.lengthOf(await ruleSet.findAll(".test-rule-part"), 2);
+      assert.lengthOf(await ruleSet.findAll(".test-rule-add"), 2);
+      assert.equal(
+        await ruleSet.find(".test-rule-part-and-memo:nth-child(2) .test-rule-acl-formula").getText(),
+        "Everyone Else",
+      );
+      assert.equal(await ruleSet.find(".test-rule-extra-add").isPresent(), false);
+    });
   });
 
   it("should support renames and refresh rules when they get updated", async function() {
@@ -846,9 +850,12 @@ describe("AccessRules2", function() {
     // All users the doc is shared with should be listed, with correct Access.
     // Wait for menu items to render before reading them, otherwise the name1
     // absence check can pass spuriously and the name2/name3 reads can race.
-    assert.include(await driver.findContentWait(".grist-floating-menu a", name2, 1000).getText(), "(Owner)");
-    assert.include(await driver.findContentWait(".grist-floating-menu a", name3, 1000).getText(), "(Editor)");
-    assert.equal(await driver.findContent(".grist-floating-menu a", name1).isPresent(), false);
+    // Use waitToPass to avoid StaleElementReferenceError if the menu re-renders.
+    await gu.waitToPass(async () => {
+      assert.include(await driver.findContentWait(".grist-floating-menu a", name2, 1000).getText(), "(Owner)");
+      assert.include(await driver.findContentWait(".grist-floating-menu a", name3, 1000).getText(), "(Editor)");
+      assert.equal(await driver.findContent(".grist-floating-menu a", name1).isPresent(), false);
+    });
 
     await driver.findContent(".grist-floating-menu a", name3).click();
     await gu.waitForUrl(/aclAsUser/);

--- a/test/nbrowser/AccessRules2.ts
+++ b/test/nbrowser/AccessRules2.ts
@@ -471,7 +471,9 @@ describe("AccessRules2", function() {
 
     // Table options should update
     await driver.findContentWait("button", /Add table rules/, 2000).click();
-    const options = await driver.findAll(".grist-floating-menu li", e => e.getText());
+    // Wait for the menu to actually open; popweasel opens via setTimeout(0) and
+    // findAll can otherwise return [] before any items render.
+    const options = await gu.findOpenMenuAllItems("li", e => e.getText(), 1000);
     assert.deepEqual(options, ["ACCESS2", "CLIENT LIST", "CLIENT LIST [by Shared]", "FinancialsTable"]);
     await driver.sendKeys(Key.ESCAPE);    // Close menu.
 
@@ -842,9 +844,11 @@ describe("AccessRules2", function() {
       .map(name => new RegExp(escapeRegExp(name), "i"));
 
     // All users the doc is shared with should be listed, with correct Access.
+    // Wait for menu items to render before reading them, otherwise the name1
+    // absence check can pass spuriously and the name2/name3 reads can race.
+    assert.include(await driver.findContentWait(".grist-floating-menu a", name2, 1000).getText(), "(Owner)");
+    assert.include(await driver.findContentWait(".grist-floating-menu a", name3, 1000).getText(), "(Editor)");
     assert.equal(await driver.findContent(".grist-floating-menu a", name1).isPresent(), false);
-    assert.include(await driver.findContent(".grist-floating-menu a", name2).getText(), "(Owner)");
-    assert.include(await driver.findContent(".grist-floating-menu a", name3).getText(), "(Editor)");
 
     await driver.findContent(".grist-floating-menu a", name3).click();
     await gu.waitForUrl(/aclAsUser/);

--- a/test/nbrowser/ActiveUserList.ts
+++ b/test/nbrowser/ActiveUserList.ts
@@ -119,11 +119,17 @@ describe("ActiveUserList", async function() {
     // There should be several copies of Kiwi here, but I don't think counting them improves anything
     assert.includeMembers(menuItemTexts, [gu.translateUser(User2).name, gu.translateUser(User3).name]);
 
-    let iconVisibility = await driver.findAll(".test-aul-container .test-aul-user-icon", el => el.isDisplayed());
-    assert.isTrue(iconVisibility.every(visible => visible === false));
+    await gu.waitToPass(async () => {
+      const iconVisibility = await driver.findAll(
+        ".test-aul-container .test-aul-user-icon", el => el.isDisplayed());
+      assert.isTrue(iconVisibility.every(visible => visible === false));
+    });
     await gu.sendKeys(Key.ESCAPE);
-    iconVisibility = await driver.findAll(".test-aul-container .test-aul-user-icon", el => el.isDisplayed());
-    assert.isTrue(iconVisibility.every(visible => visible === true));
+    await gu.waitToPass(async () => {
+      const iconVisibility = await driver.findAll(
+        ".test-aul-container .test-aul-user-icon", el => el.isDisplayed());
+      assert.isTrue(iconVisibility.every(visible => visible === true));
+    });
   });
 
   it("keeps the user list open when a new user appears", async function() {

--- a/test/nbrowser/AdminPanel.ts
+++ b/test/nbrowser/AdminPanel.ts
@@ -193,7 +193,9 @@ describe("AdminPanel", function() {
     assert.equal(await adminAccounts.isDisplayed(), true);
     const adminDisplay = await driver.find(".test-admin-panel-admin-accounts-display");
 
-    assert.equal("1 admin account", await adminDisplay.getText());
+    await gu.waitToPass(async () => {
+      assert.equal("1 admin account", await adminDisplay.getText());
+    }, 3000);
 
     await toggleItem("admins");
 

--- a/test/nbrowser/AttachmentsWidget.ts
+++ b/test/nbrowser/AttachmentsWidget.ts
@@ -69,6 +69,7 @@ describe("AttachmentsWidget", function() {
     await gu.waitForServer();
 
     await gu.getCell(0, 2).click();
+    await gu.waitAppFocus();
     await driver.sendKeys(Key.ENTER);
 
     await gu.fileDialogUpload("uploads/sample.pdf,uploads/grist.png", () =>
@@ -197,6 +198,7 @@ describe("AttachmentsWidget", function() {
   it("should get correct headers from the server", async function() {
     const cell: any = gu.getCell(0, 2);
     await cell.click();
+    await gu.waitAppFocus();
     await driver.sendKeys(Key.ENTER);
 
     const fetchOptions = {
@@ -319,6 +321,7 @@ describe("AttachmentsWidget", function() {
     // Then do it again via the attachment editor.
     await gu.fileDialogUpload("uploads/grist.png", async () => {
       await gu.getCell({ col: 0, rowNum: 6 }).click();
+      await gu.waitAppFocus();
       await driver.sendKeys(Key.ENTER);
       await driver.sleep(500);
       await driver.find(".test-pw-add").click();
@@ -616,6 +619,7 @@ describe("AttachmentsWidget", function() {
     await driver.executeScript("window.testGrist = {fakeSlowUploads: true}");
     await gu.fileDialogUpload("uploads/grist.png", async () => {
       await cell.click();
+      await gu.waitAppFocus();
       await driver.sendKeys(Key.ENTER);
       await driver.sleep(500);
       await driver.find(".test-pw-add").click();

--- a/test/nbrowser/BootPage.ts
+++ b/test/nbrowser/BootPage.ts
@@ -310,7 +310,7 @@ describe("BootPage", function() {
       await gu.waitForAdminPanel();
 
       assert.equal(
-        await driver.find(".test-admin-panel-item-value-boot-key").getText(),
+        await driver.findWait(".test-admin-panel-item-value-boot-key", 2000).getText(),
         "enabled",
       );
 
@@ -320,7 +320,8 @@ describe("BootPage", function() {
     });
 
     it("can remove boot key via Admin Panel", async function() {
-      await driver.find(".test-boot-key-status-remove-boot-key").click();
+      await gu.waitToPass(async () =>
+        driver.find(".test-boot-key-status-remove-boot-key").click());
       await driver.find(".test-modal-confirm").click();
       await gu.waitForServer();
       await gu.waitToPass(async () =>

--- a/test/nbrowser/CellColor.ts
+++ b/test/nbrowser/CellColor.ts
@@ -299,8 +299,8 @@ describe("CellColor", function() {
 
     // Empty cell to clear error from converting toggle to date
     await cell.click();
-    await driver.sendKeys(Key.DELETE);
     await gu.waitAppFocus();
+    await driver.sendKeys(Key.DELETE);
 
     // open color picker
     await gu.openCellColorPicker();

--- a/test/nbrowser/CellFormat.ts
+++ b/test/nbrowser/CellFormat.ts
@@ -114,6 +114,7 @@ describe("CellFormat", function() {
   it("can display Markdown-formatted text", async function() {
     await gu.getCell(0, 1).click();
     await gu.setFieldWidgetType("TextBox");
+    await gu.getCell(0, 1).click();
     await gu.enterCell([
       "# Heading",
       Key.chord(Key.SHIFT, Key.ENTER),

--- a/test/nbrowser/Choice.ts
+++ b/test/nbrowser/Choice.ts
@@ -41,8 +41,11 @@ describe("Choice", function() {
 
     // Start editing a cell in column A and click away to close the editor.
     await gu.getCell({ rowNum: 1, col: "A" }).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.ENTER);
+    await gu.waitAppFocus(false);
     await gu.getCell({ rowNum: 1, col: "C" }).click();
+    await gu.waitAppFocus();
     await gu.waitForServer();
 
     // Check that the values in column A are unchanged.

--- a/test/nbrowser/ChoiceList.ts
+++ b/test/nbrowser/ChoiceList.ts
@@ -341,6 +341,7 @@ describe("ChoiceList", function() {
 
     // Hit enter, click to delete a token, save.
     await gu.getCell({ rowNum: 1, col: "B" }).click();
+    await gu.waitAppFocus();
     await driver.sendKeys(Key.ENTER);
     await driver.sendKeys(Key.BACK_SPACE);
     await driver.sendKeys(Key.ENTER);
@@ -389,6 +390,7 @@ describe("ChoiceList", function() {
     assert.equal(await cell.getText(), "");
     await gu.waitCellFocus(cell);
     await cell.click();
+    await gu.waitAppFocus();
     await driver.sendKeys(Key.ENTER);
     await gu.waitForCellEditor();
     await driver.findContent(".test-autocomplete li", /Green/).click();
@@ -605,6 +607,7 @@ describe("ChoiceList", function() {
       ],
     );
     await gu.getCell({ rowNum: 1, col: "B" }).click();
+    await gu.waitAppFocus();
     await driver.sendKeys(Key.ENTER);
     assert.deepEqual(await getEditorTokens(), ["Green", "Orange", "Apricot"]);
     assert.deepEqual(await getEditorTokensIsInvalid(), [false, true, false]);

--- a/test/nbrowser/ColumnFilterMenu.ts
+++ b/test/nbrowser/ColumnFilterMenu.ts
@@ -382,14 +382,16 @@ describe("ColumnFilterMenu", function() {
     await gu.setRangeFilterBound("max", "4");
     await driver.find(".test-filter-menu-apply-btn").click();
 
-    assert.deepEqual(
-      await gu.getVisibleGridCells({ cols: ["Name", "Count"], rowNums: [1, 2, 3, 4] }),
-      ["Oranges", "3",
-        "Bananas", "2",
-        "", "",
-        undefined, undefined,
-      ],
-    );
+    await gu.waitToPass(async () => {
+      assert.deepEqual(
+        await gu.getVisibleGridCells({ cols: ["Name", "Count"], rowNums: [1, 2, 3, 4] }),
+        ["Oranges", "3",
+          "Bananas", "2",
+          "", "",
+          undefined, undefined,
+        ],
+      );
+    });
 
     // remove both min and max
     await driver.findContent(".test-filter-field", /Count/).click();
@@ -482,17 +484,19 @@ describe("ColumnFilterMenu", function() {
 
     // Click Cancel, and check that the filter is no longer applied to the table data.
     await driver.find(".test-filter-menu-cancel-btn").click();
-    assert.deepEqual(
-      await gu.getVisibleGridCells({ cols: ["Name", "Count"], rowNums: [1, 2, 3, 4, 5, 6, 7] }),
-      ["Apples", "1",
-        "Oranges", "3",
-        "Bananas", "2",
-        "Grapes", "-1",
-        "Grapefruit", "n/a",
-        "Clementines", "5",
-        "Apples", "0",
-      ],
-    );
+    await gu.waitToPass(async () => {
+      assert.deepEqual(
+        await gu.getVisibleGridCells({ cols: ["Name", "Count"], rowNums: [1, 2, 3, 4, 5, 6, 7] }),
+        ["Apples", "1",
+          "Oranges", "3",
+          "Bananas", "2",
+          "Grapes", "-1",
+          "Grapefruit", "n/a",
+          "Clementines", "5",
+          "Apples", "0",
+        ],
+      );
+    });
 
     // Check that Count is still pinned to the filter bar.
     assert.deepEqual(

--- a/test/nbrowser/Comparison.ts
+++ b/test/nbrowser/Comparison.ts
@@ -552,6 +552,7 @@ describe("Comparison", function() {
     await gu.switchToWindow(windowHandles[1]);
     await gu.waitForDocToLoad();
     await gu.getCell(0, 1).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(Key.SHIFT, Key.ARROW_RIGHT));
     assert.isFalse(await driver.find(".test-selection-summary-count").isPresent());
     await gu.checkForErrors();

--- a/test/nbrowser/CopyPasteFiles.ts
+++ b/test/nbrowser/CopyPasteFiles.ts
@@ -58,6 +58,7 @@ describe("CopyPasteFiles", function() {
 
     // Check in more detail the content in one of the cells.
     await gu.getCell({ rowNum: 2, col: "Photo" }).click();
+    await gu.waitAppFocus();
     await driver.sendKeys(Key.ENTER);
     assert.equal(await driver.findWait(".test-pw-counter", 500).getText(), "1 of 2");
     assert.equal(await driver.find(".test-pw-name").value(), "flower.png");

--- a/test/nbrowser/DateEditor.ts
+++ b/test/nbrowser/DateEditor.ts
@@ -29,6 +29,7 @@ async function testDateFormat(initialDateStr: string, newDay: string, finalDateS
 
   // Reopen the editor, check that our previously-selected date is still selected.
   await gu.getCell({ col: "A", rowNum: 1 }).click();
+  await gu.waitAppFocus();
   await driver.sendKeys(Key.ENTER);
   await gu.checkTextEditor(new RegExp(escapeRegExp(finalDateStr)));
   assert.isTrue(await driver.findContent("td.day", newDay).matches(".active"));
@@ -65,6 +66,7 @@ describe("DateEditor", function() {
 
     // Use shortcut to populate today's date, mainly to ensure that our date-mocking is working.
     await gu.getCell({ col: "A", rowNum: 1 }).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(await gu.modKey(), ";"));
     await gu.waitForServer();
     assert.equal(await gu.getCell({ col: "A", rowNum: 1 }).getText(), "2020-02-01");
@@ -85,6 +87,7 @@ describe("DateEditor", function() {
   it("should allow editing invalid alt-text", async function() {
     let cell = await gu.getCell({ col: "A", rowNum: 2 });
     await cell.click();
+    await gu.waitAppFocus();
     await driver.sendKeys(Key.ENTER);
     await gu.waitAppFocus(false);
 
@@ -99,6 +102,7 @@ describe("DateEditor", function() {
 
     // Open for editing, and check that the invalid value is present in the editor.
     await cell.click();
+    await gu.waitAppFocus();
     await driver.sendKeys(Key.ENTER);
     await gu.waitAppFocus(false);
     await gu.checkTextEditor(/2020-03-14pi/);
@@ -113,6 +117,7 @@ describe("DateEditor", function() {
 
   async function openCellEditor(cell: WebElement) {
     await cell.click();
+    await gu.waitAppFocus();
     await driver.sendKeys(Key.ENTER);
     await gu.waitAppFocus(false);
   }

--- a/test/nbrowser/Dates.ntest.js
+++ b/test/nbrowser/Dates.ntest.js
@@ -251,6 +251,7 @@ describe("Dates.ntest", function() {
         await gu.waitCellFocus(gu.getCellRC(1, i));
         await gu.sendKeys([$.MOD, ";"]);
         await gu.waitForServer();
+        await gu.waitAppFocus();
         await gu.sendKeys($.TAB);
       }
 
@@ -260,6 +261,7 @@ describe("Dates.ntest", function() {
         await gu.waitCellFocus(gu.getCellRC(2, i));
         await gu.sendKeys([$.MOD, $.SHIFT, ";"]);
         await gu.waitForServer();
+        await gu.waitAppFocus();
         await gu.sendKeys($.TAB);
       }
     }

--- a/test/nbrowser/Dates.ntest.js
+++ b/test/nbrowser/Dates.ntest.js
@@ -227,14 +227,11 @@ describe("Dates.ntest", function() {
     await gu.assertType("DateTime");
     await gu.clickCellRC(0, 1);
     await gu.assertType("Date");
-    // Insert a few more columns: empty, Text, Numeric.
-    await addColumn();
-    await addColumn();
-    await addColumn();
-    await gu.clickCellRC(0, 3);
-    await gu.setType("Numeric");
-    await gu.clickCellRC(0, 4);
-    await gu.setType("Text");
+    // Insert a few more columns at the cursor position: empty, Numeric, Text.
+    // Cursor is on B (col 1) from above, so these land at visible positions 2, 3, 4.
+    await gu.insertColumn();
+    await gu.insertColumn("Numeric");
+    await gu.insertColumn("Text");
 
     // Override Date.now() and timezone in the current browser page to return a consistent value,
     // used e.g. for the default for the year and month.
@@ -252,14 +249,18 @@ describe("Dates.ntest", function() {
       await gu.clickCellRC(1, 0);
       for (var i = 0; i < 6; i++) {
         await gu.waitCellFocus(gu.getCellRC(1, i));
-        await gu.sendKeys([$.MOD, ";"], $.TAB);
+        await gu.sendKeys([$.MOD, ";"]);
+        await gu.waitForServer();
+        await gu.sendKeys($.TAB);
       }
 
       // Type the Date-Time shortcut into each cell in the third row.
       await gu.clickCellRC(2, 0);
       for (i = 0; i < 6; i++) {
         await gu.waitCellFocus(gu.getCellRC(2, i));
-        await gu.sendKeys([$.MOD, $.SHIFT, ";"], $.TAB);
+        await gu.sendKeys([$.MOD, $.SHIFT, ";"]);
+        await gu.waitForServer();
+        await gu.sendKeys($.TAB);
       }
     }
 
@@ -268,14 +269,17 @@ describe("Dates.ntest", function() {
     await setGlobalTimezone("US/Hawaii");
     await fillWithShortcuts();
     // Compare the values. NOTE: this assumes EST timezone for the browser's local time.
-    assert.deepEqual(await gu.getGridValues({rowNums: [2, 3], cols: [0, 1, 2, 3, 4]}), [
-      // Note that column A has Los_Angeles timezone set, so time differs from Hawaii.
-      // Note that Date column gets the date in Hawaii, not local or UTC (both 2016-10-27).
-      // The originally empty column had its type guessed as Date when the current date was first entered,
-      // hence "2016-10-26" appears in both rows.
-      "October 26th, 2016 11:04pm", "October 26th, 2016", "2016-10-26", "0", "2016-10-26",
-      "October 26th, 2016 11:04pm", "October 26th, 2016", "2016-10-26", "0", "2016-10-26 20:04:56",
-    ]);
+    // Wrap in waitToPass: grainjs may not have flushed observables to DOM after waitForServer.
+    await gu.waitToPass(async () => {
+      assert.deepEqual(await gu.getGridValues({rowNums: [2, 3], cols: [0, 1, 2, 3, 4]}), [
+        // Note that column A has Los_Angeles timezone set, so time differs from Hawaii.
+        // Note that Date column gets the date in Hawaii, not local or UTC (both 2016-10-27).
+        // The originally empty column had its type guessed as Date when the current date was first entered,
+        // hence "2016-10-26" appears in both rows.
+        "October 26th, 2016 11:04pm", "October 26th, 2016", "2016-10-26", "0", "2016-10-26",
+        "October 26th, 2016 11:04pm", "October 26th, 2016", "2016-10-26", "0", "2016-10-26 20:04:56",
+      ]);
+    }, 2000);
 
     // Undo the 8 cells we actually filled in, and check that the empty column reverted to Any
     await gu.undo(8);
@@ -286,11 +290,13 @@ describe("Dates.ntest", function() {
     await setGlobalTimezone("America/New_York");
     await fillWithShortcuts();
     // Compare the values. NOTE: this assumes EST timezone for the browser's local time.
-    assert.deepEqual(await gu.getGridValues({rowNums: [2, 3], cols: [0, 1, 2, 3, 4]}), [
-      // Note that column A has Los_Angeles timezone set, so date differs by one from New_York.
-      "October 26th, 2016 11:04pm", "October 27th, 2016", "2016-10-27", "0", "2016-10-27",
-      "October 26th, 2016 11:04pm", "October 27th, 2016", "2016-10-27", "0", "2016-10-27 02:04:56",
-    ]);
+    await gu.waitToPass(async () => {
+      assert.deepEqual(await gu.getGridValues({rowNums: [2, 3], cols: [0, 1, 2, 3, 4]}), [
+        // Note that column A has Los_Angeles timezone set, so date differs by one from New_York.
+        "October 26th, 2016 11:04pm", "October 27th, 2016", "2016-10-27", "0", "2016-10-27",
+        "October 26th, 2016 11:04pm", "October 27th, 2016", "2016-10-27", "0", "2016-10-27 02:04:56",
+      ]);
+    }, 2000);
   });
 
   it("should allow navigating the datepicker with the keyboard", async function() {
@@ -307,6 +313,7 @@ describe("Dates.ntest", function() {
     // Do the same in the datetime editor.
     cell = await gu.getCellRC(1, 0);
     await cell.click();
+    await gu.waitAppFocus();
     await gu.sendKeys($.ENTER);
     await gu.waitAppFocus(false);
     await gu.sendKeys($.UP, $.RIGHT, $.RIGHT, $.ENTER);
@@ -319,12 +326,19 @@ describe("Dates.ntest", function() {
     await cell.click();
     // The first backspace should return to cell edit mode, then the following keys should
     // change the year to 2009.
+    await gu.waitAppFocus();
+
     await gu.sendKeys($.ENTER);
     await gu.waitAppFocus(false);
+    // Wait for the datepicker to mount before sending keys — its key handler is bound
+    // asynchronously and BACK_SPACE can be eaten if it arrives first.
+    await driver.findWait(".datepicker", 1000);
     await gu.sendKeys($.DOWN, $.RIGHT, $.BACK_SPACE, "9", $.LEFT, $.BACK_SPACE, "0", $.ENTER);
     await gu.waitAppFocus(true);
     await gu.waitForServer();
-    assert.equal(await cell.text(), "October 27th, 2009");
+    await gu.waitToPass(async () => {
+      assert.equal(await cell.text(), "October 27th, 2009");
+    }, 1000);
   });
 
   // NOTE: This addresses a bug where typical date entry formats were not recognized.
@@ -457,7 +471,7 @@ describe("Dates.ntest", function() {
 
   it("should default timezone to document's timezone", async function() {
     // add a DateTime column
-    await addDateTimeColumn();
+    await gu.insertColumn("DateTime");
     await gu.timeFormat("HH:mm:ss");
     // BUG: it is required to click somewhere after setting the type of a column for the shortcut to
     // work
@@ -472,7 +486,7 @@ describe("Dates.ntest", function() {
     // set global document timezone to 'Europe/Paris'
     await setGlobalTimezone("America/Los_Angeles");
     // add another DateTime column
-    await addDateTimeColumn();
+    await gu.insertColumn("DateTime");
     await gu.timeFormat("HH:mm:ss");
     // todo: same as for gu.getCellRC(1, 3).click();
     await gu.getCellRC(1, 4).click();
@@ -490,17 +504,6 @@ describe("Dates.ntest", function() {
   });
 });
 
-async function addDateTimeColumn() {
-  await addColumn();
-  return gu.setType("DateTime");
-}
-
-async function addColumn() {
-  await gu.sendKeys([$.ALT, "="]);
-  await gu.waitForServer();
-  return gu.sendKeys($.ESCAPE);
-}
-
 async function setGlobalTimezone(name) {
   await $(".test-user-icon").click();   // open the user menu
   await $(".test-dm-doc-settings").wait().click();
@@ -509,4 +512,5 @@ async function setGlobalTimezone(name) {
   await driver.sleep(100); // the request is not always triggered immediately, we wait a little bit.
   await gu.waitForServer();
   await driver.navigate().back();
+  await gu.waitForDocToLoad();
 }

--- a/test/nbrowser/DeleteColumnsUndo.ts
+++ b/test/nbrowser/DeleteColumnsUndo.ts
@@ -18,6 +18,7 @@ describe("DeleteColumnsUndo", function() {
     const revert = await gu.begin();
     assert.deepEqual(await gu.getColumnNames(), ["A", "B", "C", "D"]);
     await gu.getColumnHeader({ col: "A" }).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(Key.SHIFT, Key.RIGHT));
     await gu.sendKeys(Key.chord(Key.SHIFT, Key.RIGHT));
     const selectedCols = await driver.findAll(".column_name.selected");

--- a/test/nbrowser/DropdownConditionEditor.ts
+++ b/test/nbrowser/DropdownConditionEditor.ts
@@ -108,12 +108,14 @@ describe("DropdownConditionEditor", function() {
       ]);
       await gu.sendKeys(Key.ESCAPE);
       await gu.getCell(1, 4).click();
+      await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
       assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
         "Trainee",
       ]);
       await gu.sendKeys(Key.ESCAPE);
       await gu.getCell(1, 6).click();
+      await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
       assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
         "Trainee",
@@ -128,6 +130,7 @@ describe("DropdownConditionEditor", function() {
         "choice not in $Role",
       );
       await gu.getCell(1, 4).click();
+      await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
       assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
         "Trainee",
@@ -232,6 +235,7 @@ describe("DropdownConditionEditor", function() {
 
       // Should be no options on row 2 because of $id != 2 part of condition.
       await gu.getCell(2, 2).click();
+      await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
       assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
       ]);
@@ -239,6 +243,7 @@ describe("DropdownConditionEditor", function() {
 
       // Row 3 should be like row 1.
       await gu.getCell(2, 3).click();
+      await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
       assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
         "Pavan Madilyn",
@@ -247,10 +252,12 @@ describe("DropdownConditionEditor", function() {
       await gu.sendKeys(Key.ESCAPE);
 
       await gu.getCell(2, 4).click();
+      await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
       assert.isEmpty(await driver.findAll(".test-autocomplete li", el => el.getText()));
       await gu.sendKeys(Key.ESCAPE);
       await gu.getCell(2, 6).click();
+      await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
       assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
         "Marie Ziyad",
@@ -265,6 +272,7 @@ describe("DropdownConditionEditor", function() {
         'choice.Role == "Supervisor" and $Role != "Supervisor" and $id != 2\n',
       );
       await gu.getCell(2, 4).click();
+      await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
       assert.isEmpty(await driver.findAll(".test-autocomplete li", el => el.getText()));
       await gu.sendKeys(Key.ESCAPE);
@@ -386,6 +394,7 @@ describe("DropdownConditionEditor", function() {
     const session = await gu.session().user("user2").login();
     await session.loadDoc(`/doc/${docId}`);
     await gu.getCell(1, 1).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.ENTER);
     assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), []);
     await gu.sendKeys(Key.ESCAPE);

--- a/test/nbrowser/FieldEditor.ts
+++ b/test/nbrowser/FieldEditor.ts
@@ -160,7 +160,6 @@ describe("FieldEditor", function() {
         await driver.sendKeys(Key.ESCAPE);
         await gu.waitAppFocus(true);
         // Second cell should be clickable - this means view was scrolled to the active record.
-        // The scroll-back may still be rendering, so retry if the cell element is stale.
         await gu.waitToPass(async () => gu.getCell(1, 1).click());
         await gu.waitForServer();
         await gu.checkForErrors();

--- a/test/nbrowser/FieldEditor.ts
+++ b/test/nbrowser/FieldEditor.ts
@@ -28,6 +28,7 @@ describe("FieldEditor", function() {
     await (await gu.openRowMenu(1)).findContent("li", /Insert row above/).click();
     await gu.waitForServer();
     await gu.getCell(0, 1).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.ENTER);
     await gu.checkTextEditor(gu.exactMatch(""));
     await gu.getCell(2, 1).click(); // Click away to save
@@ -85,6 +86,7 @@ describe("FieldEditor", function() {
     await driver.findContent(".test-treeview-itemHeader", /Friends/).doClick();
     assert.equal(await gu.getCell({ rowNum: 1, col: 0 }).getText(), "Roger");
     await gu.getCell({ rowNum: 1, col: 0 }).click();
+    await gu.waitAppFocus();
     await gu.sendKeys("FieldEditor2");
     assert.equal(await driver.find(".cell_editor").isDisplayed(), true);
 

--- a/test/nbrowser/FieldEditor.ts
+++ b/test/nbrowser/FieldEditor.ts
@@ -160,7 +160,8 @@ describe("FieldEditor", function() {
         await driver.sendKeys(Key.ESCAPE);
         await gu.waitAppFocus(true);
         // Second cell should be clickable - this means view was scrolled to the active record.
-        await gu.getCell(1, 1).click();
+        // The scroll-back may still be rendering, so retry if the cell element is stale.
+        await gu.waitToPass(async () => gu.getCell(1, 1).click());
         await gu.waitForServer();
         await gu.checkForErrors();
       });

--- a/test/nbrowser/FilteringBugs.ts
+++ b/test/nbrowser/FilteringBugs.ts
@@ -20,6 +20,7 @@ describe("FilteringBugs", function() {
     // Change column A of the first record from foo to bar; bar should still be
     // visible, even though it's excluded by a filter.
     await gu.getCell({ section: "TABLE2 Filtered", rowNum: 1, col: "A" }).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.ENTER, Key.ARROW_DOWN, Key.ENTER);
     await gu.waitForServer();
     assert.deepEqual(
@@ -30,6 +31,7 @@ describe("FilteringBugs", function() {
     // With the same record selected, change column C in the linked card section.
     await gu.getCell({ section: "TABLE2 Filtered", rowNum: 1, col: "A" }).click();
     await gu.getCardCell("C", "TABLE2 Card").click();
+    await gu.waitAppFocus();
     await gu.sendKeys("2", Key.ENTER);
     await gu.waitForServer();
 

--- a/test/nbrowser/FormulaAutocomplete.ts
+++ b/test/nbrowser/FormulaAutocomplete.ts
@@ -196,6 +196,7 @@ describe("FormulaAutocomplete", function() {
     // Add a new column 'T' of type Text
     await gu.addColumn("T");
     await gu.getCell({ rowNum: 1, col: "T" }).click();
+    await gu.waitAppFocus();
     await gu.enterCell("abc");
 
     // Write a new formula starting with `$Title.` and check that the autocomplete options are correct

--- a/test/nbrowser/FormulaAutocomplete.ts
+++ b/test/nbrowser/FormulaAutocomplete.ts
@@ -229,6 +229,7 @@ describe("FormulaAutocomplete", function() {
     await gu.addColumn("B");
     await gu.getCell({ rowNum: 1, col: "B" }).click();
     await startFormulaAutocomplete("$A");
+    await gu.waitForServer();
     await gu.waitToPass(async () => {
       const completions = await getCompletionLines();
       assert.lengthOf(completions, 3);

--- a/test/nbrowser/GranularAccess.ts
+++ b/test/nbrowser/GranularAccess.ts
@@ -1665,6 +1665,7 @@ describe("GranularAccess", function() {
     await gu.getPageItem(/Data1/).click();
     await gu.waitForServer();
     await gu.getCell("Pics", 1).click();
+    await gu.waitAppFocus();
     await driver.sendKeys(Key.ENTER);
     await gu.fileDialogUpload("uploads/sample.pdf,uploads/file1.mov", () => driver.find(".test-pw-add").click());
     await driver.findContentWait(".test-pw-counter", /of 2/, 3000);
@@ -1672,6 +1673,7 @@ describe("GranularAccess", function() {
     await gu.waitForServer();
 
     await gu.getCell("Pics", 2).click();
+    await gu.waitAppFocus();
     await driver.sendKeys(Key.ENTER);
     await gu.fileDialogUpload("uploads/grist.png", () => driver.find(".test-pw-add").click());
     await driver.findContentWait(".test-pw-counter", /of 1/, 3000);
@@ -1679,6 +1681,7 @@ describe("GranularAccess", function() {
     await gu.waitForServer();
 
     await gu.getCell("Pics", 3).click();
+    await gu.waitAppFocus();
     await driver.sendKeys(Key.ENTER);
     await gu.fileDialogUpload("uploads/gplaypattern.png", () => driver.find(".test-pw-add").click());
     await driver.findContentWait(".test-pw-counter", /of 1/, 3000);

--- a/test/nbrowser/GranularAccess.ts
+++ b/test/nbrowser/GranularAccess.ts
@@ -958,9 +958,11 @@ describe("GranularAccess", function() {
     assert.deepEqual(await gu.getSectionTitles(), ["TABLE1", "TABLE2"]);
 
     // Editor can't add a section.
-    const otherSession = await gu.session().teamSite.user("user2").addLogin();
+    const otherSession = await gu.session().teamSite.user("user2").login({
+      showTips: false,
+      retainExistingLogin: true,
+    });
     await otherSession.loadDoc(`/doc/${doc.id}`);
-    await gu.disableTips(gu.translateUser("user2").email);
     await gu.getPageItem(/Table1/).click();
     await gu.waitForServer();
     // TODO: Can remove dismissTips after a fix has landed for user prefs not loading correctly.
@@ -1613,8 +1615,9 @@ describe("GranularAccess", function() {
     await gu.waitAppFocus(false);
     await gu.sendKeys("user.Name", Key.ENTER);
     await gu.waitForServer();
-    await driver.find(".test-field-formula-apply-on-changes").click();
-    await driver.findWait(".test-field-triggers-select", 100).click();
+    await driver.findWait(".test-field-formula-apply-on-changes", 1000).click();
+    await gu.waitForServer();
+    await driver.findWait(".test-field-triggers-select", 3000).click();
     await driver.findContentWait(".test-field-triggers-dropdown label", "Any field", 100).click();
     await driver.find(".test-trigger-deps-apply").click();
     await gu.waitForServer();

--- a/test/nbrowser/Importer2.ts
+++ b/test/nbrowser/Importer2.ts
@@ -691,6 +691,7 @@ describe("Importer2", function() {
       // Delete the first row of the Country column. (Needed for a later assertion.)
       await gu.sendKeys(Key.chord(await gu.modKey(), Key.UP));
       await gu.getCell(3, 1).click();
+      await gu.waitAppFocus();
       await gu.sendKeys(Key.DELETE);
       await gu.waitForServer();
 

--- a/test/nbrowser/LinkingSelector.ts
+++ b/test/nbrowser/LinkingSelector.ts
@@ -116,6 +116,13 @@ describe("LinkingSelector", function() {
     // when it was filtered out, for self-linking.
     await gu.selectSectionByTitle("List");
     await gu.removeFilters();
+    await gu.waitForServer();
+
+    // Make sure all filters are removed and all rows are visible.
+    await gu.waitToPass(async () => {
+      assert.equal(await gu.getCell("Start_Date", 1, "List").getText(), "2018-09-13");
+      assert.equal(await gu.getCell("Start_Date", 2, "List").getText(), "2018-09-14");
+    }, 1000);
 
     // Select first row.
     await gu.getCell("Start_Date", 1).click();

--- a/test/nbrowser/MultiColumn.ts
+++ b/test/nbrowser/MultiColumn.ts
@@ -939,6 +939,7 @@ async function testChoices(colA: string = "Left", colB: string = "Right") {
   await choiceEditor.add("two");
   await choiceEditor.save();
   await gu.getCell(colA, 1).click();
+  await gu.waitAppFocus();
   await gu.sendKeys("one", Key.ENTER);
   // If this is choice list we need one more enter.
   if (await getColumnType() === "Choice List") {
@@ -946,6 +947,7 @@ async function testChoices(colA: string = "Left", colB: string = "Right") {
   }
   await gu.waitForServer();
   await gu.getCell(colB, 1).click();
+  await gu.waitAppFocus();
   await gu.sendKeys("one", Key.ENTER);
   if (await getColumnType() === "Choice List") {
     await gu.sendKeys(Key.ENTER);

--- a/test/nbrowser/MultiColumn.ts
+++ b/test/nbrowser/MultiColumn.ts
@@ -959,11 +959,15 @@ async function testChoices(colA: string = "Left", colB: string = "Right") {
   await choiceEditor.save();
   await gu.waitForServer();
   // Test if grid is ok.
-  assert.equal(await gu.getCell(colA, 1).getText(), "one renamed");
-  assert.equal(await gu.getCell(colB, 1).getText(), "one renamed");
+  await gu.waitToPass(async () => {
+    assert.equal(await gu.getCell(colA, 1).getText(), "one renamed");
+    assert.equal(await gu.getCell(colB, 1).getText(), "one renamed");
+  });
   await undo();
-  assert.equal(await gu.getCell(colA, 1).getText(), "one");
-  assert.equal(await gu.getCell(colB, 1).getText(), "one");
+  await gu.waitToPass(async () => {
+    assert.equal(await gu.getCell(colA, 1).getText(), "one");
+    assert.equal(await gu.getCell(colB, 1).getText(), "one");
+  });
 
   // Test that colors are also treated as different.
   await selectColumns(colA, colB);

--- a/test/nbrowser/NumericEditor.ts
+++ b/test/nbrowser/NumericEditor.ts
@@ -135,6 +135,7 @@ describe("NumericEditor", function() {
       it("should allow editing and saving a formatted value", async function() {
         for (const [i, entry] of Object.entries(entriesByColumn)) {
           await gu.getCell({ rowNum: 1, col: Number(i) }).click();
+          await gu.waitAppFocus();
           await gu.sendKeys(Key.ENTER);
           await gu.waitAppFocus(false);
           // Save the value the way it's opened in the editor. It's important that it doesn't

--- a/test/nbrowser/Pages.ts
+++ b/test/nbrowser/Pages.ts
@@ -189,7 +189,7 @@ describe("Pages", function() {
   it("should allow renaming table", async () => {
     // open dots menu and click rename
     await gu.openPageMenu("People");
-    await driver.find(".test-docpage-rename").doClick();
+    await driver.findWait(".test-docpage-rename", 1000).doClick();
 
     // do rename
     await driver.find(".test-docpage-editor").sendKeys("PeopleRenamed", Key.ENTER);
@@ -230,7 +230,7 @@ describe("Pages", function() {
   it("should not allow blank page name", async () => {
     // Begin renaming of People page
     await gu.openPageMenu("People");
-    await driver.find(".test-docpage-rename").doClick();
+    await driver.findWait(".test-docpage-rename", 1000).doClick();
 
     // Delete page name and check editor's value equals ''
     await driver.find(".test-docpage-editor").sendKeys(Key.DELETE);
@@ -253,7 +253,7 @@ describe("Pages", function() {
     // rename pages.
     async function renamePage(origName: string | RegExp, newName: string) {
       await gu.openPageMenu(origName);
-      await driver.find(".test-docpage-rename").doClick();
+      await driver.findWait(".test-docpage-rename", 1000).doClick();
       const editor = await driver.find(".test-docpage-editor");
       await driver.executeScript((el: HTMLInputElement, text: string) => { el.value = text; }, editor, newName);
       await editor.sendKeys(Key.ENTER);
@@ -286,7 +286,7 @@ describe("Pages", function() {
 
   it("should show tooltip for long page names on hover", async () => {
     await gu.openPageMenu("People");
-    await driver.find(".test-docpage-rename").doClick();
+    await driver.findWait(".test-docpage-rename", 1000).doClick();
     await driver.find(".test-docpage-editor")
       .sendKeys("People, Persons, Humans, Ladies & Gentlemen", Key.ENTER);
     await gu.waitForServer();
@@ -310,7 +310,7 @@ describe("Pages", function() {
 
     // start renaming Documents and click the input
     await gu.openPageMenu("Documents");
-    await driver.find(".test-docpage-rename").doClick();
+    await driver.findWait(".test-docpage-rename", 1000).doClick();
     await driver.find(".test-docpage-editor").click();
 
     // check that People is still the selected page.

--- a/test/nbrowser/ProposedChangesPage.ts
+++ b/test/nbrowser/ProposedChangesPage.ts
@@ -1612,10 +1612,12 @@ describe("ProposedChangesPage", function() {
 
     // Copy the value from the new row's B cell.
     await gu.getCell("B", 3).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(await gu.modKey(), "c"));
 
     // Paste into the new row's A cell.
     await gu.getCell("A", 3).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(await gu.modKey(), "v"));
     await gu.waitForServer();
 
@@ -1630,10 +1632,12 @@ describe("ProposedChangesPage", function() {
 
     // Copy the edited cell (B1 now shows Fish→Cat diff, has CellVersions).
     await gu.getCell("B", 1).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(await gu.modKey(), "c"));
 
     // Paste into A1.
     await gu.getCell("A", 1).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(await gu.modKey(), "v"));
     await gu.waitForServer();
 
@@ -1660,6 +1664,7 @@ describe("ProposedChangesPage", function() {
 
     // Select a range spanning the deleted row (position 1) and the real row (position 2).
     await gu.getCell("B", 1).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(Key.SHIFT, Key.DOWN));
 
     // Attempt fill-down (Mod+D). The selection includes a synthetic row ID.

--- a/test/nbrowser/ProposedChangesPage.ts
+++ b/test/nbrowser/ProposedChangesPage.ts
@@ -1765,7 +1765,7 @@ describe("ProposedChangesPage", function() {
     // Right-click on it and select Delete.
     try {
       await gu.openRowMenu(1);
-      const deleteItem = await driver.findContent(".grist-floating-menu li", /Delete/);
+      const deleteItem = await gu.findOpenMenuItem("li", /Delete/);
       await deleteItem.click();
       await gu.confirm();
       await gu.waitForServer();

--- a/test/nbrowser/RawData.ts
+++ b/test/nbrowser/RawData.ts
@@ -224,6 +224,7 @@ describe("RawData", function() {
     await driver.findContent(".test-raw-data-table-title", "Empire").click();
     await gu.waitForServer();
     await gu.getCell(2, 9).click();
+    await gu.waitAppFocus();
     await driver.sendKeys("123456789");
     await gu.refreshDismiss();
     await gu.waitForDocToLoad();
@@ -521,18 +522,22 @@ describe("RawData", function() {
   });
 
   it("should open raw data as a popup", async () => {
-    // We are at City table, in first row/first cell.
+    // Navigate to City table, first row/first cell.
     // Send some keys, to make sure we have focus on active section.
     // RawData popup is manipulating what section has focus, so we need to make sure that
     // focus is properly restored.
+    await gu.openPage("City");
+    await gu.waitForServer();
     assert.deepEqual(await gu.getCursorPosition(), { rowNum: 1, col: 0 });
     await gu.getCell(0, 2).click();
+    await gu.waitAppFocus();
     await gu.sendKeys("abc");
     await gu.checkTextEditor("abc");
     await gu.sendKeys(Key.ESCAPE);
     await gu.showRawData();
     assert.equal(await gu.getActiveSectionTitle(3_000), "City");
     assert.deepEqual(await gu.getCursorPosition(), { rowNum: 20, col: 0 }); // raw popup is not sorted
+    await gu.waitAppFocus();
     await gu.sendKeys("abc");
     await gu.checkTextEditor("abc");
     await gu.sendKeys(Key.ESCAPE);

--- a/test/nbrowser/RecordCards.ts
+++ b/test/nbrowser/RecordCards.ts
@@ -94,6 +94,7 @@ describe("RecordCards", function() {
 
     it("updates popup when reference icon is clicked within Record Card popup", async function() {
       await gu.getCell(0, 4).find(".test-ref-text").click();
+      await gu.waitAppFocus();
       await gu.sendKeys(Key.SPACE);
       assert.isTrue(await driver.findWait(".test-record-card-popup-overlay", 100).isDisplayed());
       assert.equal(
@@ -112,6 +113,7 @@ describe("RecordCards", function() {
 
     it("does not open popup if cell is empty", async function() {
       await gu.getCell(0, 4).find(".test-ref-text").click();
+      await gu.waitAppFocus();
       await driver.sendKeys(Key.DELETE);
       await gu.waitForServer();
       await gu.getCell(0, 4).find(".test-ref-link-icon").click();
@@ -169,6 +171,7 @@ describe("RecordCards", function() {
 
     it("updates popup when reference icon is clicked within Record Card popup", async function() {
       await gu.getCell(0, 4).click();
+      await gu.waitAppFocus();
       await gu.sendKeys(Key.SPACE);
       assert.isTrue(await driver.findWait(".test-record-card-popup-overlay", 100).isDisplayed());
       assert.equal(

--- a/test/nbrowser/RecordLayout.ts
+++ b/test/nbrowser/RecordLayout.ts
@@ -262,6 +262,7 @@ describe("RecordLayout", function() {
     await editLayoutMenu.findContent("button", "Cancel").click();
 
     // check Mumbai is still selected
+    await driver.findWait(".active_section .selected_cursor", 1000);
     assert.equal(await gu.getActiveCell().getText(), "Mumbai (Bombay)");
 
     // open editor for Mumbai name

--- a/test/nbrowser/ReferenceColumns.ts
+++ b/test/nbrowser/ReferenceColumns.ts
@@ -83,6 +83,7 @@ describe("ReferenceColumns", function() {
       await server.pauseUntil(async () => {
         assert.equal(await cell.getText(), "Films[1]");
         await cell.click();
+        await gu.waitAppFocus();
         await driver.sendKeys(Key.ENTER);
         await gu.waitForCellEditor();
         await gu.sendKeys(await gu.selectAllKey(), "5");
@@ -403,6 +404,7 @@ describe("ReferenceColumns", function() {
 
       // Check that for the same cell, the dropdown no longer has an "add new" option.
       await cell.click();
+      await gu.waitAppFocus();
       await driver.sendKeys(Key.ENTER);
       assert.equal(await driver.find(".celleditor_text_editor").value(), "hello");
       await driver.findWait(".test-ref-editor-item", 1000);

--- a/test/nbrowser/ReferenceList.ts
+++ b/test/nbrowser/ReferenceList.ts
@@ -800,6 +800,7 @@ describe("ReferenceList", function() {
 
       // Check that for the same cell, the dropdown no longer has an "add new" option.
       await cell.click();
+      await gu.waitAppFocus();
       await driver.sendKeys(Key.ENTER, "hello");
       await driver.findWait(".test-ref-editor-item", 1000);
       assert.equal(await driver.find(".test-ref-editor-item.selected").isPresent(), false);

--- a/test/nbrowser/ReferenceList.ts
+++ b/test/nbrowser/ReferenceList.ts
@@ -666,7 +666,7 @@ describe("ReferenceList", function() {
     });
 
     it("should return to text-as-typed when nothing is selected", async function() {
-      const cell = await gu.getCell({ section: "References", col: "Colors", rowNum: 2 }).doClick();
+      await gu.getCell({ section: "References", col: "Colors", rowNum: 2 }).doClick();
       await gu.enterCell(["da"], { validate: false });
       assert.deepEqual(await getACOptions(2), ["Dark Blue", "Dark Cyan"]);
 
@@ -701,14 +701,24 @@ describe("ReferenceList", function() {
       // Re-enter the typed-in text and click away. Check the cell is now empty since
       // no reference items were added.
       await driver.sendKeys("da", Key.UP);
-      await gu.getCell({ section: "References", col: "Colors", rowNum: 1 }).doClick();
+      await gu.getCell({ section: "References", col: "Colors", rowNum: 1 }).click();
       await gu.waitForServer();
-      assert.equal(await cell.getText(), "");
-      assert.equal(await cell.find(".field_clip").matches(".invalid"), false);
+      await gu.waitToPass(async () => {
+        assert.equal(
+          await gu.getCell({ section: "References", col: "Colors", rowNum: 2 }).getText(), "");
+      });
+      assert.equal(
+        await gu.getCell({ section: "References", col: "Colors", rowNum: 2 })
+          .find(".field_clip").matches(".invalid"), false);
 
       await gu.undo();
-      assert.equal(await cell.getText(), "Red");
-      assert.equal(await cell.find(".field_clip").matches(".invalid"), false);
+      await gu.waitToPass(async () => {
+        assert.equal(
+          await gu.getCell({ section: "References", col: "Colors", rowNum: 2 }).getText(), "Red");
+      });
+      assert.equal(
+        await gu.getCell({ section: "References", col: "Colors", rowNum: 2 })
+          .find(".field_clip").matches(".invalid"), false);
     });
 
     it("should save text as typed when nothing is selected", async function() {

--- a/test/nbrowser/RightPanel.ts
+++ b/test/nbrowser/RightPanel.ts
@@ -413,8 +413,8 @@ describe("RightPanel", function() {
 
     // click on the first cell on the grid: make sure keyboard nav is reset
     await gu.getCell({ col: 0, rowNum: 1 }).click();
-    await gu.sendKeys(Key.TAB);
     await gu.waitAppFocus();
+    await gu.sendKeys(Key.TAB);
   });
 
   it("should not disable tabbing in active widget when clicking on tabs", async function() {

--- a/test/nbrowser/RowMenu.ts
+++ b/test/nbrowser/RowMenu.ts
@@ -85,8 +85,10 @@ describe("RowMenu", function() {
   it("should work even when no columns are visible", async function() {
     // Previously, a bug would cause an error to be thrown instead.
     await gu.openColumnMenu({ col: 0 }, "Hide column");
+    await gu.waitForServer();
     // After hiding the first column, the second one will be the new first column.
     await gu.openColumnMenu({ col: 0 }, "Hide column");
+    await gu.waitForServer();
     await assertRowMenuOpensAndCloses();
     await assertRowMenuOpensWithRightClick();
   });

--- a/test/nbrowser/Search2.ts
+++ b/test/nbrowser/Search2.ts
@@ -61,7 +61,7 @@ describe("Search2", async function() {
     await gu.getSection("CITY Card List").click();
     await gu.toggleSidePanel("right", "open");
     await driver.findContent(".test-right-panel button", /Change widget/).click();
-    await driver.find(".test-wselect-selectby").doClick();
+    await driver.findWait(".test-wselect-selectby", 1000).doClick();
     await driver.findContent(".test-wselect-selectby option", /CITY/).doClick();
     await driver.find(".test-wselect-addBtn").doClick();
     await gu.waitForServer();

--- a/test/nbrowser/Search2.ts
+++ b/test/nbrowser/Search2.ts
@@ -61,7 +61,7 @@ describe("Search2", async function() {
     await gu.getSection("CITY Card List").click();
     await gu.toggleSidePanel("right", "open");
     await driver.findContent(".test-right-panel button", /Change widget/).click();
-    await driver.findWait(".test-wselect-selectby", 1000).doClick();
+    await driver.find(".test-wselect-selectby").doClick();
     await driver.findContent(".test-wselect-selectby option", /CITY/).doClick();
     await driver.find(".test-wselect-addBtn").doClick();
     await gu.waitForServer();

--- a/test/nbrowser/SectionFilter.ts
+++ b/test/nbrowser/SectionFilter.ts
@@ -79,8 +79,10 @@ describe("SectionFilter", function() {
         ["Oranges", "Bananas", "Bananas"]);
 
       await menu.find(".test-filter-menu-cancel-btn").click();
-      assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3, 4, 5, 6]),
-        ["Apples", "Oranges", "Bananas", "Apples", "Bananas", "Apples"]);
+      await gu.waitToPass(async () => {
+        assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3, 4, 5, 6]),
+          ["Apples", "Oranges", "Bananas", "Apples", "Bananas", "Apples"]);
+      });
     });
 
     it("should display new/updated rows even when only certain values are filtered in", async () => {
@@ -108,8 +110,10 @@ describe("SectionFilter", function() {
 
       await driver.find(".test-filter-menu-apply-btn").click();
 
-      assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3, 4]),
-        ["Apples", "Apples", "Apples", ""]);
+      await gu.waitToPass(async () => {
+        assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3, 4]),
+          ["Apples", "Apples", "Apples", ""]);
+      });
 
       // Update first row to Oranges; it should remain shown.
       await gu.getCell(0, 1).click();
@@ -123,8 +127,10 @@ describe("SectionFilter", function() {
       await gu.enterCell("Bananas");
 
       // Ensure all 3 changes are visible.
-      assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3, 4, 5, 6]),
-        ["Oranges", "Apples", "", "Apples", "Bananas", ""]);
+      await gu.waitToPass(async () => {
+        assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3, 4, 5, 6]),
+          ["Oranges", "Apples", "", "Apples", "Bananas", ""]);
+      });
 
       // Check that the filter menu looks as expected.
       menu = await gu.openColumnMenu("A", "Filter");
@@ -137,8 +143,10 @@ describe("SectionFilter", function() {
 
       // Apply the filter to make it only-Apples again.
       await menu.find(".test-filter-menu-apply-btn").click();
-      assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3]),
-        ["Apples", "Apples", ""]);
+      await gu.waitToPass(async () => {
+        assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3]),
+          ["Apples", "Apples", ""]);
+      });
 
       // Reset the filter
       menu = await gu.openColumnMenu("A", "Filter");
@@ -147,13 +155,17 @@ describe("SectionFilter", function() {
         ["All", "None"]);
       await driver.findContent(".test-filter-menu-bulk-action", /All/).click();
       await menu.find(".test-filter-menu-apply-btn").click();
-      assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3, 4, 5, 6, 7, 8]),
-        ["Oranges", "Oranges", "Bananas", "Apples", "Bananas", "", "Apples", "Bananas"]);
+      await gu.waitToPass(async () => {
+        assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3, 4, 5, 6, 7, 8]),
+          ["Oranges", "Oranges", "Bananas", "Apples", "Bananas", "", "Apples", "Bananas"]);
+      });
 
       // Restore changes of this test case.
       await gu.undo(3);
-      assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3, 4, 5, 6]),
-        ["Apples", "Oranges", "Bananas", "Apples", "Bananas", "Apples"]);
+      await gu.waitToPass(async () => {
+        assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3, 4, 5, 6]),
+          ["Apples", "Oranges", "Bananas", "Apples", "Bananas", "Apples"]);
+      });
     });
 
     it("should display new/updated rows even when filtered, but refilter on menu changes", async () => {
@@ -165,8 +177,10 @@ describe("SectionFilter", function() {
       await menu.findContent("label", /Apples/).click();
       await driver.find(".test-filter-menu-apply-btn").click();
 
-      assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3]),
-        ["Oranges", "Bananas", "Bananas"]);
+      await gu.waitToPass(async () => {
+        assert.deepEqual(await gu.getVisibleGridCells(0, [1, 2, 3]),
+          ["Oranges", "Bananas", "Bananas"]);
+      });
 
       // Update Oranges to Apples and make sure it's not filtered out
       await (await gu.getCell(0, 1)).click();

--- a/test/nbrowser/ShiftSelection.ts
+++ b/test/nbrowser/ShiftSelection.ts
@@ -100,30 +100,35 @@ describe("ShiftSelection", function() {
 
   it("Shift+Up extends the selection up", async function() {
     await gu.getCell(1, 2).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(Key.SHIFT, Key.UP));
     await assertCellSelection({ colStart: 1, colEnd: 1, rowStart: 0, rowEnd: 1 });
   });
 
   it("Shift+Down extends the selection down", async function() {
     await gu.getCell(1, 2).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(Key.SHIFT, Key.DOWN));
     await assertCellSelection({ colStart: 1, colEnd: 1, rowStart: 1, rowEnd: 2 });
   });
 
   it("Shift+Left extends the selection left", async function() {
     await gu.getCell(1, 2).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(Key.SHIFT, Key.LEFT));
     await assertCellSelection({ colStart: 0, colEnd: 1, rowStart: 1, rowEnd: 1 });
   });
 
   it("Shift+Right extends the selection right", async function() {
     await gu.getCell(1, 2).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(Key.SHIFT, Key.RIGHT));
     await assertCellSelection({ colStart: 1, colEnd: 2, rowStart: 1, rowEnd: 1 });
   });
 
   it("Shift+Right + Shift+Left leads to the initial selection", async function() {
     await gu.getCell(1, 2).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(Key.SHIFT, Key.RIGHT));
     await gu.sendKeys(Key.chord(Key.SHIFT, Key.LEFT));
     await assertCellSelection({ colStart: 1, colEnd: 1, rowStart: 1, rowEnd: 1 });
@@ -131,6 +136,7 @@ describe("ShiftSelection", function() {
 
   it("Shift+Up + Shift+Down leads to the initial selection", async function() {
     await gu.getCell(1, 2).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(Key.SHIFT, Key.UP));
     await gu.sendKeys(Key.chord(Key.SHIFT, Key.DOWN));
     await assertCellSelection({ colStart: 1, colEnd: 1, rowStart: 1, rowEnd: 1 });
@@ -206,6 +212,7 @@ describe("ShiftSelection", function() {
     await assertCellSelection({ colStart: 3, colEnd: 4, rowStart: 2, rowEnd: 6 });
 
     await gu.getCell(4, 7).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(Key.SHIFT, Key.LEFT));
     await gu.sendKeys(Key.chord(ctrlKey, Key.SHIFT, Key.UP));
     await assertCellSelection({ colStart: 3, colEnd: 4, rowStart: 4, rowEnd: 6 });

--- a/test/nbrowser/SortFilterSectionOptions.ts
+++ b/test/nbrowser/SortFilterSectionOptions.ts
@@ -330,7 +330,7 @@ describe("SortFilterSectionOptions", function() {
 
     // Filter this column and apply.
     await gu.openColumnMenu("Name", "Filter");
-    await driver.findContent(".test-filter-menu-wrapper .test-filter-menu-value", /Apples/).click();
+    await driver.findContentWait(".test-filter-menu-wrapper .test-filter-menu-value", /Apples/, 200).click();
     await driver.find(".test-filter-menu-apply-btn").click();
 
     // The section-filter button should highlight, and menu should show the filtered column.
@@ -347,7 +347,7 @@ describe("SortFilterSectionOptions", function() {
   it("should not change filter state when a filtered column is hidden", async function() {
     // Filter a column and apply.
     await gu.openColumnMenu("Name", "Filter");
-    await driver.findContent(".test-filter-menu-wrapper .test-filter-menu-value", /Apples/).click();
+    await driver.findContentWait(".test-filter-menu-wrapper .test-filter-menu-value", /Apples/, 200).click();
     await driver.find(".test-filter-menu-apply-btn").click();
 
     // Check that the section-filter button is highlighted.
@@ -435,7 +435,7 @@ describe("SortFilterSectionOptions", function() {
 
     // uncheck Bananas
     const menu2 = await driver.findWait(".test-filter-menu-wrapper", 2000);
-    await menu2.findContent(".test-filter-menu-value", /Bananas/).click();
+    await menu2.findContentWait(".test-filter-menu-value", /Bananas/, 500).click();
     await menu2.find(".test-filter-menu-apply-btn").click();
 
     // check the grid is filtered correclty
@@ -478,7 +478,7 @@ describe("SortFilterSectionOptions", function() {
     }, 1000);
 
     // click Name
-    await driver.findContent(".grist-floating-menu li", /Name/).click();
+    await gu.findOpenMenuItem("li", /Name/).click();
 
     // check the filter menu is shown (wait for it to render after clicking Name)
     await driver.findWait(".test-filter-menu-wrapper", 2000);

--- a/test/nbrowser/Timing.ts
+++ b/test/nbrowser/Timing.ts
@@ -34,7 +34,7 @@ describe("Timing", function() {
   async function assertOff() {
     await gu.waitToPass(async () => {
       assert.equal(await timingText.text(), "Find slow formulas");
-    });
+    }, 10000);
     assert.isTrue(await startTiming.visible());
     assert.isFalse(await stopTiming.present());
   }

--- a/test/nbrowser/TokenField.ts
+++ b/test/nbrowser/TokenField.ts
@@ -41,6 +41,7 @@ describe("TokenField", function() {
 
     // Add a second value to the first row.
     await gu.getCell("A", 1).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.ENTER);
     await gu.sendKeys("two", Key.ENTER);
     await gu.sendKeys(Key.ENTER);
@@ -55,6 +56,7 @@ describe("TokenField", function() {
     // Clicking on the cell twice will put it in edit mode, so we will first click other cell.
     await gu.getDetailCell("B", 1).click();
     await gu.getDetailCell("A", 1).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.DELETE);
     await gu.waitForServer();
     assert.isEmpty(await gu.getDetailCell("A", 1).getText());
@@ -64,6 +66,7 @@ describe("TokenField", function() {
     assert.equal(await gu.getDetailCell("A", 1).getText(), "one\ntwo");
     await gu.getDetailCell("B", 1).click();
     await gu.getDetailCell("A", 1).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.BACK_SPACE);
     await gu.waitForServer();
     assert.isEmpty(await gu.getDetailCell("A", 1).getText());
@@ -102,6 +105,7 @@ describe("TokenField", function() {
 
     // Make sure it works in Grid view.
     await gu.getCell(0, 1).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.DELETE);
     await gu.waitForServer();
     assert.equal(await gu.getCell(0, 1).getText(), "");

--- a/test/nbrowser/TwoWayReference.ts
+++ b/test/nbrowser/TwoWayReference.ts
@@ -53,6 +53,7 @@ describe("TwoWayReference", function() {
     // Change Rex owner to Alice.
     await gu.selectSectionByTitle("PETS");
     await gu.getCell("Owner", 1).click();
+    await gu.waitAppFocus();
     await gu.sendKeys("Alice", Key.ENTER);
     await gu.waitForServer();
     await gu.selectSectionByTitle("OWNERS");
@@ -130,6 +131,7 @@ describe("TwoWayReference", function() {
     // Now reasign Azor to Bob using Owners table.
     await gu.selectSectionByTitle("OWNERS");
     await gu.getCell("Pets", 2).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.ENTER, "Azor", Key.ENTER, Key.ENTER);
     await gu.waitForServer();
 
@@ -183,6 +185,7 @@ describe("TwoWayReference", function() {
 
     await gu.selectSectionByTitle("Pets");
     await gu.getCell("Owner", 1).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.DELETE);
     await gu.waitForServer();
 

--- a/test/nbrowser/UploadLimits.ts
+++ b/test/nbrowser/UploadLimits.ts
@@ -104,6 +104,7 @@ describe("UploadLimits", function() {
 
     // Clear the first cell.
     await gu.getCell(0, 1).click();
+    await gu.waitAppFocus();
     await driver.sendKeys(Key.DELETE);
     await gu.waitForServer();
 

--- a/test/nbrowser/WebhookPage.ts
+++ b/test/nbrowser/WebhookPage.ts
@@ -332,5 +332,7 @@ async function openWebhookPage() {
 async function waitForWebhookPage() {
   await driver.findContentWait("button", /Clear queue/, 3000);
   // No section, so no easy utility for setting focus. Click on a random cell.
-  await gu.getDetailCell({ col: "Webhook Id", rowNum: 1 }).click();
+  await gu.waitToPass(async () => {
+    await gu.getDetailCell({ col: "Webhook Id", rowNum: 1 }).click();
+  });
 }

--- a/test/nbrowser/WebhookPage.ts
+++ b/test/nbrowser/WebhookPage.ts
@@ -106,6 +106,7 @@ describe("WebhookPage", function() {
     // Remove the webhook and make sure it is no longer listed.
     assert.equal(await gu.getCardListCount(), 2);
     await gu.getDetailCell({ col: "Name", rowNum: 1 }).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(await gu.modKey(), Key.DELETE));
     await gu.confirm(true, true);
     await gu.waitForServer();
@@ -134,6 +135,7 @@ describe("WebhookPage", function() {
       assert.equal(await getField(1, "Header Authorization"), "Bearer 1234");
     });
     await gu.getDetailCell({ col: "Header Authorization", rowNum: 1 }).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.DELETE);
     await gu.waitForServer();
   });
@@ -166,10 +168,12 @@ describe("WebhookPage", function() {
     assert.lengthOf((await docApi.getRows("Table3")).A, 1);
     // Break everything down.
     await gu.getDetailCell({ col: "Name", rowNum: 1 }).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(await gu.modKey(), Key.DELETE));
     await gu.confirm(true, true);
     await gu.waitForServer();
     await gu.getDetailCell({ col: "Memo", rowNum: 1 }).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(await gu.modKey(), Key.DELETE));
     await gu.waitForServer();
     assert.equal(await gu.getCardListCount(), 1);
@@ -208,6 +212,7 @@ describe("WebhookPage", function() {
 
     // Break everything down.
     await gu.getDetailCell({ col: "Name", rowNum: 1 }).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(await gu.modKey(), Key.DELETE));
     await gu.confirm(true, true);
     await gu.waitForServer();
@@ -264,6 +269,7 @@ describe("WebhookPage", function() {
     });
 
     await gu.getDetailCell({ col: "Name", rowNum: 1 }).click();
+    await gu.waitAppFocus();
     await gu.sendKeys(Key.chord(await gu.modKey(), Key.DELETE));
     await gu.confirm(true, true);
     await driver.switchTo().window(ownerTab);

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -718,7 +718,7 @@ namespace gristUtils {
     }, ...(clear ? [""] : []));
     // Wait for the editor to appear
     await waitForCellEditor();
-    // Select the content (so it is cleared) and press the keys requested by the caller
+    await waitAppFocus(false);
     await sendKeys(...keys);
     await waitForServer();    // Wait for the value to be saved
   }
@@ -734,7 +734,7 @@ namespace gristUtils {
   }
 
   export async function waitForCellEditor() {
-    await driver.wait(() => driver.find(".cell_editor").isDisplayed(), 1000);
+    await driver.wait(() => driver.find(".cell_editor").isDisplayed(), 1000, undefined, 20);
   }
 
   /**
@@ -850,6 +850,10 @@ namespace gristUtils {
       const end = await getCell({ rowNum: endRowNum, col: endCol });
       await driver.withActions(a => a.click(start).keyDown(Key.SHIFT).click(end).keyUp(Key.SHIFT));
     }
+    // driver.withActions uses raw pointer input that doesn't always transfer focus
+    // to the grid's hidden .copypaste textarea reliably. Without this wait, a
+    // subsequent Ctrl+X / Ctrl+C / sendKeys can be dropped. (nbrowser Pattern 4.)
+    await waitAppFocus();
   }
 
   /**
@@ -1605,7 +1609,7 @@ namespace gristUtils {
  */
   export async function openWidgetPanel(tab: "widget" | "sortAndFilter" | "data" = "widget") {
     await toggleSidePanel("right", "open");
-    await retryOnStale(() => driver.findWait(".test-right-tab-pagewidget", 100).click());
+    await waitToPass(() => driver.findWait(".test-right-tab-pagewidget", 100).click(), 500);
     await driver.find(`.test-config-${tab}`).click();
   }
 
@@ -2823,6 +2827,28 @@ namespace gristUtils {
     }
   }
 
+  /**
+   * Inserts a new column at the current cursor position using the Alt+= shortcut,
+   * keeping the server-generated name. Waits for the rename popup to open before
+   * dismissing it with Escape — without that wait, the Escape can race the popup
+   * mount and the next keystroke can land on a still-open popup, eating it.
+   */
+  export async function insertColumn(type?: string) {
+    await sendKeys(Key.chord(Key.ALT, "="));
+    await waitForServer();
+    // Wait for the rename popup to actually open, otherwise Escape is racy.
+    await driver.findWait(".test-column-title-popup", 1000);
+    await sendKeys(Key.ESCAPE);
+    // Make sure the popup is gone before returning, so a subsequent insertColumn
+    // call doesn't have its Alt+= swallowed by a still-closing popup.
+    await waitToPass(async () => {
+      assert.isFalse(await driver.find(".test-column-title-popup").isPresent());
+    });
+    if (type) {
+      await setType(exactMatch(type));
+    }
+  }
+
   export async function showColumn(name: string) {
     await scrollIntoView(await driver.find(".active_section .mod-add-column"));
     await driver.find(".active_section .mod-add-column").click();
@@ -3402,7 +3428,7 @@ namespace gristUtils {
         return this;
       },
       async close() {
-        await driver.find(".test-filter-menu-apply-btn").click();
+        await driver.findWait(".test-filter-menu-apply-btn", 1000).click();
         return this;
       },
       async save() {
@@ -3414,7 +3440,7 @@ namespace gristUtils {
      * Clicks the filter icon in the current section (can be used to close the filter menu or open it)
      */
       async click() {
-        await driver.find(".active_section .test-section-menu-filter-icon").click();
+        await driver.findWait(".active_section .test-section-menu-filter-icon", 200).click();
         return this;
       },
       async filters() {
@@ -3547,6 +3573,14 @@ namespace gristUtils {
   export async function renameActiveSection(name: string) {
     await driver.find(".active_section .test-viewsection-title .test-widget-title-text").click();
     await doRenameSection(name);
+    // Wait for the section title to update in the DOM — the reactive re-render
+    // can lag slightly after waitForServer(), causing getSection() lookups to fail.
+    if (name) {
+      await waitToPass(async () => {
+        const title = await driver.find(".active_section .test-viewsection-title").getText();
+        assert.equal(title.trim(), name);
+      }, 1000);
+    }
   }
 
   async function doRenameSection(name: string) {
@@ -4250,8 +4284,10 @@ namespace gristUtils {
     return driver.findWait(".grist-floating-menu", timeoutMsec);
   }
 
-  export function findOpenMenuItem(itemSelector: string, itemContentMatcher: string | RegExp,  timeoutMsec = 100) {
-    return driver.findContentWait(`.grist-floating-menu ${itemSelector}`, itemContentMatcher, timeoutMsec);
+  export function findOpenMenuItem(itemSelector: string, itemContentMatcher?: string | RegExp,  timeoutMsec = 100) {
+    return itemContentMatcher ?
+      driver.findContentWait(`.grist-floating-menu ${itemSelector}`, itemContentMatcher, timeoutMsec) :
+      driver.findWait(`.grist-floating-menu ${itemSelector}`, timeoutMsec);
   }
 
   export async function findOpenMenuAllItems<T>(
@@ -4259,8 +4295,12 @@ namespace gristUtils {
     mapper: (e: WebElement) => Promise<T>,
     timeoutMsec = 100,
   ): Promise<T[]>   {
-  // Find at least one item to ensure the menu is open.
-    await driver.findWait(`.grist-floating-menu ${itemSelector}`, timeoutMsec);
+    try {
+      // Find at least one item to ensure the menu is open.
+      await driver.findWait(`.grist-floating-menu ${itemSelector}`, timeoutMsec);
+    } catch {
+      // Keep going if we find nothing after the brief wait; we may be expecting to find 0 elements.
+    }
     return await driver.findAll(`.grist-floating-menu ${itemSelector}`, mapper);
   }
 

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -1397,7 +1397,7 @@ namespace gristUtils {
     }
     if (newName === undefined) { throw new Error("newName must be specified"); }
     await openPageMenu(oldName);
-    await driver.find(".test-docpage-rename").click();
+    await driver.findWait(".test-docpage-rename", 1000).click();
     await driver.find(".test-docpage-editor").sendKeys(newName, Key.ENTER);
     await waitForServer();
   }

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -4282,7 +4282,7 @@ namespace gristUtils {
     return driver.findWait(".grist-floating-menu", timeoutMsec);
   }
 
-  export function findOpenMenuItem(itemSelector: string, itemContentMatcher?: string | RegExp,  timeoutMsec = 100) {
+  export function findOpenMenuItem(itemSelector: string, itemContentMatcher?: string | RegExp, timeoutMsec = 100) {
     return itemContentMatcher ?
       driver.findContentWait(`.grist-floating-menu ${itemSelector}`, itemContentMatcher, timeoutMsec) :
       driver.findWait(`.grist-floating-menu ${itemSelector}`, timeoutMsec);

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -3404,6 +3404,10 @@ namespace gristUtils {
  */
   export async function removeFilters(save = false) {
     const sectionFilter = await sortAndFilter();
+    // Wait for the filter config panel to finish rendering its items — it opens
+    // via a popweasel popup (setTimeout(0)) and its filter rows are rendered
+    // reactively, so an immediate findAll can miss them.
+    await driver.findWait(".test-filter-config-container", 1000);
     for (const filter of await sectionFilter.filters()) {
       await filter.remove();
     }

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -2832,7 +2832,6 @@ namespace gristUtils {
    */
   export async function insertColumn(type?: string) {
     await sendKeys(Key.chord(Key.ALT, "="));
-    await waitForServer();
     // Wait for the rename popup to actually open, otherwise Escape is racy.
     await driver.findWait(".test-column-title-popup", 1000);
     await sendKeys(Key.ESCAPE);

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -850,9 +850,6 @@ namespace gristUtils {
       const end = await getCell({ rowNum: endRowNum, col: endCol });
       await driver.withActions(a => a.click(start).keyDown(Key.SHIFT).click(end).keyUp(Key.SHIFT));
     }
-    // driver.withActions uses raw pointer input that doesn't always transfer focus
-    // to the grid's hidden .copypaste textarea reliably. Without this wait, a
-    // subsequent Ctrl+X / Ctrl+C / sendKeys can be dropped. (nbrowser Pattern 4.)
     await waitAppFocus();
   }
 
@@ -3404,9 +3401,6 @@ namespace gristUtils {
  */
   export async function removeFilters(save = false) {
     const sectionFilter = await sortAndFilter();
-    // Wait for the filter config panel to finish rendering its items — it opens
-    // via a popweasel popup (setTimeout(0)) and its filter rows are rendered
-    // reactively, so an immediate findAll can miss them.
     await driver.findWait(".test-filter-config-container", 1000);
     for (const filter of await sectionFilter.filters()) {
       await filter.remove();
@@ -3577,8 +3571,6 @@ namespace gristUtils {
   export async function renameActiveSection(name: string) {
     await driver.find(".active_section .test-viewsection-title .test-widget-title-text").click();
     await doRenameSection(name);
-    // Wait for the section title to update in the DOM — the reactive re-render
-    // can lag slightly after waitForServer(), causing getSection() lookups to fail.
     if (name) {
       await waitToPass(async () => {
         const title = await driver.find(".active_section .test-viewsection-title").getText();
@@ -3773,6 +3765,9 @@ namespace gristUtils {
           await driver.find(`.test-filter-menu-${minMax}`).click();
         }
         await findOpenMenuItem("li", value.relative).click();
+      });
+      await waitToPass(async () => {
+        assert.isFalse(await driver.find(".grist-floating-menu").isPresent());
       });
     }
   }

--- a/test/projects/DateRangeFilter.ts
+++ b/test/projects/DateRangeFilter.ts
@@ -171,7 +171,7 @@ describe("DateRangeFilter", function() {
 
     // check menus still offer 4 days from now
     await fu.openRelativeOptionsMenu("min");
-    assert.equal(await driver.findContent(".grist-floating-menu li", "4 days from now").isPresent(), true);
+    assert.equal(await gu.findOpenMenuItem("li", "4 days from now").isPresent(), true);
     await driver.sendKeys(Key.ESCAPE);
   });
 
@@ -420,7 +420,7 @@ describe("DateRangeFilter", function() {
       // click Last week
       await driver.findContent(".test-filter-menu-presets-links button", "More").click();
       await gu.findOpenMenu();
-      await driver.findContent(".grist-floating-menu li", "Last week").click();
+      await gu.findOpenMenuItem("li", "Last week").click();
 
       // check min bounds shows '1st day of last week'
       assert.equal(await fu.getBoundText("min"), "1st day of last week");

--- a/test/projects/DateRangeFilter.ts
+++ b/test/projects/DateRangeFilter.ts
@@ -283,13 +283,10 @@ describe("DateRangeFilter", function() {
 
   it("should hide options on Escape", async function() {
     await fu.findBound("max").click();
-    await gu.waitToPass(async () => {
-      assert.equal(await fu.isOptionsVisible(), true);
-    });
+    await fu.assertOptionsVisible();
     await driver.sendKeys(Key.ESCAPE);
-    await gu.waitToPass(async () => {
-      assert.equal(await fu.isOptionsVisible(), false);
-    });
+    await gu.waitForMenuToClose();
+    await fu.assertOptionsNotRendered();
   });
 
   it("should show relative dates options when value changes", async function() {
@@ -297,10 +294,10 @@ describe("DateRangeFilter", function() {
     await gu.findOpenMenu();
     await driver.sendKeys(Key.ESCAPE);
     await gu.waitForMenuToClose();
-    assert.equal(await fu.isOptionsVisible(), false);
+    await fu.assertOptionsNotRendered();
     await fu.pickDateInCurrentMonth("18");
     await gu.findOpenMenu();
-    assert.equal(await fu.isOptionsVisible(), true);
+    await fu.assertOptionsVisible();
     await driver.sendKeys(Key.ESCAPE);
     await gu.waitForMenuToClose();
   });
@@ -310,19 +307,19 @@ describe("DateRangeFilter", function() {
     await gu.findOpenMenu();
     await driver.sendKeys(Key.ESCAPE);
     await gu.waitForMenuToClose();
-    assert.equal(await fu.isOptionsVisible(), false);
+    await fu.assertOptionsNotRendered();
     await driver.sendKeys(Key.TAB);
     await gu.findOpenMenu();
-    assert.equal(await fu.isOptionsVisible(), true);
+    await fu.assertOptionsVisible();
   });
 
   it("should toggle relative dates on click", async function() {
     await fu.findBound("min").click();
     await gu.findOpenMenu();
-    assert.equal(await fu.isOptionsVisible(), true);
+    await fu.assertOptionsVisible();
     await fu.findBound("min").click();
     await gu.waitForMenuToClose();
-    assert.equal(await fu.isOptionsVisible(), false);
+    await fu.assertOptionsNotRendered();
   });
 
   it("should show relative dates options when pressing Enter while the options are closed", async function() {
@@ -330,10 +327,10 @@ describe("DateRangeFilter", function() {
     await gu.findOpenMenu();
     await driver.sendKeys(Key.ESCAPE); // Escape to close
     await gu.waitForMenuToClose();
-    assert.equal(await fu.isOptionsVisible(), false);
+    await fu.assertOptionsNotRendered();
     await driver.sendKeys(Key.ENTER); // Enter to reopen
     await gu.findOpenMenu();
-    assert.equal(await fu.isOptionsVisible(), true);
+    await fu.assertOptionsVisible();
     assert.equal(await fu.getSelected(), "min");
   });
 

--- a/test/projects/DocumentSettings.ts
+++ b/test/projects/DocumentSettings.ts
@@ -14,15 +14,15 @@ describe("DocumentSettings", () => {
     this.timeout(4000);
 
     await driver.findWait(".test-tz-autocomplete", 500).click();
-    await driver.findContent(".test-acselect-dropdown li", /Europe\/Paris/).click();
+    await driver.findContentWait(".test-acselect-dropdown li", /Europe\/Paris/, 1000).click();
     assert.equal(await driver.find(".test-result-timezone").value(), "Europe/Paris");
 
     await driver.findWait(".test-settings-locale-autocomplete", 500).click();
-    await driver.findContent(".test-acselect-dropdown li", /Spain \(Spanish\)/).click();
+    await driver.findContentWait(".test-acselect-dropdown li", /Spain \(Spanish\)/, 1000).click();
     assert.equal(await driver.find(".test-result-locale").value(), "es-ES");
 
     await driver.findWait(".test-currency-autocomplete", 500).click();
-    await driver.findContent(".test-acselect-dropdown li", /Yen/).click();
+    await driver.findContentWait(".test-acselect-dropdown li", /Yen/, 1000).click();
     assert.equal(await driver.find(".test-result-currency").value(), "JPY");
   });
 

--- a/test/projects/PagesComponent.ts
+++ b/test/projects/PagesComponent.ts
@@ -17,7 +17,7 @@ describe("PagesComponent", function() {
 
   async function beginRenaming(name: RegExp) {
     await findPage(name).mouseMove().find(".test-docpage-dots").click();
-    await driver.find(".test-docpage-rename").doClick();
+    await driver.findWait(".test-docpage-rename", 1000).doClick();
     // A textbox should open and get selected: wait for it, since it's not immediate, and
     // trying to type into it too soon may miss some initial characters.
     await driver.wait(() => driver.executeScript(
@@ -49,7 +49,7 @@ describe("PagesComponent", function() {
     // starts renaming People
     const page = driver.findContent(".test-treeview-label", /People/);
     await page.mouseMove().find(".test-docpage-dots").click();
-    await driver.find(".test-docpage-rename").doClick();
+    await driver.findWait(".test-docpage-rename", 1000).doClick();
 
     // click on the text input
     await driver.find(".test-docpage-editor").click();

--- a/test/projects/RangeFilter.ts
+++ b/test/projects/RangeFilter.ts
@@ -111,14 +111,14 @@ describe("RangeFilter", function() {
 
   it("should toggle relative options on click only for date column", async function() {
     await setFilterType("Numeric");
-    assert.equal(await fu.isOptionsVisible(), false);
+    await fu.assertOptionsNotRendered();
     await fu.findBound("min").click();
-    assert.equal(await fu.isOptionsVisible(), false);
+    await fu.assertOptionsNotRendered();
 
     await setFilterType("Date");
-    assert.equal(await fu.isOptionsVisible(), false);
+    await fu.assertOptionsNotRendered();
     await fu.findBound("min").click();
-    assert.equal(await fu.isOptionsVisible(), true);
+    await fu.assertOptionsVisible();
   });
 
   it("should handle Date column correctly", async function() {

--- a/test/projects/TreeViewComponent.ts
+++ b/test/projects/TreeViewComponent.ts
@@ -310,7 +310,7 @@ describe("TreeViewComponent", () => {
     await startDrag(/Page6/);
     await findItem(/Page1/).mouseMove();
     // target is above Page1
-    assert.equal(await driver.find(".test-treeview-target").isDisplayed(), true);
+    assert.equal(await driver.findWait(".test-treeview-target", 1000).isDisplayed(), true);
     assert.deepEqual(await driver.findAll(`.test-treeview-itemHeader.highlight`, e => e.getText()), []);
     await assertTargetPos(await target.rect(), "above", await findItemRectangles(/Page1/));
     await delay(1200);

--- a/test/projects/TreeViewComponent.ts
+++ b/test/projects/TreeViewComponent.ts
@@ -513,7 +513,22 @@ function findTarget() {
 async function withTreeviewChange(cb: () => WebElementPromise | Promise<void>) {
   const getItemTexts = async () =>
     (await driver.findAll(".test-treeview-itemHeaderWrapper", e => e.getText())).join(",");
-  const before = await getItemTexts();
+  // Retry on StaleElementReferenceError: the treeview re-renders in response
+  // to `cb()`, which can invalidate element references that `findAll` collected
+  // a microtask earlier, causing `getText()` to throw mid-poll. We want the
+  // wait to just try again on the next tick.
+  const getItemTextsSafe = async () => {
+    try {
+      return await getItemTexts();
+    } catch (e) {
+      if (e.name === "StaleElementReferenceError") { return null; }
+      throw e;
+    }
+  };
+  const before = await getItemTextsSafe();
   await cb();
-  await driver.wait(async () => (await getItemTexts()) !== before);
+  await driver.wait(async () => {
+    const now = await getItemTextsSafe();
+    return now !== null && now !== before;
+  });
 }

--- a/test/projects/TreeViewComponent.ts
+++ b/test/projects/TreeViewComponent.ts
@@ -513,10 +513,7 @@ function findTarget() {
 async function withTreeviewChange(cb: () => WebElementPromise | Promise<void>) {
   const getItemTexts = async () =>
     (await driver.findAll(".test-treeview-itemHeaderWrapper", e => e.getText())).join(",");
-  // Retry on StaleElementReferenceError: the treeview re-renders in response
-  // to `cb()`, which can invalidate element references that `findAll` collected
-  // a microtask earlier, causing `getText()` to throw mid-poll. We want the
-  // wait to just try again on the next tick.
+  // Retry on StaleElementReferenceError
   const getItemTextsSafe = async () => {
     try {
       return await getItemTexts();

--- a/test/projects/UI2018.ts
+++ b/test/projects/UI2018.ts
@@ -321,13 +321,15 @@ describe("UI2018", () => {
 
       // Open the menu and check 2 more option, triggering the error observable from the fixture to be true.
       await driver.find("#menus .test-multi-select").click();
-      await driver.findContent(
+      await driver.findContentWait(
         ".test-multi-select-menu .test-multi-select-menu-option",
         /Text/,
+        1000,
       ).click();
-      await driver.findContent(
+      await driver.findContentWait(
         ".test-multi-select-menu .test-multi-select-menu-option",
         /Date/,
+        1000,
       ).click();
 
       // Check that the outline is now red.

--- a/test/projects/contextMenu.ts
+++ b/test/projects/contextMenu.ts
@@ -64,7 +64,7 @@ describe("contextMenu", function() {
     await contextMenu();
 
     // check action worked
-    await driver.findContent(".grist-floating-menu li", "Reset").click();
+    await gu.findOpenMenuItem("li", "Reset").click();
     await checkLogs([]);
 
     // open context menu

--- a/test/projects/filterUtils.ts
+++ b/test/projects/filterUtils.ts
@@ -1,6 +1,6 @@
 import * as gu from "test/nbrowser/gristUtils";
 
-import { addToRepl, driver, WebElementPromise } from "mocha-webdriver";
+import { addToRepl, assert, driver, WebElementPromise } from "mocha-webdriver";
 
 export async function openRelativeOptionsMenu(minMax: "min" | "max") {
   if (!await driver.find(".grist-floating-menu").isPresent()) {
@@ -16,8 +16,12 @@ export async function findCalendarDates(selector: string): Promise<string[]> {
   return res;
 }
 
-export function isOptionsVisible() {
-  return driver.find(".test-filter-menu-wrapper .grist-floating-menu").isPresent();
+export async function assertOptionsVisible() {
+  await driver.findWait(".test-filter-menu-wrapper .grist-floating-menu", 1000);
+}
+
+export async function assertOptionsNotRendered() {
+  assert.isFalse(await driver.find(".test-filter-menu-wrapper .grist-floating-menu").isPresent());
 }
 
 export async function isBoundSelected(minMax: "min" | "max") {
@@ -67,7 +71,8 @@ export function addFilterUtilsToRepl() {
   addToRepl("findCalendarDates", findCalendarDates);
   addToRepl("setBound", setBound);
   addToRepl("getSelected", getSelected);
-  addToRepl("isOptionsVisible", isOptionsVisible);
+  addToRepl("assertOptionsVisible", assertOptionsVisible);
+  addToRepl("assertOptionsNotRendered", assertOptionsNotRendered);
   addToRepl("pickDateInCurrentMonth", pickDateInCurrentMonth);
   addToRepl("getViewType", getViewType);
   addToRepl("getSelectedOption", getSelectedOption);

--- a/test/projects/transitions.ts
+++ b/test/projects/transitions.ts
@@ -40,7 +40,7 @@ describe("transitions", function() {
 
   it("should run callbacks and transition properties", async function() {
     await driver.get(`${server.getHost()}/transitions`);
-    await driver.find(".test-duration").doClear().doSendKeys(`${kDelayMs * 2}ms`, Key.ENTER);
+    await driver.findWait(".test-duration", 2000).doClear().doSendKeys(`${kDelayMs * 2}ms`, Key.ENTER);
     leftDiv = driver.find(".test-left");
     countFinishedDiv = driver.find(".test-finished");
     await assertState({ width: 30, opacity: 1, finished: 0 });
@@ -68,7 +68,7 @@ describe("transitions", function() {
   it("should handle interrupted transitions well", async function() {
     // Load the page fresh (for new counts) and give more time for this transition.
     await driver.get(`${server.getHost()}/transitions`);
-    await driver.find(".test-duration").doClear().doSendKeys(`${kDelayMs * 4}ms`, Key.ENTER);
+    await driver.findWait(".test-duration", 2000).doClear().doSendKeys(`${kDelayMs * 4}ms`, Key.ENTER);
 
     leftDiv = driver.find(".test-left");
     countFinishedDiv = driver.find(".test-finished");

--- a/test/server/lib/HostedStorageManager.ts
+++ b/test/server/lib/HostedStorageManager.ts
@@ -1181,9 +1181,9 @@ describe("HostedStorageManager", function() {
 
     // If competing with intense user writes, backups should pause writes.
     it(`backups will make time for themselves if competing with writes`, async function() {
-      this.timeout("10s");
+      this.timeout("30s");
       for (const allowPause of [false, true] as const) {
-        const { db, src, dest } = await makeDb(1000);
+        const { db, src, dest } = await makeDb(2000);
         let busy = 0;
         let done = false;
         function progress(event: BackupEvent) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2387,11 +2387,6 @@ ansi-align@^3.0.1:
   dependencies:
     string-width "^4.1.0"
 
-ansi-colors@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
-  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
-
 ansi-html-community@0.0.8, ansi-html-community@^0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"


### PR DESCRIPTION
Fixing many flaky tests.

Most fixes are just adding `await gu.waitAppFocus();` before typing things into a cell, adding missing `waitForServer` calls, and waiting for the popup menus to open.

Will run it several times in a row, and after all green will ask for review.