### PR TITLE
Makes the calendar widget load from a specific plugin, prefer bundled widgets

### DIFF
--- a/app/client/components/CustomCalendarView.ts
+++ b/app/client/components/CustomCalendarView.ts
@@ -5,6 +5,7 @@ export class CustomCalendarView extends CustomView {
   protected getBuiltInSettings(): CustomViewSettings {
     return {
       widgetId: "@gristlabs/widget-calendar",
+      pluginId: "bundled/grist-bundled",
       accessLevel: AccessLevel.full,
     };
   }

--- a/app/client/components/CustomView.ts
+++ b/app/client/components/CustomView.ts
@@ -42,6 +42,7 @@ const testId = makeTestId("test-custom-widget-");
  */
 export interface CustomViewSettings {
   widgetId?: string;
+  pluginId?: string;
   accessLevel?: AccessLevel;
 }
 
@@ -268,7 +269,7 @@ Please contact document owner or modify access rules."),
               access: builtInSettings.accessLevel || (_access as AccessLevel || AccessLevel.none),
               showAfterReady: showAfterReady(),
               widgetId: builtInSettings.widgetId || _widgetId,
-              pluginId: _pluginId,
+              pluginId: builtInSettings.pluginId || _pluginId,
             }),
           ) :
           null,

--- a/app/common/CustomWidget.ts
+++ b/app/common/CustomWidget.ts
@@ -106,8 +106,13 @@ export function matchWidget(widgets: ICustomWidget[], options: {
   pluginId?: string,
 }): ICustomWidget | undefined {
   const prefs = sortBy(widgets, (w) => {
-    return [w.widgetId !== options.widgetId,
-      (w.source?.pluginId || "") !== options.pluginId];
+    return [
+      w.widgetId !== options.widgetId,
+      // Prefer an exact plugin match if pluginId is given
+      !(options.pluginId && w.source?.pluginId === options.pluginId),
+      // Prefer a bundled widget copy over a remotely sourced one
+      !(w.source?.pluginId),
+    ];
   });
   if (prefs.length === 0) { return; }
   if (prefs[0].widgetId !== options.widgetId) { return; }

--- a/app/server/lib/WidgetRepository.ts
+++ b/app/server/lib/WidgetRepository.ts
@@ -1,7 +1,7 @@
 import { ApiError } from "app/common/ApiError";
 import { AsyncCreate } from "app/common/AsyncCreate";
 import { ICustomWidget } from "app/common/CustomWidget";
-import { isAffirmative, removeTrailingSlash } from "app/common/gutil";
+import { isAffirmative, isNonNullish, removeTrailingSlash } from "app/common/gutil";
 import { GristServer } from "app/server/lib/GristServer";
 import log from "app/server/lib/log";
 import { agents } from "app/server/lib/ProxyAgent";
@@ -153,7 +153,7 @@ export class UrlWidgetRepository implements IWidgetRepository {
 export class WidgetRepositoryImpl implements IWidgetRepository {
   protected _staticUrl: string | undefined;
   private _diskWidgets?: IWidgetRepository;
-  private _urlWidgets: UrlWidgetRepository;
+  private _urlWidgets?: UrlWidgetRepository;
   private _combinedWidgets: CombinedWidgetRepository;
 
   constructor(_options: {
@@ -186,20 +186,24 @@ export class WidgetRepositoryImpl implements IWidgetRepository {
   }
 
   public testSetUrl(overrideUrl: string | undefined) {
-    const repos: IWidgetRepository[] = [];
     this._staticUrl = overrideUrl ?? Deps.STATIC_URL;
     if (this._staticUrl) {
       const optional = isAffirmative(process.env.GRIST_WIDGET_LIST_URL_OPTIONAL);
       this._urlWidgets = new UrlWidgetRepository(this._staticUrl,
         !optional);
-      repos.push(this._urlWidgets);
+    } else {
+      this._urlWidgets = undefined;
     }
-    if (this._diskWidgets) { repos.push(this._diskWidgets); }
-    this._combinedWidgets = new CombinedWidgetRepository(repos);
+    this._refreshCombinedWidgetRepository();
   }
 
   public async getWidgets(): Promise<ICustomWidget[]> {
     return this._combinedWidgets.getWidgets();
+  }
+
+  private _refreshCombinedWidgetRepository() {
+    const repos = [this._diskWidgets, this._urlWidgets].filter(isNonNullish);
+    this._combinedWidgets = new CombinedWidgetRepository(repos);
   }
 }
 

--- a/test/common/CustomWidget.ts
+++ b/test/common/CustomWidget.ts
@@ -2,7 +2,7 @@ import { ICustomWidget, matchWidget } from "app/common/CustomWidget";
 
 import { assert } from "chai";
 
-describe("matchWidget", function() {
+describe("CustomWidget", function() {
   // Helper to create a minimal widget for testing.
   function makeWidget(widgetId: string, opts?: {
     pluginId?: string,

--- a/test/common/CustomWidget.ts
+++ b/test/common/CustomWidget.ts
@@ -1,0 +1,70 @@
+import { ICustomWidget, matchWidget } from "app/common/CustomWidget";
+
+import { assert } from "chai";
+
+describe("matchWidget", function() {
+  // Helper to create a minimal widget for testing.
+  function makeWidget(widgetId: string, opts?: {
+    pluginId?: string,
+    url?: string,
+  }): ICustomWidget {
+    return {
+      widgetId,
+      name: widgetId,
+      url: opts?.url ?? `https://example.com/${widgetId}`,
+      ...(opts?.pluginId ? { source: { pluginId: opts.pluginId, name: opts.pluginId } } : {}),
+    };
+  }
+
+  it("should return undefined for an empty list", function() {
+    assert.isUndefined(matchWidget([], { widgetId: "w1" }));
+  });
+
+  it("should return undefined when no widget has a matching widgetId", function() {
+    const widgets = [makeWidget("w1"), makeWidget("w2")];
+    assert.isUndefined(matchWidget(widgets, { widgetId: "w3" }));
+  });
+
+  it("should return an exact widgetId match", function() {
+    const widgets = [makeWidget("w1"), makeWidget("w2")];
+    const result = matchWidget(widgets, { widgetId: "w2" });
+    assert.equal(result?.widgetId, "w2");
+  });
+
+  it("should prefer a bundled widget over a non-bundled one", function() {
+    const external = makeWidget("calendar", { url: "https://external.com/calendar" });
+    const bundled = makeWidget("calendar", { pluginId: "bundled/grist-bundled" });
+    // Order should not matter — try both orderings.
+    for (const widgets of [[external, bundled], [bundled, external]]) {
+      const result = matchWidget(widgets, { widgetId: "calendar" });
+      assert.exists(result?.source, "expected bundled widget to be selected");
+      assert.equal(result?.source?.pluginId, "bundled/grist-bundled");
+    }
+  });
+
+  it("should prefer an exact pluginId match over other bundled widgets", function() {
+    const bundledA = makeWidget("w1", { pluginId: "plugin-a" });
+    const bundledB = makeWidget("w1", { pluginId: "plugin-b" });
+    for (const widgets of [[bundledA, bundledB], [bundledB, bundledA]]) {
+      const result = matchWidget(widgets, { widgetId: "w1", pluginId: "plugin-b" });
+      assert.equal(result?.source?.pluginId, "plugin-b");
+    }
+  });
+
+  it("should fall back to a bundled widget when pluginId doesn't match any", function() {
+    const external = makeWidget("w1");
+    const bundled = makeWidget("w1", { pluginId: "some-plugin" });
+    const result = matchWidget([external, bundled], {
+      widgetId: "w1",
+      pluginId: "nonexistent-plugin",
+    });
+    assert.equal(result?.source?.pluginId, "some-plugin");
+  });
+
+  it("should fall back to an external widget when no bundled version exists", function() {
+    const external = makeWidget("w1", { url: "https://external.com/w1" });
+    const result = matchWidget([external], { widgetId: "w1", pluginId: "some-plugin" });
+    assert.equal(result?.widgetId, "w1");
+    assert.isUndefined(result?.source);
+  });
+});

--- a/test/nbrowser/AttachedCustomWidget.ts
+++ b/test/nbrowser/AttachedCustomWidget.ts
@@ -106,6 +106,12 @@ describe("AttachedCustomWidget", function() {
     assert.exists(widgetMapping, "Widget mapping is expected to be present");
   });
 
+  it("should be loading the server widget, not a bundled version", async () => {
+    const src = await driver.findWait("iframe.custom_view", 1000).getAttribute("src");
+    const srcUrl = new URL(src);
+    assert.equal(srcUrl.origin, widgetServerUrl);
+  });
+
   it("should display the content of the widget", async () => {
     await gu.getSection("TABLE1 Calendar").click();
     try {

--- a/test/nbrowser/AttachedCustomWidget.ts
+++ b/test/nbrowser/AttachedCustomWidget.ts
@@ -64,6 +64,8 @@ describe("AttachedCustomWidget", function() {
   before(async function() {
     await buildWidgetServer();
     oldEnv = new EnvironmentSnapshot();
+    // Disable the bundled Calendar widget so that the version in the remote list is used instead.
+    process.env.GRIST_SKIP_BUNDLED_WIDGETS = "true";
     process.env.GRIST_WIDGET_LIST_URL = `${widgetServerUrl}${manifestEndpoint}`;
     process.env.PERMITTED_CUSTOM_WIDGETS = "calendar";
     await server.restart();

--- a/test/nbrowser/CustomWidgets.ts
+++ b/test/nbrowser/CustomWidgets.ts
@@ -962,98 +962,8 @@ describe("CustomWidgets", function() {
           CUSTOM_URL, widget1.name,
         ]);
 
-        // Get a temporary directory that will be cleaned up,
-        // and populated it as follows ('flat' variant)
-        //   plugins/
-        //     my-widgets/
-        //       manifest.yml   # a plugin manifest, listing widgets.json
-        //       widgets.json   # a widget set manifest, grist-widget style
-        //       p1.html        # one of the widgets in widgets.json
-        //       p2.html        # another of the widgets in widgets.json
-        //       grist-plugin-api.js   # a dummy api file, to check it is overridden
-        // In 'nested' variant, widgets.json and the files it refers to are in
-        // a subdirectory.
-        const dir = await createTmpDir();
-        const pluginDir = path.join(dir, "plugins", "my-widgets");
-        const widgetDir = variant === "nested" ? path.join(pluginDir, "nested") : pluginDir;
-        await fse.mkdirp(pluginDir);
-        await fse.mkdirp(widgetDir);
-
-        // A plugin, with some widgets in it.
-        await fse.writeFile(
-          path.join(pluginDir, "manifest.yml"),
-          `name: My Widgets\n` +
-          `components:\n` +
-          `  widgets: ${variant === "nested" ? "nested/" : ""}widgets.json\n`,
-        );
-
-        // A list of a pair of custom widgets, with the widget
-        // source in the same directory.
-        await fse.writeFile(
-          path.join(widgetDir, "widgets.json"),
-          JSON.stringify([
-            {
-              widgetId: "p1",
-              name: "P1",
-              url: "./p1.html",
-            },
-            {
-              widgetId: "p2",
-              name: "P2",
-              url: "./p2.html",
-            },
-            {
-              widgetId: "p3",
-              name: "P3",
-              url: "./p3.html",
-              published: false,
-            },
-          ]),
-        );
-
-        // The first widget - just contains the text P1.
-        await fse.writeFile(
-          path.join(widgetDir, "p1.html"),
-          "<html><body>P1</body></html>",
-        );
-
-        // The second widget. This contains the text P2
-        // if grist is defined after loading grist-plugin-api.js
-        // (but the js bundled with the widget just throws an
-        // alert).
-        await fse.writeFile(
-          path.join(widgetDir, "p2.html"),
-          `
-          <html>
-          <head><script src="./grist-plugin-api.js"></script></head>
-          <body>
-          <div id="readout"></div>
-          <script>
-            if (typeof grist !== 'undefined') {
-              document.getElementById('readout').innerText = 'P2';
-            }
-          </script>
-          </body>
-          </html>
-          `,
-        );
-
-        // The third widget - just contains the text P3.
-        await fse.writeFile(
-          path.join(widgetDir, "p3.html"),
-          "<html><body>P3</body></html>",
-        );
-
-        // A dummy grist-plugin-api.js - hopefully the actual
-        // js for the current version of Grist will be served in
-        // its place.
-        await fse.writeFile(
-          path.join(widgetDir, "grist-plugin-api.js"),
-          'alert("Error: built in api version used");',
-        );
-
         // Restart server and reload doc now plugins are in place.
-        process.env.GRIST_USER_ROOT = dir;
+        process.env.GRIST_USER_ROOT = await createBundledCustomWidgetDirectory(variant);
         await server.restart();
         await gu.reloadDoc();
 
@@ -1106,3 +1016,101 @@ describe("CustomWidgets", function() {
     }
   });
 });
+
+/**
+ *
+ * Get a temporary directory that will be cleaned up,
+ * and populated it as follows ('flat' variant)
+ *   plugins/
+ *     my-widgets/
+ *       manifest.yml   # a plugin manifest, listing widgets.json
+ *       widgets.json   # a widget set manifest, grist-widget style
+ *       p1.html        # one of the widgets in widgets.json
+ *       p2.html        # another of the widgets in widgets.json
+ *       grist-plugin-api.js   # a dummy api file, to check it is overridden
+ * In 'nested' variant, widgets.json and the files it refers to are in
+ * a subdirectory.
+ * @returns {Promise<void>}
+ */
+async function createBundledCustomWidgetDirectory(variant: "nested" | "flat") {
+  const dir = await createTmpDir();
+  const pluginDir = path.join(dir, "plugins", "my-widgets");
+  const widgetDir = variant === "nested" ? path.join(pluginDir, "nested") : pluginDir;
+  await fse.mkdirp(pluginDir);
+  await fse.mkdirp(widgetDir);
+
+  // A plugin, with some widgets in it.
+  await fse.writeFile(
+    path.join(pluginDir, "manifest.yml"),
+    `name: My Widgets\n` +
+    `components:\n` +
+    `  widgets: ${variant === "nested" ? "nested/" : ""}widgets.json\n`,
+  );
+
+  // A list of a pair of custom widgets, with the widget
+  // source in the same directory.
+  await fse.writeFile(
+    path.join(widgetDir, "widgets.json"),
+    JSON.stringify([
+      {
+        widgetId: "p1",
+        name: "P1",
+        url: "./p1.html",
+      },
+      {
+        widgetId: "p2",
+        name: "P2",
+        url: "./p2.html",
+      },
+      {
+        widgetId: "p3",
+        name: "P3",
+        url: "./p3.html",
+        published: false,
+      },
+    ]),
+  );
+
+  // The first widget - just contains the text P1.
+  await fse.writeFile(
+    path.join(widgetDir, "p1.html"),
+    "<html><body>P1</body></html>",
+  );
+
+  // The second widget. This contains the text P2
+  // if grist is defined after loading grist-plugin-api.js
+  // (but the js bundled with the widget just throws an
+  // alert).
+  await fse.writeFile(
+    path.join(widgetDir, "p2.html"),
+    `
+          <html>
+          <head><script src="./grist-plugin-api.js"></script></head>
+          <body>
+          <div id="readout"></div>
+          <script>
+            if (typeof grist !== 'undefined') {
+              document.getElementById('readout').innerText = 'P2';
+            }
+          </script>
+          </body>
+          </html>
+          `,
+  );
+
+  // The third widget - just contains the text P3.
+  await fse.writeFile(
+    path.join(widgetDir, "p3.html"),
+    "<html><body>P3</body></html>",
+  );
+
+  // A dummy grist-plugin-api.js - hopefully the actual
+  // js for the current version of Grist will be served in
+  // its place.
+  await fse.writeFile(
+    path.join(widgetDir, "grist-plugin-api.js"),
+    'alert("Error: built in api version used");',
+  );
+
+  return dir;
+}

--- a/test/nbrowser/CustomWidgets.ts
+++ b/test/nbrowser/CustomWidgets.ts
@@ -962,8 +962,98 @@ describe("CustomWidgets", function() {
           CUSTOM_URL, widget1.name,
         ]);
 
+        // Get a temporary directory that will be cleaned up,
+        // and populated it as follows ('flat' variant)
+        //   plugins/
+        //     my-widgets/
+        //       manifest.yml   # a plugin manifest, listing widgets.json
+        //       widgets.json   # a widget set manifest, grist-widget style
+        //       p1.html        # one of the widgets in widgets.json
+        //       p2.html        # another of the widgets in widgets.json
+        //       grist-plugin-api.js   # a dummy api file, to check it is overridden
+        // In 'nested' variant, widgets.json and the files it refers to are in
+        // a subdirectory.
+        const dir = await createTmpDir();
+        const pluginDir = path.join(dir, "plugins", "my-widgets");
+        const widgetDir = variant === "nested" ? path.join(pluginDir, "nested") : pluginDir;
+        await fse.mkdirp(pluginDir);
+        await fse.mkdirp(widgetDir);
+
+        // A plugin, with some widgets in it.
+        await fse.writeFile(
+          path.join(pluginDir, "manifest.yml"),
+          `name: My Widgets\n` +
+          `components:\n` +
+          `  widgets: ${variant === "nested" ? "nested/" : ""}widgets.json\n`,
+        );
+
+        // A list of a pair of custom widgets, with the widget
+        // source in the same directory.
+        await fse.writeFile(
+          path.join(widgetDir, "widgets.json"),
+          JSON.stringify([
+            {
+              widgetId: "p1",
+              name: "P1",
+              url: "./p1.html",
+            },
+            {
+              widgetId: "p2",
+              name: "P2",
+              url: "./p2.html",
+            },
+            {
+              widgetId: "p3",
+              name: "P3",
+              url: "./p3.html",
+              published: false,
+            },
+          ]),
+        );
+
+        // The first widget - just contains the text P1.
+        await fse.writeFile(
+          path.join(widgetDir, "p1.html"),
+          "<html><body>P1</body></html>",
+        );
+
+        // The second widget. This contains the text P2
+        // if grist is defined after loading grist-plugin-api.js
+        // (but the js bundled with the widget just throws an
+        // alert).
+        await fse.writeFile(
+          path.join(widgetDir, "p2.html"),
+          `
+          <html>
+          <head><script src="./grist-plugin-api.js"></script></head>
+          <body>
+          <div id="readout"></div>
+          <script>
+            if (typeof grist !== 'undefined') {
+              document.getElementById('readout').innerText = 'P2';
+            }
+          </script>
+          </body>
+          </html>
+          `,
+        );
+
+        // The third widget - just contains the text P3.
+        await fse.writeFile(
+          path.join(widgetDir, "p3.html"),
+          "<html><body>P3</body></html>",
+        );
+
+        // A dummy grist-plugin-api.js - hopefully the actual
+        // js for the current version of Grist will be served in
+        // its place.
+        await fse.writeFile(
+          path.join(widgetDir, "grist-plugin-api.js"),
+          'alert("Error: built in api version used");',
+        );
+
         // Restart server and reload doc now plugins are in place.
-        process.env.GRIST_USER_ROOT = await createBundledCustomWidgetDirectory(variant);
+        process.env.GRIST_USER_ROOT = dir;
         await server.restart();
         await gu.reloadDoc();
 
@@ -1016,101 +1106,3 @@ describe("CustomWidgets", function() {
     }
   });
 });
-
-/**
- *
- * Get a temporary directory that will be cleaned up,
- * and populated it as follows ('flat' variant)
- *   plugins/
- *     my-widgets/
- *       manifest.yml   # a plugin manifest, listing widgets.json
- *       widgets.json   # a widget set manifest, grist-widget style
- *       p1.html        # one of the widgets in widgets.json
- *       p2.html        # another of the widgets in widgets.json
- *       grist-plugin-api.js   # a dummy api file, to check it is overridden
- * In 'nested' variant, widgets.json and the files it refers to are in
- * a subdirectory.
- * @returns {Promise<void>}
- */
-async function createBundledCustomWidgetDirectory(variant: "nested" | "flat") {
-  const dir = await createTmpDir();
-  const pluginDir = path.join(dir, "plugins", "my-widgets");
-  const widgetDir = variant === "nested" ? path.join(pluginDir, "nested") : pluginDir;
-  await fse.mkdirp(pluginDir);
-  await fse.mkdirp(widgetDir);
-
-  // A plugin, with some widgets in it.
-  await fse.writeFile(
-    path.join(pluginDir, "manifest.yml"),
-    `name: My Widgets\n` +
-    `components:\n` +
-    `  widgets: ${variant === "nested" ? "nested/" : ""}widgets.json\n`,
-  );
-
-  // A list of a pair of custom widgets, with the widget
-  // source in the same directory.
-  await fse.writeFile(
-    path.join(widgetDir, "widgets.json"),
-    JSON.stringify([
-      {
-        widgetId: "p1",
-        name: "P1",
-        url: "./p1.html",
-      },
-      {
-        widgetId: "p2",
-        name: "P2",
-        url: "./p2.html",
-      },
-      {
-        widgetId: "p3",
-        name: "P3",
-        url: "./p3.html",
-        published: false,
-      },
-    ]),
-  );
-
-  // The first widget - just contains the text P1.
-  await fse.writeFile(
-    path.join(widgetDir, "p1.html"),
-    "<html><body>P1</body></html>",
-  );
-
-  // The second widget. This contains the text P2
-  // if grist is defined after loading grist-plugin-api.js
-  // (but the js bundled with the widget just throws an
-  // alert).
-  await fse.writeFile(
-    path.join(widgetDir, "p2.html"),
-    `
-          <html>
-          <head><script src="./grist-plugin-api.js"></script></head>
-          <body>
-          <div id="readout"></div>
-          <script>
-            if (typeof grist !== 'undefined') {
-              document.getElementById('readout').innerText = 'P2';
-            }
-          </script>
-          </body>
-          </html>
-          `,
-  );
-
-  // The third widget - just contains the text P3.
-  await fse.writeFile(
-    path.join(widgetDir, "p3.html"),
-    "<html><body>P3</body></html>",
-  );
-
-  // A dummy grist-plugin-api.js - hopefully the actual
-  // js for the current version of Grist will be served in
-  // its place.
-  await fse.writeFile(
-    path.join(widgetDir, "grist-plugin-api.js"),
-    'alert("Error: built in api version used");',
-  );
-
-  return dir;
-}


### PR DESCRIPTION
## Context

The [Grist Calendar widget](https://github.com/gristlabs/grist-widget/tree/master/calendar) is both available on Github, and bundled into Grist's built code directly. 

The version hosted on Github uses external resources (uicdn.toast.com, maxcdn.bootstrapcdn.com, cdn.jsdelivr.net) for Javascript and CSS. These are sometimes flagged by ad blockers / privacy extensions (e.g. Privacy Badger) and blocked.

The bundled version avoids this by caching those external dependencies locally, and should be preferred by Grist installations.

Currently, the Calendar widget prefers to use the externally hosted (i.e. Github) version over the bundled version when added to page.

## Proposed solution

This change:
1. Makes the built-in Calendar widget explicitly request the bundled widget (but will still fall-back on the external widget if not available).
2. Makes Grist prefer bundled widgets over external widgets, when two known widgets have the same ID.

It introduces a behaviour change in `matchWidget` to achieve this. Previously, if the `pluginId` parameter was set to the empty string `""`, `matchWidget` would _always_ prefer external widgets over bundled widgets.

However, the default configured value for `pluginId` in a view section is `""` and is persisted to the `_grist_Views_section` table in the database, meaning any existing saved widget will prefer the non-bundled version.

To fix this, `matchWidget`'s `pluginId` parameter no longer treats `""` as meaning "a non-plugin widget". 

## Related issues

https://community.getgrist.com/t/calendar-widget-broken/13771/7

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [X] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
