### PR TITLE
Adding linking info for custom widgets

### DIFF
--- a/app/client/components/LinkingState.ts
+++ b/app/client/components/LinkingState.ts
@@ -21,8 +21,6 @@ import merge from "lodash/merge";
 import pick from "lodash/pick";
 import pickBy from "lodash/pickBy";
 
-// LinkType is defined in app/plugin/CustomSectionAPI.ts so it can also be exposed to custom widgets
-// via InteractionOptions.linking. See that file for the enum values.
 // TODO JV: Eventually, switching the main block of linking logic in LinkingState constructor to be a big
 //          switch(linkType){} would make things cleaner.
 // TODO JV: also should add "Custom-widget-linked" to this, but holding off until Jarek's changes land

--- a/app/client/components/LinkingState.ts
+++ b/app/client/components/LinkingState.ts
@@ -9,6 +9,7 @@ import { LinkConfig } from "app/client/ui/LinkConfig";
 import { FilterColValues, QueryOperation } from "app/common/ActiveDocAPI";
 import { isList, isListType, isRefListType } from "app/common/gristTypes";
 import * as gutil from "app/common/gutil";
+import { LinkType } from "app/plugin/CustomSectionAPI";
 import { UIRowId } from "app/plugin/GristAPI";
 import { CellValue } from "app/plugin/GristData";
 import { encodeObject } from "app/plugin/objtypes";
@@ -20,19 +21,11 @@ import merge from "lodash/merge";
 import pick from "lodash/pick";
 import pickBy from "lodash/pickBy";
 
-// Descriptive string enum for each case of linking
-// Currently used for rendering user-facing link info
+// LinkType is defined in app/plugin/CustomSectionAPI.ts so it can also be exposed to custom widgets
+// via InteractionOptions.linking. See that file for the enum values.
 // TODO JV: Eventually, switching the main block of linking logic in LinkingState constructor to be a big
 //          switch(linkType){} would make things cleaner.
 // TODO JV: also should add "Custom-widget-linked" to this, but holding off until Jarek's changes land
-type LinkType = "Filter:Summary-Group" |
-  "Filter:Col->Col" |
-  "Filter:Row->Col" |
-  "Summary" |
-  "Show-Referenced-Records" |
-  "Cursor:Same-Table" |
-  "Cursor:Reference" |
-  "Error:Invalid";
 
 // If this LinkingState represents a filter link, it will set its filterState to this object
 // The filterColValues portion is just the data needed for filtering (same as manual filtering), and is passed

--- a/app/client/components/WidgetFrame.ts
+++ b/app/client/components/WidgetFrame.ts
@@ -15,6 +15,7 @@ import { BulkColValues, CellValue, fromTableDataAction, RowRecord } from "app/co
 import { extractInfoFromColType, GristTypeInfo, reencodeAsTypedCellValue } from "app/common/gristTypes";
 import { convertThemeKeysToCssVars } from "app/common/ThemePrefs";
 import { getGristConfig } from "app/common/urlUtils";
+import { LinkingInfo } from "app/plugin/CustomSectionAPI";
 import {
   AccessTokenOptions, CursorPos, CustomSectionAPI, FetchSelectedOptions, GristDocAPI, GristView,
   InteractionOptionsRequest, WidgetAPI, WidgetColumnMap,
@@ -684,18 +685,32 @@ export class ConfigNotifier extends BaseEventSource {
     return options;
   });
 
+  // Tracks the incoming link type (asTarget). linkingState is a ko.pureComputed that depends
+  // on linkSrcSectionRef, linkSrcColRef, linkTargetColRef, and column types (via LinkConfig),
+  // so this grainjs Computed catches any change to the incoming link configuration.
+  private _currentLinkTarget = Computed.create(this, (use) => {
+    const linkingState = use(this._section.linkingState);
+    if (linkingState?.isDisposed() === false) {
+      return use(linkingState.linkTypeDescription) ?? null;
+    }
+    return null;
+  });
+
+  // Tracks whether other sections link to us (asSource). linkedSections is a recordSet
+  // (ko.Computed<KoArray>) — grainjs use() can't subscribe to KoArray mutations, so we
+  // derive a boolean Computed separately.
+  private _currentLinkSource = Computed.create(this, (use) => {
+    return use(use(this._section.linkedSections).getObservable()).length > 0;
+  });
+
   // Debounced call to let the view know linked cursor changed.
   private _debounced = debounce((options?: { fromReady?: boolean }) => this._update(options), 0);
 
   constructor(private _section: ViewSectionRec, private _options: ConfigNotifierOptions) {
     super();
-    this.autoDispose(
-      this._currentConfig.addListener((newConfig, oldConfig) => {
-        if (isEqual(newConfig, oldConfig)) { return; }
-
-        this._debounced();
-      }),
-    );
+    this._debouncedOnChange(this._currentConfig);
+    this._debouncedOnChange(this._currentLinkTarget);
+    this._debouncedOnChange(this._currentLinkSource);
   }
 
   protected _ready() {
@@ -703,13 +718,26 @@ export class ConfigNotifier extends BaseEventSource {
     this._debounced({ fromReady: true });
   }
 
+  /** Subscribes to a Computed and calls _debounced() when the value changes (deep equality). */
+  private _debouncedOnChange<T>(obs: Computed<T>) {
+    this.autoDispose(obs.addListener((newVal, oldVal) => {
+      if (isEqual(newVal, oldVal)) { return; }
+      this._debounced();
+    }));
+  }
+
   private _update({ fromReady}: { fromReady?: boolean } = {}) {
     if (this.isDisposed()) { return; }
 
+    const linking: LinkingInfo = {
+      asTarget: this._currentLinkTarget.get(),
+      asSource: this._currentLinkSource.get(),
+    };
     this._notify({
       options: this._currentConfig.get(),
       settings: {
         accessLevel: this._accessLevel,
+        linking,
       },
       fromReady,
     });

--- a/app/plugin/CustomSectionAPI-ti.ts
+++ b/app/plugin/CustomSectionAPI-ti.ts
@@ -23,8 +23,16 @@ export const InteractionOptionsRequest = t.iface([], {
   "allowSelectBy": t.opt("boolean"),
 });
 
+export const LinkType = t.union(t.lit("Filter:Summary-Group"), t.lit("Filter:Col->Col"), t.lit("Filter:Row->Col"), t.lit("Summary"), t.lit("Show-Referenced-Records"), t.lit("Cursor:Same-Table"), t.lit("Cursor:Reference"), t.lit("Error:Invalid"));
+
+export const LinkingInfo = t.iface([], {
+  "asTarget": t.union("LinkType", "null"),
+  "asSource": "boolean",
+});
+
 export const InteractionOptions = t.iface([], {
   "accessLevel": "string",
+  "linking": t.opt("LinkingInfo"),
 });
 
 export const WidgetColumnMap = t.iface([], {
@@ -40,6 +48,8 @@ const exportedTypeSuite: t.ITypeSuite = {
   ColumnToMap,
   ColumnsToMap,
   InteractionOptionsRequest,
+  LinkType,
+  LinkingInfo,
   InteractionOptions,
   WidgetColumnMap,
   CustomSectionAPI,

--- a/app/plugin/CustomSectionAPI-ti.ts
+++ b/app/plugin/CustomSectionAPI-ti.ts
@@ -32,7 +32,7 @@ export const LinkingInfo = t.iface([], {
 
 export const InteractionOptions = t.iface([], {
   "accessLevel": "string",
-  "linking": t.opt("LinkingInfo"),
+  "linking": "LinkingInfo",
 });
 
 export const WidgetColumnMap = t.iface([], {

--- a/app/plugin/CustomSectionAPI.ts
+++ b/app/plugin/CustomSectionAPI.ts
@@ -66,6 +66,34 @@ export interface InteractionOptionsRequest {
 }
 
 /**
+ * Descriptive enum of how this section is linked to another section.
+ * See app/client/components/LinkingState.ts for classification logic.
+ */
+export type LinkType = "Filter:Summary-Group" |
+  "Filter:Col->Col" |
+  "Filter:Row->Col" |
+  "Summary" |
+  "Show-Referenced-Records" |
+  "Cursor:Same-Table" |
+  "Cursor:Reference" |
+  "Error:Invalid";
+
+/**
+ * Linking state of a custom widget's section, reported to the widget via InteractionOptions.
+ */
+export interface LinkingInfo {
+  /**
+   * If this section is a link target (driven by another section), the type of that link.
+   * Null if no incoming link.
+   */
+  asTarget: LinkType | null;
+  /**
+   * True if at least one other section uses this section as its link source.
+   */
+  asSource: boolean;
+}
+
+/**
  * Widget configuration set and approved by Grist, sent as part of ready message.
  */
 export interface InteractionOptions {
@@ -73,6 +101,11 @@ export interface InteractionOptions {
    * Granted access level.
    */
   accessLevel: string,
+  /**
+   * Linking state of this section at the time of the message. Always present; fields inside
+   * describe whether this section is a link target and/or a link source.
+   */
+  linking?: LinkingInfo,
 }
 
 /**

--- a/app/plugin/CustomSectionAPI.ts
+++ b/app/plugin/CustomSectionAPI.ts
@@ -105,7 +105,7 @@ export interface InteractionOptions {
    * Linking state of this section at the time of the message. Always present; fields inside
    * describe whether this section is a link target and/or a link source.
    */
-  linking?: LinkingInfo,
+  linking: LinkingInfo,
 }
 
 /**

--- a/app/plugin/CustomSectionAPI.ts
+++ b/app/plugin/CustomSectionAPI.ts
@@ -102,10 +102,11 @@ export interface InteractionOptions {
    */
   accessLevel: string,
   /**
-   * Linking state of this section at the time of the message. Always present; fields inside
+   * Linking state of this section at the time of the message. May be absent on older
+   * Grist builds that do not support linking information; when present, fields inside
    * describe whether this section is a link target and/or a link source.
    */
-  linking: LinkingInfo,
+  linking?: LinkingInfo,
 }
 
 /**

--- a/test/fixtures/sites/config/index.html
+++ b/test/fixtures/sites/config/index.html
@@ -12,6 +12,9 @@
     <div>onOptions event data:</div>
     <pre id="onOptions"></pre>
 
+    <div>onOptions event settings:</div>
+    <pre id="onOptionsSettings"></pre>
+
     <div>onRecord event data:</div>
     <pre id="onRecord"></pre>
 

--- a/test/fixtures/sites/config/page.js
+++ b/test/fixtures/sites/config/page.js
@@ -13,8 +13,9 @@ function setup() {
 
   grist.ready(ready);
 
-  grist.onOptions(data => {
+  grist.onOptions((data, settings) => {
     document.getElementById("onOptions").innerHTML = JSON.stringify(data);
+    document.getElementById("onOptionsSettings").innerHTML = JSON.stringify(settings);
   });
 
   grist.onRecord((data, mappings) => {

--- a/test/nbrowser/CustomWidgetLinking.ts
+++ b/test/nbrowser/CustomWidgetLinking.ts
@@ -1,0 +1,75 @@
+import { AccessLevel } from "app/common/CustomWidget";
+import { serveCustomViews, Serving } from "test/nbrowser/customUtil";
+import * as gu from "test/nbrowser/gristUtils";
+import { server, setupTestSuite } from "test/nbrowser/testUtils";
+
+import { assert, driver } from "mocha-webdriver";
+
+/**
+ * Tests that a custom widget receives linking state (asTarget, asSource) via
+ * the InteractionOptions.linking field of the ready/onOptions message.
+ *
+ * Uses the config fixture at test/fixtures/sites/config/, which renders the
+ * second argument of grist.onOptions into the #onOptionsSettings DOM element
+ * as JSON. The test reads that element inside the iframe.
+ */
+describe("CustomWidgetLinking", function() {
+  this.timeout("30s");
+
+  const cleanup = setupTestSuite();
+  let serving: Serving;
+  let session: gu.Session;
+
+  before(async function() {
+    if (server.isExternalServer()) {
+      this.skip();
+    }
+    serving = await serveCustomViews();
+    session = await gu.session().teamSite.login();
+    await session.tempNewDoc(cleanup);
+  });
+
+  after(async function() {
+    if (serving && !gu.noCleanup) {
+      await serving.shutdown();
+    }
+  });
+
+  afterEach(() => gu.checkForErrors());
+
+  async function readWidgetSettings(): Promise<any> {
+    const iframe = await driver.findWait(".active_section iframe", 4000);
+    await driver.switchTo().frame(iframe);
+    try {
+      const text = await driver.find("#onOptionsSettings").getText();
+      return text ? JSON.parse(text) : undefined;
+    } finally {
+      await driver.switchTo().defaultContent();
+    }
+  }
+
+  it("reports asTarget=Cursor:Same-Table when linked by a same-table source", async function() {
+    // Page with TABLE1 grid.
+    await gu.addNewTable("Data");
+    await gu.sendActions([
+      ["AddRecord", "Data", null, { A: "one" }],
+      ["AddRecord", "Data", null, { A: "two" }],
+    ]);
+
+    // Add a custom widget on the same table. addNewSection leaves the widget gallery open
+    // when no customWidget is specified, so setCustomWidgetUrl can run with openGallery: false.
+    await gu.openWidgetPanel("widget");
+    await gu.addNewSection("Custom", "Data");
+    await gu.setCustomWidgetUrl(`${serving.url}/config`, { openGallery: false });
+    await gu.widgetAccess(AccessLevel.read_table);
+
+    // Link the custom widget to the grid so the widget becomes a target.
+    await gu.selectBy("DATA");
+
+    await gu.waitToPass(async () => {
+      const settings = await readWidgetSettings();
+      assert.isObject(settings, "widget should receive a settings object");
+      assert.deepEqual(settings.linking, { asTarget: "Cursor:Same-Table", asSource: false });
+    }, 100);
+  });
+});

--- a/test/nbrowser/CustomWidgetLinking.ts
+++ b/test/nbrowser/CustomWidgetLinking.ts
@@ -21,7 +21,9 @@ describe("CustomWidgetLinking", function() {
   });
 
   after(async function() {
-    await serving.shutdown();
+    if (serving && !gu.noCleanup) {
+      await serving.shutdown();
+    }
   });
 
   afterEach(() => gu.checkForErrors());

--- a/test/nbrowser/CustomWidgetLinking.ts
+++ b/test/nbrowser/CustomWidgetLinking.ts
@@ -4,15 +4,6 @@ import * as gu from "test/nbrowser/gristUtils";
 import { server, setupTestSuite } from "test/nbrowser/testUtils";
 
 import { assert, driver } from "mocha-webdriver";
-
-/**
- * Tests that a custom widget receives linking state (asTarget, asSource) via
- * the InteractionOptions.linking field of the ready/onOptions message.
- *
- * Uses the config fixture at test/fixtures/sites/config/, which renders the
- * second argument of grist.onOptions into the #onOptionsSettings DOM element
- * as JSON. The test reads that element inside the iframe.
- */
 describe("CustomWidgetLinking", function() {
   this.timeout("30s");
 
@@ -30,9 +21,7 @@ describe("CustomWidgetLinking", function() {
   });
 
   after(async function() {
-    if (serving && !gu.noCleanup) {
-      await serving.shutdown();
-    }
+    await serving.shutdown();
   });
 
   afterEach(() => gu.checkForErrors());
@@ -49,15 +38,13 @@ describe("CustomWidgetLinking", function() {
   }
 
   it("reports asTarget=Cursor:Same-Table when linked by a same-table source", async function() {
-    // Page with TABLE1 grid.
     await gu.addNewTable("Data");
     await gu.sendActions([
       ["AddRecord", "Data", null, { A: "one" }],
       ["AddRecord", "Data", null, { A: "two" }],
     ]);
 
-    // Add a custom widget on the same table. addNewSection leaves the widget gallery open
-    // when no customWidget is specified, so setCustomWidgetUrl can run with openGallery: false.
+    // Add a custom widget on the same table.
     await gu.openWidgetPanel("widget");
     await gu.addNewSection("Custom", "Data");
     await gu.setCustomWidgetUrl(`${serving.url}/config`, { openGallery: false });
@@ -71,5 +58,82 @@ describe("CustomWidgetLinking", function() {
       assert.isObject(settings, "widget should receive a settings object");
       assert.deepEqual(settings.linking, { asTarget: "Cursor:Same-Table", asSource: false });
     }, 100);
+  });
+
+  it("always includes linking in settings even without a link", async function() {
+    // Close any open panel/menu from the previous test.
+    await gu.toggleSidePanel("right", "close");
+    // Create a standalone custom widget with no selectBy — no link at all.
+    await gu.addNewPage("Custom", "Data", { customWidget: /Custom URL/ });
+    await gu.setCustomWidgetUrl(`${serving.url}/config`);
+    await gu.widgetAccess(AccessLevel.read_table);
+
+    await gu.waitToPass(async () => {
+      const settings = await readWidgetSettings();
+      assert.isObject(settings, "widget should receive a settings object");
+      // linking must always be present (not undefined) so widgets that are aware of the linking
+      // can be run on grist that doesn't support it yet. So undefined means "linking not supported".
+      assert.deepEqual(settings.linking, { asTarget: null, asSource: false });
+    }, 2000);
+  });
+
+  it("reports asSource=true when another section is linked by this widget", async function() {
+    // New page: custom widget as source, grid linked by it.
+    await gu.addNewPage("Custom", "Data", { customWidget: /Custom URL/ });
+    await gu.setCustomWidgetUrl(`${serving.url}/config`);
+    await gu.widgetAccess(AccessLevel.read_table);
+    // Tell Grist this widget can be used as a linking source.
+    await gu.customCode(grist => grist.sectionApi.configure({ allowSelectBy: true }));
+    // Add a grid linked by the custom widget.
+    await gu.addNewSection("Table", "Data", { selectBy: /DATA custom/i });
+    // Switch back to the custom widget to read its settings.
+    await gu.selectSectionByTitle("DATA custom");
+
+    await gu.waitToPass(async () => {
+      const settings = await readWidgetSettings();
+      assert.deepEqual(settings.linking, { asTarget: null, asSource: true });
+    }, 2000);
+
+    // Remove the link from the grid so the widget is no longer a source.
+    await gu.selectSectionByTitle("DATA");
+    await gu.selectBy(/Select widget/);
+    await gu.selectSectionByTitle("DATA custom");
+
+    await gu.waitToPass(async () => {
+      const settings = await readWidgetSettings();
+      assert.deepEqual(settings.linking, { asTarget: null, asSource: false });
+    }, 2000);
+  });
+
+  it("updates linking reactively when selectBy changes", async function() {
+    // New page: grid + custom widget on the same table, linked by the grid.
+    await gu.addNewPage("Table", "Data");
+    await gu.addNewSection("Custom", "Data", { selectBy: "DATA", customWidget: /Custom URL/ });
+    await gu.setCustomWidgetUrl(`${serving.url}/config`);
+    await gu.widgetAccess(AccessLevel.read_table);
+
+    // Verify initial linked state.
+    await gu.waitToPass(async () => {
+      const settings = await readWidgetSettings();
+      assert.deepEqual(settings.linking, { asTarget: "Cursor:Same-Table", asSource: false });
+    }, 2000);
+
+    // Remove the link.
+    await gu.selectBy(/Select widget/);
+
+    // Widget should now report no incoming link.
+    await gu.waitToPass(async () => {
+      const settings = await readWidgetSettings();
+      assert.deepEqual(settings.linking, { asTarget: null, asSource: false });
+    }, 2000);
+
+    // Re-add the link.
+    await gu.selectBy("DATA");
+
+    // Widget should now report the link again.
+    await gu.waitToPass(async () => {
+      const settings = await readWidgetSettings();
+      assert.deepEqual(settings.linking, { asTarget: "Cursor:Same-Table", asSource: false });
+    }, 2000);
   });
 });

--- a/test/nbrowser/CustomWidgetLinking.ts
+++ b/test/nbrowser/CustomWidgetLinking.ts
@@ -57,7 +57,7 @@ describe("CustomWidgetLinking", function() {
       const settings = await readWidgetSettings();
       assert.isObject(settings, "widget should receive a settings object");
       assert.deepEqual(settings.linking, { asTarget: "Cursor:Same-Table", asSource: false });
-    }, 100);
+    }, 2000);
   });
 
   it("always includes linking in settings even without a link", async function() {

--- a/test/projects/PagesComponent.ts
+++ b/test/projects/PagesComponent.ts
@@ -17,7 +17,7 @@ describe("PagesComponent", function() {
 
   async function beginRenaming(name: RegExp) {
     await findPage(name).mouseMove().find(".test-docpage-dots").click();
-    await driver.findWait(".test-docpage-rename", 1000).doClick();
+    await driver.findWait(".test-docpage-rename", 1000).click();
     // A textbox should open and get selected: wait for it, since it's not immediate, and
     // trying to type into it too soon may miss some initial characters.
     await driver.wait(() => driver.executeScript(


### PR DESCRIPTION
## Context

Custom widgets can't detect if they are part of linking or not. Lack of this knowladge prevents some of them
from deciding what the initial state (like cursor position) should be. For example in the calendar control, we can't
blindly set the today's date, as the calendar might be used as a subsection, were position is controlled by 
other section with list of some events.

## Proposed solution

Adding basic information about what the linking configuration is. Now widget receives a `linking` field
as part of the `InteractionOptions` (onOptions callback). This field is **always** present and contains:

  - asTarget: the type of incoming link (e.g. "Cursor:Same-Table", "Filter:Col->Col", "Summary", etc.) or null if the widget is not driven by another section.       
  - asSource: true if at least one other section uses this widget as its linking source, false otherwise.

If the `linking` field is falsy (or not present), it means that Grist doesn't support this option yet. This is for added
backward compatibility.

## Related issues

https://github.com/gristlabs/grist-widget/pull/198

## Has this been tested?

- [X] 👍 yes, I added tests to the test suite