### PR TITLE
add in-process server restart without dropping the HTTP socket

### DIFF
--- a/app/server/declarations.d.ts
+++ b/app/server/declarations.d.ts
@@ -6,6 +6,8 @@ declare module "app/server/lib/shutdown" {
   export function addCleanupHandler<T>(context: T, method: (this: T) => void, timeout?: number, name?: string): void;
   export function removeCleanupHandlers<T>(context: T): void;
   export function cleanupOnSignals(...signalNames: string[]): void;
+  export function resetCleanupHandlers(): void;
+  export function installProcessHandlers(): void;
   export function exit(optExitCode?: number): Promise<void>;
 }
 

--- a/app/server/lib/AppSettings.ts
+++ b/app/server/lib/AppSettings.ts
@@ -327,11 +327,14 @@ export class AppSettings {
 export const appSettings = new AppSettings("grist");
 
 /**
- * Whether in-process restart is enabled (GRIST_CAN_RESTART).
+ * Whether to wrap the server in a ServerShell that supports in-process
+ * restart while keeping the HTTP socket alive. Defaults to false.
+ * Enabled with GRIST_SERVER_SHELL_ENABLED=true.
  */
-export function canRestart() {
-  return appSettings.section("server").flag("canRestart").readBool({
-    envVar: "GRIST_CAN_RESTART",
+export function isServerShellEnabled() {
+  return appSettings.section("server").flag("shellEnabled").readBool({
+    envVar: "GRIST_SERVER_SHELL_ENABLED",
+    defaultValue: false,
   });
 }
 

--- a/app/server/lib/AppSettings.ts
+++ b/app/server/lib/AppSettings.ts
@@ -289,6 +289,17 @@ export class AppSettings {
   }
 
   /**
+   * Clear all cached values, children, and info. Used during in-process
+   * restart so that stale configuration doesn't persist.
+   */
+  public reset(): void {
+    this._value = undefined;
+    this._children = undefined;
+    this._info = undefined;
+    this._envFile = undefined;
+  }
+
+  /**
    * As for describe(), but include all nested settings also.
    * Used dotted notation for setting names. Omit settings that
    * are undefined and without useful information about how they

--- a/app/server/lib/AppSettings.ts
+++ b/app/server/lib/AppSettings.ts
@@ -327,6 +327,15 @@ export class AppSettings {
 export const appSettings = new AppSettings("grist");
 
 /**
+ * Whether in-process restart is enabled (GRIST_CAN_RESTART).
+ */
+export function canRestart() {
+  return appSettings.section("server").flag("canRestart").readBool({
+    envVar: "GRIST_CAN_RESTART",
+  });
+}
+
+/**
  * Hints for how to define a setting, including possible
  * environment variables and default values.
  */

--- a/app/server/lib/Comm.ts
+++ b/app/server/lib/Comm.ts
@@ -131,7 +131,7 @@ export class Comm extends EventEmitter {
     this._clients.delete(client.clientId);
   }
 
-  public async testServerShutdown() {
+  public async shutdown() {
     if (this._wss) {
       for (const wssi of this._wss) {
         await fromCallback(cb => wssi.close(cb));
@@ -140,8 +140,8 @@ export class Comm extends EventEmitter {
     }
   }
 
-  public async testServerRestart() {
-    await this.testServerShutdown();
+  public async restart() {
+    await this.shutdown();
     this._wss = this._startServer();
   }
 

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -121,6 +121,8 @@ const DOC_ID_NEW_USER_INFO = process.env.DOC_ID_NEW_USER_INFO;
 // PubSub channel we use to inform all servers when a new available Grist version is detected.
 const latestVersionChannel = "latestVersionAvailable";
 
+export function getGristHost() { return process.env.GRIST_HOST || "localhost"; }
+
 export interface FlexServerOptions {
   dataDir?: string;
 
@@ -131,6 +133,10 @@ export interface FlexServerOptions {
 
   // Global grist config options
   settings?: IGristCoreConfig;
+
+  // An existing http.Server to use instead of creating a new one.
+  // When provided, FlexServer will not close it on shutdown.
+  server?: http.Server;
 }
 
 export class FlexServer implements GristServer {
@@ -184,6 +190,8 @@ export class FlexServer implements GristServer {
   private _internalPermitStore: IPermitStore;  // store for permits that stay within our servers
   private _externalPermitStore: IPermitStore;  // store for permits that pass through outside servers
   private _disabled: boolean = false;
+  private _ownsServer: boolean;
+  private _restartCallback: (() => void) | null = null;
   private _disableExternalStorage: boolean = false;
   private _healthy: boolean = true;  // becomes false if a serious error has occurred and
   // server cannot do its work.
@@ -221,12 +229,13 @@ export class FlexServer implements GristServer {
   constructor(public port: number, public name: string = "flexServer",
     public readonly options: FlexServerOptions = {}) {
     this._getLoginSystem = create.getLoginSystem.bind(create);
+    this._ownsServer = !options.server;
     this.settings = options.settings;
     this.app = express();
     this.app.set("port", port);
 
     this.appRoot = getAppRoot();
-    this.host = process.env.GRIST_HOST || "localhost";
+    this.host = getGristHost();
     log.info(`== Grist version is ${version.version} (commit ${version.gitcommit})`);
     this.info.push(["appRoot", this.appRoot]);
     // Initialize locales files.
@@ -746,28 +755,9 @@ export class FlexServer implements GristServer {
 
   public addCleanup() {
     if (this._check("cleanup")) { return; }
-    // Set up signal handlers. Note that nodemon sends SIGUSR2 to restart node.
-    shutdown.cleanupOnSignals("SIGINT", "SIGTERM", "SIGHUP", "SIGUSR2");
-
-    // We listen for uncaughtExceptions / unhandledRejections, but do exit when they happen. It is
-    // a strong recommendation, which seems best to follow
-    // (https://nodejs.org/docs/latest-v18.x/api/process.html#warning-using-uncaughtexception-correctly).
-    // We do try to shutdown cleanly (i.e. do any planned cleanup), which goes somewhat against
-    // the recommendation to do only synchronous work.
-
-    let counter = 0;
-
-    // Note that this event catches also 'unhandledRejection' (origin should be either
-    // 'uncaughtException' or 'unhandledRejection').
-    process.on("uncaughtException", (err, origin) => {
-      log.error(`UNHANDLED ERROR ${origin} (${counter}):`, err);
-      if (counter === 0) {
-        // Only call shutdown once. It's async and could in theory fail, in which case it would be
-        // another unhandledRejection, and would get caught and reported by this same handler.
-        void (shutdown.exit(1));
-      }
-      counter++;
-    });
+    // installProcessHandlers is idempotent -- safe to call from both
+    // FlexServer (standalone) and ServerShell (restart mode).
+    shutdown.installProcessHandlers();
   }
 
   public addTagChecker() {
@@ -1108,8 +1098,11 @@ export class FlexServer implements GristServer {
     this._emitNotifier.removeAllListeners();
     this._dbManager?.clearCaches();
     this._installAdmin?.clearCaches();
-    if (this.server)      { this.server.close(); }
-    if (this.httpsServer) { this.httpsServer.close(); }
+    if (this._ownsServer) {
+      if (this.server)      { this.server.close(); }
+      if (this.httpsServer) { this.httpsServer.close(); }
+    }
+    if (this._comm) { await this._comm.shutdown(); }
     if (this.housekeeper) { await this.housekeeper.stop(); }
     if (this._jobs)       { await this._jobs.stop(); }
     if (this._docNotificationManager) {
@@ -1172,8 +1165,10 @@ export class FlexServer implements GristServer {
           this._comm.destroyAllClients();
         }
       }
-      this.server.close();
-      if (this.httpsServer) { this.httpsServer.close(); }
+      if (this._ownsServer) {
+        this.server.close();
+        if (this.httpsServer) { this.httpsServer.close(); }
+      }
     }
   }
 
@@ -1990,6 +1985,26 @@ export class FlexServer implements GristServer {
     this._isReady = value;
   }
 
+  public onRestart(cb: () => void) {
+    this._restartCallback = cb;
+  }
+
+  /**
+   * Request an in-process restart. The restart happens asynchronously:
+   * this method returns immediately, but the callback registered via
+   * onRestart() begins tearing down this FlexServer and building a new
+   * one. After triggerRestart() returns, this FlexServer instance is
+   * being shut down -- do not use it for further work. When running
+   * under ServerShell, the shell holds the HTTP socket open and creates
+   * a replacement FlexServer; callers that need the new instance should
+   * obtain it from the ServerShell handle. Has no effect if no
+   * restart callback has been registered (e.g. when GRIST_CAN_RESTART
+   * is not set).
+   */
+  public triggerRestart() {
+    this._restartCallback?.();
+  }
+
   public checkOptionCombinations() {
     // Check for some bad combinations we should warn about.
     const allowedWebhookDomains = appSettings.section("integrations").flag("allowedWebhookDomains").readString({
@@ -2009,10 +2024,14 @@ export class FlexServer implements GristServer {
   public async start() {
     if (this._check("start")) { return; }
 
-    const servers = this._createServers();
-    this.server = servers.server;
-    this.httpsServer = servers.httpsServer;
-    await this._startServers(this.server, this.httpsServer, this.name, this.port, true);
+    if (this.options.server) {
+      this.server = this.options.server;
+    } else {
+      const servers = this._createServers();
+      this.server = servers.server;
+      this.httpsServer = servers.httpsServer;
+      await this._startServers(this.server, this.httpsServer, this.name, this.port, true);
+    }
   }
 
   public addNotifier() {

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -121,6 +121,10 @@ const DOC_ID_NEW_USER_INFO = process.env.DOC_ID_NEW_USER_INFO;
 // PubSub channel we use to inform all servers when a new available Grist version is detected.
 const latestVersionChannel = "latestVersionAvailable";
 
+// The host that the HTTP server binds to. Read from GRIST_HOST,
+// defaulting to "localhost". Exported so that ServerShell (which
+// owns the socket when running in restart mode) and FlexServer
+// (which records the host for getOwnUrl) agree on the same value.
 export function getGristHost() { return process.env.GRIST_HOST || "localhost"; }
 
 export interface FlexServerOptions {
@@ -1998,8 +2002,8 @@ export class FlexServer implements GristServer {
    * under ServerShell, the shell holds the HTTP socket open and creates
    * a replacement FlexServer; callers that need the new instance should
    * obtain it from the ServerShell handle. Has no effect if no
-   * restart callback has been registered (e.g. when GRIST_CAN_RESTART
-   * is not set).
+   * restart callback has been registered (e.g. when
+   * GRIST_SERVER_SHELL_ENABLED is not set).
    */
   public triggerRestart() {
     this._restartCallback?.();

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -2819,7 +2819,7 @@ export class FlexServer implements GristServer {
  * better if long imports were made using a mechanism that
  * isn't just a single http request)
  */
-function getServerFlags(): https.ServerOptions {
+export function getServerFlags(): https.ServerOptions {
   const flags: https.ServerOptions = {};
 
   // We used to set the socket timeout to 0, but that has been

--- a/app/server/lib/GristServer.ts
+++ b/app/server/lib/GristServer.ts
@@ -115,6 +115,7 @@ export interface GristServer extends StorageCoordinator {
   onUserChange(callback: (change: UserChange) => Promise<void>): void;
   onStreamingDestinationsChange(callback: (orgId?: number) => Promise<void>): void;
   setReady(value: boolean): void;
+  triggerRestart(): void;
   getSigninUrl(req: express.Request, options: {
     signUp?: boolean;
     nextUrl?: URL;
@@ -233,6 +234,7 @@ export function createDummyGristServer(): GristServer {
     onStreamingDestinationsChange() { /* do nothing */ },
     hardDeleteDoc() { return Promise.resolve(); },
     setReady() { /* do nothing */ },
+    triggerRestart() { /* do nothing */ },
     getSigninUrl() { return Promise.resolve(""); },
     getUserIdMiddleware() { throw new Error("no user id middleware"); },
   };

--- a/app/server/lib/GristSocketServer.ts
+++ b/app/server/lib/GristSocketServer.ts
@@ -66,11 +66,10 @@ export class GristSocketServer {
   /**
    * Closes the WS servers and removes any associated connection handlers.
    *
-   * Removal of connection handlers is done as a precaution for scenarios where
-   * a new GristSocketServer is instantiated after a previous one was closed.
-   * Currently, this only happens during tests where the Comm object is shut
-   * down or restarted. (See `Comm.testServerShutdown` and
-   * `Comm.testServerRestart`.)
+   * Removal of connection handlers is done for scenarios where a new
+   * GristSocketServer is instantiated after a previous one was closed,
+   * such as in-process restart (see ServerShell) or tests (see
+   * `Comm.shutdown` and `Comm.restart`).
    *
    * If handlers are not removed, requests to the HTTP server associated with
    * this GristSocketServer will continue to be handled by listeners for a

--- a/app/server/lib/ServerShell.ts
+++ b/app/server/lib/ServerShell.ts
@@ -1,0 +1,191 @@
+/**
+ * ServerShell: an outer shell that keeps the HTTP socket alive across
+ * in-process restarts of the Grist server internals.
+ *
+ * The shell creates and owns the http.Server and the listening socket.
+ * On each (re)start, it creates a new MergedServer that attaches to
+ * the existing socket. The /status health-check endpoint is handled
+ * directly by the shell so it stays reachable even while the inner
+ * server is being torn down and rebuilt.
+ *
+ * When GRIST_CAN_RESTART is not set, falls back to a plain
+ * MergedServer without the restart-capable shell.
+ */
+
+import { isAffirmative } from "app/common/gutil";
+import { appSettings } from "app/server/lib/AppSettings";
+import { FlexServer, getGristHost } from "app/server/lib/FlexServer";
+import log from "app/server/lib/log";
+import { listenPromise } from "app/server/lib/serverUtils";
+import * as shutdown from "app/server/lib/shutdown";
+import { MergedServer, ServerType } from "app/server/MergedServer";
+
+import * as http from "http";
+
+export const Deps = {
+  testWaitBeforeReadyMs: 0,     // ms to wait before setting ready=true (for tests)
+  restartTimeoutMs: 60000,      // mark unhealthy if restart takes longer than this
+};
+
+export interface ServerShellOptions {
+  port: number;
+  serverTypes: ServerType[];
+
+  // Hook that runs before each MergedServer.create(), e.g. for DB setup.
+  // Called on initial start and on every restart.
+  beforeStart?: () => Promise<void>;
+
+  // Hook that runs after MergedServer.run(), e.g. for testing hooks.
+  afterStart?: (flexServer: FlexServer) => Promise<void>;
+}
+
+/**
+ * Start a Grist server. When GRIST_CAN_RESTART is set, wraps it in
+ * a shell that supports in-process restart. Otherwise does a plain
+ * MergedServer start.
+ */
+export async function startServer(options: ServerShellOptions) {
+  if (isAffirmative(process.env.GRIST_CAN_RESTART)) {
+    const shell = new ServerShell(options);
+    await shell.start();
+    return shell;
+  }
+  return _startPlain(options);
+}
+
+async function _startPlain(options: ServerShellOptions) {
+  const { port, serverTypes } = options;
+  await options.beforeStart?.();
+  const mergedServer = await MergedServer.create(port, serverTypes);
+  await mergedServer.run();
+  await options.afterStart?.(mergedServer.flexServer);
+  return {
+    flexServer: mergedServer.flexServer,
+    async shutdown() { await mergedServer.close(); },
+  };
+}
+
+class ServerShell {
+  public flexServer: FlexServer;
+
+  private _server: http.Server;
+  private _mergedServer: MergedServer | undefined;
+  private _currentApp: ((...args: any[]) => void) | undefined;
+  private _healthy: boolean = true;
+  private _port: number;
+
+  constructor(private _options: ServerShellOptions) {}
+
+  public async start() {
+    const host = getGristHost();
+    this._server = http.createServer();
+    await listenPromise(this._server.listen(this._options.port, host));
+    this._port = (this._server.address() as { port: number }).port;
+    log.info(`ServerShell listening on ${host}:${this._port}`);
+
+    this._server.on("request", (req, res) => this._handleRequest(req, res));
+    shutdown.installProcessHandlers();
+
+    await this._startGrist();
+  }
+
+  public async shutdown() {
+    await this._mergedServer?.close();
+    this._server.close();
+  }
+
+  // All requests pass through this handler. During restart, /status
+  // is answered directly to keep liveness probes happy while there is
+  // no Express app to delegate to. The restart is correct functioning
+  // of the app, rather than a failure.
+  //
+  // /status?ready=1 is always delegated to the Express app, or returns
+  // failure, since it is specifically asking if the app is operating
+  // fully.
+  //
+  // /status/hooks is also always delegated since it too is checking for
+  // something specific (test hooks).
+  private _handleRequest(req: http.IncomingMessage, res: http.ServerResponse) {
+    if (req.url === "/status" || req.url?.startsWith("/status?")) {
+      if (!this._healthy) {
+        res.writeHead(503, { "Content-Type": "text/plain" });
+        res.end("unhealthy");
+        return;
+      }
+      if (this._currentApp) {
+        this._currentApp(req, res);
+      } else if (new URL(req.url, "http://localhost").searchParams.get("ready") === "1") {
+        res.writeHead(503, { "Content-Type": "text/plain" });
+        res.end("not ready");
+      } else {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("ok");
+      }
+      return;
+    }
+    if (!this._currentApp) {
+      res.writeHead(503, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "restarting" }));
+      return;
+    }
+    this._currentApp(req, res);
+  }
+
+  private async _startGrist() {
+    this._currentApp = undefined;
+
+    shutdown.resetCleanupHandlers();
+    appSettings.reset();
+
+    await this._options.beforeStart?.();
+
+    this._mergedServer = await MergedServer.create(this._port, this._options.serverTypes, {
+      server: this._server,
+    });
+    // Wire up the Express app before run(), so that /status requests
+    // can reach the health-check handler during startup. This matters
+    // for worker registration, which polls /status to confirm the
+    // server is reachable. Non-health endpoints are still gated by
+    // FlexServer's denyRequestsIfNotReady middleware until run()
+    // calls setReady(true).
+    this._currentApp = this._mergedServer.flexServer.app;
+    if (Deps.testWaitBeforeReadyMs) {
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(() => resolve(), Deps.testWaitBeforeReadyMs);
+        // Don't keep the process alive for test-only delays.
+        if (typeof timer === "object" && "unref" in timer) { timer.unref(); }
+      });
+    }
+    await this._mergedServer.run();
+    this.flexServer = this._mergedServer.flexServer;
+    this._healthy = true;
+
+    await this._options.afterStart?.(this.flexServer);
+
+    this.flexServer.onRestart(() => this._doRestart());
+  }
+
+  private async _doRestart() {
+    if (!this._currentApp) { return; }  // Already restarting.
+    log.info("ServerShell: restart requested");
+    this._currentApp = undefined;
+
+    const timeout = setTimeout(() => {
+      log.error("ServerShell: restart timed out, marking unhealthy");
+      this._healthy = false;
+    }, Deps.restartTimeoutMs);
+    timeout.unref();
+
+    try {
+      await this._mergedServer!.close();
+      await this._startGrist();
+    } catch (err) {
+      log.error("ServerShell: error during restart", err);
+      this._healthy = false;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export type ServerShellHandle = Awaited<ReturnType<typeof startServer>>;

--- a/app/server/lib/ServerShell.ts
+++ b/app/server/lib/ServerShell.ts
@@ -4,15 +4,27 @@
  *
  * The shell creates and owns the http.Server and the listening socket.
  * On each (re)start, it creates a new MergedServer that attaches to
- * the existing socket. The /status health-check endpoint is handled
- * directly by the shell so it stays reachable even while the inner
- * server is being torn down and rebuilt.
+ * the existing socket.
  *
- * When GRIST_CAN_RESTART is not set, falls back to a plain
+ * Health check behavior:
+ * - During normal operation, /status (and variants like ?db=1) is
+ *   delegated to the inner Express app for a real check.
+ * - During a restart, when there is no Express app, the shell answers
+ *   /status directly with 200 (liveness: the process is alive, just
+ *   restarting). /status?ready=1 returns 503 since the app is not yet
+ *   serving requests.
+ * - If a restart fails or hangs past restartTimeoutMs, the shell
+ *   marks itself unhealthy and /status starts returning 503 so that
+ *   orchestration can recreate the container.
+ * - If a restart eventually completes after the timeout fired, the
+ *   shell resets itself to healthy and /status returns to normal.
+ *   This handles the case where a restart was just slow, not stuck.
+ *
+ * When GRIST_SERVER_SHELL_ENABLED is not set, falls back to a plain
  * MergedServer without the restart-capable shell.
  */
 
-import { appSettings, canRestart } from "app/server/lib/AppSettings";
+import { appSettings, isServerShellEnabled } from "app/server/lib/AppSettings";
 import { FlexServer, getGristHost, getServerFlags } from "app/server/lib/FlexServer";
 import log from "app/server/lib/log";
 import { listenPromise } from "app/server/lib/serverUtils";
@@ -32,19 +44,19 @@ export interface ServerShellOptions {
 
   // Hook that runs before each MergedServer.create(), e.g. for DB setup.
   // Called on initial start and on every restart.
-  beforeStart?: () => Promise<void>;
+  beforeCreate?: () => Promise<void>;
 
   // Hook that runs after MergedServer.run(), e.g. for testing hooks.
-  afterStart?: (flexServer: FlexServer) => Promise<void>;
+  afterRun?: (flexServer: FlexServer) => Promise<void>;
 }
 
 /**
- * Start a Grist server. When GRIST_CAN_RESTART is set, wraps it in
+ * Start a Grist server. When GRIST_SERVER_SHELL_ENABLED is set, wraps it in
  * a shell that supports in-process restart. Otherwise does a plain
  * MergedServer start.
  */
 export async function startServer(options: ServerShellOptions) {
-  if (canRestart()) {
+  if (isServerShellEnabled()) {
     const shell = new ServerShell(options);
     await shell.start();
     return shell;
@@ -54,10 +66,10 @@ export async function startServer(options: ServerShellOptions) {
 
 async function _startPlain(options: ServerShellOptions) {
   const { port, serverTypes } = options;
-  await options.beforeStart?.();
+  await options.beforeCreate?.();
   const mergedServer = await MergedServer.create(port, serverTypes);
   await mergedServer.run();
-  await options.afterStart?.(mergedServer.flexServer);
+  await options.afterRun?.(mergedServer.flexServer);
   return {
     flexServer: mergedServer.flexServer,
     async shutdown() { await mergedServer.close(); },
@@ -91,8 +103,10 @@ class ServerShell {
 
   public async shutdown() {
     await this._mergedServer?.close();
-    await new Promise<void>((resolve, reject) =>
-      this._server.close(err => err ? reject(err) : resolve()));
+    if (this._server) {
+      await new Promise<void>((resolve, reject) =>
+        this._server.close(err => err ? reject(err) : resolve()));
+    }
   }
 
   // All requests pass through this handler. During restart, /status
@@ -134,23 +148,24 @@ class ServerShell {
     this._currentApp(req, res);
   }
 
+  // Build a fresh MergedServer attached to the existing socket. The
+  // Express app is hooked up between MergedServer.create() and .run(),
+  // so /status requests can reach FlexServer's health-check handler
+  // during startup -- this matters for worker registration, which
+  // polls /status to confirm the server is reachable. Non-health
+  // endpoints remain gated by FlexServer's denyRequestsIfNotReady
+  // middleware until run() calls setReady(true).
   private async _startGrist() {
     this._currentApp = undefined;
 
     shutdown.resetCleanupHandlers();
     appSettings.reset();
 
-    await this._options.beforeStart?.();
+    await this._options.beforeCreate?.();
 
     this._mergedServer = await MergedServer.create(this._port, this._options.serverTypes, {
       server: this._server,
     });
-    // Wire up the Express app before run(), so that /status requests
-    // can reach the health-check handler during startup. This matters
-    // for worker registration, which polls /status to confirm the
-    // server is reachable. Non-health endpoints are still gated by
-    // FlexServer's denyRequestsIfNotReady middleware until run()
-    // calls setReady(true).
     this._currentApp = this._mergedServer.flexServer.app;
     if (Deps.testWaitBeforeReadyMs) {
       await new Promise<void>((resolve) => {
@@ -161,13 +176,17 @@ class ServerShell {
     }
     await this._mergedServer.run();
     this.flexServer = this._mergedServer.flexServer;
-    this._healthy = true;
 
-    await this._options.afterStart?.(this.flexServer);
+    await this._options.afterRun?.(this.flexServer);
 
     this.flexServer.onRestart(() => this._doRestart());
   }
 
+  // Tear down the current MergedServer and start a fresh one. Marks
+  // the shell unhealthy if either step fails or takes longer than
+  // restartTimeoutMs (so orchestration can detect a hung restart and
+  // recreate the container). On a successful restart, _healthy is
+  // reset to true.
   private async _doRestart() {
     if (!this._currentApp) { return; }  // Already restarting.
     log.info("ServerShell: restart requested");
@@ -182,6 +201,7 @@ class ServerShell {
     try {
       await this._mergedServer!.close();
       await this._startGrist();
+      this._healthy = true;  // recover from any earlier timeout
     } catch (err) {
       log.error("ServerShell: error during restart", err);
       this._healthy = false;

--- a/app/server/lib/ServerShell.ts
+++ b/app/server/lib/ServerShell.ts
@@ -12,7 +12,7 @@
  * MergedServer without the restart-capable shell.
  */
 
-import { appSettings } from "app/server/lib/AppSettings";
+import { appSettings, canRestart } from "app/server/lib/AppSettings";
 import { FlexServer, getGristHost, getServerFlags } from "app/server/lib/FlexServer";
 import log from "app/server/lib/log";
 import { listenPromise } from "app/server/lib/serverUtils";
@@ -25,12 +25,6 @@ export const Deps = {
   testWaitBeforeReadyMs: 0,     // ms to wait before setting ready=true (for tests)
   restartTimeoutMs: 60000,      // mark unhealthy if restart takes longer than this
 };
-
-export function canRestart() {
-  return appSettings.section("server").flag("canRestart").readBool({
-    envVar: "GRIST_CAN_RESTART",
-  });
-}
 
 export interface ServerShellOptions {
   port: number;
@@ -121,7 +115,9 @@ class ServerShell {
       }
       if (this._currentApp) {
         this._currentApp(req, res);
-      } else if (new URL(req.url, "http://localhost").searchParams.get("ready") === "1") {
+      // Simple string match is fine here -- this is our own /status
+      // endpoint, not user input, and avoids URL parsing edge cases.
+      } else if (req.url.includes("ready=1")) {
         res.writeHead(503, { "Content-Type": "text/plain" });
         res.end("not ready");
       } else {

--- a/app/server/lib/ServerShell.ts
+++ b/app/server/lib/ServerShell.ts
@@ -12,9 +12,8 @@
  * MergedServer without the restart-capable shell.
  */
 
-import { isAffirmative } from "app/common/gutil";
 import { appSettings } from "app/server/lib/AppSettings";
-import { FlexServer, getGristHost } from "app/server/lib/FlexServer";
+import { FlexServer, getGristHost, getServerFlags } from "app/server/lib/FlexServer";
 import log from "app/server/lib/log";
 import { listenPromise } from "app/server/lib/serverUtils";
 import * as shutdown from "app/server/lib/shutdown";
@@ -26,6 +25,12 @@ export const Deps = {
   testWaitBeforeReadyMs: 0,     // ms to wait before setting ready=true (for tests)
   restartTimeoutMs: 60000,      // mark unhealthy if restart takes longer than this
 };
+
+export function canRestart() {
+  return appSettings.section("server").flag("canRestart").readBool({
+    envVar: "GRIST_CAN_RESTART",
+  });
+}
 
 export interface ServerShellOptions {
   port: number;
@@ -45,7 +50,7 @@ export interface ServerShellOptions {
  * MergedServer start.
  */
 export async function startServer(options: ServerShellOptions) {
-  if (isAffirmative(process.env.GRIST_CAN_RESTART)) {
+  if (canRestart()) {
     const shell = new ServerShell(options);
     await shell.start();
     return shell;
@@ -78,7 +83,8 @@ class ServerShell {
 
   public async start() {
     const host = getGristHost();
-    this._server = http.createServer();
+    const flags = getServerFlags();
+    this._server = http.createServer(flags);
     await listenPromise(this._server.listen(this._options.port, host));
     this._port = (this._server.address() as { port: number }).port;
     log.info(`ServerShell listening on ${host}:${this._port}`);
@@ -91,7 +97,8 @@ class ServerShell {
 
   public async shutdown() {
     await this._mergedServer?.close();
-    this._server.close();
+    await new Promise<void>((resolve, reject) =>
+      this._server.close(err => err ? reject(err) : resolve()));
   }
 
   // All requests pass through this handler. During restart, /status

--- a/app/server/lib/TestingHooks.ts
+++ b/app/server/lib/TestingHooks.ts
@@ -104,17 +104,17 @@ export class TestingHooks implements ITestingHooks {
 
   public async commShutdown(): Promise<void> {
     log.info("TestingHooks.commShutdown called");
-    await this._comm.testServerShutdown();
+    await this._comm.shutdown();
     for (const server of this._workerServers) {
-      await server.getComm().testServerShutdown();
+      await server.getComm().shutdown();
     }
   }
 
   public async commRestart(): Promise<void> {
     log.info("TestingHooks.commRestart called");
-    await this._comm.testServerRestart();
+    await this._comm.restart();
     for (const server of this._workerServers) {
-      await server.getComm().testServerRestart();
+      await server.getComm().restart();
     }
   }
 

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -14,7 +14,7 @@ import {
   PreviousAndCurrent,
   QueryResult,
 } from "app/gen-server/lib/homedb/Interfaces";
-import { appSettings, canRestart } from "app/server/lib/AppSettings";
+import { appSettings, isServerShellEnabled } from "app/server/lib/AppSettings";
 import { RequestWithLogin } from "app/server/lib/Authorizer";
 import { BootProbes } from "app/server/lib/BootProbes";
 import { expressWrap } from "app/server/lib/expressWrap";
@@ -70,7 +70,7 @@ export function attachEarlyEndpoints(options: AttachOptions) {
     expressWrap(async (req, res) => {
       const config: Partial<AdminPageConfig> = {
         runningUnderSupervisor: isAffirmative(process.env.GRIST_RUNNING_UNDER_SUPERVISOR) ||
-          canRestart(),
+          isServerShellEnabled(),
         adminControls: gristServer.create.areAdminControlsAvailable(),
       };
       return gristServer.sendAppPage(req, res, {
@@ -110,7 +110,7 @@ export function attachEarlyEndpoints(options: AttachOptions) {
         if (process.send && process.env.GRIST_RUNNING_UNDER_SUPERVISOR) {
           log.rawDebug(`Restart[${mreq.method}] requesting supervisor to restart home server:`, meta);
           process.send({ action: "restart" });
-        } else if (canRestart()) {
+        } else if (isServerShellEnabled()) {
           try {
             gristServer.triggerRestart();
           } catch (err) {
@@ -118,7 +118,7 @@ export function attachEarlyEndpoints(options: AttachOptions) {
           }
         }
       });
-      if (!process.env.GRIST_RUNNING_UNDER_SUPERVISOR && !canRestart()) {
+      if (!process.env.GRIST_RUNNING_UNDER_SUPERVISOR && !isServerShellEnabled()) {
         // On the topic of http response codes, thus spake MDN:
         // "409: This response is sent when a request conflicts with the current state of the server."
         return res.status(409).send({

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -14,7 +14,7 @@ import {
   PreviousAndCurrent,
   QueryResult,
 } from "app/gen-server/lib/homedb/Interfaces";
-import { appSettings } from "app/server/lib/AppSettings";
+import { appSettings, canRestart } from "app/server/lib/AppSettings";
 import { RequestWithLogin } from "app/server/lib/Authorizer";
 import { BootProbes } from "app/server/lib/BootProbes";
 import { expressWrap } from "app/server/lib/expressWrap";
@@ -26,7 +26,6 @@ import {
   sendReply,
   stringParam,
 } from "app/server/lib/requestUtils";
-import { canRestart } from "app/server/lib/ServerShell";
 import { updateGristServerLatestVersion } from "app/server/lib/updateChecker";
 
 import {
@@ -111,8 +110,7 @@ export function attachEarlyEndpoints(options: AttachOptions) {
         if (process.send && process.env.GRIST_RUNNING_UNDER_SUPERVISOR) {
           log.rawDebug(`Restart[${mreq.method}] requesting supervisor to restart home server:`, meta);
           process.send({ action: "restart" });
-        }
-        if (canRestart()) {
+        } else if (canRestart()) {
           try {
             gristServer.triggerRestart();
           } catch (err) {

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -26,6 +26,7 @@ import {
   sendReply,
   stringParam,
 } from "app/server/lib/requestUtils";
+import { canRestart } from "app/server/lib/ServerShell";
 import { updateGristServerLatestVersion } from "app/server/lib/updateChecker";
 
 import {
@@ -70,7 +71,7 @@ export function attachEarlyEndpoints(options: AttachOptions) {
     expressWrap(async (req, res) => {
       const config: Partial<AdminPageConfig> = {
         runningUnderSupervisor: isAffirmative(process.env.GRIST_RUNNING_UNDER_SUPERVISOR) ||
-          isAffirmative(process.env.GRIST_CAN_RESTART),
+          canRestart(),
         adminControls: gristServer.create.areAdminControlsAvailable(),
       };
       return gristServer.sendAppPage(req, res, {
@@ -111,7 +112,7 @@ export function attachEarlyEndpoints(options: AttachOptions) {
           log.rawDebug(`Restart[${mreq.method}] requesting supervisor to restart home server:`, meta);
           process.send({ action: "restart" });
         }
-        if (process.env.GRIST_CAN_RESTART) {
+        if (canRestart()) {
           try {
             gristServer.triggerRestart();
           } catch (err) {
@@ -119,7 +120,7 @@ export function attachEarlyEndpoints(options: AttachOptions) {
           }
         }
       });
-      if (!process.env.GRIST_RUNNING_UNDER_SUPERVISOR && !process.env.GRIST_CAN_RESTART) {
+      if (!process.env.GRIST_RUNNING_UNDER_SUPERVISOR && !canRestart()) {
         // On the topic of http response codes, thus spake MDN:
         // "409: This response is sent when a request conflicts with the current state of the server."
         return res.status(409).send({

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -69,7 +69,8 @@ export function attachEarlyEndpoints(options: AttachOptions) {
     userIdMiddleware,
     expressWrap(async (req, res) => {
       const config: Partial<AdminPageConfig> = {
-        runningUnderSupervisor: isAffirmative(process.env.GRIST_RUNNING_UNDER_SUPERVISOR),
+        runningUnderSupervisor: isAffirmative(process.env.GRIST_RUNNING_UNDER_SUPERVISOR) ||
+          isAffirmative(process.env.GRIST_CAN_RESTART),
         adminControls: gristServer.create.areAdminControlsAvailable(),
       };
       return gristServer.sendAppPage(req, res, {
@@ -110,8 +111,15 @@ export function attachEarlyEndpoints(options: AttachOptions) {
           log.rawDebug(`Restart[${mreq.method}] requesting supervisor to restart home server:`, meta);
           process.send({ action: "restart" });
         }
+        if (process.env.GRIST_CAN_RESTART) {
+          try {
+            gristServer.triggerRestart();
+          } catch (err) {
+            log.error("Restart: triggerRestart failed:", err);
+          }
+        }
       });
-      if (!process.env.GRIST_RUNNING_UNDER_SUPERVISOR) {
+      if (!process.env.GRIST_RUNNING_UNDER_SUPERVISOR && !process.env.GRIST_CAN_RESTART) {
         // On the topic of http response codes, thus spake MDN:
         // "409: This response is sent when a request conflicts with the current state of the server."
         return res.status(409).send({

--- a/app/server/lib/shutdown.js
+++ b/app/server/lib/shutdown.js
@@ -105,6 +105,51 @@ export function cleanupOnSignals(varSignalNames) {
 }
 
 /**
+ * Reset cleanup state so that a fresh set of handlers can be registered.
+ * Used during in-process restart. Signal handlers (registered via
+ * installProcessHandlers) are intentionally NOT reset -- they are
+ * process-global and must only be registered once.
+ */
+export function resetCleanupHandlers() {
+  cleanupHandlers = [];
+  _cleanupHandlersPromise = null;
+}
+
+/**
+ * Register signal handlers and an uncaughtException handler that
+ * runs cleanup before exiting. Safe to call once per process.
+ * Used by both FlexServer (standalone) and ServerShell (restart mode).
+ */
+var _processHandlersInstalled = false;
+export function installProcessHandlers() {
+  if (_processHandlersInstalled) { return; }
+  _processHandlersInstalled = true;
+
+  // Set up signal handlers. Note that nodemon sends SIGUSR2 to restart node.
+  cleanupOnSignals("SIGINT", "SIGTERM", "SIGHUP", "SIGUSR2");
+
+  // We listen for uncaughtExceptions / unhandledRejections, but do exit when they happen. It is
+  // a strong recommendation, which seems best to follow
+  // (https://nodejs.org/docs/latest-v18.x/api/process.html#warning-using-uncaughtexception-correctly).
+  // We do try to shutdown cleanly (i.e. do any planned cleanup), which goes somewhat against
+  // the recommendation to do only synchronous work.
+
+  let counter = 0;
+
+  // Note that this event catches also 'unhandledRejection' (origin should be either
+  // 'uncaughtException' or 'unhandledRejection').
+  process.on("uncaughtException", (err, origin) => {
+    log.error(`UNHANDLED ERROR ${origin} (${counter}):`, err);
+    if (counter === 0) {
+      // Only call shutdown once. It's async and could in theory fail, in which case it would be
+      // another unhandledRejection, and would get caught and reported by this same handler.
+      void (exit(1));
+    }
+    counter++;
+  });
+}
+
+/**
  * Run cleanup handlers and exit the process with the given exit code (0 if omitted).
  */
 export function exit(optExitCode) {

--- a/stubs/app/server/server.ts
+++ b/stubs/app/server/server.ts
@@ -224,7 +224,7 @@ export async function main() {
   const handle = await startServer({
     port: G.port,
     serverTypes,
-    beforeStart: async () => {
+    beforeCreate: async () => {
       if (serverTypes.includes("home")) {
         log.info("Setting up database...");
         const db = await createOrUpdateDb();
@@ -233,7 +233,7 @@ export async function main() {
         log.info("Database setup complete.");
       }
     },
-    afterStart: async (flexServer) => {
+    afterRun: async (flexServer) => {
       if (process.env.GRIST_TESTING_SOCKET) {
         await flexServer.addTestingHooks();
       }

--- a/stubs/app/server/server.ts
+++ b/stubs/app/server/server.ts
@@ -47,8 +47,10 @@ setDefaultEnv("GRIST_WIDGET_LIST_URL", commonUrls.gristLabsWidgetRepository);
 // It's important that this comes after the setDefaultEnv calls above. MergedServer reads
 // some env vars at import time, including GRIST_WIDGET_LIST_URL.
 // TODO: Fix this reliance on side effects during import.
-// eslint-disable-next-line @import-x/order
-import { MergedServer, parseServerTypes } from "app/server/MergedServer";
+/* eslint-disable @import-x/order */
+import { parseServerTypes } from "app/server/MergedServer";
+import { startServer } from "app/server/lib/ServerShell";
+/* eslint-enable @import-x/order */
 
 const G = {
   port: parseInt(process.env.PORT!, 10) || 8484,
@@ -219,25 +221,28 @@ export async function main() {
 
   await fse.mkdirp(process.env.GRIST_DATA_DIR!);
 
-  if (serverTypes.includes("home")) {
-    log.info("Setting up database...");
-    const db = await createOrUpdateDb();
-    await setUpAdminEmail(db);
-    await setUpSingleOrg(db);
-    log.info("Database setup complete.");
-  }
-
-  // Launch single-port, self-contained version of Grist.
-  const mergedServer = await MergedServer.create(G.port, serverTypes);
-  await mergedServer.run();
-  if (process.env.GRIST_TESTING_SOCKET) {
-    await mergedServer.flexServer.addTestingHooks();
-  }
-  if (process.env.GRIST_SERVE_PLUGINS_PORT) {
-    await mergedServer.flexServer.startCopy("pluginServer", parseInt(process.env.GRIST_SERVE_PLUGINS_PORT, 10));
-  }
-
-  return mergedServer.flexServer;
+  const handle = await startServer({
+    port: G.port,
+    serverTypes,
+    beforeStart: async () => {
+      if (serverTypes.includes("home")) {
+        log.info("Setting up database...");
+        const db = await createOrUpdateDb();
+        await setUpAdminEmail(db);
+        await setUpSingleOrg(db);
+        log.info("Database setup complete.");
+      }
+    },
+    afterStart: async (flexServer) => {
+      if (process.env.GRIST_TESTING_SOCKET) {
+        await flexServer.addTestingHooks();
+      }
+      if (process.env.GRIST_SERVE_PLUGINS_PORT) {
+        await flexServer.startCopy("pluginServer", parseInt(process.env.GRIST_SERVE_PLUGINS_PORT, 10));
+      }
+    },
+  });
+  return handle.flexServer;
 }
 
 if (require.main === module) {

--- a/test/server/Comm.ts
+++ b/test/server/Comm.ts
@@ -77,7 +77,7 @@ describe("Comm", function() {
 
   async function stopComm() {
     comm?.destroyAllClients();
-    await comm?.testServerShutdown();
+    await comm?.shutdown();
     await fromCallback((cb) => {
       server.close(cb);
       server.closeAllConnections();

--- a/test/server/lib/ServerShell.ts
+++ b/test/server/lib/ServerShell.ts
@@ -21,7 +21,7 @@ describe("ServerShell", function() {
 
   before(function() {
     oldEnv = new EnvironmentSnapshot();
-    process.env.GRIST_CAN_RESTART = "true";
+    process.env.GRIST_SERVER_SHELL_ENABLED = "true";
     setUpDB(this);
   });
 

--- a/test/server/lib/ServerShell.ts
+++ b/test/server/lib/ServerShell.ts
@@ -1,0 +1,189 @@
+import { delay } from "app/common/delay";
+import { Deps, startServer } from "app/server/lib/ServerShell";
+import { parseServerTypes } from "app/server/MergedServer";
+import { createInitialDb, removeConnection, setUpDB } from "test/gen-server/seed";
+import { configForUser } from "test/gen-server/testUtils";
+import { openClient } from "test/server/gristClient";
+import { EnvironmentSnapshot } from "test/server/testUtils";
+
+import axios from "axios";
+import { assert } from "chai";
+import sinon from "sinon";
+
+describe("ServerShell", function() {
+  this.timeout(30000);
+
+  let oldEnv: EnvironmentSnapshot;
+  let serverUrl: string;
+  let handle: Awaited<ReturnType<typeof startServer>>;
+  const sandbox = sinon.createSandbox();
+  const chimpy = configForUser("Chimpy");
+
+  before(function() {
+    oldEnv = new EnvironmentSnapshot();
+    process.env.GRIST_CAN_RESTART = "true";
+    setUpDB(this);
+  });
+
+  beforeEach(async function() {
+    await createInitialDb();
+    handle = await startServer({
+      port: 0,
+      serverTypes: parseServerTypes("home,docs,static"),
+    });
+    serverUrl = handle.flexServer.getOwnUrl();
+  });
+
+  afterEach(async function() {
+    sandbox.restore();
+    await handle.shutdown();
+  });
+
+  after(async function() {
+    await removeConnection();
+    oldEnv.restore();
+  });
+
+  it("should respond to /status and /status?ready=1", async function() {
+    const resp = await axios.get(`${serverUrl}/status`);
+    assert.equal(resp.status, 200);
+    const readyResp = await axios.get(`${serverUrl}/status?ready=1`, chimpy);
+    assert.equal(readyResp.status, 200);
+  });
+
+  it("should complete a restart cycle and keep /status reachable", async function() {
+    sandbox.stub(Deps, "testWaitBeforeReadyMs").value(500);
+
+    handle.flexServer.triggerRestart();
+    const notReadyPolls = await pollUntilReady(serverUrl);
+    assert.isAbove(notReadyPolls, 0, "server should have been not-ready during restart");
+  });
+
+  it("should mark unhealthy if restart times out, then recover", async function() {
+    this.timeout(15000);
+    // Make restart slow enough to trip the timeout.
+    sandbox.stub(Deps, "testWaitBeforeReadyMs").value(3000);
+    sandbox.stub(Deps, "restartTimeoutMs").value(500);
+
+    handle.flexServer.triggerRestart();
+
+    // Wait for the timeout to fire.
+    await delay(1000);
+
+    // /status should return 500 while restart is still in progress.
+    const unhealthyResp = await axios.get(`${serverUrl}/status`, { validateStatus: () => true });
+    assert.equal(unhealthyResp.status, 503);
+
+    // Wait for the slow restart to finish and health to recover.
+    const deadline = Date.now() + 10000;
+    let recovered = false;
+    while (Date.now() < deadline) {
+      const resp = await axios.get(`${serverUrl}/status`, { validateStatus: () => true });
+      if (resp.status === 200) { recovered = true; break; }
+      await delay(200);
+    }
+    assert.isTrue(recovered, "/status should recover after slow restart completes");
+  });
+
+  it("should serve documents after 10 restarts", async function() {
+    this.timeout(120000);
+
+    // Create a doc as Chimpy in their personal org.
+    const orgsResp = await axios.get(`${serverUrl}/api/orgs`, chimpy);
+    assert.equal(orgsResp.status, 200);
+    const org = orgsResp.data[0];
+    const wsResp = await axios.get(`${serverUrl}/api/orgs/${org.id}/workspaces`, chimpy);
+    assert.equal(wsResp.status, 200);
+    const wsId = wsResp.data[0].id;
+    const docResp = await axios.post(
+      `${serverUrl}/api/workspaces/${wsId}/docs`, { name: "RestartTest" }, chimpy);
+    assert.equal(docResp.status, 200);
+    const docId = docResp.data;
+
+    try {
+      sandbox.stub(Deps, "testWaitBeforeReadyMs").value(200);
+      for (let i = 0; i < 10; i++) {
+        handle.flexServer.triggerRestart();
+        // Wait until the doc API becomes unavailable (503), confirming
+        // the restart is in progress.
+        const sawUnavailable = await pollUntilUnavailable(
+          `${serverUrl}/api/docs/${docId}/tables/Table1/records`, chimpy);
+        assert.isTrue(sawUnavailable, `restart ${i + 1}: doc API should become unavailable`);
+        const notReadyPolls = await pollUntilReady(serverUrl);
+        assert.isAbove(notReadyPolls, 0, `restart ${i + 1}: server should have been not-ready`);
+        // Confirm the doc API works after restart.
+        const resp = await axios.get(
+          `${serverUrl}/api/docs/${docId}/tables/Table1/records`, chimpy);
+        assert.equal(resp.status, 200);
+        assert.isArray(resp.data.records);
+      }
+    } finally {
+      await axios.delete(`${serverUrl}/api/docs/${docId}`, chimpy);
+    }
+  });
+
+  it("should open a doc via WebSocket after restart", async function() {
+    this.timeout(30000);
+
+    // Create a doc.
+    const orgsResp = await axios.get(`${serverUrl}/api/orgs`, chimpy);
+    const org = orgsResp.data[0];
+    const wsResp = await axios.get(`${serverUrl}/api/orgs/${org.id}/workspaces`, chimpy);
+    const wsId = wsResp.data[0].id;
+    const docResp = await axios.post(
+      `${serverUrl}/api/workspaces/${wsId}/docs`, { name: "WsTest" }, chimpy);
+    assert.equal(docResp.status, 200);
+    const docId = docResp.data;
+
+    try {
+      // Open doc via WebSocket before restart.
+      let cli = await openClient(handle.flexServer, "chimpy@getgrist.com", "docs");
+      let openDoc = await cli.openDocOnConnect(docId);
+      assert.isUndefined(openDoc.error);
+      await cli.close();
+
+      handle.flexServer.triggerRestart();
+      await pollUntilReady(serverUrl);
+
+      // Open doc via WebSocket after restart.
+      cli = await openClient(handle.flexServer, "chimpy@getgrist.com", "docs");
+      openDoc = await cli.openDocOnConnect(docId);
+      assert.isUndefined(openDoc.error);
+      await cli.close();
+    } finally {
+      await axios.delete(`${serverUrl}/api/docs/${docId}`, chimpy);
+    }
+  });
+});
+
+// Poll until /status?ready=1 succeeds. On each iteration, assert
+// that bare /status is always 200 (the shell keeps it alive).
+// Returns the number of not-ready polls seen before ready.
+async function pollUntilReady(url: string, timeoutMs = 10000) {
+  let notReadyCount = 0;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const statusResp = await axios.get(`${url}/status`);
+    assert.equal(statusResp.status, 200, "/status should always be reachable");
+    try {
+      await axios.get(`${url}/status?ready=1`);
+      return notReadyCount;
+    } catch {
+      notReadyCount++;
+    }
+    await delay(50);
+  }
+  throw new Error("Server did not become ready in time");
+}
+
+// Poll until the given URL returns a non-200 status, confirming
+// that the server is no longer serving normal requests.
+async function pollUntilUnavailable(url: string, config: object, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const resp = await axios.get(url, { ...config, validateStatus: () => true });
+    if (resp.status !== 200) { return true; }
+    await delay(20);
+  }
+  return false;
+}

--- a/test/server/lib/ServerShell.ts
+++ b/test/server/lib/ServerShell.ts
@@ -70,7 +70,7 @@ describe("ServerShell", function() {
     // Wait for the timeout to fire.
     await delay(1000);
 
-    // /status should return 500 while restart is still in progress.
+    // /status should return 503 while restart is still in progress.
     const unhealthyResp = await axios.get(`${serverUrl}/status`, { validateStatus: () => true });
     assert.equal(unhealthyResp.status, 503);
 


### PR DESCRIPTION
When an admin changes settings via the admin panel, Grist may need to restart for them to take effect. The existing supervisor approach kills and respawns the process. There are two problems:

 * The health endpoint becomes unreachable during the restart window. Orchestration tools (Docker, K8s) may interpret this as a crash and may kill the container, leading to a much slower recovery of what was not actually a failure.
 * Many Grist installations are run without the supervisor. It is build into our standard docker image, but not everyone uses that. Those people get a janky experience.

This is an attempt at something better. Currently experimental, you need to set `GRIST_CAN_RESTART=true` to enable the new behavior I'm proposing. With that on, a `ServerShell` instance owns the HTTP socket and keeps `/status` available while tearing down and rebuilding the inner `MergedServer`. Without the env var, behavior is unchanged.

I have a follow-up for this PR that deals with the multi-server case, which is just the obvious coordination via redis so all servers restart.

Caveat: any settings cached in module-level variables at import time won't refresh on restart. The problem of refreshing settings throughout the app is not addressed in this PR, which is why it is not enabled by default.
