### PR TITLE
(tiny) form view: fix a flaky test

### DIFF
--- a/test/nbrowser/FormView1.ts
+++ b/test/nbrowser/FormView1.ts
@@ -1474,7 +1474,7 @@ describe("FormView1", function() {
 
       // Now unhide it using menu.
       await plusButton().click();
-      await driver.find(".test-forms-menu-unmapped").click();
+      await driver.findWait(".test-forms-menu-unmapped", 200).click();
       await gu.waitForServer();
 
       assert.deepEqual(await labels(), ["A", "B", "C", "Choice"]);


### PR DESCRIPTION
## Context

I stumbled upon a test that sometimes break because of the usual menu appearing and the test trying to click things in the menu too fast.

## Proposed solution

Repeat the logic used earlier in the code for this case: just wait a tiny bit before clicking the thing that just appeared. 

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
