### PR TITLE
turn on GRIST_IN_SERVICE for docker tests

### DIFF
--- a/test/test_under_docker.sh
+++ b/test/test_under_docker.sh
@@ -48,6 +48,7 @@ docker run --name $DOCKER_CONTAINER --rm \
   --env GRIST_LOG_HTTP_BODY=${GRIST_LOG_HTTP_BODY:-false} \
   --env TEST_SUPPORT_API_KEY=api_key_for_support \
   --env GRIST_TEMPLATE_ORG=templates \
+  --env GRIST_IN_SERVICE=1 \
   ${TEST_DOCKER_OPTIONS:-} \
   ${TEST_IMAGE:-gristlabs/grist} &
 set +x


### PR DESCRIPTION
Docker tests started failing now that Grist needs to be explicitly put in service. Add the needed flag.
