### PR TITLE
fix(forms): keep field labels independent across duplicated forms

### DIFF
--- a/app/client/models/entities/ViewFieldRec.ts
+++ b/app/client/models/entities/ViewFieldRec.ts
@@ -10,6 +10,7 @@ import { DropdownCondition, DropdownConditionCompilationResult } from "app/commo
 import { compilePredicateFormula } from "app/common/PredicateFormula";
 import { BaseFormatter } from "app/common/ValueFormatter";
 import { createParser } from "app/common/ValueParser";
+import { WidgetType } from "app/common/widgetTypes";
 
 import { Computed } from "grainjs";
 import * as ko from "knockout";
@@ -231,8 +232,17 @@ export function createViewFieldRec(this: ViewFieldRec, docModel: DocModel): void
 
   // The widgetOptions to read and write: either the column's or the field's own.
   this._widgetOptionsStr = this.autoDispose(modelUtil.savingComputed({
-    read: () => this._fieldOrColumn().widgetOptions(),
-    write: (setter, val) => setter(this._fieldOrColumn().widgetOptions, val),
+    read: () => {
+      const isForm = this.viewSection().widgetType() === WidgetType.Form;
+      return isForm && !this.widgetOptions() ? this.column().widgetOptions() : this._fieldOrColumn().widgetOptions();
+    },
+    write: (setter, val) => {
+      if (this.viewSection().widgetType() === WidgetType.Form) {
+        setter(this.widgetOptions, val);
+      } else {
+        setter(this._fieldOrColumn().widgetOptions, val);
+      }
+    },
   }));
 
   // Observable for the object with the current options, either for the field or for the column,

--- a/test/nbrowser/FormView2.ts
+++ b/test/nbrowser/FormView2.ts
@@ -254,6 +254,32 @@ describe("FormView2", function() {
       await revert();
     });
 
+    it("keeps labels independent across duplicated forms", async function() {
+      const revert = await gu.begin();
+      await gu.selectSectionByTitle(originalWidgetTitle);
+      await duplicateForm(originalWidgetTitle, undefined, clonedWidgetTitle);
+      await gu.openColumnPanel();
+
+      await gu.selectSectionByTitle(originalWidgetTitle);
+      await question("A").click();
+      assert.equal(await driver.find(".test-field-title").value(), "");
+      await driver.find(".test-field-title").doClear().doSendKeys("First name", Key.ENTER);
+      await gu.waitForServer();
+      assert.deepEqual(await labels(), ["First name", "B", "C"]);
+
+      await gu.selectSectionByTitle(clonedWidgetTitle);
+      await question("A").click();
+      assert.equal(await driver.find(".test-field-title").value(), "");
+      await driver.find(".test-field-title").doClear().doSendKeys("Given name", Key.ENTER);
+      await gu.waitForServer();
+      assert.deepEqual(await labels(), ["Given name", "B", "C"]);
+
+      await gu.selectSectionByTitle(originalWidgetTitle);
+      assert.deepEqual(await labels(), ["First name", "B", "C"]);
+
+      await revert();
+    });
+
     it("clones default form without publishing", async function() {
       // Original form is not yet changed.
       // Publish it.


### PR DESCRIPTION
## Context

Fixes a bug where editing a field label/title in one form also changed it in duplicated forms, which prevents per-form customization

**User story:**
As a document owner, I want each form to keep its own field titles so I can localize forms independently

## Proposed solution

- Update form specific `widgetOptions` behavior:
  - write form edits to field-level `widgetOptions` per form
  - keep read fallback to column-level options when field-level options are missing

## Related issues

- Closes #1360

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help

Ran:
- `yarn build`
- `MOCHA_WEBDRIVER_HEADLESS=1 GREP_TESTS='duplicating forms' yarn test:nbrowser:ci`