### PR TITLE
When Ref/RefList column shows a Choice column, render it as a choice

### DIFF
--- a/app/client/widgets/ChoiceListCell.ts
+++ b/app/client/widgets/ChoiceListCell.ts
@@ -6,12 +6,7 @@ import {
 } from "app/client/components/Forms/FormConfig";
 import { DataRowModel } from "app/client/models/DataRowModel";
 import { testId } from "app/client/ui2018/cssVars";
-import {
-  ChoiceOptionsByName,
-  ChoiceTextBox,
-} from "app/client/widgets/ChoiceTextBox";
-import { choiceToken } from "app/client/widgets/ChoiceToken";
-import { CellValue } from "app/common/DocActions";
+import { ChoiceTextBox } from "app/client/widgets/ChoiceTextBox";
 import { decodeObject } from "app/plugin/objtypes";
 
 import { dom, styled } from "grainjs";
@@ -27,32 +22,19 @@ export class ChoiceListCell extends ChoiceTextBox {
       dom.cls("field_clip"),
       cssChoiceList.cls("-wrap", this.wrapping),
       dom.style("justify-content", use => use(this.alignment) === "right" ? "flex-end" : use(this.alignment)),
-      dom.domComputed((use) => {
+      dom.maybe((use) => {
         return use(row._isAddRow) ? null :
-          [
-            use(value), use(this.getChoiceValuesSet()),
-            use(this.getChoiceOptions()),
-          ] as [CellValue, Set<string>, ChoiceOptionsByName];
-      }, (input) => {
-        if (!input) { return null; }
-        const [rawValue, choiceSet, choiceOptionsByName] = input;
+          [use(value), use(this._choiceRenderer)] as const;
+      }, ([rawValue, choiceRenderer]) => {
         const val = decodeObject(rawValue);
         if (!val) { return null; }
         // Handle any unexpected values we might get (non-array, or array with non-strings).
         const tokens: unknown[] = Array.isArray(val) ? val : [val];
-        return tokens.map((token) => {
-          const isBlank = String(token).trim() === "";
-          return choiceToken(
-            isBlank ? "[Blank]" : String(token),
-            {
-              ...(choiceOptionsByName.get(String(token)) || {}),
-              invalid: !choiceSet.has(String(token)),
-              blank: String(token).trim() === "",
-            },
-            dom.cls(cssToken.className),
-            testId("choice-list-cell-token"),
-          );
-        });
+        return tokens.map(token => choiceRenderer.renderChoiceToken(
+          String(token),
+          dom.cls(cssToken.className),
+          testId("choice-list-cell-token"),
+        ));
       }),
     );
   }

--- a/app/client/widgets/ChoiceTextBox.ts
+++ b/app/client/widgets/ChoiceTextBox.ts
@@ -8,40 +8,64 @@ import { GristDoc } from "app/client/components/GristDoc";
 import { makeT } from "app/client/lib/localization";
 import { DataRowModel } from "app/client/models/DataRowModel";
 import { ViewFieldRec } from "app/client/models/entities/ViewFieldRec";
-import { KoSaveableObservable } from "app/client/models/modelUtil";
 import { Style } from "app/client/models/Styles";
 import { cssLabel, cssRow } from "app/client/ui/RightPanelStyles";
 import { testId, theme } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
 import { ChoiceListEntry } from "app/client/widgets/ChoiceListEntry";
-import { choiceToken } from "app/client/widgets/ChoiceToken";
+import { choiceToken, IChoiceTokenOptions } from "app/client/widgets/ChoiceToken";
 import { NTextBox } from "app/client/widgets/NTextBox";
+import { WidgetOptions } from "app/common/WidgetOptions";
 
-import { Computed, dom, styled } from "grainjs";
+import { Computed, dom, DomElementArg, styled } from "grainjs";
 
 export type IChoiceOptions = Style;
 export type ChoiceOptions = Record<string, IChoiceOptions | undefined>;
 export type ChoiceOptionsByName = Map<string, IChoiceOptions | undefined>;
+export type ChoiceOptionsMap = Map<string, IChoiceOptions>;
 
 const t = makeT("ChoiceTextBox");
+
+export class ChoiceRenderer {
+  private _choiceMap: ChoiceOptionsMap;
+
+  constructor(options: WidgetOptions) {
+    const { choices, choiceOptions } = options;
+    this._choiceMap = new Map((choices || []).map(c => [c, choiceOptions?.[c] || {}]));
+  }
+
+  public renderChoiceToken(token: string, ...args: DomElementArg[]) {
+    const blank = (token.trim() === "");
+    return choiceToken(
+      blank ? "[Blank]" : token,
+      this.getChoiceTokenOptions(token, blank),
+      ...args,
+    );
+  }
+
+  public getChoiceTokenOptions(token: string, blank?: boolean): IChoiceTokenOptions {
+    return {
+      ...this._choiceMap.get(token),
+      invalid: !this._choiceMap.has(token),
+      blank,
+    };
+  }
+}
 
 /**
  * ChoiceTextBox - A textbox for choice values.
  */
 export class ChoiceTextBox extends NTextBox {
-  private _choices: KoSaveableObservable<string[]>;
+  protected _choiceRenderer: Computed<ChoiceRenderer>;
+
   private _choiceValues: Computed<string[]>;
-  private _choiceValuesSet: Computed<Set<string>>;
-  private _choiceOptions: KoSaveableObservable<ChoiceOptions | null | undefined>;
   private _choiceOptionsByName: Computed<ChoiceOptionsByName>;
 
   constructor(field: ViewFieldRec) {
     super(field);
-    this._choices = this.options.prop("choices");
-    this._choiceOptions = this.options.prop("choiceOptions");
-    this._choiceValues = Computed.create(this, use => use(this._choices) || []);
-    this._choiceValuesSet = Computed.create(this, this._choiceValues, (_use, values) => new Set(values));
-    this._choiceOptionsByName = Computed.create(this, use => toMap(use(this._choiceOptions)));
+    this._choiceRenderer = Computed.create(this, use => new ChoiceRenderer(use(this.options)));
+    this._choiceValues = Computed.create(this, use => use(this.options.prop("choices")) || []);
+    this._choiceOptionsByName = Computed.create(this, use => toMap(use(this.options.prop("choiceOptions"))));
   }
 
   public buildDom(row: DataRowModel) {
@@ -59,12 +83,8 @@ export class ChoiceTextBox extends NTextBox {
           const formattedValue = use(this.valueFormatter).formatAny(use(value));
           if (formattedValue === "") { return null; }
 
-          return choiceToken(
+          return use(this._choiceRenderer).renderChoiceToken(
             formattedValue,
-            {
-              ...(use(this._choiceOptionsByName).get(formattedValue) || {}),
-              invalid: !use(this._choiceValuesSet).has(formattedValue),
-            },
             dom.cls(cssChoiceText.className),
             testId("choice-token"),
           );
@@ -100,14 +120,6 @@ export class ChoiceTextBox extends NTextBox {
     return [
       this.buildChoicesConfigDom(),
     ];
-  }
-
-  protected getChoiceValuesSet(): Computed<Set<string>> {
-    return this._choiceValuesSet;
-  }
-
-  protected getChoiceOptions(): Computed<ChoiceOptionsByName> {
-    return this._choiceOptionsByName;
   }
 
   protected save(choices: string[], choiceOptions: ChoiceOptionsByName, renames: Record<string, string>) {

--- a/app/client/widgets/Reference.ts
+++ b/app/client/widgets/Reference.ts
@@ -15,6 +15,7 @@ import { cssLabel, cssRow } from "app/client/ui/RightPanelStyles";
 import { hideInPrintView, testId, theme } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
 import { IOptionFull, select } from "app/client/ui2018/menus";
+import { ChoiceRenderer } from "app/client/widgets/ChoiceTextBox";
 import { NTextBox } from "app/client/widgets/NTextBox";
 import { ReverseReferenceConfig } from "app/client/widgets/ReverseReferenceConfig";
 import { isFullReferencingType, isVersions } from "app/common/gristTypes";
@@ -29,6 +30,7 @@ const t = makeT("Reference");
  */
 export class Reference extends NTextBox {
   protected _refTable: Computed<TableRec | null>;
+  protected _choiceRenderer: Computed<ChoiceRenderer | null>;
   private _visibleColRef: Computed<number>;
   private _validCols: Computed<IOptionFull<number>[]>;
 
@@ -40,6 +42,12 @@ export class Reference extends NTextBox {
     this._visibleColRef.onWrite(val => this.field.visibleColRef.saveOnly(val));
 
     this._refTable = Computed.create(this, use => use(use(this.field.column).refTable));
+
+    this._choiceRenderer = Computed.create(this, (use) => {
+      const visibleColModel = use(this.field.visibleColModel);
+      const colType = use(visibleColModel.type);
+      return colType === "Choice" ? new ChoiceRenderer(use(visibleColModel.widgetOptionsJson)) : null;
+    });
 
     this._validCols = Computed.create(this, (use) => {
       const refTable = use(this._refTable);
@@ -163,13 +171,16 @@ export class Reference extends NTextBox {
         hideInPrintView(),
         testId("ref-link-icon"),
       ),
-      dom("span",
-        dom.text((use) => {
-          if (use(referenceId) === 0) { return ""; }
-          if (use(formattedValue).hasBlankReference) { return "[Blank]"; }
-          return use(formattedValue).value;
-        }),
-        testId("ref-text"),
+      dom.domComputed(use => [use(this._choiceRenderer), use(referenceId), use(formattedValue)] as const,
+        ([choiceRenderer, refId, formatted]) => {
+          if (choiceRenderer) {
+            return refId == 0 ? null : choiceRenderer.renderChoiceToken(formatted.value, cssRefChoice.cls(""));
+          }
+          return dom("span",
+            (refId === 0 ? "" : formatted.hasBlankReference ? "[Blank]" : formatted.value),
+            testId("ref-text"),
+          );
+        },
       ),
     );
   }
@@ -192,4 +203,10 @@ const cssRef = styled("div.field_clip", `
   &-blank {
     color: ${theme.lightText}
   }
+`);
+
+const cssRefChoice = styled("div", `
+  line-height: 16px;
+  vertical-align: top;
+  margin-top: -1px;
 `);

--- a/app/client/widgets/ReferenceList.ts
+++ b/app/client/widgets/ReferenceList.ts
@@ -31,7 +31,7 @@ export class ReferenceList extends Reference {
       dom.cls("field_clip"),
       cssChoiceList.cls("-wrap", this.wrapping),
       dom.style("justify-content", use => use(this.alignment) === "right" ? "flex-end" : use(this.alignment)),
-      dom.domComputed((use) => {
+      dom.maybe((use) => {
         if (use(row._isAddRow) || this.isDisposed() || use(this.field.displayColModel).isDisposed()) {
           // Work around JS errors during certain changes (noticed when visibleCol field gets removed
           // for a column using per-field settings).
@@ -59,19 +59,18 @@ export class ReferenceList extends Reference {
         // Use field.visibleColFormatter instead of field.formatter
         // because we're formatting each list element to render tokens, not the whole list.
         const formatter = use(this.field.visibleColFormatter);
-        return values.map((referenceId, i) => {
+        const renderValues = values.map((referenceId, i) => {
           return {
             referenceId,
             formattedValue: formatter.formatAny(displayValues[i]),
           };
         });
+        return { values: renderValues, choiceRenderer: use(this._choiceRenderer) };
       },
-      (values) => {
-        if (!values) {
-          return null;
-        }
+      ({ values, choiceRenderer }) => {
         return values.map(({ referenceId, formattedValue }) => {
           const isBlankReference = formattedValue.trim() === "";
+          const token = isBlankReference ? "[Blank]" : formattedValue;
           return choiceToken(
             [
               cssRefIcon("FieldReference",
@@ -95,14 +94,13 @@ export class ReferenceList extends Reference {
                 }),
                 testId("ref-list-link-icon"),
               ),
-              cssLabel(isBlankReference ? "[Blank]" : formattedValue,
+              cssLabel(token,
                 testId("ref-list-cell-token-label"),
               ),
               dom.cls(cssRefIconAndLabel.className),
+              cssRefIconAndLabel.cls("-choice", Boolean(choiceRenderer)),
             ],
-            {
-              blank: isBlankReference,
-            },
+            choiceRenderer?.getChoiceTokenOptions(token, isBlankReference) ?? { blank: isBlankReference },
             dom.cls(cssToken.className),
             testId("ref-list-cell-token"),
           );
@@ -139,6 +137,14 @@ const cssRefIcon = styled(icon, `
 const cssRefIconAndLabel = styled("div", `
   position: relative;
   padding-left: 20px;
+  &-choice {
+    padding-left: 4px;
+    margin-left: 20px;
+    overflow: visible;
+  }
+  &-choice > .${cssRefIcon.className} {
+    left: -16px;
+  }
 `);
 
 const cssLabel = styled("div", `


### PR DESCRIPTION
## Context

A Reference or Reference List column may show a column from the referenced table of type Choice, but it's always rendered without color. It would be nicer to keep the styling in such cases.

## Proposed solution

If the "Show Column" is of type Choice, use that Choice's styling for rendering a Reference or Reference List column.

## Related issues

https://github.com/gristlabs/grist-core/issues/1222

## Has this been tested?

TBD: Tests to be created. Also, when entering a reference data, we could be showing colored choices, but the PR doesn't have this yet. 

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts


Preview with an example here: https://grist-gristlabs-grist-core-ref-to-choice.fly.dev/sbufBSzwPXTz/Restaurant-Inventory/p/8

Screenshot showing what it looks like:

<img width="2048" height="1280" alt="Screen Shot 2026-04-17 at 22 37 49" src="https://github.com/user-attachments/assets/95fe2b1c-bc55-4131-b32d-a75d5bd49a89" />

