### PR TITLE
allow Grist to restart, to reconfigure, without dropping the listening socket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -189,8 +189,7 @@ ENV \
 
 EXPOSE 8484
 
-# When run without any arguments, we run the Grist server within
-# a simple supervisor.
+# When run without any arguments, we run the Grist server directly.
 # When arguments are supplied they are treated as a command to run,
 # as is default for docker. We arrange to have a "cli" command that
 # is the same as "yarn cli" run from the source code repo.
@@ -200,4 +199,4 @@ EXPOSE 8484
 #  --json "select * from _gristsys_ActionHistory"
 
 ENTRYPOINT ["./sandbox/docker_entrypoint.sh"]
-CMD ["node", "./sandbox/supervisor.mjs"]
+CMD ["./sandbox/run.sh"]

--- a/app/server/declarations.d.ts
+++ b/app/server/declarations.d.ts
@@ -72,5 +72,10 @@ declare namespace NodeJS {
 
     // Testing and development
     GRIST_TEST_SERVER_DEPLOYMENT_TYPE?: "core" | "enterprise" | "saas" | "static" | "electron";
+
+    // When set, run as a restart shell that holds the listening
+    // socket and spawns a child Grist server, enabling restart
+    // without dropping /status.
+    GRIST_RESTART_SHELL?: string;
   }
 }

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -122,6 +122,10 @@ const DOC_ID_NEW_USER_INFO = process.env.DOC_ID_NEW_USER_INFO;
 // PubSub channel we use to inform all servers when a new available Grist version is detected.
 const latestVersionChannel = "latestVersionAvailable";
 
+// Host that the HTTP server binds to. Shared with RestartShell so
+// shell and child agree on the same value.
+export function getGristHost() { return process.env.GRIST_HOST || "localhost"; }
+
 export interface FlexServerOptions {
   dataDir?: string;
 
@@ -132,6 +136,9 @@ export interface FlexServerOptions {
 
   // Global grist config options
   settings?: IGristCoreConfig;
+
+  // An existing http.Server to use instead of creating a new one.
+  server?: http.Server;
 }
 
 export class FlexServer implements GristServer {
@@ -227,7 +234,7 @@ export class FlexServer implements GristServer {
     this.app.set("port", port);
 
     this.appRoot = getAppRoot();
-    this.host = process.env.GRIST_HOST || "localhost";
+    this.host = getGristHost();
     log.info(`== Grist version is ${version.version} (commit ${version.gitcommit})`);
     this.info.push(["appRoot", this.appRoot]);
     // Initialize locales files.
@@ -374,8 +381,11 @@ export class FlexServer implements GristServer {
   // Get the port number the server listens on.  This may be different from the port
   // number the client expects when communicating with the server if there are intermediaries.
   public getOwnPort(): number {
-    // Get the port from the server in case it was started with port 0.
-    return this.server ? (this.server.address() as AddressInfo).port : this.port;
+    // Prefer server.address() in case we were started with port 0.
+    // Under RestartShell the worker's server never listens, so
+    // address() returns null and this.port is authoritative.
+    const addr = this.server?.address();
+    return (addr && typeof addr === "object") ? addr.port : this.port;
   }
 
   /**
@@ -2018,10 +2028,15 @@ export class FlexServer implements GristServer {
   public async start() {
     if (this._check("start")) { return; }
 
-    const servers = this._createServers();
-    this.server = servers.server;
-    this.httpsServer = servers.httpsServer;
-    await this._startServers(this.server, this.httpsServer, this.name, this.port, true);
+    if (this.options.server) {
+      this.server = this.options.server;
+      this.server.on("request", this.app);
+    } else {
+      const servers = this._createServers();
+      this.server = servers.server;
+      this.httpsServer = servers.httpsServer;
+      await this._startServers(this.server, this.httpsServer, this.name, this.port, true);
+    }
   }
 
   public addNotifier() {
@@ -2809,7 +2824,7 @@ export class FlexServer implements GristServer {
  * better if long imports were made using a mechanism that
  * isn't just a single http request)
  */
-function getServerFlags(): https.ServerOptions {
+export function getServerFlags(): https.ServerOptions {
   const flags: https.ServerOptions = {};
 
   // We used to set the socket timeout to 0, but that has been

--- a/app/server/lib/RestartShell.ts
+++ b/app/server/lib/RestartShell.ts
@@ -36,6 +36,7 @@ export const Deps = {
 };
 
 // Shell lifecycle.
+//   stopped    -> starting             start() called
 //   starting   -> running              initial spawn succeeded
 //   running    -> restarting           restart() begins
 //   restarting -> running              restart succeeded
@@ -68,8 +69,9 @@ const ALIVE = plain(200, "Grist server is alive.");
  * to a forked child worker. Construct, then `await start()`; hold onto
  * the instance to `restart()` or `shutdown()`.
  */
-export class RestartShell {
-  private _status: ShellStatus = { kind: "starting" };
+export type { RestartShell };
+class RestartShell {
+  private _status: ShellStatus = { kind: "stopped" };
   private _healthy = true;
 
   // Serializes restart/shutdown.
@@ -92,6 +94,7 @@ export class RestartShell {
   /** Bind the listening socket and spawn the first child. */
   public async start(): Promise<void> {
     log.info("RestartShell: starting");
+    this._status = { kind: "starting" };
     this._actualPort = await bindPublicSocket(this._server, this._options.publicPort);
     log.info(`RestartShell: listening on port ${this._actualPort}`);
 
@@ -221,10 +224,10 @@ export class RestartShell {
   }
 
   private _fallbackResponse(req: http.IncomingMessage): FallbackResponse {
-    const url = new URL(req.url || "/", "http://x");
-    if (url.pathname !== "/status") { return RESTARTING; }
+    const [pathname, query = ""] = (req.url || "/").split("?");
+    if (pathname !== "/status") { return RESTARTING; }
     if (!this._healthy) { return UNHEALTHY; }
-    if (isParameterOn(url.searchParams.get("ready"))) { return NOT_READY; }
+    if (isParameterOn(new URLSearchParams(query).get("ready"))) { return NOT_READY; }
     return ALIVE;
   }
 

--- a/app/server/lib/RestartShell.ts
+++ b/app/server/lib/RestartShell.ts
@@ -266,7 +266,10 @@ export class RestartShell {
 
     const exited = new Promise<ExitInfo>((resolve) => {
       c.once("exit", (code, signal) => resolve({ code, signal }));
-      c.once("error", () => resolve({ code: null, signal: null }));
+      c.once("error", (err) => {
+        log.error("RestartShell: child error event:", err);
+        resolve({ code: null, signal: null });
+      });
     });
 
     const ready = new Promise<void>((resolve, reject) => {
@@ -359,15 +362,19 @@ export function shouldRunAsRestartShell() {
   if (isUnderRestartShell()) { return false; }  // never recurse
   const explicit = process.env.GRIST_RESTART_SHELL;
   if (explicit !== undefined && explicit !== "") { return isAffirmative(explicit); }
+  // Tests use SIGSTOP/SIGCONT on the spawned process to pause the server;
+  // under RestartShell that only pauses the shell while the worker keeps
+  // serving, breaking pauseUntil() in browser tests.
+  if (process.env.GRIST_TESTING_SOCKET) { return false; }
   const isElectron = Boolean((process.versions as { electron?: string }).electron);
   return process.platform === "linux" && !isElectron;
 }
 
 /** Bind `server` to `port` on the Grist host; return the actual bound port. */
 async function bindPublicSocket(server: net.Server, port: number): Promise<number> {
+  server.on("error", err => log.error("RestartShell: server error:", err));
   const listening = listenPromise(server);
   server.listen(port, getGristHost());
   await listening;
-  server.on("error", err => log.error("RestartShell: server error:", err));
   return (server.address() as net.AddressInfo).port;
 }

--- a/app/server/lib/RestartShell.ts
+++ b/app/server/lib/RestartShell.ts
@@ -1,0 +1,379 @@
+/**
+ * RestartShell: owns the listening TCP socket and forwards each
+ * accepted connection to a forked child worker via IPC, so admin-
+ * triggered restarts don't drop the port. If the child crashes
+ * unexpectedly, the shell exits too -- it is not a general process
+ * manager.
+ */
+
+import { isAffirmative, PromiseChain } from "app/common/gutil";
+import { getGristHost } from "app/server/lib/FlexServer";
+import log from "app/server/lib/log";
+import { isParameterOn } from "app/server/lib/requestUtils";
+import {
+  isUnderRestartShell,
+  ShellToWorker,
+  WorkerToShell,
+} from "app/server/lib/RestartShellWorker";
+import { exitPromise, listenPromise } from "app/server/lib/serverUtils";
+import * as shutdownLib from "app/server/lib/shutdown";
+
+import * as childProcess from "child_process";
+import * as http from "http";
+import * as net from "net";
+
+export interface RestartShellOptions {
+  publicPort: number;
+  childEntryPoint: string;
+}
+
+// Tunables exposed for tests.
+export const Deps = {
+  // If a spawn hasn't completed within this window, /status starts
+  // reporting 500 so orchestration can react. Flips back to healthy
+  // if the spawn eventually succeeds.
+  unhealthyTimeoutMs: 15000,
+};
+
+// Shell lifecycle.
+//   starting   -> running              initial spawn succeeded
+//   running    -> restarting           restart() begins
+//   restarting -> running              restart succeeded
+//   *          -> stopping -> stopped  shutdown()
+// A failed spawn sets a non-zero exitCode and queues shutdown().
+type ShellStatus =
+  { kind: "starting" } |
+  { kind: "running", child: childProcess.ChildProcess } |
+  { kind: "restarting" } |
+  { kind: "stopping" } |
+  { kind: "stopped" };
+
+type SpawnResult =
+  { ok: true, child: childProcess.ChildProcess } |
+  { ok: false, err: unknown };
+
+interface ExitInfo { code: number | null; signal: NodeJS.Signals | null; }
+
+interface FallbackResponse { status: number; contentType: string; body: string; }
+const plain = (status: number, body: string): FallbackResponse =>
+  ({ status, contentType: "text/plain", body });
+const RESTARTING: FallbackResponse =
+  { status: 503, contentType: "application/json", body: JSON.stringify({ error: "restarting" }) };
+const UNHEALTHY = plain(500, "Grist server is unhealthy.");
+const NOT_READY = plain(500, "Grist server is unhealthy (ready not ok).");
+const ALIVE = plain(200, "Grist server is alive.");
+
+/**
+ * Owns the public listening socket and forwards accepted connections
+ * to a forked child worker. Construct, then `await start()`; hold onto
+ * the instance to `restart()` or `shutdown()`.
+ */
+export class RestartShell {
+  private _status: ShellStatus = { kind: "starting" };
+  private _healthy = true;
+
+  // Serializes restart/shutdown.
+  private readonly _ops = new PromiseChain<void>();
+
+  // Sockets accepted but not yet handed off to the child. A socket
+  // leaves when it closes locally or is successfully sent to the child
+  // (after which the child owns it). shutdown() destroys the rest.
+  private readonly _connections = new Set<net.Socket>();
+
+  private readonly _server: net.Server;
+  private readonly _fallbackServer: http.Server;
+  private _actualPort = 0;
+
+  constructor(private readonly _options: RestartShellOptions) {
+    this._fallbackServer = this._createFallbackServer();
+    this._server = this._createPublicServer();
+  }
+
+  /** Bind the listening socket and spawn the first child. */
+  public async start(): Promise<void> {
+    log.info("RestartShell: starting");
+    this._actualPort = await bindPublicSocket(this._server, this._options.publicPort);
+    log.info(`RestartShell: listening on port ${this._actualPort}`);
+
+    // Signal handling via shutdown.js -- on SIGINT/SIGTERM it runs
+    // our cleanup handler (capped at 15s) and exits 128+signum, which
+    // is the expected kill-by-signal contract even when Grist runs as
+    // pid 1 in a container (see grist-core#830, #892).
+    shutdownLib.addCleanupHandler(this, () => this.shutdown(), 15000, "RestartShell");
+    shutdownLib.cleanupOnSignals("SIGINT", "SIGTERM");
+
+    const result = await this._spawnOrFail();
+    if (!result.ok) {
+      // Shut down so the event loop drains and the process exits
+      // naturally; exitCode makes that exit non-zero.
+      process.exitCode = 1;
+      await this.shutdown();
+      throw new Error(`RestartShell: initial spawn failed: ${result.err}`);
+    }
+    this._status = { kind: "running", child: result.child };
+  }
+
+  public get port(): number { return this._actualPort; }
+
+  public getChildPid(): number | undefined {
+    return this._status.kind === "running" ? this._status.child.pid : undefined;
+  }
+
+  public restart(): Promise<void> {
+    return this._ops.add(() => this._doRestart());
+  }
+
+  public shutdown(killSig: NodeJS.Signals = "SIGTERM"): Promise<void> {
+    return this._ops.add(() => this._doShutdown(killSig));
+  }
+
+  private async _doRestart(): Promise<void> {
+    if (this._status.kind !== "running") { return; }
+    const oldChild = this._status.child;
+    this._status = { kind: "restarting" };
+    log.info("RestartShell: restart requested");
+    try {
+      await this._stopChild(oldChild);
+      const result = await this._spawnOrFail();
+      if (result.ok) {
+        this._status = { kind: "running", child: result.child };
+      } else {
+        log.error("RestartShell: restart failed; shutting down");
+        this._failFast();
+      }
+    } catch (err) {
+      this._failFast("restart", err);
+    }
+  }
+
+  private async _doShutdown(killSig: NodeJS.Signals): Promise<void> {
+    if (this._status.kind === "stopping" || this._status.kind === "stopped") { return; }
+    const liveChild = this._status.kind === "running" ? this._status.child : undefined;
+    this._status = { kind: "stopping" };
+    shutdownLib.removeCleanupHandlers(this);
+
+    try {
+      for (const conn of this._connections) { conn.destroy(); }
+      this._connections.clear();
+      // server.close() is not awaited: the sockets we've handed to the
+      // child keep its internal count up until the child closes them,
+      // which can take the full _stopChild timeout. The synchronous
+      // effect (stop accepting new connections) is all we need.
+      this._server.close();
+      if (liveChild) { await this._stopChild(liveChild, killSig); }
+    } catch (err) {
+      // Defensive: the steps above are designed not to throw. Reach
+      // "stopped" anyway so the op queue isn't left broken.
+      log.error("RestartShell: unexpected error in shutdown:", err);
+    }
+    this._status = { kind: "stopped" };
+  }
+
+  // Called when we hit an unrecoverable state (spawn failed, or an
+  // "impossible" throw from _stopChild / _spawnOrFail). Set a non-zero
+  // exit code and queue a shutdown so the process drains and exits.
+  private _failFast(context?: string, err?: unknown): void {
+    if (context) { log.error(`RestartShell: unexpected error in ${context}:`, err); }
+    process.exitCode = 1;
+    // void: callers run on the _ops queue, so awaiting shutdown here
+    // would deadlock (it's queued behind the current op).
+    void this.shutdown();
+  }
+
+  // When the child dies, `child.connected` flips to false immediately
+  // but our status stays "running" until `_onChildExitAfterReady` runs
+  // on the next tick. Checking both avoids sending to a dead IPC
+  // channel during that window.
+  private _childIfForwardable(): childProcess.ChildProcess | undefined {
+    const s = this._status;
+    return s.kind === "running" && s.child.connected ? s.child : undefined;
+  }
+
+  private _createPublicServer(): net.Server {
+    return net.createServer({ pauseOnConnect: true }, (socket) => {
+      this._connections.add(socket);
+      socket.on("close", () => this._connections.delete(socket));
+
+      const forwardTo = this._childIfForwardable();
+      if (forwardTo) {
+        this._forwardSocketToChild(forwardTo, socket);
+      } else {
+        this._fallbackServer.emit("connection", socket);
+        socket.resume();
+      }
+    });
+  }
+
+  // An http.Server that's never bound to a port. We feed raw sockets
+  // to it via emit("connection", socket) -- saves reimplementing
+  // HTTP parsing just to answer /status.
+  private _createFallbackServer(): http.Server {
+    return http.createServer((req, res) => this._handleFallbackRequest(req, res));
+  }
+
+  private _handleFallbackRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
+    // Connection:close so the next request opens a fresh TCP
+    // connection and routes to the new child once it's up.
+    res.setHeader("Connection", "close");
+    const { status, contentType, body } = this._fallbackResponse(req);
+    res.writeHead(status, { "Content-Type": contentType });
+    res.end(body);
+  }
+
+  private _fallbackResponse(req: http.IncomingMessage): FallbackResponse {
+    const url = new URL(req.url || "/", "http://x");
+    if (url.pathname !== "/status") { return RESTARTING; }
+    if (!this._healthy) { return UNHEALTHY; }
+    if (isParameterOn(url.searchParams.get("ready"))) { return NOT_READY; }
+    return ALIVE;
+  }
+
+  private _forwardSocketToChild(c: childProcess.ChildProcess, socket: net.Socket): void {
+    const msg: ShellToWorker = { action: "connection" };
+    // Narrow race: if the child dies between our send-ack and its
+    // "connection" handler running, the client's TCP connection is
+    // closed by the kernel when the child's fd is reclaimed -- the
+    // client sees a reset and can reconnect.
+    c.send(msg, socket, (err: Error | null) => {
+      if (err) {
+        // Close outright -- client would otherwise hang with no reader.
+        log.warn("RestartShell: failed to send socket to child:", err.message);
+        socket.destroy();
+      } else {
+        this._connections.delete(socket);
+      }
+    });
+  }
+
+  /**
+   * Fork a worker and return the child plus promises for its "ready"
+   * signal and its eventual exit. `ready` rejects if the child exits
+   * before signalling ready.
+   */
+  private _forkWorker(): { child: childProcess.ChildProcess; ready: Promise<void>; exited: Promise<ExitInfo> } {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      GRIST_UNDER_RESTART_SHELL: "1",
+      PORT: String(this._actualPort),
+    };
+    // Clear GRIST_RESTART_SHELL so the child can't re-detect shell mode.
+    delete env.GRIST_RESTART_SHELL;
+
+    const c = childProcess.fork(this._options.childEntryPoint, [], {
+      env,
+      stdio: ["inherit", "inherit", "inherit", "ipc"],
+    });
+
+    const exited = new Promise<ExitInfo>((resolve) => {
+      c.once("exit", (code, signal) => resolve({ code, signal }));
+    });
+
+    const ready = new Promise<void>((resolve, reject) => {
+      c.on("message", (msg: WorkerToShell) => {
+        switch (msg?.action) {
+          case "ready": resolve(); break;
+          case "restart": void this.restart(); break;
+        }
+      });
+      void exited.then(({ code, signal }) =>
+        reject(new Error(`child exited before ready code=${code} signal=${signal}`)));
+    });
+
+    return { child: c, ready, exited };
+  }
+
+  private _onChildExitAfterReady(code: number | null, signal: NodeJS.Signals | null): void {
+    log.info(`RestartShell: child exited code=${code} signal=${signal}`);
+    // "starting" is reachable only in the narrow sync gap between the
+    // spawn resolving and start() updating status; treat as running.
+    switch (this._status.kind) {
+      case "restarting":
+      case "stopping":
+      case "stopped":
+        return;
+      case "starting":
+      case "running":
+        log.error("RestartShell: child crashed unexpectedly, shutting down");
+        process.exitCode = code ?? 1;
+        void this.shutdown();
+    }
+  }
+
+  private async _stopChild(
+    child: childProcess.ChildProcess,
+    sig: NodeJS.Signals = "SIGTERM",
+    timeoutMs = 10000,
+  ): Promise<void> {
+    if (child.exitCode === null) {
+      child.kill(sig);
+      await waitForExit(child, timeoutMs);
+    }
+  }
+
+  /**
+   * Fork a worker, wait for ready, and arm the "unexpected exit ⇒
+   * shell exits" policy. A watchdog flips `_healthy` to false if the
+   * spawn stalls, so /status can report unhealthy to orchestration.
+   */
+  private async _spawnOrFail(): Promise<SpawnResult> {
+    log.info("RestartShell: spawning child");
+    const watchdog = setTimeout(() => {
+      log.error(`RestartShell: spawn still running after ${Deps.unhealthyTimeoutMs}ms, marking unhealthy`);
+      this._healthy = false;
+    }, Deps.unhealthyTimeoutMs);
+    const { child, ready, exited } = this._forkWorker();
+    try {
+      await ready;
+      log.info("RestartShell: child ready");
+      this._healthy = true;
+      // Pre-ready exits reject `ready`; this only fires for post-ready.
+      void exited.then(({ code, signal }) => this._onChildExitAfterReady(code, signal));
+      return { ok: true, child };
+    } catch (err) {
+      log.error("RestartShell: child failed to start:", err);
+      return { ok: false, err };
+    } finally {
+      clearTimeout(watchdog);
+    }
+  }
+}
+
+/** Build and start a RestartShell. */
+export async function runRestartShell(options: RestartShellOptions): Promise<RestartShell> {
+  const shell = new RestartShell(options);
+  await shell.start();
+  return shell;
+}
+
+/**
+ * GRIST_RESTART_SHELL is honored if set; otherwise defaults to true on
+ * Linux under plain Node, false elsewhere -- Windows FD-passing works
+ * per Node docs but is untested, and Electron has issues with forking.
+ */
+export function shouldRunAsRestartShell() {
+  if (isUnderRestartShell()) { return false; }  // never recurse
+  const explicit = process.env.GRIST_RESTART_SHELL;
+  if (explicit !== undefined && explicit !== "") { return isAffirmative(explicit); }
+  const isElectron = Boolean((process.versions as { electron?: string }).electron);
+  return process.platform === "linux" && !isElectron;
+}
+
+/** Bind `server` to `port` on the Grist host; return the actual bound port. */
+async function bindPublicSocket(server: net.Server, port: number): Promise<number> {
+  const listening = listenPromise(server);
+  server.listen(port, getGristHost());
+  await listening;
+  server.on("error", err => log.error("RestartShell: server error:", err));
+  return (server.address() as net.AddressInfo).port;
+}
+
+/** Wait for `child` to exit; SIGKILL it if it doesn't within timeoutMs. */
+async function waitForExit(child: childProcess.ChildProcess, timeoutMs: number): Promise<void> {
+  if (child.exitCode !== null) { return; }
+  const exited = exitPromise(child).catch(() => { /* treat errors as exit */ });
+  const timer = setTimeout(() => {
+    log.warn("RestartShell: child did not exit in time, sending SIGKILL");
+    child.kill("SIGKILL");
+  }, timeoutMs);
+  try { await exited; } finally { clearTimeout(timer); }
+}

--- a/app/server/lib/RestartShell.ts
+++ b/app/server/lib/RestartShell.ts
@@ -15,7 +15,7 @@ import {
   ShellToWorker,
   WorkerToShell,
 } from "app/server/lib/RestartShellWorker";
-import { exitPromise, listenPromise } from "app/server/lib/serverUtils";
+import { listenPromise } from "app/server/lib/serverUtils";
 import * as shutdownLib from "app/server/lib/shutdown";
 
 import * as childProcess from "child_process";
@@ -43,13 +43,13 @@ export const Deps = {
 // A failed spawn sets a non-zero exitCode and queues shutdown().
 type ShellStatus =
   { kind: "starting" } |
-  { kind: "running", child: childProcess.ChildProcess } |
+  { kind: "running", child: childProcess.ChildProcess, exited: Promise<ExitInfo> } |
   { kind: "restarting" } |
   { kind: "stopping" } |
   { kind: "stopped" };
 
 type SpawnResult =
-  { ok: true, child: childProcess.ChildProcess } |
+  { ok: true, child: childProcess.ChildProcess, exited: Promise<ExitInfo> } |
   { ok: false, err: unknown };
 
 interface ExitInfo { code: number | null; signal: NodeJS.Signals | null; }
@@ -110,7 +110,7 @@ export class RestartShell {
       await this.shutdown();
       throw new Error(`RestartShell: initial spawn failed: ${result.err}`);
     }
-    this._status = { kind: "running", child: result.child };
+    this._status = { kind: "running", child: result.child, exited: result.exited };
   }
 
   public get port(): number { return this._actualPort; }
@@ -129,14 +129,14 @@ export class RestartShell {
 
   private async _doRestart(): Promise<void> {
     if (this._status.kind !== "running") { return; }
-    const oldChild = this._status.child;
+    const { child: oldChild, exited: oldExited } = this._status;
     this._status = { kind: "restarting" };
     log.info("RestartShell: restart requested");
     try {
-      await this._stopChild(oldChild);
+      await this._stopChild(oldChild, oldExited);
       const result = await this._spawnOrFail();
       if (result.ok) {
-        this._status = { kind: "running", child: result.child };
+        this._status = { kind: "running", child: result.child, exited: result.exited };
       } else {
         log.error("RestartShell: restart failed; shutting down");
         this._failFast();
@@ -148,7 +148,7 @@ export class RestartShell {
 
   private async _doShutdown(killSig: NodeJS.Signals): Promise<void> {
     if (this._status.kind === "stopping" || this._status.kind === "stopped") { return; }
-    const liveChild = this._status.kind === "running" ? this._status.child : undefined;
+    const live = this._status.kind === "running" ? this._status : undefined;
     this._status = { kind: "stopping" };
     shutdownLib.removeCleanupHandlers(this);
 
@@ -160,7 +160,7 @@ export class RestartShell {
       // which can take the full _stopChild timeout. The synchronous
       // effect (stop accepting new connections) is all we need.
       this._server.close();
-      if (liveChild) { await this._stopChild(liveChild, killSig); }
+      if (live) { await this._stopChild(live.child, live.exited, killSig); }
     } catch (err) {
       // Defensive: the steps above are designed not to throw. Reach
       // "stopped" anyway so the op queue isn't left broken.
@@ -266,6 +266,7 @@ export class RestartShell {
 
     const exited = new Promise<ExitInfo>((resolve) => {
       c.once("exit", (code, signal) => resolve({ code, signal }));
+      c.once("error", () => resolve({ code: null, signal: null }));
     });
 
     const ready = new Promise<void>((resolve, reject) => {
@@ -301,13 +302,17 @@ export class RestartShell {
 
   private async _stopChild(
     child: childProcess.ChildProcess,
+    exited: Promise<ExitInfo>,
     sig: NodeJS.Signals = "SIGTERM",
     timeoutMs = 10000,
   ): Promise<void> {
-    if (child.exitCode === null) {
-      child.kill(sig);
-      await waitForExit(child, timeoutMs);
-    }
+    if (child.exitCode !== null) { return; }
+    child.kill(sig);
+    const timer = setTimeout(() => {
+      log.warn("RestartShell: child did not exit in time, sending SIGKILL");
+      child.kill("SIGKILL");
+    }, timeoutMs);
+    try { await exited; } finally { clearTimeout(timer); }
   }
 
   /**
@@ -328,7 +333,7 @@ export class RestartShell {
       this._healthy = true;
       // Pre-ready exits reject `ready`; this only fires for post-ready.
       void exited.then(({ code, signal }) => this._onChildExitAfterReady(code, signal));
-      return { ok: true, child };
+      return { ok: true, child, exited };
     } catch (err) {
       log.error("RestartShell: child failed to start:", err);
       return { ok: false, err };
@@ -365,15 +370,4 @@ async function bindPublicSocket(server: net.Server, port: number): Promise<numbe
   await listening;
   server.on("error", err => log.error("RestartShell: server error:", err));
   return (server.address() as net.AddressInfo).port;
-}
-
-/** Wait for `child` to exit; SIGKILL it if it doesn't within timeoutMs. */
-async function waitForExit(child: childProcess.ChildProcess, timeoutMs: number): Promise<void> {
-  if (child.exitCode !== null) { return; }
-  const exited = exitPromise(child).catch(() => { /* treat errors as exit */ });
-  const timer = setTimeout(() => {
-    log.warn("RestartShell: child did not exit in time, sending SIGKILL");
-    child.kill("SIGKILL");
-  }, timeoutMs);
-  try { await exited; } finally { clearTimeout(timer); }
 }

--- a/app/server/lib/RestartShellWorker.ts
+++ b/app/server/lib/RestartShellWorker.ts
@@ -1,0 +1,53 @@
+/**
+ * Helpers that run in a RestartShell worker process (the forked child).
+ * Everything flows to the shell via IPC. Split from RestartShell so
+ * it's physically obvious which code runs in which process.
+ */
+
+import { delay } from "app/common/delay";
+import { isAffirmative } from "app/common/gutil";
+import { getServerFlags } from "app/server/lib/FlexServer";
+
+import * as http from "http";
+
+// IPC messages exchanged between shell and worker.
+export interface ShellToWorker { action: "connection"; }
+export interface WorkerToShell { action: "ready" | "restart"; }
+
+export function isUnderRestartShell(): boolean {
+  return isAffirmative(process.env.GRIST_UNDER_RESTART_SHELL);
+}
+
+/**
+ * Create an http.Server that receives connections from the parent
+ * RestartShell via IPC rather than binding a port itself. Passed into
+ * MergedServer via its `server` option.
+ */
+export function createRestartShellWorkerServer(): http.Server {
+  // Unref IPC so it alone doesn't keep the worker alive: on a failed
+  // boot, handles drain and the process exits, matching pre-shell
+  // Grist where a dead listen socket meant a dead process.
+  process.channel?.unref();
+
+  const server = http.createServer(getServerFlags());
+  process.on("message", (msg: ShellToWorker, socket: any) => {
+    if (msg?.action === "connection" && socket) {
+      server.emit("connection", socket);
+      socket.resume();
+    }
+  });
+  return server;
+}
+
+/**
+ * Tell the parent RestartShell that this worker is ready to accept
+ * forwarded connections. Caller must wait until the server is fully
+ * set up (including any testing hooks tests will probe for).
+ */
+export async function signalRestartShellReady(): Promise<void> {
+  if (process.env.GRIST_TEST_RESTART_SHELL_READY_DELAY) {
+    await delay(Number(process.env.GRIST_TEST_RESTART_SHELL_READY_DELAY));
+  }
+  const ready: WorkerToShell = { action: "ready" };
+  process.send?.(ready);
+}

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -38,6 +38,11 @@ import {
 } from "express";
 import pick from "lodash/pick";
 
+function canRestart() {
+  return isAffirmative(process.env.GRIST_RUNNING_UNDER_SUPERVISOR) ||
+    isAffirmative(process.env.GRIST_UNDER_RESTART_SHELL);
+}
+
 export interface AttachOptions {
   app: Application;
   gristServer: GristServer;
@@ -69,7 +74,7 @@ export function attachEarlyEndpoints(options: AttachOptions) {
     userIdMiddleware,
     expressWrap(async (req, res) => {
       const config: Partial<AdminPageConfig> = {
-        runningUnderSupervisor: isAffirmative(process.env.GRIST_RUNNING_UNDER_SUPERVISOR),
+        runningUnderSupervisor: canRestart(),
         adminControls: gristServer.create.areAdminControlsAvailable(),
       };
       return gristServer.sendAppPage(req, res, {
@@ -106,12 +111,12 @@ export function attachEarlyEndpoints(options: AttachOptions) {
         // Docker) tell the parent that we have a new environment so it
         // can restart us.
         log.rawDebug(`Restart[${mreq.method}] finishing:`, meta);
-        if (process.send && process.env.GRIST_RUNNING_UNDER_SUPERVISOR) {
-          log.rawDebug(`Restart[${mreq.method}] requesting supervisor to restart home server:`, meta);
+        if (process.send && canRestart()) {
+          log.rawDebug(`Restart[${mreq.method}] requesting restart:`, meta);
           process.send({ action: "restart" });
         }
       });
-      if (!process.env.GRIST_RUNNING_UNDER_SUPERVISOR) {
+      if (!canRestart()) {
         // On the topic of http response codes, thus spake MDN:
         // "409: This response is sent when a request conflicts with the current state of the server."
         return res.status(409).send({

--- a/sandbox/supervisor.mjs
+++ b/sandbox/supervisor.mjs
@@ -1,3 +1,9 @@
+// Deprecated: Grist now starts under its own RestartShell by default
+// on Linux (see app/server/lib/RestartShell.ts), which handles
+// admin-triggered restarts without dropping the listening socket.
+// The Dockerfile no longer invokes this script; it is kept for
+// external builds that still point at it. New deployments should
+// run Grist directly and rely on RestartShell.
 import {spawn} from "child_process";
 
 let grist;

--- a/sandbox/watch.sh
+++ b/sandbox/watch.sh
@@ -26,6 +26,14 @@ tsc --build -w --preserveWatchOutput $PROJECT &
 css_files="app/client/**/*.css"
 chokidar "${css_files}" -c "bash -O globstar -c 'cat ${css_files} > static/bundle.css'" &
 webpack --config $WEBPACK_CONFIG --mode development --watch &
+# DEBUG=1 keeps dev output verbose. Historically `yarn start` was
+# noisy by accident (stubs/server.ts sets GRIST_LOG_LEVEL=error after
+# log.ts has already been imported, so the level never took effect).
+# Under RestartShell the env propagates correctly to the child and
+# the intended "error" level kicks in, so we'd otherwise see almost
+# nothing during dev. Set DEBUG explicitly to keep the old spew.
+: "${DEBUG:=1}"
+export DEBUG
 ! $NO_NODEMON && NODE_PATH=_build:_build/ext:_build/stubs nodemon ${NODE_INSPECT} --delay 1 -w _build/app/server -w _build/app/common _build/stubs/app/server/server.js &
 
 wait

--- a/stubs/app/server/server.ts
+++ b/stubs/app/server/server.ts
@@ -47,8 +47,13 @@ setDefaultEnv("GRIST_WIDGET_LIST_URL", commonUrls.gristLabsWidgetRepository);
 // It's important that this comes after the setDefaultEnv calls above. MergedServer reads
 // some env vars at import time, including GRIST_WIDGET_LIST_URL.
 // TODO: Fix this reliance on side effects during import.
-// eslint-disable-next-line @import-x/order
+/* eslint-disable @import-x/order */
 import { MergedServer, parseServerTypes } from "app/server/MergedServer";
+import { runRestartShell, shouldRunAsRestartShell } from "app/server/lib/RestartShell";
+import {
+  createRestartShellWorkerServer, isUnderRestartShell, signalRestartShellReady,
+} from "app/server/lib/RestartShellWorker";
+/* eslint-enable @import-x/order */
 
 const G = {
   port: parseInt(process.env.PORT!, 10) || 8484,
@@ -200,6 +205,15 @@ export async function main() {
     console.log("For full logs, re-run with DEBUG=1");
   }
 
+  if (shouldRunAsRestartShell()) {
+    // Shell owns the socket and manages a forked worker. Returns the
+    // RestartShell handle instead of a FlexServer.
+    return runRestartShell({
+      publicPort: G.port,
+      childEntryPoint: __filename,
+    });
+  }
+
   if (process.env.GRIST_PROMCLIENT_PORT) {
     runPrometheusExporter(parseInt(process.env.GRIST_PROMCLIENT_PORT, 10));
   }
@@ -227,14 +241,21 @@ export async function main() {
     log.info("Database setup complete.");
   }
 
-  // Launch single-port, self-contained version of Grist.
-  const mergedServer = await MergedServer.create(G.port, serverTypes);
+  // Under a RestartShell parent we receive connections via IPC;
+  // otherwise MergedServer creates its own http.Server and listens.
+  const serverOpts = isUnderRestartShell() ?
+    { server: createRestartShellWorkerServer() } :
+    {};
+  const mergedServer = await MergedServer.create(G.port, serverTypes, serverOpts);
   await mergedServer.run();
   if (process.env.GRIST_TESTING_SOCKET) {
     await mergedServer.flexServer.addTestingHooks();
   }
   if (process.env.GRIST_SERVE_PLUGINS_PORT) {
     await mergedServer.flexServer.startCopy("pluginServer", parseInt(process.env.GRIST_SERVE_PLUGINS_PORT, 10));
+  }
+  if (isUnderRestartShell()) {
+    await signalRestartShellReady();
   }
 
   return mergedServer.flexServer;

--- a/test/server/lib/RestartShell.ts
+++ b/test/server/lib/RestartShell.ts
@@ -1,0 +1,280 @@
+/**
+ * End-to-end tests for RestartShell: the mocha process spawns a real
+ * shell in-process that forks a Grist child via stubs/app/server/server.
+ */
+
+import { delay } from "app/common/delay";
+import { Deps, runRestartShell } from "app/server/lib/RestartShell";
+import { createInitialDb, removeConnection, setUpDB } from "test/gen-server/seed";
+import { configForUser } from "test/gen-server/testUtils";
+import * as testUtils from "test/server/testUtils";
+import { EnvironmentSnapshot } from "test/server/testUtils";
+
+import * as os from "os";
+import * as path from "path";
+
+import axios from "axios";
+import { assert } from "chai";
+import * as fse from "fs-extra";
+import sinon from "sinon";
+
+describe("RestartShell", function() {
+  this.timeout(60000);
+  testUtils.setTmpLogLevel("warn");
+
+  let oldEnv: EnvironmentSnapshot;
+  let serverUrl: string;
+  let handle: Awaited<ReturnType<typeof runRestartShell>>;
+  let tmpDir: string;
+  const sandbox = sinon.createSandbox();
+  const chimpy = configForUser("Chimpy");
+
+  before(async function() {
+    oldEnv = new EnvironmentSnapshot();
+    process.env.GRIST_LOG_LEVEL = "warn";
+    tmpDir = await fse.mkdtemp(path.join(os.tmpdir(), "grist-supervisor-test-"));
+  });
+
+  beforeEach(async function() {
+    // Use a file-based DB so the child process (separate process)
+    // can access the same seeded data.
+    const dbPath = path.join(tmpDir, "test.db");
+    await fse.remove(dbPath);
+    process.env.TYPEORM_DATABASE = dbPath;
+    setUpDB(this);
+    await createInitialDb();
+    // We've seeded the DB once; the child must not wipe it again.
+    delete process.env.TEST_CLEAN_DATABASE;
+    // Close the connection in the test process so the child can
+    // open it without contention.
+    await removeConnection();
+
+    process.env.GRIST_DEFAULT_EMAIL = "test@example.com";
+    process.env.GRIST_SESSION_SECRET = "test-secret";
+    process.env.GRIST_DATA_DIR = path.join(tmpDir, "docs");
+    process.env.GRIST_SERVERS = "home,docs,static";
+    await fse.mkdirp(process.env.GRIST_DATA_DIR);
+
+    handle = await runRestartShell({
+      publicPort: 0,
+      childEntryPoint: require.resolve("stubs/app/server/server"),
+    });
+    serverUrl = `http://localhost:${handle.port}`;
+  });
+
+  afterEach(async function() {
+    sandbox.restore();
+    delete process.env.GRIST_TEST_RESTART_SHELL_READY_DELAY;
+    if (handle) {
+      await handle.shutdown();
+    }
+  });
+
+  after(async function() {
+    await fse.remove(tmpDir).catch(() => {});
+    oldEnv.restore();
+  });
+
+  it("should respond to /status and /status?ready=1", async function() {
+    // Under the shell these are answered by the child, so the body
+    // should match a normal FlexServer response.
+    const resp = await axios.get(`${serverUrl}/status`);
+    assert.equal(resp.status, 200);
+    assert.include(resp.data, "alive");
+    const readyResp = await axios.get(`${serverUrl}/status?ready=1`);
+    assert.equal(readyResp.status, 200);
+    assert.include(readyResp.data, "alive");
+  });
+
+  it("should reject and set exitCode when initial spawn fails", async function() {
+    // Pre-shell Grist exited when it failed to boot; preserve that
+    // contract so Node exits non-zero when the event loop drains.
+    await handle.shutdown();
+    const priorExitCode = process.exitCode;
+    process.exitCode = 0;
+    try {
+      const failingScript = path.join(tmpDir, "fail-immediately.js");
+      await fse.writeFile(failingScript, "process.exit(7);\n");
+      let caught: unknown;
+      try {
+        await runRestartShell({ publicPort: 0, childEntryPoint: failingScript });
+      } catch (err) { caught = err; }
+      assert.isDefined(caught, "runRestartShell should reject on spawn failure");
+      assert.equal(process.exitCode, 1, "process.exitCode should be set to 1");
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+  });
+
+  it("should serialize shutdown after an in-flight restart", async function() {
+    // Slow the restart so shutdown() definitely lands while the
+    // restart is awaiting the child's ready signal.
+    process.env.GRIST_TEST_RESTART_SHELL_READY_DELAY = "500";
+    const port = handle.port;
+    const restartPromise = handle.restart();
+    await delay(50);
+    const shutdownPromise = handle.shutdown();
+    await restartPromise;
+    await shutdownPromise;
+    let portStillOpen = true;
+    try {
+      await axios.get(`http://localhost:${port}/status`, { timeout: 1000 });
+    } catch {
+      portStillOpen = false;
+    }
+    assert.isFalse(portStillOpen, "port should be released after shutdown resolves");
+  });
+
+  it("should complete a restart cycle and keep /status reachable", async function() {
+    // Force the child to wait 500ms before signalling ready so the
+    // not-ready window is definitely wider than the poll interval,
+    // without relying on real process boot time.
+    process.env.GRIST_TEST_RESTART_SHELL_READY_DELAY = "500";
+    const restartPromise = handle.restart();
+    const notReadyPolls = await pollUntilReady(serverUrl);
+    await restartPromise;
+    assert.isAbove(notReadyPolls, 0, "server should have been not-ready during restart");
+  });
+
+  it("should flip to unhealthy on slow restart, then recover", async function() {
+    // Deterministic: watchdog fires at 50ms, child sends ready at
+    // 500ms. /status must flip to 500 in the gap and recover after.
+    sandbox.stub(Deps, "unhealthyTimeoutMs").value(50);
+    process.env.GRIST_TEST_RESTART_SHELL_READY_DELAY = "500";
+    const restartPromise = handle.restart();
+
+    const deadline = Date.now() + 10000;
+    let sawUnhealthy = false;
+    while (Date.now() < deadline) {
+      const resp = await axios.get(`${serverUrl}/status`, { validateStatus: () => true });
+      if (resp.status === 500 && /unhealthy/.test(resp.data)) { sawUnhealthy = true; break; }
+      await delay(20);
+    }
+    assert.isTrue(sawUnhealthy, "/status should have reported unhealthy during slow restart");
+
+    await restartPromise;
+    // After restart completes, /status is forwarded to the child and
+    // returns the real Grist response -- just check the status code.
+    const recovered = await axios.get(`${serverUrl}/status`);
+    assert.equal(recovered.status, 200);
+  });
+
+  it("should route keep-alive connections to new child after restart", async function() {
+    // The fallback server sets Connection:close so the next request
+    // opens a fresh TCP connection and reaches the new child, instead
+    // of pinning the client to the fallback for the session.
+    const http = await import("http");
+    const keepAliveAgent = new http.Agent({ keepAlive: true });
+    const client = axios.create({ baseURL: serverUrl, httpAgent: keepAliveAgent });
+
+    const before = await client.get("/status?ready=1");
+    assert.equal(before.status, 200);
+    assert.include(before.data, "alive");
+
+    await handle.restart();
+
+    const after = await client.get("/status?ready=1");
+    assert.equal(after.status, 200);
+    assert.include(after.data, "alive");
+
+    keepAliveAgent.destroy();
+  });
+
+  it("should serve API requests", async function() {
+    const resp = await axios.get(`${serverUrl}/api/orgs`, chimpy);
+    assert.equal(resp.status, 200);
+    assert.isArray(resp.data);
+  });
+
+  it("should serve documents after 3 restarts", async function() {
+    this.timeout(120000);
+
+    const docId = await createTestDoc(serverUrl, "RestartTest");
+
+    try {
+      const noKeepAlive = { ...chimpy, headers: { ...chimpy.headers, Connection: "close" } };
+      for (let i = 0; i < 3; i++) {
+        await handle.restart();
+        const resp = await axios.get(
+          `${serverUrl}/api/docs/${docId}/tables/Table1/records`, noKeepAlive);
+        assert.equal(resp.status, 200);
+        assert.isArray(resp.data.records);
+      }
+    } finally {
+      await axios.delete(`${serverUrl}/api/docs/${docId}`, chimpy);
+    }
+  });
+
+  it("should handle WebSocket connections after restart", async function() {
+    this.timeout(60000);
+    const { GristClientSocket } = await import("app/client/components/GristClientSocket");
+
+    const docId = await createTestDoc(serverUrl, "WsTest");
+
+    async function openWsAndDoc() {
+      const ws = new GristClientSocket(`ws://localhost:${handle.port}/o/docs`, {
+        headers: { Authorization: "Bearer api_key_for_chimpy" },
+      });
+      await new Promise<void>((resolve, reject) => {
+        ws.onopen = () => resolve();
+        ws.onerror = (err: any) => reject(err instanceof Error ? err : new Error(String(err)));
+      });
+      const firstMsg: any = await new Promise((resolve) => {
+        ws.onmessage = (data: string) => resolve(JSON.parse(data));
+      });
+      assert.equal(firstMsg.type, "clientConnect");
+      const reqId = 1;
+      ws.send(JSON.stringify({ reqId, method: "openDoc", args: [docId] }));
+      const openResp: any = await new Promise((resolve) => {
+        ws.onmessage = (data: string) => {
+          const msg = JSON.parse(data);
+          if (msg.reqId === reqId) { resolve(msg); }
+        };
+      });
+      return { ws, openResp };
+    }
+
+    try {
+      let { ws, openResp } = await openWsAndDoc();
+      assert.isUndefined(openResp.error);
+      ws.close();
+
+      await handle.restart();
+      await pollUntilReady(serverUrl);
+
+      ({ ws, openResp } = await openWsAndDoc());
+      assert.isUndefined(openResp.error);
+      ws.close();
+    } finally {
+      await axios.delete(`${serverUrl}/api/docs/${docId}`, chimpy);
+    }
+  });
+});
+
+async function createTestDoc(serverUrl: string, name: string): Promise<string> {
+  const chimpy = configForUser("Chimpy");
+  const orgsResp = await axios.get(`${serverUrl}/api/orgs`, chimpy);
+  const wsResp = await axios.get(
+    `${serverUrl}/api/orgs/${orgsResp.data[0].id}/workspaces`, chimpy);
+  const docResp = await axios.post(
+    `${serverUrl}/api/workspaces/${wsResp.data[0].id}/docs`, { name }, chimpy);
+  assert.equal(docResp.status, 200);
+  return docResp.data;
+}
+
+async function pollUntilReady(url: string, timeoutMs = 30000) {
+  let notReadyCount = 0;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const statusResp = await axios.get(`${url}/status`);
+    assert.equal(statusResp.status, 200, "/status should always be reachable");
+    const readyResp = await axios.get(`${url}/status?ready=1`, { validateStatus: () => true });
+    if (readyResp.status === 200) { return notReadyCount; }
+    // 500 means the shell's fallback is reporting "not ready"; anything
+    // else is unexpected and should fail the test.
+    assert.equal(readyResp.status, 500, `unexpected /status?ready=1 status ${readyResp.status}`);
+    notReadyCount++;
+    await delay(200);
+  }
+  throw new Error("Server did not become ready in time");
+}

--- a/test/server/lib/RestartShell.ts
+++ b/test/server/lib/RestartShell.ts
@@ -167,17 +167,19 @@ describe("RestartShell", function() {
     const keepAliveAgent = new http.Agent({ keepAlive: true });
     const client = axios.create({ baseURL: serverUrl, httpAgent: keepAliveAgent });
 
-    const before = await client.get("/status?ready=1");
-    assert.equal(before.status, 200);
-    assert.include(before.data, "alive");
+    try {
+      const before = await client.get("/status?ready=1");
+      assert.equal(before.status, 200);
+      assert.include(before.data, "alive");
 
-    await handle.restart();
+      await handle.restart();
 
-    const after = await client.get("/status?ready=1");
-    assert.equal(after.status, 200);
-    assert.include(after.data, "alive");
-
-    keepAliveAgent.destroy();
+      const after = await client.get("/status?ready=1");
+      assert.equal(after.status, 200);
+      assert.include(after.data, "alive");
+    } finally {
+      keepAliveAgent.destroy();
+    }
   });
 
   it("should serve API requests", async function() {


### PR DESCRIPTION
Motivation: the existing sandbox/supervisor.mjs handles admin-triggered restarts by killing the Grist child and forking a new one. That works, but during the gap where /status is not responding, Grist may be treated as unhealthy and a longer process kicked off for replacing it. More importantly, the supervisor isn't necessarily understood or put in place by repackagers. This matters if we want a friendly installation process for new users that works reliably.

What this adds: an outer process that holds the listening socket for its entire lifetime and hands each accepted TCP connection to a child Grist via child.send(msg, socket). During the restart gap, connections go to an in-process fallback that keeps /status answering 200 (liveness) while returning 503 on /status ?ready=1 and every other endpoint (readiness). A watchdog flips /status to 503-unhealthy if a restart takes too long, and recovers to 200 if the slow restart eventually completes.

Alternative considered: an in-process shell that keeps the http.Server and rebuilds FlexServer on top of it. More obviously portable to all systems than socket tricks. Cheaper per restart (no process boot, warm V8/module cache), but it makes every env-caching module (and more) in Grist participate in a restart contract.

Defaults to on for Linux under plain Node; off on Windows (FD-passing works per Node docs but is untested here) and Electron (forking has issues). Toggle with GRIST_RESTART_SHELL=true/false.

Dockerfile now runs ./sandbox/run.sh directly and lets RestartShell handle admin-triggered restarts; unexpected crashes fall through to Docker's restart policy.
