### PR TITLE
add Server section to admin panel and setup wizard

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -3,7 +3,9 @@ import path from "path";
 import type { StorybookConfig } from "@storybook/html-webpack5";
 
 // Root of grist-core (whether standalone or as core/ inside grist-saas).
-const coreRoot = path.resolve(__dirname, "..");
+// `yarn run storybook` sets cwd to the package root. Using process.cwd()
+// instead of __dirname so this works under Node 23+'s ESM loader too.
+const coreRoot = process.cwd();
 
 const config: StorybookConfig = {
   stories: [

--- a/app/client/models/AdminChecks.ts
+++ b/app/client/models/AdminChecks.ts
@@ -163,6 +163,12 @@ from the network."),
     info: t("The main page of Grist should be available."),
   },
 
+  "home-url": {
+    info: t("APP_HOME_URL is the base URL where users and integrations reach \
+this Grist server. Auth callbacks, API links, and email notifications \
+all depend on this being correct."),
+  },
+
   "websockets": {
     // TODO: add a link to https://support.getgrist.com/self-managed/#how-do-i-run-grist-on-a-server
     info: t("Websocket connections need HTTP 1.1 and the ability to pass a few \

--- a/app/client/models/ToggleEnterpriseModel.ts
+++ b/app/client/models/ToggleEnterpriseModel.ts
@@ -70,22 +70,11 @@ export class ToggleEnterpriseModel extends Disposable {
   }
 
   private async _reloadWhenReady() {
-    // Now wait about 30 seconds for the server to come back up, and
-    // refresh the page.
-    let maxTries = 30;
-    while (maxTries-- > 0) {
-      try {
-        await this._configAPI.healthcheck();
-        // We're done, last step is to reload the page.
-        this.busy.set(false);
-        window.location.reload();
-        return;
-      } catch (err) {
-        console.warn("Server not ready yet, will retry", err);
-        await delay(1000);
-      }
+    if (!await this._configAPI.waitUntilReady()) {
+      throw new Error(t("Timed out on waiting for the Grist backend to restart"));
     }
-    throw new Error(t("Timed out on waiting for the Grist backend to restart"));
+    this.busy.set(false);
+    window.location.reload();
   }
 }
 

--- a/app/client/ui/AdminLeftPanel.ts
+++ b/app/client/ui/AdminLeftPanel.ts
@@ -5,6 +5,7 @@ import { AppHeader } from "app/client/ui/AppHeader";
 import * as css from "app/client/ui/LeftPanelCommon";
 import { PageSidePanel } from "app/client/ui/PagePanels";
 import { infoTooltip } from "app/client/ui/tooltips";
+import { theme } from "app/client/ui2018/cssVars";
 import { IconName } from "app/client/ui2018/IconList";
 import { cssLink } from "app/client/ui2018/links";
 import { AdminPanelPage } from "app/common/gristUrls";
@@ -14,6 +15,7 @@ import { getAdminConfig } from "app/common/urlUtils";
 import { Computed, dom, DomContents, MultiHolder, Observable, styled } from "grainjs";
 
 import type { AppModel } from "app/client/models/AppModel";
+import type { RestartBannerController } from "app/client/ui/AdminPanel";
 
 const t = makeT("AdminLeftPanel");
 const testId = makeTestId("test-admin-controls-");
@@ -42,7 +44,11 @@ export function getPageNames() {
   };
 }
 
-export function buildAdminLeftPanel(owner: MultiHolder, appModel: AppModel): PageSidePanel {
+export function buildAdminLeftPanel(
+  owner: MultiHolder,
+  appModel: AppModel,
+  restartBanner?: RestartBannerController,
+): PageSidePanel {
   const pageObs = Computed.create(owner, use => use(urlState().state).adminPanel);
 
   const isSetup = pageObs.get() === "setup";
@@ -77,6 +83,16 @@ export function buildAdminLeftPanel(owner: MultiHolder, appModel: AppModel): Pag
       buildPageEntry("admin", "Home"),
       // TODO: Uncomment when setup page is ready.
       // buildPageEntry("setup", "Settings"),
+      restartBanner ? dom.maybe(restartBanner.isVisible, () =>
+        cssApplyChangesEntry(
+          css.cssPageButton(
+            css.cssPageIcon("Warning"),
+            css.cssLinkText(t("Apply changes")),
+            dom.on("click", () => restartBanner.focus()),
+          ),
+          testId("page-apply-changes"),
+        ),
+      ) : null,
       css.cssSectionHeader(css.cssSectionHeaderText(pageNames.adminControls),
         (adminControlsAvailable ?
           infoTooltip("adminControls", { popupOptions: { placement: "bottom-start" } }) :
@@ -117,4 +133,13 @@ const cssLearnMoreLink = styled(cssLink, `
   display: inline-flex;
   gap: 8px;
   align-items: center;
+`);
+
+const cssApplyChangesEntry = styled(css.cssPageEntry, `
+  color: ${theme.dangerText};
+  --icon-color: ${theme.dangerText};
+  cursor: pointer;
+  & .${css.cssPageLink.className} {
+    color: inherit;
+  }
 `);

--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -36,9 +36,9 @@ import { BackupsSection } from "app/client/ui/BackupsSection";
 import { BaseUrlSection } from "app/client/ui/BaseUrlSection";
 import { BootKeyStatus } from "app/client/ui/BootKeyStatus";
 import { InstallConfigsAPI } from "app/client/ui/ConfigsAPI";
+import { DraftChangesManager } from "app/client/ui/DraftChanges";
 import { EditionSection } from "app/client/ui/EditionSection";
 import { pagePanels } from "app/client/ui/PagePanels";
-import { PendingChangesManager } from "app/client/ui/PendingChanges";
 import { QuickSetup } from "app/client/ui/QuickSetup";
 import { ServiceStatus } from "app/client/ui/ServiceStatus";
 import { SupportGristPage } from "app/client/ui/SupportGristPage";
@@ -202,7 +202,7 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
     notifier: this._appModel.notifier,
   });
 
-  private _pending = PendingChangesManager.create(this);
+  private _drafts = DraftChangesManager.create(this);
 
   private _checks: AdminChecks;
   private readonly _installAPI: InstallAPI = new InstallAPIImpl(getHomeUrl());
@@ -220,13 +220,13 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
   constructor(private _appModel: AppModel, private _restartBanner: RestartBannerController) {
     super();
     this._checks = new AdminChecks(this, this._installAPI);
-    this._pending.addSection(this._baseUrlSection);
-    this._pending.addSection(this._editionSection);
+    this._drafts.addSection(this._baseUrlSection);
+    this._drafts.addSection(this._editionSection);
 
     // Restart banner appears when a section's pending changes require one.
     // Sections without needsRestart are saved inline without needing the banner.
-    this.needsRestart.set(this._pending.needsRestart.get());
-    this.autoDispose(this._pending.needsRestart.addListener(v => this.needsRestart.set(v)));
+    this.needsRestart.set(this._drafts.needsRestart.get());
+    this.autoDispose(this._drafts.needsRestart.addListener(v => this.needsRestart.set(v)));
 
     // Mirror visibility into the shared controller so the left-panel entry
     // appears/disappears with the banner.
@@ -290,11 +290,11 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
   }
 
   private async _performRestart() {
-    // When a section needs a restart, PendingChangesManager handles the
+    // When a section needs a restart, DraftChangesManager handles the
     // apply+restart+wait cycle. Otherwise the banner was shown for another
     // reason (e.g. a section saved inline) and we restart directly.
-    if (this._pending.needsRestart.get()) {
-      await this._pending.applyAll();
+    if (this._drafts.needsRestart.get()) {
+      await this._drafts.applyAll();
     } else {
       await this._configAPI.restartServer();
     }
@@ -303,7 +303,7 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
 
   private async _applyWithoutRestart() {
     try {
-      await spinnerModal(t("Saving..."), this._pending.applyWithoutRestart());
+      await spinnerModal(t("Saving..."), this._drafts.applyWithoutRestart());
       this._awaitingManualRestart.set(true);
     } catch (err) {
       reportError(err as Error);
@@ -346,15 +346,15 @@ Please log in as an administrator.`)),
               t("Changes have been saved. Restart Grist to apply them.") :
               t("Restart Grist to apply pending changes.")),
           ),
-          dom.domComputed(this._pending.changes, (changes) => {
+          dom.domComputed(this._drafts.changes, (changes) => {
             if (changes.length === 0) { return null; }
-            return cssPendingChangesList(
+            return cssDraftChangesList(
               changes.map(c => dom("li",
-                cssPendingChangeLabel(c.label + ":"),
+                cssDraftChangeLabel(c.label + ":"),
                 " ",
                 dom("span", c.value),
               )),
-              testId("admin-panel-pending-changes"),
+              testId("admin-panel-draft-changes"),
             );
           }),
           cssWell(
@@ -372,7 +372,7 @@ Please log in as an administrator.`)),
                 ),
                 // Allow persisting pending changes to the DB so a manual
                 // restart picks them up.
-                dom.maybe(this._pending.hasPendingChanges, () =>
+                dom.maybe(this._drafts.hasDraftChanges, () =>
                   dom("p",
                     basicButton(
                       t("Apply changes (manual restart required)"),
@@ -1241,7 +1241,7 @@ const cssRestartBannerShell = styled("div", `
 
 const cssRestartBanner = styled(cssSection, ``);
 
-const cssPendingChangesList = styled("ul", `
+const cssDraftChangesList = styled("ul", `
   margin: 0 0 12px 0;
   padding-left: 20px;
   color: ${theme.text};
@@ -1250,7 +1250,7 @@ const cssPendingChangesList = styled("ul", `
   }
 `);
 
-const cssPendingChangeLabel = styled("span", `
+const cssDraftChangeLabel = styled("span", `
   font-weight: 600;
 `);
 

--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -271,15 +271,11 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
     confirmModal(
       t("Restart Grist?"),
       t("Restart"),
-      async () => {
-        try {
-          await spinnerModal(
-            t("Restarting Grist..."),
-            this._performRestart(),
-          );
-        } catch (err) {
-          reportError(err as Error);
-        }
+      () => {
+        // Fire-and-forget so confirmModal closes immediately; otherwise it
+        // hangs on top of the spinner for the whole restart duration.
+        spinnerModal(t("Restarting Grist..."), this._performRestart())
+          .catch(err => reportError(err as Error));
       },
       {
         explanation: dom("div",
@@ -344,7 +340,17 @@ Please log in as an administrator.`)),
 
     return [
       dom.maybe(this._showRestartBanner, () => cssRestartBannerShell(
-        (elem) => { this._restartBanner.bannerElem.current = elem; },
+        (elem) => {
+          this._restartBanner.bannerElem.current = elem;
+          // Without the slide-in, confirming (e.g.) Base URL shoves the
+          // user's focal section down by ~150px in one layout step -- the
+          // thing they just clicked jumps away from their cursor. Nested
+          // rAF lets the closed state paint first so the grid-rows
+          // transition has a "from" frame to interpolate against.
+          requestAnimationFrame(() =>
+            requestAnimationFrame(() => elem.classList.add("-open")),
+          );
+        },
         cssRestartBanner(
           cssSectionTitle(t("Restart Grist")),
           dom.domComputed(this._awaitingManualRestart, waiting =>
@@ -440,6 +446,17 @@ Please log in as an administrator.`)),
           description: t("Take Grist out of service for maintenance"),
           value: this._buildServiceStatusDisplay(),
           expandedContent: this._buildServiceStatusContent(),
+        }),
+        dom.create(AdminSectionItem, {
+          id: "restart",
+          name: t("Restart"),
+          description: t("Restart the Grist server"),
+          value: this._supportsRestart ?
+            basicButton(t("Restart"),
+              dom.on("click", () => this.restartGrist()),
+              testId("admin-panel-restart-item"),
+            ) :
+            cssValueLabel(t("unavailable")),
         }),
       ]),
       dom.create(AdminSection, t("Security Settings"), [
@@ -1228,14 +1245,20 @@ const cssRestartBannerFlash = keyframes(`
   30%      { box-shadow: 0 0 0 3px ${theme.controlFg}; }
 `);
 
-const cssRestartBannerReveal = keyframes(`
-  from { max-height: 0; opacity: 0; }
-  to   { max-height: 400px; opacity: 1; }
-`);
-
+// Reveal uses a grid-template-rows transition rather than an animation so
+// it doesn't collide with the `-flash` keyframe animation (adding a shared
+// `animation:` declaration in `-flash` would replace the reveal mid-flight).
 const cssRestartBannerShell = styled("div", `
-  animation: ${cssRestartBannerReveal} 0.3s ease-out;
-  overflow: hidden;
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.3s ease-out;
+  & > * {
+    overflow: hidden;
+    min-height: 0;
+  }
+  &.-open {
+    grid-template-rows: 1fr;
+  }
   &.-flash {
     animation: ${cssRestartBannerFlash} 1s ease-out;
     border-radius: 4px;

--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -8,7 +8,6 @@ import { AuditLogsModel, AuditLogsModelImpl } from "app/client/models/AuditLogsM
 import { urlState } from "app/client/models/gristUrlState";
 import { AccountWidget } from "app/client/ui/AccountWidget";
 import { cssEmail, cssUserInfo, cssUserName } from "app/client/ui/AccountWidgetCss";
-import { showEnterpriseToggle } from "app/client/ui/ActivationPage";
 import { buildAdminData } from "app/client/ui/AdminControls";
 import { buildAdminLeftPanel, getPageNames } from "app/client/ui/AdminLeftPanel";
 import {
@@ -26,6 +25,7 @@ import {
   cssWell,
   cssWellContent,
   cssWellTitle,
+  focusAdminItem,
   HidableToggle,
 } from "app/client/ui/AdminPanelCss";
 import { getAdminPanelName } from "app/client/ui/AdminPanelName";
@@ -33,13 +33,16 @@ import { App } from "app/client/ui/App";
 import { AuditLogStreamingConfig, getDestinationDisplayName } from "app/client/ui/AuditLogStreamingConfig";
 import { AuthenticationSection } from "app/client/ui/AuthenticationSection";
 import { BackupsSection } from "app/client/ui/BackupsSection";
+import { BaseUrlSection } from "app/client/ui/BaseUrlSection";
 import { BootKeyStatus } from "app/client/ui/BootKeyStatus";
 import { InstallConfigsAPI } from "app/client/ui/ConfigsAPI";
+import { EditionSection } from "app/client/ui/EditionSection";
 import { pagePanels } from "app/client/ui/PagePanels";
+import { PendingChangesManager } from "app/client/ui/PendingChanges";
 import { QuickSetup } from "app/client/ui/QuickSetup";
 import { ServiceStatus } from "app/client/ui/ServiceStatus";
 import { SupportGristPage } from "app/client/ui/SupportGristPage";
-import { ToggleEnterpriseWidget } from "app/client/ui/ToggleEnterpriseWidget";
+import { buildInstallationIdDisplay } from "app/client/ui/ToggleEnterpriseWidget";
 import { createTopBarHome } from "app/client/ui/TopBar";
 import { createUserImage } from "app/client/ui/UserImage";
 import { cssBreadcrumbs, separator } from "app/client/ui2018/breadcrumbs";
@@ -66,6 +69,7 @@ import {
   Disposable,
   dom,
   IDisposable,
+  keyframes,
   MultiHolder,
   Observable,
   styled,
@@ -79,8 +83,38 @@ const t = makeT("AdminPanel");
 // still far away from the max at Number.MAX_SAFE_INTEGER
 const STALE_VERSION_CHECK_TIME_IN_MS = 14 * 24 * 60 * 60 * 1000;
 
+/**
+ * Shared restart-banner state so the left-panel "Apply changes" entry can
+ * reflect banner visibility and trigger a scroll-into-view + flash.
+ */
+export interface RestartBannerController {
+  isVisible: Observable<boolean>;
+  /** Registered by the banner's DOM to receive focus() calls. */
+  bannerElem: { current: HTMLElement | null };
+  /** Scroll the banner into view and briefly highlight it. */
+  focus(): void;
+}
+
+function createRestartBannerController(owner: Disposable): RestartBannerController {
+  const bannerElem: { current: HTMLElement | null } = { current: null };
+  return {
+    isVisible: Observable.create(owner, false),
+    bannerElem,
+    focus() {
+      const el = bannerElem.current;
+      if (!el) { return; }
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+      el.classList.remove("-flash");
+      // Force reflow so the animation restarts if it's already set.
+      void el.offsetWidth;
+      el.classList.add("-flash");
+    },
+  };
+}
+
 export class AdminPanel extends Disposable {
   private _page = Computed.create<AdminPanelPage>(this, use => use(urlState().state).adminPanel || "admin");
+  private _restartBanner = createRestartBannerController(this);
 
   constructor(private _appModel: AppModel, private _appObj: App) {
     super();
@@ -88,7 +122,7 @@ export class AdminPanel extends Disposable {
   }
 
   public buildDom() {
-    const leftPanel = buildAdminLeftPanel(this, this._appModel);
+    const leftPanel = buildAdminLeftPanel(this, this._appModel, this._restartBanner);
 
     // When left panel is fully hidden, hide breadcrumbs and extra buttons so top bar is mostly empty.
     const width = leftPanel.collapsedWidth;
@@ -140,7 +174,7 @@ export class AdminPanel extends Disposable {
 
       dom.domComputed(this._page, (page) => {
         if (page === "admin") {
-          return dom.create(AdminInstallationPanel, this._appModel);
+          return dom.create(AdminInstallationPanel, this._appModel, this._restartBanner);
         } else if (page === "setup") {
           return dom.create(QuickSetup);
         } else {
@@ -157,17 +191,48 @@ export class AdminPanel extends Disposable {
 
 class AdminInstallationPanel extends Disposable implements AdminPanelControls {
   public needsRestart = Observable.create(this, false);
+  // Sticky flag: true after the user has applied changes without a restart
+  // in an environment that doesn't support auto-restart. Keeps the manual
+  // restart reminder on screen until the user reloads the page.
+  private _awaitingManualRestart = Observable.create<boolean>(this, false);
   private _supportsRestart = !!getAdminConfig().runningUnderSupervisor;
-  private _toggleEnterprise = ToggleEnterpriseWidget.create(this, this._appModel.notifier);
+  private _baseUrlSection = BaseUrlSection.create(this, { controls: this });
+  private _editionSection = EditionSection.create(this, {
+    controls: this,
+    notifier: this._appModel.notifier,
+  });
+
+  private _pending = PendingChangesManager.create(this);
+
   private _checks: AdminChecks;
   private readonly _installAPI: InstallAPI = new InstallAPIImpl(getHomeUrl());
   private readonly _configAPI: ConfigAPI = new ConfigAPI(getHomeUrl());
   private _authCheck: Observable<AdminCheckRequest | undefined>;
   private _loginProvider: Observable<string | undefined>;
 
-  constructor(private _appModel: AppModel) {
+  // Banner visibility: shown when there are pending changes to apply OR
+  // when the user has already applied changes and still owes us a manual
+  // restart.
+  private _showRestartBanner = Computed.create(this, use =>
+    use(this.needsRestart) || use(this._awaitingManualRestart),
+  );
+
+  constructor(private _appModel: AppModel, private _restartBanner: RestartBannerController) {
     super();
     this._checks = new AdminChecks(this, this._installAPI);
+    this._pending.addSection(this._baseUrlSection);
+    this._pending.addSection(this._editionSection);
+
+    // Restart banner appears when a section's pending changes require one.
+    // Sections without needsRestart are saved inline without needing the banner.
+    this.autoDispose(this._pending.needsRestart.addListener(v => this.needsRestart.set(v)));
+
+    // Mirror visibility into the shared controller so the left-panel entry
+    // appears/disappears with the banner.
+    this.autoDispose(this._showRestartBanner.addListener(v => this._restartBanner.isVisible.set(v)));
+    // Initial sync.
+    this._restartBanner.isVisible.set(this._showRestartBanner.get());
+
     this._authCheck = Computed.create(this, (use) => {
       return this._checks.requestCheckById(use, "authentication");
     });
@@ -224,8 +289,24 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
   }
 
   private async _performRestart() {
-    await this._configAPI.restartServer();
+    // When a section needs a restart, PendingChangesManager handles the
+    // apply+restart+wait cycle. Otherwise the banner was shown for another
+    // reason (e.g. a section saved inline) and we restart directly.
+    if (this._pending.needsRestart.get()) {
+      await this._pending.applyAll();
+    } else {
+      await this._configAPI.restartServer();
+    }
     await reloadSafe();
+  }
+
+  private async _applyWithoutRestart() {
+    try {
+      await spinnerModal(t("Saving..."), this._pending.applyWithoutRestart());
+      this._awaitingManualRestart.set(true);
+    } catch (err) {
+      reportError(err as Error);
+    }
   }
 
   /**
@@ -254,10 +335,27 @@ Please log in as an administrator.`)),
     const supportGrist = SupportGristPage.create(this, this._appModel);
 
     return [
-      dom.maybe(this.needsRestart, () => [
-        cssSection(
+      cssRestartBannerShell(
+        cssRestartBannerShell.cls("-open", this._showRestartBanner),
+        (elem) => { this._restartBanner.bannerElem.current = elem; },
+        cssRestartBanner(
           cssSectionTitle(t("Restart Grist")),
-          dom("p", t("Restart Grist to apply pending changes.")),
+          dom.domComputed(this._awaitingManualRestart, waiting =>
+            dom("p", waiting ?
+              t("Changes have been saved. Restart Grist to apply them.") :
+              t("Restart Grist to apply pending changes.")),
+          ),
+          dom.domComputed(this._pending.changes, (changes) => {
+            if (changes.length === 0) { return null; }
+            return cssPendingChangesList(
+              changes.map(c => dom("li",
+                cssPendingChangeLabel(c.label + ":"),
+                " ",
+                dom("span", c.value),
+              )),
+              testId("admin-panel-pending-changes"),
+            );
+          }),
           cssWell(
             cssWell.cls("-warning"),
             cssWellIcon(icon("Warning")),
@@ -271,6 +369,17 @@ Please log in as an administrator.`)),
                   t("Please restart Grist manually."),
                   testId("admin-panel-restart-unsupported-warning"),
                 ),
+                // Allow persisting pending changes to the DB so a manual
+                // restart picks them up.
+                dom.maybe(this._pending.hasPendingChanges, () =>
+                  dom("p",
+                    basicButton(
+                      t("Apply changes (manual restart required)"),
+                      dom.on("click", () => this._applyWithoutRestart()),
+                      testId("admin-panel-apply-no-restart"),
+                    ),
+                  ),
+                ),
               ),
             ),
             dom.hide(this._supportsRestart),
@@ -282,7 +391,7 @@ Please log in as an administrator.`)),
             dom.show(this._supportsRestart),
           ),
         ),
-      ]),
+      ),
       dom.create(AdminSection, t("Support Grist"), [
         dom.create(AdminSectionItem, {
           id: "telemetry",
@@ -303,7 +412,21 @@ Please log in as an administrator.`)),
           expandedContent: supportGrist.buildSponsorshipSection(),
         }),
       ]),
-      dom.create(AdminSection, t("Maintenance"), [
+      dom.create(AdminSection, t("Server"), [
+        dom.create(AdminSectionItem, {
+          id: "base-url",
+          name: t("Base URL"),
+          description: t("The URL where users and integrations reach this Grist server"),
+          value: this._baseUrlSection.buildStatusDisplay(),
+          expandedContent: this._baseUrlSection.buildDom(),
+        }),
+        dom.create(AdminSectionItem, {
+          id: "edition",
+          name: t("Edition"),
+          description: EditionSection.description(),
+          value: this._editionSection.buildStatusDisplay(),
+          expandedContent: this._editionSection.buildDom(),
+        }),
         dom.create(AdminSectionItem, {
           id: "service-status",
           name: t("Service status"),
@@ -380,29 +503,68 @@ Please log in as an administrator.`)),
     ];
   }
 
+  // Stub for users following older documentation that still refers to an
+  // "Enterprise" item in this section. The real controls live in the new
+  // "Server → Edition" item above. The toggle mirrors the real edition
+  // state but intercepts clicks and bounces the user to Edition instead.
   private _maybeAddEnterpriseToggle() {
-    if (!showEnterpriseToggle()) {
-      return null;
-    }
+    const enterpriseObs = this._editionSection.getEnterpriseToggleObservable();
 
-    let makeToggle = () => dom.create(
-      HidableToggle,
-      this._toggleEnterprise.getEnterpriseToggleObservable(),
-      { labelId: "admin-panel-item-description-enterprise" },
-    );
+    const interceptClick = (ev: Event) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      focusAdminItem("edition");
+    };
 
-    // If the enterprise edition is forced, we don't show the toggle.
-    if (getGristConfig().forceEnableEnterprise) {
-      makeToggle = () => cssValueLabel(cssHappyText(t("On")));
-    }
+    const makeToggle = () => {
+      if (getGristConfig().forceEnableEnterprise) {
+        return cssValueLabel(cssHappyText(t("On")));
+      }
+      if (!enterpriseObs) {
+        return cssValueLabel(t("moved to Edition"));
+      }
+      // Wrap the toggle in a container that intercepts clicks at the
+      // capture phase so the underlying observable never changes; the
+      // user is redirected to the real Edition item instead.
+      return dom("span",
+        dom.on("click", interceptClick, { useCapture: true }),
+        dom.create(HidableToggle, enterpriseObs, {
+          labelId: "admin-panel-item-description-enterprise",
+        }),
+      );
+    };
 
     return dom.create(AdminSectionItem, {
       id: "enterprise",
       name: t("Enterprise"),
-      description: t("Enable Grist Enterprise"),
+      description: EditionSection.description(),
       value: makeToggle(),
-      expandedContent: this._toggleEnterprise.buildEnterpriseSection(),
+      expandedContent: dom("div",
+        // Installation ID is only surfaced when the enterprise activation-
+        // status endpoint is available (i.e. Full Grist). On community
+        // builds the observable is null and we hide the row entirely.
+        this._buildInstallationIdRow(),
+        dom("p", t(
+          "What used to be called \"Grist Enterprise\" is now called \"Full Grist\".",
+        )),
+        dom("p",
+          t("Its controls have moved to {{editionLink}} above.", {
+            editionLink: cssLink(t("Server → Edition"),
+              dom.on("click", (ev) => { ev.preventDefault(); focusAdminItem("edition"); }),
+              { href: "#edition" },
+            ),
+          }),
+        ),
+        testId("admin-panel-enterprise-stub"),
+      ),
     });
+  }
+
+  // Shown only on builds that mount `/api/activation/status` (Full Grist);
+  // buildInstallationIdDisplay no-ops until the ID has loaded.
+  private _buildInstallationIdRow() {
+    const installationId = this._editionSection.getInstallationIdObservable();
+    return installationId && dom("p", buildInstallationIdDisplay(installationId));
   }
 
   private _buildSandboxingDisplay() {
@@ -1050,6 +1212,45 @@ const cssStatus = styled("div", `
   text-align: center;
   width: 40px;
   padding: 5px;
+`);
+
+// Smooth reveal of the restart banner. We keep the banner always in the
+// DOM and animate an outer grid shell's grid-template-rows from 0fr to 1fr.
+// This makes the content below slide down smoothly instead of jumping.
+const cssRestartBannerFlash = keyframes(`
+  0%, 100% { box-shadow: none; }
+  30%      { box-shadow: 0 0 0 3px ${theme.controlFg}; }
+`);
+
+const cssRestartBannerShell = styled("div", `
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.4s ease-out, opacity 0.4s ease-out;
+  opacity: 0;
+  & > * { overflow: hidden; }
+  &-open {
+    grid-template-rows: 1fr;
+    opacity: 1;
+  }
+  &.-flash > * {
+    animation: ${cssRestartBannerFlash} 1s ease-out;
+    border-radius: 4px;
+  }
+`);
+
+const cssRestartBanner = styled(cssSection, ``);
+
+const cssPendingChangesList = styled("ul", `
+  margin: 0 0 12px 0;
+  padding-left: 20px;
+  color: ${theme.text};
+  & > li {
+    margin-bottom: 4px;
+  }
+`);
+
+const cssPendingChangeLabel = styled("span", `
+  font-weight: 600;
 `);
 
 const cssPageContainer = styled("div", `

--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -225,6 +225,7 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
 
     // Restart banner appears when a section's pending changes require one.
     // Sections without needsRestart are saved inline without needing the banner.
+    this.needsRestart.set(this._pending.needsRestart.get());
     this.autoDispose(this._pending.needsRestart.addListener(v => this.needsRestart.set(v)));
 
     // Mirror visibility into the shared controller so the left-panel entry

--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -190,10 +190,15 @@ export class AdminPanel extends Disposable {
 }
 
 class AdminInstallationPanel extends Disposable implements AdminPanelControls {
+  // Signal from legacy sections (e.g. AuthenticationSection) that their own
+  // state change now requires a restart. Draft-tracked sections contribute
+  // separately via `_drafts.needsRestart`; both are combined into
+  // `_showRestartBanner`.
   public needsRestart = Observable.create(this, false);
   // Sticky flag: true after the user has applied changes without a restart
   // in an environment that doesn't support auto-restart. Keeps the manual
-  // restart reminder on screen until the user reloads the page.
+  // restart reminder on screen until the user reloads the page. Cleared only
+  // by a full page reload (see reloadSafe at the bottom of this file).
   private _awaitingManualRestart = Observable.create<boolean>(this, false);
   private _supportsRestart = !!getAdminConfig().runningUnderSupervisor;
   private _baseUrlSection = BaseUrlSection.create(this, { controls: this });
@@ -210,11 +215,13 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
   private _authCheck: Observable<AdminCheckRequest | undefined>;
   private _loginProvider: Observable<string | undefined>;
 
-  // Banner visibility: shown when there are pending changes to apply OR
-  // when the user has already applied changes and still owes us a manual
-  // restart.
+  // Banner visibility: shown when draft-tracked sections have pending
+  // changes, or a legacy section has flagged that a restart is required,
+  // or the user has applied changes without a restart and still owes us one.
   private _showRestartBanner = Computed.create(this, use =>
-    use(this.needsRestart) || use(this._awaitingManualRestart),
+    use(this._drafts.needsRestart) ||
+    use(this.needsRestart) ||
+    use(this._awaitingManualRestart),
   );
 
   constructor(private _appModel: AppModel, private _restartBanner: RestartBannerController) {
@@ -223,16 +230,10 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
     this._drafts.addSection(this._baseUrlSection);
     this._drafts.addSection(this._editionSection);
 
-    // Restart banner appears when a section's pending changes require one.
-    // Sections without needsRestart are saved inline without needing the banner.
-    this.needsRestart.set(this._drafts.needsRestart.get());
-    this.autoDispose(this._drafts.needsRestart.addListener(v => this.needsRestart.set(v)));
-
     // Mirror visibility into the shared controller so the left-panel entry
     // appears/disappears with the banner.
-    this.autoDispose(this._showRestartBanner.addListener(v => this._restartBanner.isVisible.set(v)));
-    // Initial sync.
     this._restartBanner.isVisible.set(this._showRestartBanner.get());
+    this.autoDispose(this._showRestartBanner.addListener(v => this._restartBanner.isVisible.set(v)));
 
     this._authCheck = Computed.create(this, (use) => {
       return this._checks.requestCheckById(use, "authentication");
@@ -293,6 +294,11 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
     // When a section needs a restart, DraftChangesManager handles the
     // apply+restart+wait cycle. Otherwise the banner was shown for another
     // reason (e.g. a section saved inline) and we restart directly.
+    //
+    // Note: individual sections never call `configAPI.restartServer()` on
+    // their own. They only mark themselves `needsRestart` and route through
+    // here, so a single user click always produces exactly one restart even
+    // when several sections are dirty at once.
     if (this._drafts.needsRestart.get()) {
       await this._drafts.applyAll();
     } else {
@@ -304,6 +310,7 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
   private async _applyWithoutRestart() {
     try {
       await spinnerModal(t("Saving..."), this._drafts.applyWithoutRestart());
+      // Stays on until the page is reloaded by the user (see reloadSafe()).
       this._awaitingManualRestart.set(true);
     } catch (err) {
       reportError(err as Error);
@@ -336,8 +343,7 @@ Please log in as an administrator.`)),
     const supportGrist = SupportGristPage.create(this, this._appModel);
 
     return [
-      cssRestartBannerShell(
-        cssRestartBannerShell.cls("-open", this._showRestartBanner),
+      dom.maybe(this._showRestartBanner, () => cssRestartBannerShell(
         (elem) => { this._restartBanner.bannerElem.current = elem; },
         cssRestartBanner(
           cssSectionTitle(t("Restart Grist")),
@@ -392,7 +398,7 @@ Please log in as an administrator.`)),
             dom.show(this._supportsRestart),
           ),
         ),
-      ),
+      )),
       dom.create(AdminSection, t("Support Grist"), [
         dom.create(AdminSectionItem, {
           id: "telemetry",
@@ -1215,25 +1221,22 @@ const cssStatus = styled("div", `
   padding: 5px;
 `);
 
-// Smooth reveal of the restart banner. We keep the banner always in the
-// DOM and animate an outer grid shell's grid-template-rows from 0fr to 1fr.
-// This makes the content below slide down smoothly instead of jumping.
+// Brief highlight applied when the user clicks "Apply changes" in the left
+// panel to locate the banner.
 const cssRestartBannerFlash = keyframes(`
   0%, 100% { box-shadow: none; }
   30%      { box-shadow: 0 0 0 3px ${theme.controlFg}; }
 `);
 
+const cssRestartBannerReveal = keyframes(`
+  from { max-height: 0; opacity: 0; }
+  to   { max-height: 400px; opacity: 1; }
+`);
+
 const cssRestartBannerShell = styled("div", `
-  display: grid;
-  grid-template-rows: 0fr;
-  transition: grid-template-rows 0.4s ease-out, opacity 0.4s ease-out;
-  opacity: 0;
-  & > * { overflow: hidden; }
-  &-open {
-    grid-template-rows: 1fr;
-    opacity: 1;
-  }
-  &.-flash > * {
+  animation: ${cssRestartBannerReveal} 0.3s ease-out;
+  overflow: hidden;
+  &.-flash {
     animation: ${cssRestartBannerFlash} 1s ease-out;
     border-radius: 4px;
   }

--- a/app/client/ui/AdminPanelCss.ts
+++ b/app/client/ui/AdminPanelCss.ts
@@ -53,7 +53,7 @@ export function focusAdminItem(itemId: string): void {
     const wrap = row.querySelector("." + cssExpandedContentWrap.className);
     const header = row.querySelector("." + cssItemShort.className);
     const isCollapsed = wrap instanceof HTMLElement &&
-      (wrap.style.maxHeight === "" || wrap.style.maxHeight === "0px");
+      (wrap.style.maxHeight === "" || wrap.style.maxHeight === "0" || wrap.style.maxHeight === "0px");
     if (header instanceof HTMLElement && isCollapsed) {
       header.click();
     }

--- a/app/client/ui/AdminPanelCss.ts
+++ b/app/client/ui/AdminPanelCss.ts
@@ -1,6 +1,8 @@
+import { makeT } from "app/client/lib/localization";
 import { textarea } from "app/client/ui/inputs";
 import { hoverTooltip } from "app/client/ui/tooltips";
 import { transition } from "app/client/ui/transitions";
+import { textButton } from "app/client/ui2018/buttons";
 import { mediaSmall, testId, theme, vars } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
 import { toggleSwitch } from "app/client/ui2018/toggleSwitch";
@@ -29,6 +31,38 @@ export function AdminSection(owner: IDisposableOwner, title: DomContents, items:
     cssSectionTitle(title),
     ...items,
   );
+}
+
+/**
+ * Scrolls the admin panel item with the given id into view and briefly
+ * flashes it, so users notice where they landed. Safe to call with an
+ * id that doesn't exist yet (no-op).
+ */
+export function focusAdminItem(itemId: string): void {
+  const elem = document.getElementById(itemId);
+  if (!elem) { return; }
+  // The id lands on the tiny item name span; scroll the surrounding
+  // full-width row into view so the whole item is visible, not just
+  // the label.
+  const row = elem.closest("." + cssItem.className);
+  (row ?? elem).scrollIntoView({ behavior: "smooth", block: "center" });
+
+  // If the item is expandable and currently collapsed, expand it by
+  // clicking its header — the existing click handler toggles state.
+  if (row) {
+    const wrap = row.querySelector("." + cssExpandedContentWrap.className);
+    const header = row.querySelector("." + cssItemShort.className);
+    const isCollapsed = wrap instanceof HTMLElement &&
+      (wrap.style.maxHeight === "" || wrap.style.maxHeight === "0px");
+    if (header instanceof HTMLElement && isCollapsed) {
+      header.click();
+    }
+  }
+
+  elem.classList.remove(cssItemName.className + "-flash");
+  // Force reflow so the animation restarts if it's already applied.
+  void elem.offsetWidth;
+  elem.classList.add(cssItemName.className + "-flash");
 }
 
 export function AdminSectionItem(owner: IDisposableOwner, options: {
@@ -260,16 +294,19 @@ export const cssValueLabel = styled("div", `
   border-radius: ${vars.controlBorderRadius};
 `);
 
+/** Green text for positive/success status values. */
+export const cssHappyText = styled("span", `
+  color: ${theme.controlFg};
+`);
+
+/** Red text for error status values. */
 export const cssErrorText = styled("span", `
   color: ${theme.errorText};
 `);
 
+/** Orange/amber text for warning/danger status values. */
 export const cssDangerText = styled("div", `
   color: ${theme.dangerText};
-`);
-
-export const cssHappyText = styled("span", `
-  color: ${theme.controlFg};
 `);
 
 export const cssTextArea = styled(textarea, `
@@ -373,3 +410,89 @@ export const cssFadeUpSubHeading = styled("div", `
   margin-bottom: 24px;
   text-align: center;
 `);
+
+// --- Shared styles for section components (BaseUrlSection, EditionSection, etc.) ---
+
+/** Flex column container for section content. */
+export const cssSectionContainer = styled("div", `
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`);
+
+/** Subdued description text within a section. */
+export const cssSectionDescription = styled("div", `
+  color: ${theme.lightText};
+  font-size: ${vars.mediumFontSize};
+  line-height: 1.5;
+  margin-bottom: 4px;
+`);
+
+/** Inline status text for collapsed section display. */
+export const cssSectionStatusText = styled("span", `
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+`);
+
+/** Inline row of small buttons (confirm, skip, etc.). */
+export const cssSectionButtonRow = styled("div", `
+  display: flex;
+  gap: 8px;
+  align-items: center;
+`);
+
+const cssSectionConfirmedRow = styled("div", `
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`);
+
+const cssSectionConfirmedPill = styled("span", `
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: ${theme.controlPrimaryBg};
+  font-size: ${vars.smallFontSize};
+`);
+
+const cssSectionSkippedPill = styled("span", `
+  color: ${theme.controlPrimaryBg};
+  font-size: ${vars.smallFontSize};
+`);
+
+/**
+ * Builds the confirmed/skipped status row with a pencil-edit button.
+ * Shared by all wizard section components.
+ *
+ * @param confirmed - observable controlling visibility of the whole row
+ * @param onEdit - callback when the pencil is clicked (should reset confirmed)
+ * @param options.skipped - if set and true, renders the skipped pill instead
+ *   of the "Confirmed" pill
+ * @param options.skippedLabel - text for the skipped pill (default: "For later")
+ * @param options.testPrefix - prefix for test IDs
+ */
+export function buildConfirmedRow(
+  confirmed: Observable<boolean>,
+  onEdit: () => void,
+  options: { skipped?: Observable<boolean>; skippedLabel?: string; testPrefix?: string } = {},
+) {
+  const tid = options.testPrefix ? (id: string) => testId(`${options.testPrefix}-${id}`) : testId;
+  return dom.domComputed((use) => {
+    if (!use(confirmed)) { return null; }
+    const isSkipped = options.skipped ? use(options.skipped) : false;
+    return cssSectionConfirmedRow(
+      isSkipped ?
+        cssSectionSkippedPill(options.skippedLabel || t("For later")) :
+        cssSectionConfirmedPill(t("Confirmed")),
+      textButton(
+        icon("Pencil"),
+        dom.on("click", onEdit),
+        tid("edit"),
+      ),
+      tid("confirmed-row"),
+    );
+  });
+}
+
+const t = makeT("AdminPanelCss");

--- a/app/client/ui/BaseUrlSection.ts
+++ b/app/client/ui/BaseUrlSection.ts
@@ -303,7 +303,7 @@ Auth callbacks, API links, and email notifications all depend on this being corr
   }
 
   // url=null clears APP_HOME_URL (revert to auto-detect); url=string pins it.
-  // Caller (PendingChangesManager) invokes markApplied() on success, which
+  // Caller (DraftChangesManager) invokes markApplied() on success, which
   // updates _serverUrl, so we only manage transient status flags here.
   private async _persist(url: string | null) {
     this._status.set("saving");

--- a/app/client/ui/BaseUrlSection.ts
+++ b/app/client/ui/BaseUrlSection.ts
@@ -1,0 +1,372 @@
+import { makeT } from "app/client/lib/localization";
+import { getHomeUrl, reportError } from "app/client/models/AppModel";
+import {
+  AdminPanelControls,
+  buildConfirmedRow,
+  cssHappyText,
+  cssSectionButtonRow,
+  cssSectionContainer,
+  cssSectionDescription,
+  cssValueLabel,
+} from "app/client/ui/AdminPanelCss";
+import { basicButton, primaryButton } from "app/client/ui2018/buttons";
+import { theme, vars } from "app/client/ui2018/cssVars";
+import { icon } from "app/client/ui2018/icons";
+import { unstyledButton } from "app/client/ui2018/unstyled";
+import { ConfigAPI, ServerConfig } from "app/common/ConfigAPI";
+import { InstallAPIImpl } from "app/common/InstallAPI";
+
+import { Computed, Disposable, dom, DomContents, input, makeTestId,
+  Observable, styled } from "grainjs";
+
+const t = makeT("BaseUrlSection");
+const testId = makeTestId("test-base-url-");
+
+type UrlStatus = "loading" | "loaded" | "saving" | "saved" | "error";
+type TestResult = "idle" | "testing" | "passed" | "failed";
+
+interface BaseUrlSectionOptions {
+  controls?: AdminPanelControls;
+}
+
+export class BaseUrlSection extends Disposable {
+  /**
+   * True when the URL has been confirmed (saved or skipped). Used by the wizard
+   * to gate the Continue button.
+   */
+  public canProceed: Computed<boolean>;
+
+  /** True when current state differs from what the server has. */
+  public isDirty: Computed<boolean>;
+
+  /** Base URL changes require a server restart to take effect safely. */
+  public readonly needsRestart = true;
+
+  private _detectedUrl = window.location.origin;
+  // Empty string means the server has no APP_HOME_URL set (client auto-detects).
+  private _serverUrl = Observable.create<string>(this, "");
+  private _isManuallySet = Computed.create<boolean>(this, use => Boolean(use(this._serverUrl)));
+  private _editedUrl = Observable.create<string>(this, "");
+  private _status = Observable.create<UrlStatus>(this, "loading");
+  private _error = Observable.create<string>(this, "");
+  private _urlConfirmed = Observable.create<boolean>(this, false);
+  private _urlSkipped = Observable.create<boolean>(this, false);
+  private _testedUrlValue = "";
+  private _isGrist = false;
+  private _testResult = Observable.create<TestResult>(this, "idle");
+  private _testError = Observable.create<string>(this, "");
+  private _testAbort?: AbortController;
+
+  private _configAPI = new ConfigAPI(getHomeUrl());
+  private _installAPI = new InstallAPIImpl(getHomeUrl());
+
+  constructor(_options: BaseUrlSectionOptions = {}) {
+    super();
+
+    this.canProceed = Computed.create(this, use => use(this._urlConfirmed));
+    this.isDirty = Computed.create(this, (use) => {
+      if (!use(this._urlConfirmed)) { return false; }
+      // "Leave automatic" is dirty only when the server currently has a
+      // manually-set URL that needs clearing.
+      if (use(this._urlSkipped)) { return use(this._isManuallySet); }
+      const current = use(this._editedUrl).trim();
+      if (!current) { return false; }
+      if (current === use(this._serverUrl)) { return false; }
+      return true;
+    });
+
+    this._editedUrl.addListener((url) => {
+      if (this._testResult.get() === "passed" && url.trim() !== this._testedUrlValue) {
+        this._testResult.set("idle");
+        this._testError.set("");
+      }
+    });
+
+    this.onDispose(() => this._testAbort?.abort());
+    this._load().catch(reportError);
+  }
+
+  public async apply() {
+    if (!this.isDirty.get()) { return; }
+    await this._persist(this._urlSkipped.get() ? null : this._editedUrl.get().trim());
+  }
+
+  public markApplied() {
+    if (this._urlSkipped.get()) {
+      this._serverUrl.set("");
+    } else {
+      this._serverUrl.set(this._editedUrl.get().trim());
+    }
+  }
+
+  public describeChange() {
+    if (this._urlSkipped.get()) {
+      return { label: t("Base URL"), value: t("automatic") };
+    }
+    return { label: t("Base URL"), value: this._editedUrl.get().trim() };
+  }
+
+  public buildStatusDisplay(): DomContents {
+    return dom.domComputed((use) => {
+      if (use(this._status) === "loading") {
+        return cssValueLabel(t("checking"), testId("status"));
+      }
+      if (use(this._isManuallySet)) {
+        return cssValueLabel(cssHappyText(t("set")), testId("status"));
+      }
+      return cssValueLabel(t("not set"), testId("status"));
+    });
+  }
+
+  public buildDom(): DomContents { return this._buildSection({ allowSkip: false }); }
+  public buildWizardDom(): DomContents { return this._buildSection({ allowSkip: true }); }
+
+  // allowSkip=true shows a "Leave automatic" button alongside Confirm;
+  // in admin-panel mode we don't offer it.
+  private _buildSection(opts: { allowSkip: boolean }): DomContents {
+    return cssSectionContainer(
+      this._buildCore(),
+      buildConfirmedRow(this._urlConfirmed, () => {
+        this._urlConfirmed.set(false);
+        this._urlSkipped.set(false);
+        this._testResult.set("idle");
+      }, { skipped: this._urlSkipped, skippedLabel: t("Automatic"), testPrefix: "base-url" }),
+      dom.maybe(use => !use(this._urlConfirmed), () => [
+        dom.domComputed(this._testResult, result => this._buildTestStatus(result)),
+        cssSectionButtonRow(
+          dom.domComputed(this._testResult, (result) => {
+            if (result !== "passed") {
+              return primaryButton(
+                t("Test URL"),
+                dom.on("click", () => this._testUrl()),
+                dom.boolAttr("disabled", use =>
+                  use(this._editedUrl).trim() === "" || use(this._testResult) === "testing",
+                ),
+                testId("test"),
+              );
+            }
+            return primaryButton(
+              t("Confirm URL"),
+              dom.on("click", () => this._urlConfirmed.set(true)),
+              testId("save"),
+            );
+          }),
+          opts.allowSkip ? basicButton(
+            t("Leave automatic"),
+            dom.on("click", () => {
+              this._urlSkipped.set(true);
+              this._urlConfirmed.set(true);
+            }),
+            testId("skip"),
+          ) : null,
+        ),
+      ]),
+      testId("section"),
+    );
+  }
+
+  private _buildCore(): DomContents {
+    return [
+      cssSectionDescription(
+        t("The URL where users and integrations reach this Grist server. \
+Auth callbacks, API links, and email notifications all depend on this being correct."),
+      ),
+      cssUrlRow(
+        cssUrlInput(
+          this._editedUrl,
+          { onInput: true },
+          { placeholder: t("https://grist.example.com") },
+          dom.boolAttr("disabled", use =>
+            use(this._status) === "saving" || use(this._urlConfirmed),
+          ),
+          testId("input"),
+        ),
+      ),
+      dom.domComputed((use) => {
+        if (use(this._status) !== "loaded") { return null; }
+        const current = use(this._editedUrl).trim();
+        if (!current) { return null; }
+        if (current === use(this._serverUrl)) {
+          return cssSavedMsg(
+            icon("Tick"),
+            t("Already set on this server."),
+            testId("current-hint"),
+          );
+        }
+        if (!use(this._isManuallySet) && current === this._detectedUrl) {
+          return cssWarning(
+            icon("Warning"),
+            t("This URL was auto-detected — confirm it is correct, then save."),
+            testId("not-saved-warning"),
+          );
+        }
+        return null;
+      }),
+      dom.maybe(
+        use => use(this._status) === "error",
+        () => cssErrorMsg(
+          dom.text(this._error),
+          testId("error"),
+        ),
+      ),
+    ];
+  }
+
+  private _buildTestStatus(result: TestResult): DomContents {
+    if (result === "testing") {
+      return cssHint(t("Testing..."), testId("test-status"));
+    }
+    if (result === "passed") {
+      return cssSavedMsg(
+        icon("Tick"),
+        this._isGrist ? t("Grist is reachable") : t("URL is reachable"),
+        testId("test-status"),
+      );
+    }
+    if (result === "failed") {
+      const showDetail = Observable.create(this, false);
+      const detailId = "base-url-test-error-detail";
+      return cssErrorMsg(
+        dom("div",
+          t("Could not reach server at this URL. "),
+          cssDisclosureButton(
+            dom.attr("type", "button"),
+            dom.attr("aria-expanded", use => use(showDetail) ? "true" : "false"),
+            dom.attr("aria-controls", detailId),
+            dom.text(use => use(showDetail) ? "\u25BC" : "\u25B6"),
+            dom.on("click", () => showDetail.set(!showDetail.get())),
+          ),
+        ),
+        dom.maybe(showDetail, () =>
+          dom("div",
+            dom.attr("id", detailId),
+            dom.style("margin-top", "4px"),
+            dom.text(this._testError),
+          ),
+        ),
+        testId("test-status"),
+      );
+    }
+    return null;
+  }
+
+  private async _testUrl() {
+    const url = this._editedUrl.get().trim();
+    if (!url) { return; }
+    this._testResult.set("testing");
+    this._testError.set("");
+    this._testedUrlValue = url;
+    // Replace any in-flight test's abort controller so only the latest
+    // one's result is applied. Also aborts on disposal via onDispose below.
+    this._testAbort?.abort();
+    const controller = this._testAbort = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+    try {
+      const statusUrl = new URL("status", url.endsWith("/") ? url : url + "/").href;
+      const resp = await fetch(statusUrl, { signal: controller.signal });
+      if (!resp.ok) { throw new Error(`${resp.status} ${resp.statusText}`); }
+      const body = await resp.text();
+      if (this.isDisposed() || controller.signal.aborted) { return; }
+      this._isGrist = /grist/i.test(body);
+      this._testResult.set("passed");
+    } catch (err) {
+      // Aborted by a superseding call (not by our own timeout): drop the
+      // stale error. isDisposed() catches teardown-mid-flight.
+      if (this.isDisposed() || (controller.signal.aborted && this._testAbort !== controller)) { return; }
+      this._testError.set((err as Error).message || t("Could not reach server"));
+      this._testResult.set("failed");
+    } finally {
+      clearTimeout(timeoutId);
+      if (this._testAbort === controller) { this._testAbort = undefined; }
+    }
+  }
+
+  private async _load() {
+    try {
+      const config: ServerConfig = await this._configAPI.getServerConfig();
+      if (this.isDisposed()) { return; }
+      this._serverUrl.set(config.APP_HOME_URL || "");
+      this._editedUrl.set(config.APP_HOME_URL || this._detectedUrl);
+      this._status.set("loaded");
+    } catch (err) {
+      // Silently continue on error (endpoint may not exist during early startup).
+      if (this.isDisposed()) { return; }
+      this._editedUrl.set(this._detectedUrl);
+      this._status.set("loaded");
+    }
+  }
+
+  // url=null clears APP_HOME_URL (revert to auto-detect); url=string pins it.
+  // Caller (PendingChangesManager) invokes markApplied() on success, which
+  // updates _serverUrl, so we only manage transient status flags here.
+  private async _persist(url: string | null) {
+    this._status.set("saving");
+    this._error.set("");
+    try {
+      await this._installAPI.updateInstallPrefs({ envVars: { APP_HOME_URL: url } });
+      if (this.isDisposed()) { return; }
+      if (url === null) { this._editedUrl.set(this._detectedUrl); }
+      this._status.set("loaded");
+    } catch (err) {
+      if (this.isDisposed()) { return; }
+      this._error.set((err as Error).message || t("Failed to save"));
+      this._status.set("error");
+      throw err;
+    }
+  }
+}
+
+const cssUrlRow = styled("div", `
+  display: flex;
+  gap: 8px;
+`);
+
+const cssUrlInput = styled(input, `
+  color: ${theme.inputFg};
+  background-color: ${theme.inputBg};
+  font-size: ${vars.mediumFontSize};
+  height: 42px;
+  line-height: 16px;
+  width: 100%;
+  padding: 13px;
+  border: 1px solid ${theme.inputBorder};
+  border-radius: 3px;
+  outline: none;
+
+  &::placeholder {
+    color: ${theme.inputPlaceholderFg};
+  }
+`);
+
+const cssHint = styled("div", `
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: ${theme.lightText};
+  font-size: ${vars.smallFontSize};
+`);
+
+const cssWarning = styled("div", `
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: ${theme.controlFg};
+  font-size: ${vars.smallFontSize};
+`);
+
+const cssErrorMsg = styled("div", `
+  color: ${theme.errorText};
+  font-size: ${vars.smallFontSize};
+`);
+
+const cssSavedMsg = styled("div", `
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: ${theme.controlPrimaryBg};
+  font-size: ${vars.smallFontSize};
+`);
+
+const cssDisclosureButton = styled(unstyledButton, `
+  cursor: pointer;
+`);

--- a/app/client/ui/BaseUrlSection.ts
+++ b/app/client/ui/BaseUrlSection.ts
@@ -13,7 +13,6 @@ import { basicButton, primaryButton } from "app/client/ui2018/buttons";
 import { theme, vars } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
 import { unstyledButton } from "app/client/ui2018/unstyled";
-import { HomeUrlBootProbeDetails } from "app/common/BootProbe";
 import { InstallAPIImpl } from "app/common/InstallAPI";
 
 import { Computed, Disposable, dom, DomContents, input, makeTestId,
@@ -88,15 +87,10 @@ export class BaseUrlSection extends Disposable {
 
   public async apply() {
     if (!this.isDirty.get()) { return; }
-    await this._persist(this._urlSkipped.get() ? null : this._editedUrl.get().trim());
-  }
-
-  public markApplied() {
-    if (this._urlSkipped.get()) {
-      this._serverUrl.set("");
-    } else {
-      this._serverUrl.set(this._editedUrl.get().trim());
-    }
+    const skipped = this._urlSkipped.get();
+    const url = skipped ? null : this._editedUrl.get().trim();
+    await this._persist(url);
+    this._serverUrl.set(skipped ? "" : url!);
   }
 
   public describeChange() {
@@ -289,8 +283,7 @@ Auth callbacks, API links, and email notifications all depend on this being corr
     try {
       const result = await this._installAPI.runCheck("home-url");
       if (this.isDisposed()) { return; }
-      const details = (result.details ?? {}) as Partial<HomeUrlBootProbeDetails>;
-      const value = details.value ?? "";
+      const value = (result.details?.value as string | null | undefined) ?? "";
       this._serverUrl.set(value);
       this._editedUrl.set(value || this._detectedUrl);
       this._status.set("loaded");
@@ -303,8 +296,6 @@ Auth callbacks, API links, and email notifications all depend on this being corr
   }
 
   // url=null clears APP_HOME_URL (revert to auto-detect); url=string pins it.
-  // Caller (DraftChangesManager) invokes markApplied() on success, which
-  // updates _serverUrl, so we only manage transient status flags here.
   private async _persist(url: string | null) {
     this._status.set("saving");
     this._error.set("");

--- a/app/client/ui/BaseUrlSection.ts
+++ b/app/client/ui/BaseUrlSection.ts
@@ -13,7 +13,7 @@ import { basicButton, primaryButton } from "app/client/ui2018/buttons";
 import { theme, vars } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
 import { unstyledButton } from "app/client/ui2018/unstyled";
-import { ConfigAPI, ServerConfig } from "app/common/ConfigAPI";
+import { HomeUrlBootProbeDetails } from "app/common/BootProbe";
 import { InstallAPIImpl } from "app/common/InstallAPI";
 
 import { Computed, Disposable, dom, DomContents, input, makeTestId,
@@ -58,7 +58,6 @@ export class BaseUrlSection extends Disposable {
   private _testDetailOpen = Observable.create<boolean>(this, false);
   private _testAbort?: AbortController;
 
-  private _configAPI = new ConfigAPI(getHomeUrl());
   private _installAPI = new InstallAPIImpl(getHomeUrl());
 
   constructor(_options: BaseUrlSectionOptions = {}) {
@@ -288,13 +287,15 @@ Auth callbacks, API links, and email notifications all depend on this being corr
 
   private async _load() {
     try {
-      const config: ServerConfig = await this._configAPI.getServerConfig();
+      const result = await this._installAPI.runCheck("home-url");
       if (this.isDisposed()) { return; }
-      this._serverUrl.set(config.APP_HOME_URL || "");
-      this._editedUrl.set(config.APP_HOME_URL || this._detectedUrl);
+      const details = (result.details ?? {}) as Partial<HomeUrlBootProbeDetails>;
+      const value = details.value ?? "";
+      this._serverUrl.set(value);
+      this._editedUrl.set(value || this._detectedUrl);
       this._status.set("loaded");
     } catch (err) {
-      // Silently continue on error (endpoint may not exist during early startup).
+      // Silently continue on error (probe may not exist during early startup).
       if (this.isDisposed()) { return; }
       this._editedUrl.set(this._detectedUrl);
       this._status.set("loaded");

--- a/app/client/ui/BaseUrlSection.ts
+++ b/app/client/ui/BaseUrlSection.ts
@@ -55,6 +55,7 @@ export class BaseUrlSection extends Disposable {
   private _isGrist = false;
   private _testResult = Observable.create<TestResult>(this, "idle");
   private _testError = Observable.create<string>(this, "");
+  private _testDetailOpen = Observable.create<boolean>(this, false);
   private _testAbort?: AbortController;
 
   private _configAPI = new ConfigAPI(getHomeUrl());
@@ -224,7 +225,11 @@ Auth callbacks, API links, and email notifications all depend on this being corr
       );
     }
     if (result === "failed") {
-      const showDetail = Observable.create(this, false);
+      // Reset on each render so a fresh failure shows the detail collapsed;
+      // the observable is reused (instance field) so we don't leak across
+      // repeated failures.
+      this._testDetailOpen.set(false);
+      const showDetail = this._testDetailOpen;
       const detailId = "base-url-test-error-detail";
       return cssErrorMsg(
         dom("div",

--- a/app/client/ui/DraftChanges.ts
+++ b/app/client/ui/DraftChanges.ts
@@ -7,6 +7,16 @@
  * tracks aggregate dirty state and provides `applyAll()` to persist
  * everything, restart if needed, and reset dirty tracking.
  *
+ * Sections report two things about their draft changes:
+ *   - `isDirty`: there is an unsaved change to persist.
+ *   - `needsRestart`: the change, once persisted, requires a server
+ *     restart to take effect.
+ * A section can be dirty without needing a restart -- e.g. a setting
+ * stored in the DB that the server picks up live. We still route it
+ * through here so the Apply button can save *all* draft changes in
+ * one click and so the restart banner only triggers when at least one
+ * dirty section actually needs a restart.
+ *
  * "Draft" here is an in-memory, session-scoped concept: changes the
  * user has made in the current page load but not yet saved. Not to
  * be confused with `PendingChanges` in `app/common/Install.ts`, which
@@ -14,7 +24,6 @@
  */
 import { getHomeUrl } from "app/client/models/AppModel";
 import { ConfigAPI } from "app/common/ConfigAPI";
-import { delay } from "app/common/delay";
 
 import { Computed, Disposable, Observable } from "grainjs";
 
@@ -33,61 +42,28 @@ export interface ConfigSection {
   isDirty: Computed<boolean>;
   /** True when the section's changes require a server restart to take effect. */
   needsRestart: boolean;
-  /** Persist this section's changes to the server. No-op if not dirty. */
+  /**
+   * Persist the section's changes to the server and update its own view of
+   * the server state so `isDirty` goes false. No-op if not dirty. On error,
+   * throws without updating; `isDirty` stays true.
+   */
   apply(): Promise<void>;
-  /** Update internal tracking so isDirty becomes false. */
-  markApplied(): void;
   /**
    * Describe the draft change for display in the restart banner.
    * Only called when isDirty is true. Re-read whenever any section's
    * `isDirty` fires -- sections whose described value can drift while
    * `isDirty` stays true should toggle `isDirty` to trigger a refresh.
    */
-  describeChange?(): DraftChangeDescription;
+  describeChange(): DraftChangeDescription;
 }
-
-/**
- * Thrown by `applyAll` / `applyWithoutRestart` when one or more sections
- * failed to persist. Successful sections will already have been marked
- * applied by the time this is thrown; only the listed `failures` remain
- * dirty. When `restartSkipped` is true, the manager declined to restart
- * the server because the set of changes wasn't fully applied.
- */
-export class PartialApplyError extends Error {
-  public readonly name = "PartialApplyError";
-
-  constructor(
-    public readonly failures: readonly { label: string; error: Error }[],
-    public readonly restartSkipped: boolean,
-  ) {
-    const parts = failures.map(f => `${f.label}: ${f.error.message || String(f.error)}`);
-    const prefix = failures.length === 1 ?
-      "Could not apply change" :
-      `Could not apply ${failures.length} changes`;
-    const suffix = restartSkipped ? " -- server was not restarted" : "";
-    super(`${prefix}${suffix}: ${parts.join("; ")}`);
-  }
-}
-
-/** Aggregate state across all registered sections, recomputed whenever any section's `isDirty` flips. */
-export interface DraftState {
-  hasDraftChanges: boolean;
-  needsRestart: boolean;
-  changes: DraftChangeDescription[];
-}
-
-const EMPTY_STATE: DraftState = { hasDraftChanges: false, needsRestart: false, changes: [] };
 
 export class DraftChangesManager extends Disposable {
-  /**
-   * Aggregate draft-state derived from all registered sections. Readers
-   * bind to `state` for reactive UI, or to the convenience projections
-   * (`hasDraftChanges`, `needsRestart`, `changes`) that unwrap fields.
-   */
-  public readonly state: Computed<DraftState>;
+  /** List of draft changes, one per dirty section. Drives the banner's bullet list. */
+  public readonly changes: Computed<readonly DraftChangeDescription[]>;
+  /** True when at least one section has an unsaved change. */
   public readonly hasDraftChanges: Computed<boolean>;
+  /** True when at least one dirty section requires a restart to take effect. */
   public readonly needsRestart: Computed<boolean>;
-  public readonly changes: Computed<DraftChangeDescription[]>;
 
   private _sections: Observable<ConfigSection[]> = Observable.create(this, []);
   private _configAPI = new ConfigAPI(getHomeUrl());
@@ -95,18 +71,13 @@ export class DraftChangesManager extends Disposable {
 
   constructor() {
     super();
-    this.state = Computed.create(this, (use) => {
-      const dirty = use(this._sections).filter(s => use(s.isDirty));
-      if (dirty.length === 0) { return EMPTY_STATE; }
-      return {
-        hasDraftChanges: true,
-        needsRestart: dirty.some(s => s.needsRestart),
-        changes: dirty.flatMap(s => s.describeChange ? [s.describeChange()] : []),
-      };
-    });
-    this.hasDraftChanges = Computed.create(this, use => use(this.state).hasDraftChanges);
-    this.needsRestart = Computed.create(this, use => use(this.state).needsRestart);
-    this.changes = Computed.create(this, use => use(this.state).changes);
+    this.changes = Computed.create(this, use =>
+      use(this._sections).filter(s => use(s.isDirty)).map(s => s.describeChange()),
+    );
+    this.hasDraftChanges = Computed.create(this, use => use(this.changes).length > 0);
+    this.needsRestart = Computed.create(this, use =>
+      use(this._sections).some(s => use(s.isDirty) && s.needsRestart),
+    );
   }
 
   public addSection(section: ConfigSection) {
@@ -127,67 +98,41 @@ export class DraftChangesManager extends Disposable {
     await this._apply({ restart: false });
   }
 
-  /** One-shot accessor; prefer binding to `state`/`changes` for reactive UI. */
-  public describeChanges(): DraftChangeDescription[] {
-    return this.state.get().changes;
-  }
-
   private async _apply({ restart }: { restart: boolean }): Promise<void> {
     if (this._applying.get()) { return; }
     this._applying.set(true);
     try {
-      // Apply sections sequentially so one section's failure doesn't leave
-      // another mid-flight. We collect per-section outcomes and only mark
-      // successful ones applied -- any failure keeps its section dirty so the
-      // UI stays aligned with the server and the user can retry.
+      // Snapshot labels before apply() -- a section's state can change as
+      // it applies, and we want the error message to name the change the
+      // user asked for, not whatever it looks like after the attempt.
       const dirty = this._sections.get().filter(s => s.isDirty.get());
-      const applied: ConfigSection[] = [];
-      const failures: { label: string; error: Error }[] = [];
+      const labels = new Map(dirty.map(s => [s, s.describeChange().label]));
 
+      const failures: { label: string; error: Error }[] = [];
       for (const section of dirty) {
         try {
           await section.apply();
-          applied.push(section);
         } catch (err) {
-          failures.push({
-            label: section.describeChange?.().label ?? "change",
-            error: err as Error,
-          });
+          failures.push({ label: labels.get(section)!, error: err as Error });
         }
       }
 
-      // Reflect DB state: sections that persisted successfully should appear
-      // clean regardless of whether a peer failed.
-      for (const section of applied) {
-        section.markApplied();
-      }
-
-      // Only restart when every dirty section succeeded. Restarting with a
-      // half-applied set would either strand draft changes behind another
-      // restart (if we re-try later) or advertise the run as complete when
-      // it isn't. Better to require retry first.
-      if (restart && failures.length === 0 && applied.some(s => s.needsRestart)) {
+      // Only restart when every dirty section succeeded -- a half-applied
+      // set would either strand changes behind another restart or look
+      // complete when it wasn't.
+      if (restart && failures.length === 0 && dirty.some(s => s.needsRestart)) {
         await this._configAPI.restartServer();
-        await this._waitForServer();
+        if (!await this._configAPI.waitUntilReady()) {
+          throw new Error("Timed out waiting for Grist server to restart");
+        }
       }
 
       if (failures.length > 0) {
-        throw new PartialApplyError(failures, restart && dirty.some(s => s.needsRestart));
+        const parts = failures.map(f => `${f.label}: ${f.error.message || String(f.error)}`);
+        throw new Error(`Could not apply: ${parts.join("; ")}`);
       }
     } finally {
-      this._applying.set(false);
+      if (!this.isDisposed()) { this._applying.set(false); }
     }
-  }
-
-  private async _waitForServer() {
-    for (let i = 0; i < 30; i++) {
-      try {
-        await this._configAPI.healthcheck();
-        return;
-      } catch {
-        await delay(1000);
-      }
-    }
-    throw new Error("Timed out waiting for Grist server to restart");
   }
 }

--- a/app/client/ui/DraftChanges.ts
+++ b/app/client/ui/DraftChanges.ts
@@ -1,11 +1,16 @@
 /**
- * Accumulates pending configuration changes from multiple sections,
+ * Accumulates draft configuration changes from multiple sections,
  * then applies them together. Used by both the setup wizard and the
  * admin panel to batch saves and minimize restarts.
  *
  * Each section registers itself via `addSection()`. The manager
  * tracks aggregate dirty state and provides `applyAll()` to persist
  * everything, restart if needed, and reset dirty tracking.
+ *
+ * "Draft" here is an in-memory, session-scoped concept: changes the
+ * user has made in the current page load but not yet saved. Not to
+ * be confused with `PendingChanges` in `app/common/Install.ts`, which
+ * is the server-side durable list of on-restart directives.
  */
 import { getHomeUrl } from "app/client/models/AppModel";
 import { ConfigAPI } from "app/common/ConfigAPI";
@@ -14,11 +19,11 @@ import { delay } from "app/common/delay";
 import { Computed, Disposable, Observable } from "grainjs";
 
 /**
- * A human-readable description of a pending change. The `label` is
+ * A human-readable description of a draft change. The `label` is
  * translated (e.g. "Base URL"); the `value` is a literal (e.g. a URL)
  * that shouldn't pass through the translation pipeline.
  */
-export interface PendingChangeDescription {
+export interface DraftChangeDescription {
   label: string;
   value: string;
 }
@@ -33,12 +38,12 @@ export interface ConfigSection {
   /** Update internal tracking so isDirty becomes false. */
   markApplied(): void;
   /**
-   * Describe the pending change for display in the restart banner.
+   * Describe the draft change for display in the restart banner.
    * Only called when isDirty is true. Re-read whenever any section's
    * `isDirty` fires -- sections whose described value can drift while
    * `isDirty` stays true should toggle `isDirty` to trigger a refresh.
    */
-  describeChange?(): PendingChangeDescription;
+  describeChange?(): DraftChangeDescription;
 }
 
 /**
@@ -65,24 +70,24 @@ export class PartialApplyError extends Error {
 }
 
 /** Aggregate state across all registered sections, recomputed whenever any section's `isDirty` flips. */
-export interface PendingState {
-  hasPendingChanges: boolean;
+export interface DraftState {
+  hasDraftChanges: boolean;
   needsRestart: boolean;
-  changes: PendingChangeDescription[];
+  changes: DraftChangeDescription[];
 }
 
-const EMPTY_STATE: PendingState = { hasPendingChanges: false, needsRestart: false, changes: [] };
+const EMPTY_STATE: DraftState = { hasDraftChanges: false, needsRestart: false, changes: [] };
 
-export class PendingChangesManager extends Disposable {
+export class DraftChangesManager extends Disposable {
   /**
-   * Aggregate pending-state derived from all registered sections. Readers
+   * Aggregate draft-state derived from all registered sections. Readers
    * bind to `state` for reactive UI, or to the convenience projections
-   * (`hasPendingChanges`, `needsRestart`, `changes`) that unwrap fields.
+   * (`hasDraftChanges`, `needsRestart`, `changes`) that unwrap fields.
    */
-  public readonly state: Computed<PendingState>;
-  public readonly hasPendingChanges: Computed<boolean>;
+  public readonly state: Computed<DraftState>;
+  public readonly hasDraftChanges: Computed<boolean>;
   public readonly needsRestart: Computed<boolean>;
-  public readonly changes: Computed<PendingChangeDescription[]>;
+  public readonly changes: Computed<DraftChangeDescription[]>;
 
   private _sections: Observable<ConfigSection[]> = Observable.create(this, []);
   private _configAPI = new ConfigAPI(getHomeUrl());
@@ -94,12 +99,12 @@ export class PendingChangesManager extends Disposable {
       const dirty = use(this._sections).filter(s => use(s.isDirty));
       if (dirty.length === 0) { return EMPTY_STATE; }
       return {
-        hasPendingChanges: true,
+        hasDraftChanges: true,
         needsRestart: dirty.some(s => s.needsRestart),
         changes: dirty.flatMap(s => s.describeChange ? [s.describeChange()] : []),
       };
     });
-    this.hasPendingChanges = Computed.create(this, use => use(this.state).hasPendingChanges);
+    this.hasDraftChanges = Computed.create(this, use => use(this.state).hasDraftChanges);
     this.needsRestart = Computed.create(this, use => use(this.state).needsRestart);
     this.changes = Computed.create(this, use => use(this.state).changes);
   }
@@ -115,7 +120,7 @@ export class PendingChangesManager extends Disposable {
   }
 
   /**
-   * Persist all pending changes without restarting. Use when the server
+   * Persist all draft changes without restarting. Use when the server
    * can't auto-restart (no supervisor); the user restarts manually.
    */
   public async applyWithoutRestart(): Promise<void> {
@@ -123,7 +128,7 @@ export class PendingChangesManager extends Disposable {
   }
 
   /** One-shot accessor; prefer binding to `state`/`changes` for reactive UI. */
-  public describeChanges(): PendingChangeDescription[] {
+  public describeChanges(): DraftChangeDescription[] {
     return this.state.get().changes;
   }
 
@@ -158,7 +163,7 @@ export class PendingChangesManager extends Disposable {
       }
 
       // Only restart when every dirty section succeeded. Restarting with a
-      // half-applied set would either strand pending changes behind another
+      // half-applied set would either strand draft changes behind another
       // restart (if we re-try later) or advertise the run as complete when
       // it isn't. Better to require retry first.
       if (restart && failures.length === 0 && applied.some(s => s.needsRestart)) {

--- a/app/client/ui/EditionSection.ts
+++ b/app/client/ui/EditionSection.ts
@@ -11,6 +11,7 @@ import {
   cssSectionDescription,
   cssValueLabel,
 } from "app/client/ui/AdminPanelCss";
+import { ConfigSection } from "app/client/ui/DraftChanges";
 import { ToggleEnterpriseWidget } from "app/client/ui/ToggleEnterpriseWidget";
 import { primaryButton } from "app/client/ui2018/buttons";
 import { labeledSquareCheckbox } from "app/client/ui2018/checkbox";
@@ -38,7 +39,7 @@ interface EditionSectionOptions {
   };
 }
 
-export class EditionSection extends Disposable {
+export class EditionSection extends Disposable implements ConfigSection {
   /**
    * Short description shown next to the item name in the admin panel
    * collapsed row. Exposed so stubs (e.g. the legacy "Enterprise" item)
@@ -152,7 +153,7 @@ export class EditionSection extends Disposable {
     return this._selectedEdition.get();
   }
 
-  /** Null in wizard mode (no ToggleEnterpriseWidget). */
+  /** Undefined in wizard mode (no ToggleEnterpriseWidget). */
   public getEnterpriseToggleObservable() {
     return this._toggleEnterprise?.getEnterpriseToggleObservable();
   }
@@ -167,11 +168,7 @@ export class EditionSection extends Disposable {
     const selected = this._selectedEdition.get();
     if (!selected) { return; }
     await this._configAPI.setValue({ edition: selected });
-  }
-
-  public markApplied() {
-    const selected = this._selectedEdition.get();
-    if (selected) { this._serverEdition.set(selected); }
+    this._serverEdition.set(selected);
   }
 
   public describeChange() {
@@ -181,8 +178,6 @@ export class EditionSection extends Disposable {
       value: selected === "enterprise" ? t("Full Grist") : t("Community Edition"),
     };
   }
-
-  // --- Shared core + mode-specific parts ---
 
   /**
    * Shared core: description, edition selector tabs, per-selection text.
@@ -280,9 +275,6 @@ providers, and much more."),
 
   private _buildUnavailableCore(): DomContents {
     const selectedTab = Observable.create(this, "core");
-    const acknowledged = Observable.create(this, this._editionConfirmed.get());
-    acknowledged.addListener((val) => { this._editionConfirmed.set(val); });
-    this._editionConfirmed.addListener((val) => { if (!val) { acknowledged.set(false); } });
     return [
       cssSectionDescription(
         t("Choose which edition of Grist to run on this server."),
@@ -318,7 +310,7 @@ Want Full Grist? {{enableLink}}", {
               }),
             ),
             dom.maybe(use => !use(this._editionConfirmed), () =>
-              labeledSquareCheckbox(acknowledged,
+              labeledSquareCheckbox(this._editionConfirmed,
                 t("I understand I am running Grist Community Edition"),
                 testId("acknowledge"),
               ),

--- a/app/client/ui/EditionSection.ts
+++ b/app/client/ui/EditionSection.ts
@@ -87,10 +87,13 @@ export class EditionSection extends Disposable {
       this._toggleEnterprise?.getEnterpriseToggleObservable().get() ? "enterprise" : "core",
     );
 
-    // Initial wizard selection. Default to Full Grist when it's available
-    // (or community isn't); the buttons let the user change it. Set here
-    // rather than in `_buildSelector` so a re-render can't reset it.
-    this._selectedEdition.set(
+    // In admin-panel mode, start selection at the server's current edition so
+    // the section isn't dirty before the user acts. In wizard mode, default to
+    // Full Grist when available (or when community isn't); the user can change
+    // it via the buttons. Done here rather than in `_buildSelector` so a
+    // re-render can't reset it.
+    this._selectedEdition.set(this._options.controls ?
+      this._serverEdition.get() :
       (this.fullGristAvailable || !this.communityAvailable) ? "enterprise" : "core",
     );
 

--- a/app/client/ui/EditionSection.ts
+++ b/app/client/ui/EditionSection.ts
@@ -32,10 +32,16 @@ type Edition = "enterprise" | "core";
 interface EditionSectionOptions {
   controls?: AdminPanelControls;
   notifier?: Notifier;
-  /** Override runtime detection of edition availability; used by storybook. */
-  availability?: {
-    fullGristAvailable: boolean;
-    communityAvailable: boolean;
+  /**
+   * Optional overrides for state that's normally derived from globals
+   * (`showEnterpriseToggle()`, `getGristConfig().forceEnableEnterprise`, and
+   * the toggle widget's initial value). Used by storybook so stories can
+   * exercise each render state without launching a real server.
+   */
+  overrides?: {
+    fullGristAvailable?: boolean;
+    editionForced?: boolean;
+    initialServerEdition?: Edition;
   };
 }
 
@@ -53,7 +59,6 @@ export class EditionSection extends Disposable implements ConfigSection {
   public isDirty: Computed<boolean>;
 
   public readonly fullGristAvailable: boolean;
-  public readonly communityAvailable: boolean;
   public readonly editionForced: boolean;
   public readonly needsRestart = true;
 
@@ -69,15 +74,9 @@ export class EditionSection extends Disposable implements ConfigSection {
   constructor(private _options: EditionSectionOptions = {}) {
     super();
 
-    if (_options.availability) {
-      this.fullGristAvailable = _options.availability.fullGristAvailable;
-      this.communityAvailable = _options.availability.communityAvailable;
-    } else {
-      this.fullGristAvailable = showEnterpriseToggle();
-      this.communityAvailable = true;
-    }
-
-    this.editionForced = !!getGristConfig().forceEnableEnterprise;
+    const overrides = _options.overrides ?? {};
+    this.fullGristAvailable = overrides.fullGristAvailable ?? showEnterpriseToggle();
+    this.editionForced = overrides.editionForced ?? !!getGristConfig().forceEnableEnterprise;
 
     const notifier = this._options.notifier;
     this._toggleEnterprise = notifier ?
@@ -85,17 +84,17 @@ export class EditionSection extends Disposable implements ConfigSection {
       null;
 
     this._serverEdition.set(
-      this._toggleEnterprise?.getEnterpriseToggleObservable().get() ? "enterprise" : "core",
+      overrides.initialServerEdition ??
+      (this._toggleEnterprise?.getEnterpriseToggleObservable().get() ? "enterprise" : "core"),
     );
 
     // In admin-panel mode, start selection at the server's current edition so
     // the section isn't dirty before the user acts. In wizard mode, default to
-    // Full Grist when available (or when community isn't); the user can change
-    // it via the buttons. Done here rather than in `_buildSelector` so a
-    // re-render can't reset it.
+    // Full Grist when available; the user can change it via the buttons.
+    // Done here rather than in `_buildSelector` so a re-render can't reset it.
     this._selectedEdition.set(this._options.controls ?
       this._serverEdition.get() :
-      (this.fullGristAvailable || !this.communityAvailable) ? "enterprise" : "core",
+      this.fullGristAvailable ? "enterprise" : "core",
     );
 
     this.canProceed = Computed.create(this, use => use(this._editionConfirmed));
@@ -127,10 +126,17 @@ export class EditionSection extends Disposable implements ConfigSection {
   }
 
   public buildDom(): DomContents {
+    const toggle = this._toggleEnterprise;
     return cssSectionContainer(
       this._buildCore(),
-      this.fullGristAvailable && !this.editionForced && this._toggleEnterprise ?
-        this._toggleEnterprise.buildEnterpriseSection() :
+      // Only show ToggleEnterpriseWidget when the server is actually running
+      // Full Grist -- that's where its activation-key / trial / license UI
+      // does useful work. In "core" mode its "Enable Full Grist" button
+      // duplicates the selector above.
+      this.fullGristAvailable && !this.editionForced && toggle ?
+        dom.maybe(use => use(this._serverEdition) === "enterprise", () =>
+          toggle.buildEnterpriseSection(),
+        ) :
         null,
       testId("section"),
     );
@@ -237,18 +243,6 @@ to individuals and small orgs with less than US $1 million in total annual fundi
             ) : null,
           ];
         }
-        if (!this.communityAvailable) {
-          return [
-            cssSectionDescription(
-              t("The free and open-source heart of Grist, with everything you need to open and edit \
-Grist documents, control access, create forms, connect to single sign-on (SSO) \
-providers, and much more."),
-            ),
-            cssSectionDescription(
-              t("Community Edition is not available in this installation."),
-            ),
-          ];
-        }
         return cssSectionDescription(
           t("The free and open-source heart of Grist, with everything you need to open and edit \
 Grist documents, control access, create forms, connect to single sign-on (SSO) \
@@ -256,9 +250,7 @@ providers, and much more."),
         );
       }),
       dom.domComputed((use) => {
-        const ed = use(selectedEdition);
         const confirmed = use(this._editionConfirmed);
-        if (ed === "core" && !this.communityAvailable) { return null; }
         if (confirmed) { return null; }
         return cssSectionButtonRow(
           primaryButton(

--- a/app/client/ui/EditionSection.ts
+++ b/app/client/ui/EditionSection.ts
@@ -1,0 +1,386 @@
+import { makeT } from "app/client/lib/localization";
+import { getHomeUrl } from "app/client/models/AppModel";
+import { Notifier } from "app/client/models/NotifyModel";
+import { showEnterpriseToggle } from "app/client/ui/ActivationPage";
+import {
+  AdminPanelControls,
+  buildConfirmedRow,
+  cssHappyText,
+  cssSectionButtonRow,
+  cssSectionContainer,
+  cssSectionDescription,
+  cssValueLabel,
+} from "app/client/ui/AdminPanelCss";
+import { ToggleEnterpriseWidget } from "app/client/ui/ToggleEnterpriseWidget";
+import { primaryButton } from "app/client/ui2018/buttons";
+import { labeledSquareCheckbox } from "app/client/ui2018/checkbox";
+import { cssLink } from "app/client/ui2018/links";
+import { unstyledButton } from "app/client/ui2018/unstyled";
+import { ConfigAPI } from "app/common/ConfigAPI";
+import { commonUrls } from "app/common/gristUrls";
+import { tokens } from "app/common/ThemePrefs";
+import { getGristConfig } from "app/common/urlUtils";
+
+import { Computed, Disposable, dom, DomContents, makeTestId, Observable, styled } from "grainjs";
+
+const t = makeT("EditionSection");
+const testId = makeTestId("test-edition-");
+
+type Edition = "enterprise" | "core";
+
+interface EditionSectionOptions {
+  controls?: AdminPanelControls;
+  notifier?: Notifier;
+  /** Override runtime detection of edition availability; used by storybook. */
+  availability?: {
+    fullGristAvailable: boolean;
+    communityAvailable: boolean;
+  };
+}
+
+export class EditionSection extends Disposable {
+  /**
+   * Short description shown next to the item name in the admin panel
+   * collapsed row. Exposed so stubs (e.g. the legacy "Enterprise" item)
+   * can use the same wording without duplication.
+   */
+  public static description(): string {
+    return t("Choose which edition of Grist to run on this server");
+  }
+
+  public canProceed: Computed<boolean>;
+  public isDirty: Computed<boolean>;
+
+  public readonly fullGristAvailable: boolean;
+  public readonly communityAvailable: boolean;
+  public readonly editionForced: boolean;
+  public readonly needsRestart = true;
+
+  private _selectedEdition = Observable.create<Edition | null>(this, null);
+  private _serverEdition = Observable.create<Edition>(this, "core");
+  // Pre-confirmed in admin-panel mode so the confirm/edit flow only runs in the wizard.
+  private _editionConfirmed = Observable.create<boolean>(this, !!this._options.controls);
+
+  // Only created in admin-panel mode (requires a notifier).
+  private _toggleEnterprise: ToggleEnterpriseWidget | null;
+  private _configAPI = new ConfigAPI(getHomeUrl());
+
+  constructor(private _options: EditionSectionOptions = {}) {
+    super();
+
+    if (_options.availability) {
+      this.fullGristAvailable = _options.availability.fullGristAvailable;
+      this.communityAvailable = _options.availability.communityAvailable;
+    } else {
+      this.fullGristAvailable = showEnterpriseToggle();
+      this.communityAvailable = true;
+    }
+
+    this.editionForced = !!getGristConfig().forceEnableEnterprise;
+
+    const notifier = this._options.notifier;
+    this._toggleEnterprise = notifier ?
+      ToggleEnterpriseWidget.create(this, notifier) :
+      null;
+
+    this._serverEdition.set(
+      this._toggleEnterprise?.getEnterpriseToggleObservable().get() ? "enterprise" : "core",
+    );
+
+    // Initial wizard selection. Default to Full Grist when it's available
+    // (or community isn't); the buttons let the user change it. Set here
+    // rather than in `_buildSelector` so a re-render can't reset it.
+    this._selectedEdition.set(
+      (this.fullGristAvailable || !this.communityAvailable) ? "enterprise" : "core",
+    );
+
+    this.canProceed = Computed.create(this, use => use(this._editionConfirmed));
+    this.isDirty = Computed.create(this, (use) => {
+      if (!use(this._editionConfirmed)) { return false; }
+      const selected = use(this._selectedEdition);
+      if (selected === null) { return false; }
+      return selected !== use(this._serverEdition);
+    });
+  }
+
+  public buildStatusDisplay(): DomContents {
+    if (this.editionForced) {
+      return cssValueLabel(cssHappyText(t("On")));
+    }
+    if (!this.fullGristAvailable) {
+      return cssValueLabel(t("community"));
+    }
+    const toggle = this._toggleEnterprise?.getEnterpriseToggleObservable();
+    if (!toggle) {
+      return cssValueLabel(t("community"));
+    }
+    return dom.domComputed(toggle, (isEnterprise) => {
+      if (isEnterprise) {
+        return cssValueLabel(cssHappyText(t("full")));
+      }
+      return cssValueLabel(t("community"));
+    });
+  }
+
+  public buildDom(): DomContents {
+    return cssSectionContainer(
+      this._buildCore(),
+      this.fullGristAvailable && !this.editionForced && this._toggleEnterprise ?
+        this._toggleEnterprise.buildEnterpriseSection() :
+        null,
+      testId("section"),
+    );
+  }
+
+  public buildWizardDom(): DomContents {
+    return cssSectionContainer(
+      this._buildCore(),
+      // No confirmed row when edition is forced by env -- nothing to edit.
+      this.editionForced ? null : buildConfirmedRow(
+        this._editionConfirmed,
+        () => { this._editionConfirmed.set(false); },
+        { testPrefix: "edition" },
+      ),
+      testId("wizard"),
+    );
+  }
+
+  public getSelectedEdition(): Edition | null {
+    return this._selectedEdition.get();
+  }
+
+  /** Null in wizard mode (no ToggleEnterpriseWidget). */
+  public getEnterpriseToggleObservable() {
+    return this._toggleEnterprise?.getEnterpriseToggleObservable();
+  }
+
+  /** Null on community builds (no `/api/activation/status` endpoint). */
+  public getInstallationIdObservable() {
+    return this._toggleEnterprise?.getInstallationIdObservable() ?? null;
+  }
+
+  public async apply() {
+    if (!this.isDirty.get()) { return; }
+    const selected = this._selectedEdition.get();
+    if (!selected) { return; }
+    await this._configAPI.setValue({ edition: selected });
+  }
+
+  public markApplied() {
+    const selected = this._selectedEdition.get();
+    if (selected) { this._serverEdition.set(selected); }
+  }
+
+  public describeChange() {
+    const selected = this._selectedEdition.get();
+    return {
+      label: t("Edition"),
+      value: selected === "enterprise" ? t("Full Grist") : t("Community Edition"),
+    };
+  }
+
+  // --- Shared core + mode-specific parts ---
+
+  /**
+   * Shared core: description, edition selector tabs, per-selection text.
+   * Used by both admin panel and wizard.
+   */
+  private _buildCore(): DomContents {
+    if (this.editionForced) {
+      this._editionConfirmed.set(true);
+      return cssSectionDescription(t("Full Grist is enabled via environment variable."));
+    }
+
+    if (!this.fullGristAvailable) {
+      return this._buildUnavailableCore();
+    }
+
+    return this._buildSelector();
+  }
+
+  private _buildSelector(): DomContents {
+    const selectedEdition = this._selectedEdition;
+    return [
+      cssSectionDescription(
+        t("Choose which edition of Grist to run on this server."),
+      ),
+      cssEditionButtons(
+        cssEditionButton(
+          t("Full Grist"),
+          cssEditionButton.cls("-selected", use => use(selectedEdition) === "enterprise"),
+          dom.on("click", () => { selectedEdition.set("enterprise"); this._editionConfirmed.set(false); }),
+          testId("full-grist"),
+        ),
+        cssEditionButton(
+          t("Community Edition"),
+          cssEditionButton.cls("-selected", use => use(selectedEdition) === "core"),
+          dom.on("click", () => { selectedEdition.set("core"); this._editionConfirmed.set(false); }),
+          testId("community"),
+        ),
+      ),
+      dom.domComputed((use) => {
+        const ed = use(selectedEdition);
+        if (ed === "enterprise") {
+          return [
+            cssSectionDescription(
+              t("The full Grist experience, with all features enabled for improved security, \
+governance, and collaboration."),
+            ),
+            !this.editionForced && use(this._serverEdition) !== "enterprise" ? cssSectionDescription(
+              t("You have 30 days to enter an activation key. Free activation keys are available \
+to individuals and small orgs with less than US $1 million in total annual funding. \
+{{learnMoreLink}} For larger orgs, see {{pricingLink}}.", {
+                learnMoreLink: cssLink(
+                  { href: commonUrls.helpEnterpriseOptIn, target: "_blank" },
+                  t("Learn more."),
+                ),
+                pricingLink: cssLink({ href: commonUrls.plans, target: "_blank" }, t("pricing")),
+              }),
+            ) : null,
+          ];
+        }
+        if (!this.communityAvailable) {
+          return [
+            cssSectionDescription(
+              t("The free and open-source heart of Grist, with everything you need to open and edit \
+Grist documents, control access, create forms, connect to single sign-on (SSO) \
+providers, and much more."),
+            ),
+            cssSectionDescription(
+              t("Community Edition is not available in this installation."),
+            ),
+          ];
+        }
+        return cssSectionDescription(
+          t("The free and open-source heart of Grist, with everything you need to open and edit \
+Grist documents, control access, create forms, connect to single sign-on (SSO) \
+providers, and much more."),
+        );
+      }),
+      dom.domComputed((use) => {
+        const ed = use(selectedEdition);
+        const confirmed = use(this._editionConfirmed);
+        if (ed === "core" && !this.communityAvailable) { return null; }
+        if (confirmed) { return null; }
+        return cssSectionButtonRow(
+          primaryButton(
+            t("Confirm edition"),
+            dom.on("click", () => {
+              this._editionConfirmed.set(true);
+            }),
+            testId("confirm"),
+          ),
+        );
+      }),
+    ];
+  }
+
+  private _buildUnavailableCore(): DomContents {
+    const selectedTab = Observable.create(this, "core");
+    const acknowledged = Observable.create(this, this._editionConfirmed.get());
+    acknowledged.addListener((val) => { this._editionConfirmed.set(val); });
+    this._editionConfirmed.addListener((val) => { if (!val) { acknowledged.set(false); } });
+    return [
+      cssSectionDescription(
+        t("Choose which edition of Grist to run on this server."),
+      ),
+      cssEditionButtons(
+        cssEditionButton(
+          t("Full Grist"),
+          cssEditionButton.cls("-selected", use => use(selectedTab) === "enterprise"),
+          dom.on("click", () => { selectedTab.set("enterprise"); this._editionConfirmed.set(false); }),
+          testId("full-grist"),
+        ),
+        cssEditionButton(
+          t("Community Edition"),
+          cssEditionButton.cls("-selected", use => use(selectedTab) === "core"),
+          dom.on("click", () => { selectedTab.set("core"); this._editionConfirmed.set(false); }),
+          testId("community"),
+        ),
+      ),
+      dom.domComputed(selectedTab, (tab) => {
+        if (tab === "enterprise") {
+          return [
+            cssSectionDescription(
+              t("The full Grist experience, with all features enabled for improved security, \
+governance, and collaboration."),
+            ),
+            cssSectionDescription(
+              t("Your installation does not bundle the Full Grist edition. \
+Want Full Grist? {{enableLink}}", {
+                enableLink: cssLink(
+                  { href: commonUrls.helpEnterpriseOptIn, target: "_blank" },
+                  t("See how to enable it."),
+                ),
+              }),
+            ),
+            dom.maybe(use => !use(this._editionConfirmed), () =>
+              labeledSquareCheckbox(acknowledged,
+                t("I understand I am running Grist Community Edition"),
+                testId("acknowledge"),
+              ),
+            ),
+          ];
+        }
+        return [
+          cssSectionDescription(
+            t("The free and open-source heart of Grist, with everything you need to open and edit \
+Grist documents, control access, create forms, connect to single sign-on (SSO) \
+providers, and much more."),
+          ),
+          dom.maybe(use => !use(this._editionConfirmed), () => cssSectionButtonRow(
+            primaryButton(
+              t("Confirm edition"),
+              dom.on("click", () => {
+                this._editionConfirmed.set(true);
+              }),
+              testId("confirm"),
+            ),
+          )),
+        ];
+      }),
+    ];
+  }
+}
+
+const cssEditionButtons = styled("div", `
+  background: ${tokens.bgTertiary};
+  border-radius: 10px;
+  display: flex;
+  column-gap: 3px;
+  margin-bottom: 16px;
+  padding: 3px;
+`);
+
+const cssEditionButton = styled(unstyledButton, `
+  border-radius: 7px;
+  color: ${tokens.secondary};
+  cursor: pointer;
+  flex: 1;
+  font-weight: 500;
+  padding: 8px 6px;
+  text-align: center;
+  transition: color 0.2s, background 0.2s, box-shadow 0.2s;
+
+  &:hover, &-selected {
+    color: ${tokens.body};
+  }
+
+  &:focus-visible {
+    outline: 3px solid ${tokens.primary};
+    outline-offset: 2px;
+  }
+
+  &-selected {
+    background: ${tokens.bg};
+    box-shadow:
+      0 1px 3px rgba(0, 0, 0, 0.15),
+      0 1px 2px rgba(0, 0, 0, 0.1);
+    font-weight: 600;
+  }
+
+  &-disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`);

--- a/app/client/ui/PendingChanges.ts
+++ b/app/client/ui/PendingChanges.ts
@@ -1,0 +1,188 @@
+/**
+ * Accumulates pending configuration changes from multiple sections,
+ * then applies them together. Used by both the setup wizard and the
+ * admin panel to batch saves and minimize restarts.
+ *
+ * Each section registers itself via `addSection()`. The manager
+ * tracks aggregate dirty state and provides `applyAll()` to persist
+ * everything, restart if needed, and reset dirty tracking.
+ */
+import { getHomeUrl } from "app/client/models/AppModel";
+import { ConfigAPI } from "app/common/ConfigAPI";
+import { delay } from "app/common/delay";
+
+import { Computed, Disposable, Observable } from "grainjs";
+
+/**
+ * A human-readable description of a pending change. The `label` is
+ * translated (e.g. "Base URL"); the `value` is a literal (e.g. a URL)
+ * that shouldn't pass through the translation pipeline.
+ */
+export interface PendingChangeDescription {
+  label: string;
+  value: string;
+}
+
+export interface ConfigSection {
+  /** True when the section's confirmed state differs from the server. */
+  isDirty: Computed<boolean>;
+  /** True when the section's changes require a server restart to take effect. */
+  needsRestart: boolean;
+  /** Persist this section's changes to the server. No-op if not dirty. */
+  apply(): Promise<void>;
+  /** Update internal tracking so isDirty becomes false. */
+  markApplied(): void;
+  /**
+   * Describe the pending change for display in the restart banner.
+   * Only called when isDirty is true. Re-read whenever any section's
+   * `isDirty` fires -- sections whose described value can drift while
+   * `isDirty` stays true should toggle `isDirty` to trigger a refresh.
+   */
+  describeChange?(): PendingChangeDescription;
+}
+
+/**
+ * Thrown by `applyAll` / `applyWithoutRestart` when one or more sections
+ * failed to persist. Successful sections will already have been marked
+ * applied by the time this is thrown; only the listed `failures` remain
+ * dirty. When `restartSkipped` is true, the manager declined to restart
+ * the server because the set of changes wasn't fully applied.
+ */
+export class PartialApplyError extends Error {
+  public readonly name = "PartialApplyError";
+
+  constructor(
+    public readonly failures: readonly { label: string; error: Error }[],
+    public readonly restartSkipped: boolean,
+  ) {
+    const parts = failures.map(f => `${f.label}: ${f.error.message || String(f.error)}`);
+    const prefix = failures.length === 1 ?
+      "Could not apply change" :
+      `Could not apply ${failures.length} changes`;
+    const suffix = restartSkipped ? " -- server was not restarted" : "";
+    super(`${prefix}${suffix}: ${parts.join("; ")}`);
+  }
+}
+
+/** Aggregate state across all registered sections, recomputed whenever any section's `isDirty` flips. */
+export interface PendingState {
+  hasPendingChanges: boolean;
+  needsRestart: boolean;
+  changes: PendingChangeDescription[];
+}
+
+const EMPTY_STATE: PendingState = { hasPendingChanges: false, needsRestart: false, changes: [] };
+
+export class PendingChangesManager extends Disposable {
+  /**
+   * Aggregate pending-state derived from all registered sections. Readers
+   * bind to `state` for reactive UI, or to the convenience projections
+   * (`hasPendingChanges`, `needsRestart`, `changes`) that unwrap fields.
+   */
+  public readonly state: Computed<PendingState>;
+  public readonly hasPendingChanges: Computed<boolean>;
+  public readonly needsRestart: Computed<boolean>;
+  public readonly changes: Computed<PendingChangeDescription[]>;
+
+  private _sections: Observable<ConfigSection[]> = Observable.create(this, []);
+  private _configAPI = new ConfigAPI(getHomeUrl());
+  private _applying = Observable.create<boolean>(this, false);
+
+  constructor() {
+    super();
+    this.state = Computed.create(this, (use) => {
+      const dirty = use(this._sections).filter(s => use(s.isDirty));
+      if (dirty.length === 0) { return EMPTY_STATE; }
+      return {
+        hasPendingChanges: true,
+        needsRestart: dirty.some(s => s.needsRestart),
+        changes: dirty.flatMap(s => s.describeChange ? [s.describeChange()] : []),
+      };
+    });
+    this.hasPendingChanges = Computed.create(this, use => use(this.state).hasPendingChanges);
+    this.needsRestart = Computed.create(this, use => use(this.state).needsRestart);
+    this.changes = Computed.create(this, use => use(this.state).changes);
+  }
+
+  public addSection(section: ConfigSection) {
+    this._sections.set([...this._sections.get(), section]);
+  }
+
+  public get isApplying() { return this._applying; }
+
+  public async applyAll(): Promise<void> {
+    await this._apply({ restart: true });
+  }
+
+  /**
+   * Persist all pending changes without restarting. Use when the server
+   * can't auto-restart (no supervisor); the user restarts manually.
+   */
+  public async applyWithoutRestart(): Promise<void> {
+    await this._apply({ restart: false });
+  }
+
+  /** One-shot accessor; prefer binding to `state`/`changes` for reactive UI. */
+  public describeChanges(): PendingChangeDescription[] {
+    return this.state.get().changes;
+  }
+
+  private async _apply({ restart }: { restart: boolean }): Promise<void> {
+    if (this._applying.get()) { return; }
+    this._applying.set(true);
+    try {
+      // Apply sections sequentially so one section's failure doesn't leave
+      // another mid-flight. We collect per-section outcomes and only mark
+      // successful ones applied -- any failure keeps its section dirty so the
+      // UI stays aligned with the server and the user can retry.
+      const dirty = this._sections.get().filter(s => s.isDirty.get());
+      const applied: ConfigSection[] = [];
+      const failures: { label: string; error: Error }[] = [];
+
+      for (const section of dirty) {
+        try {
+          await section.apply();
+          applied.push(section);
+        } catch (err) {
+          failures.push({
+            label: section.describeChange?.().label ?? "change",
+            error: err as Error,
+          });
+        }
+      }
+
+      // Reflect DB state: sections that persisted successfully should appear
+      // clean regardless of whether a peer failed.
+      for (const section of applied) {
+        section.markApplied();
+      }
+
+      // Only restart when every dirty section succeeded. Restarting with a
+      // half-applied set would either strand pending changes behind another
+      // restart (if we re-try later) or advertise the run as complete when
+      // it isn't. Better to require retry first.
+      if (restart && failures.length === 0 && applied.some(s => s.needsRestart)) {
+        await this._configAPI.restartServer();
+        await this._waitForServer();
+      }
+
+      if (failures.length > 0) {
+        throw new PartialApplyError(failures, restart && dirty.some(s => s.needsRestart));
+      }
+    } finally {
+      this._applying.set(false);
+    }
+  }
+
+  private async _waitForServer() {
+    for (let i = 0; i < 30; i++) {
+      try {
+        await this._configAPI.healthcheck();
+        return;
+      } catch {
+        await delay(1000);
+      }
+    }
+    throw new Error("Timed out waiting for Grist server to restart");
+  }
+}

--- a/app/client/ui/PermissionsSetupSection.ts
+++ b/app/client/ui/PermissionsSetupSection.ts
@@ -5,7 +5,6 @@ import { theme, vars } from "app/client/ui2018/cssVars";
 import { loadingSpinner } from "app/client/ui2018/loaders";
 import { toggleSwitch } from "app/client/ui2018/toggleSwitch";
 import { ConfigAPI } from "app/common/ConfigAPI";
-import { delay } from "app/common/delay";
 import { not } from "app/common/gutil";
 import { InstallAPIImpl, PermissionsStatus } from "app/common/InstallAPI";
 import { tokens } from "app/common/ThemePrefs";
@@ -150,18 +149,11 @@ export class PermissionsSetupSection extends Disposable {
     }
   }
 
-  private async _waitForReady(maxAttempts = 30) {
-    for (let i = 0; i < maxAttempts; i++) {
-      await delay(1000);
+  private async _waitForReady() {
+    if (!await this._configAPI.waitUntilReady()) {
       if (this.isDisposed()) { return; }
-      try {
-        await this._configAPI.healthcheck();
-        return;
-      } catch {
-        // Server not ready yet, keep polling.
-      }
+      throw new Error(t("Server did not restart in time. Please refresh the page."));
     }
-    throw new Error(t("Server did not restart in time. Please refresh the page."));
   }
 
   private _goHome() {

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -5,8 +5,8 @@ import { getHomeUrl } from "app/client/models/homeUrl";
 import { cssFadeUp, cssFadeUpGristLogo, cssFadeUpHeading, cssFadeUpSubHeading } from "app/client/ui/AdminPanelCss";
 import { BackupsSection } from "app/client/ui/BackupsSection";
 import { BaseUrlSection } from "app/client/ui/BaseUrlSection";
+import { DraftChangesManager } from "app/client/ui/DraftChanges";
 import { EditionSection } from "app/client/ui/EditionSection";
-import { PendingChangesManager } from "app/client/ui/PendingChanges";
 import { PermissionsSetupSection } from "app/client/ui/PermissionsSetupSection";
 import { SandboxSetupSection } from "app/client/ui/SandboxSection";
 import { bigPrimaryButton } from "app/client/ui2018/buttons";
@@ -94,9 +94,9 @@ export class QuickSetup extends Disposable {
     return dom.create((owner) => {
       const baseUrl = BaseUrlSection.create(owner);
       const edition = EditionSection.create(owner);
-      const pending = PendingChangesManager.create(owner);
-      pending.addSection(baseUrl);
-      pending.addSection(edition);
+      const drafts = DraftChangesManager.create(owner);
+      drafts.addSection(baseUrl);
+      drafts.addSection(edition);
       const canProceed = Computed.create(owner, use =>
         use(baseUrl.canProceed) && use(edition.canProceed),
       );
@@ -124,12 +124,12 @@ export class QuickSetup extends Disposable {
               if (!urlOk && !edOk) { return t("Confirm base URL and edition to continue"); }
               if (!urlOk) { return t("Confirm base URL to continue"); }
               if (!edOk) { return t("Confirm edition to continue"); }
-              return use(pending.hasPendingChanges) ? t("Apply and Continue") : t("Continue");
+              return use(drafts.hasDraftChanges) ? t("Apply and Continue") : t("Continue");
             }),
-            dom.boolAttr("disabled", use => !use(canProceed) || use(pending.isApplying)),
+            dom.boolAttr("disabled", use => !use(canProceed) || use(drafts.isApplying)),
             dom.on("click", async () => {
               try {
-                await pending.applyAll();
+                await drafts.applyAll();
                 const activeStepIndex = this._activeStep.get();
                 this._steps[activeStepIndex].completed.set(true);
                 this._activeStep.set(activeStepIndex + 1);

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -4,16 +4,22 @@ import { reportError } from "app/client/models/errors";
 import { getHomeUrl } from "app/client/models/homeUrl";
 import { cssFadeUp, cssFadeUpGristLogo, cssFadeUpHeading, cssFadeUpSubHeading } from "app/client/ui/AdminPanelCss";
 import { BackupsSection } from "app/client/ui/BackupsSection";
+import { BaseUrlSection } from "app/client/ui/BaseUrlSection";
+import { EditionSection } from "app/client/ui/EditionSection";
+import { PendingChangesManager } from "app/client/ui/PendingChanges";
 import { PermissionsSetupSection } from "app/client/ui/PermissionsSetupSection";
 import { SandboxSetupSection } from "app/client/ui/SandboxSection";
 import { bigPrimaryButton } from "app/client/ui2018/buttons";
+import { theme } from "app/client/ui2018/cssVars";
+import { icon } from "app/client/ui2018/icons";
 import { Stepper } from "app/client/ui2018/Stepper";
 import { InstallAPIImpl } from "app/common/InstallAPI";
 import { tokens } from "app/common/ThemePrefs";
 
-import { Disposable, dom, DomContents, observable, Observable, styled } from "grainjs";
+import { Computed, Disposable, dom, DomContents, makeTestId, observable, Observable, styled } from "grainjs";
 
 const t = makeT("QuickSetup");
+const testId = makeTestId("test-quick-setup-");
 
 interface Step {
   completed: Observable<boolean>;
@@ -29,8 +35,8 @@ export class QuickSetup extends Disposable {
   private _steps: Step[] = [
     {
       label: t("Server"),
-      completed: observable(false),
-      buildDom: () => null,
+      completed: Observable.create(this, false),
+      buildDom: () => this._buildServerStep(),
     },
     {
       label: t("Sandboxing"),
@@ -45,7 +51,7 @@ export class QuickSetup extends Disposable {
     },
     {
       label: t("Authentication"),
-      completed: observable(false),
+      completed: Observable.create(this, false),
       buildDom: () => null,
     },
     {
@@ -71,7 +77,9 @@ export class QuickSetup extends Disposable {
     return cssMainContent(
       cssFadeUpGristLogo(),
       cssFadeUpHeading(t("Quick setup")),
-      cssFadeUpSubHeading(t("Configure Grist for your environment.")),
+      cssFadeUpSubHeading(
+        t("Configure Grist for your environment."),
+      ),
       cssStepper(
         dom.create(Stepper, { activeStep: this._activeStep, steps: this._steps }),
       ),
@@ -80,6 +88,60 @@ export class QuickSetup extends Disposable {
         this._steps[i].buildDom(),
       )),
     );
+  }
+
+  private _buildServerStep(): DomContents {
+    return dom.create((owner) => {
+      const baseUrl = BaseUrlSection.create(owner);
+      const edition = EditionSection.create(owner);
+      const pending = PendingChangesManager.create(owner);
+      pending.addSection(baseUrl);
+      pending.addSection(edition);
+      const canProceed = Computed.create(owner, use =>
+        use(baseUrl.canProceed) && use(edition.canProceed),
+      );
+      return dom("div",
+        cssStepHeading(
+          cssStepHeadingIcon(icon("Home")),
+          t("Server"),
+        ),
+        cssStepDescription(
+          t("Set your server's base URL and choose which edition of Grist to run."),
+        ),
+        cssStepSection(
+          cssStepSectionTitle(t("Base URL")),
+          baseUrl.buildWizardDom(),
+        ),
+        cssStepSection(
+          cssStepSectionTitle(t("Edition")),
+          edition.buildWizardDom(),
+        ),
+        cssContinueRow(
+          bigPrimaryButton(
+            dom.text((use) => {
+              const urlOk = use(baseUrl.canProceed);
+              const edOk = use(edition.canProceed);
+              if (!urlOk && !edOk) { return t("Confirm base URL and edition to continue"); }
+              if (!urlOk) { return t("Confirm base URL to continue"); }
+              if (!edOk) { return t("Confirm edition to continue"); }
+              return use(pending.hasPendingChanges) ? t("Apply and Continue") : t("Continue");
+            }),
+            dom.boolAttr("disabled", use => !use(canProceed) || use(pending.isApplying)),
+            dom.on("click", async () => {
+              try {
+                await pending.applyAll();
+                const activeStepIndex = this._activeStep.get();
+                this._steps[activeStepIndex].completed.set(true);
+                this._activeStep.set(activeStepIndex + 1);
+              } catch (err) {
+                reportError(err as Error);
+              }
+            }),
+            testId("server-continue"),
+          ),
+        ),
+      );
+    });
   }
 
   private _buildBackupsStep(): DomContents {
@@ -138,6 +200,37 @@ const cssStepContent = styled("div", `
     padding: 0;
     background: none;
   }
+`);
+
+const cssStepHeading = styled("div", `
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 4px;
+`);
+
+const cssStepHeadingIcon = styled("div", `
+  display: flex;
+  --icon-color: ${theme.controlPrimaryBg};
+`);
+
+const cssStepDescription = styled("div", `
+  color: ${tokens.secondary};
+  font-size: 14px;
+  line-height: 1.5;
+  margin-bottom: 20px;
+`);
+
+const cssStepSection = styled("div", `
+  margin-bottom: 24px;
+`);
+
+const cssStepSectionTitle = styled("h3", `
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 8px 0;
 `);
 
 const cssContinueRow = styled("div", `

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -4,22 +4,17 @@ import { reportError } from "app/client/models/errors";
 import { getHomeUrl } from "app/client/models/homeUrl";
 import { cssFadeUp, cssFadeUpGristLogo, cssFadeUpHeading, cssFadeUpSubHeading } from "app/client/ui/AdminPanelCss";
 import { BackupsSection } from "app/client/ui/BackupsSection";
-import { BaseUrlSection } from "app/client/ui/BaseUrlSection";
-import { DraftChangesManager } from "app/client/ui/DraftChanges";
-import { EditionSection } from "app/client/ui/EditionSection";
 import { PermissionsSetupSection } from "app/client/ui/PermissionsSetupSection";
+import { QuickSetupServerStep } from "app/client/ui/QuickSetupServerStep";
 import { SandboxSetupSection } from "app/client/ui/SandboxSection";
 import { bigPrimaryButton } from "app/client/ui2018/buttons";
-import { theme } from "app/client/ui2018/cssVars";
-import { icon } from "app/client/ui2018/icons";
 import { Stepper } from "app/client/ui2018/Stepper";
 import { InstallAPIImpl } from "app/common/InstallAPI";
 import { tokens } from "app/common/ThemePrefs";
 
-import { Computed, Disposable, dom, DomContents, makeTestId, observable, Observable, styled } from "grainjs";
+import { Disposable, dom, DomContents, observable, Observable, styled } from "grainjs";
 
 const t = makeT("QuickSetup");
-const testId = makeTestId("test-quick-setup-");
 
 interface Step {
   completed: Observable<boolean>;
@@ -92,56 +87,15 @@ export class QuickSetup extends Disposable {
 
   private _buildServerStep(): DomContents {
     return dom.create((owner) => {
-      const baseUrl = BaseUrlSection.create(owner);
-      const edition = EditionSection.create(owner);
-      const drafts = DraftChangesManager.create(owner);
-      drafts.addSection(baseUrl);
-      drafts.addSection(edition);
-      const canProceed = Computed.create(owner, use =>
-        use(baseUrl.canProceed) && use(edition.canProceed),
-      );
-      return dom("div",
-        cssStepHeading(
-          cssStepHeadingIcon(icon("Home")),
-          t("Server"),
-        ),
-        cssStepDescription(
-          t("Set your server's base URL and choose which edition of Grist to run."),
-        ),
-        cssStepSection(
-          cssStepSectionTitle(t("Base URL")),
-          baseUrl.buildWizardDom(),
-        ),
-        cssStepSection(
-          cssStepSectionTitle(t("Edition")),
-          edition.buildWizardDom(),
-        ),
-        cssContinueRow(
-          bigPrimaryButton(
-            dom.text((use) => {
-              const urlOk = use(baseUrl.canProceed);
-              const edOk = use(edition.canProceed);
-              if (!urlOk && !edOk) { return t("Confirm base URL and edition to continue"); }
-              if (!urlOk) { return t("Confirm base URL to continue"); }
-              if (!edOk) { return t("Confirm edition to continue"); }
-              return use(drafts.hasDraftChanges) ? t("Apply and Continue") : t("Continue");
-            }),
-            dom.boolAttr("disabled", use => !use(canProceed) || use(drafts.isApplying)),
-            dom.on("click", async () => {
-              try {
-                await drafts.applyAll();
-                const activeStepIndex = this._activeStep.get();
-                this._steps[activeStepIndex].completed.set(true);
-                this._activeStep.set(activeStepIndex + 1);
-              } catch (err) {
-                reportError(err as Error);
-              }
-            }),
-            testId("server-continue"),
-          ),
-        ),
-      );
+      const step = QuickSetupServerStep.create(owner, () => this._advanceStep());
+      return step.buildDom();
     });
+  }
+
+  private _advanceStep() {
+    const i = this._activeStep.get();
+    this._steps[i].completed.set(true);
+    this._activeStep.set(i + 1);
   }
 
   private _buildBackupsStep(): DomContents {
@@ -200,37 +154,6 @@ const cssStepContent = styled("div", `
     padding: 0;
     background: none;
   }
-`);
-
-const cssStepHeading = styled("div", `
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 18px;
-  font-weight: 600;
-  margin-bottom: 4px;
-`);
-
-const cssStepHeadingIcon = styled("div", `
-  display: flex;
-  --icon-color: ${theme.controlPrimaryBg};
-`);
-
-const cssStepDescription = styled("div", `
-  color: ${tokens.secondary};
-  font-size: 14px;
-  line-height: 1.5;
-  margin-bottom: 20px;
-`);
-
-const cssStepSection = styled("div", `
-  margin-bottom: 24px;
-`);
-
-const cssStepSectionTitle = styled("h3", `
-  font-size: 14px;
-  font-weight: 600;
-  margin: 0 0 8px 0;
 `);
 
 const cssContinueRow = styled("div", `

--- a/app/client/ui/QuickSetupServerStep.ts
+++ b/app/client/ui/QuickSetupServerStep.ts
@@ -1,0 +1,116 @@
+import { makeT } from "app/client/lib/localization";
+import { reportError } from "app/client/models/errors";
+import { BaseUrlSection } from "app/client/ui/BaseUrlSection";
+import { DraftChangesManager } from "app/client/ui/DraftChanges";
+import { EditionSection } from "app/client/ui/EditionSection";
+import { bigPrimaryButton } from "app/client/ui2018/buttons";
+import { theme } from "app/client/ui2018/cssVars";
+import { icon } from "app/client/ui2018/icons";
+
+import { Computed, Disposable, dom, DomContents, makeTestId, styled } from "grainjs";
+
+const t = makeT("QuickSetupServerStep");
+const testId = makeTestId("test-quick-setup-");
+
+/**
+ * First step of the setup wizard: Base URL + Edition. Collects draft
+ * changes and applies them in a single batch when the user clicks Continue.
+ *
+ * Extracted into its own file to keep QuickSetup.ts focused on step
+ * navigation; the other setup steps (sandboxing, backups, etc.) live in
+ * their own modules too.
+ */
+export class QuickSetupServerStep extends Disposable {
+  private _baseUrl = BaseUrlSection.create(this);
+  private _edition = EditionSection.create(this);
+  private _drafts = DraftChangesManager.create(this);
+
+  private _canProceed: Computed<boolean>;
+
+  constructor(private _onComplete: () => void) {
+    super();
+    this._drafts.addSection(this._baseUrl);
+    this._drafts.addSection(this._edition);
+    this._canProceed = Computed.create(this, use =>
+      use(this._baseUrl.canProceed) && use(this._edition.canProceed),
+    );
+  }
+
+  public buildDom(): DomContents {
+    return dom("div",
+      cssStepHeading(
+        cssStepHeadingIcon(icon("Home")),
+        t("Server"),
+      ),
+      cssStepDescription(
+        t("Set your server's base URL and choose which edition of Grist to run."),
+      ),
+      cssStepSection(
+        cssStepSectionTitle(t("Base URL")),
+        this._baseUrl.buildWizardDom(),
+      ),
+      cssStepSection(
+        cssStepSectionTitle(t("Edition")),
+        this._edition.buildWizardDom(),
+      ),
+      cssContinueRow(
+        bigPrimaryButton(
+          dom.text((use) => {
+            const urlOk = use(this._baseUrl.canProceed);
+            const edOk = use(this._edition.canProceed);
+            if (!urlOk && !edOk) { return t("Confirm base URL and edition to continue"); }
+            if (!urlOk) { return t("Confirm base URL to continue"); }
+            if (!edOk) { return t("Confirm edition to continue"); }
+            return use(this._drafts.hasDraftChanges) ? t("Apply and Continue") : t("Continue");
+          }),
+          dom.boolAttr("disabled", use => !use(this._canProceed) || use(this._drafts.isApplying)),
+          dom.on("click", async () => {
+            try {
+              await this._drafts.applyAll();
+              this._onComplete();
+            } catch (err) {
+              reportError(err as Error);
+            }
+          }),
+          testId("server-continue"),
+        ),
+      ),
+    );
+  }
+}
+
+const cssStepHeading = styled("div", `
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 4px;
+`);
+
+const cssStepHeadingIcon = styled("div", `
+  display: flex;
+  --icon-color: ${theme.controlPrimaryBg};
+`);
+
+const cssStepDescription = styled("div", `
+  font-size: 14px;
+  line-height: 1.5;
+  margin-bottom: 20px;
+`);
+
+const cssStepSection = styled("div", `
+  margin-bottom: 24px;
+`);
+
+const cssStepSectionTitle = styled("h3", `
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 8px 0;
+`);
+
+const cssContinueRow = styled("div", `
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 24px;
+`);

--- a/app/client/ui/SandboxSection.ts
+++ b/app/client/ui/SandboxSection.ts
@@ -236,7 +236,10 @@ export class SandboxSetupSection extends SandboxSectionBase {
       await this._save();
       if (this._needsRestart()) {
         await this._configAPI.restartServer();
-        await waitForServerReady(this._configAPI);
+        // Brief delay so we don't catch the server before it's begun
+        // restarting; waitUntilReady then polls for ~30s.
+        await delay(2000);
+        await this._configAPI.waitUntilReady();
       }
     } catch (e) {
       reportError(e);
@@ -245,17 +248,6 @@ export class SandboxSetupSection extends SandboxSectionBase {
     }
     this._saving.set(false);
     this._onContinue();
-  }
-}
-
-/**
- * Poll the server's healthcheck until it responds OK (up to ~12s).
- */
-async function waitForServerReady(configAPI: ConfigAPI) {
-  await delay(2000);
-  for (let i = 0; i < 10; i++) {
-    try { await configAPI.healthcheck(); return; } catch { /* not ready */ }
-    await delay(1000);
   }
 }
 

--- a/app/client/ui/ToggleEnterpriseWidget.ts
+++ b/app/client/ui/ToggleEnterpriseWidget.ts
@@ -367,19 +367,26 @@ function copyHandler(value: () => string, confirmation: string) {
 
 /**
  * Standard "Installation ID: <id> [copy]" row, shared by any admin-panel
- * surface that surfaces the installation ID. Shows the full ID (this is
- * an install-admin-only context) and copies it to clipboard on click.
- * Rendered only once the ID has loaded; null renders nothing.
+ * surface that shows the installation ID. The displayed ID is redacted
+ * (first 6 characters, rest replaced with `*`) so it's safe to include
+ * in screenshots and screen shares; the full ID is still copied to the
+ * clipboard when the row is clicked. Rendered only once the ID has
+ * loaded; null renders nothing.
  */
 export function buildInstallationIdDisplay(installationId: Observable<string | null>) {
   return dom.maybe(installationId, id => cssInstallationId(
     dom("span", t("Installation ID:")),
-    dom("span", id),
+    dom("span", redactInstallationId(id)),
     copyHandler(() => id, t("Installation ID copied to clipboard")),
     testId("installation-id"),
     cssCopyButton(icon("Copy")),
     hoverTooltip(t("Copy to clipboard"), { key: TOOLTIP_KEY }),
   ));
+}
+
+function redactInstallationId(id: string): string {
+  if (id.length <= 6) { return id; }
+  return id.slice(0, 6) + "*".repeat(id.length - 6);
 }
 
 export const cssInput = styled(input, `

--- a/app/client/ui/ToggleEnterpriseWidget.ts
+++ b/app/client/ui/ToggleEnterpriseWidget.ts
@@ -36,9 +36,16 @@ export class ToggleEnterpriseWidget extends Disposable {
   private _activation = Observable.create<ActivationState | null>(this, null);
 
   private _state = Computed.create<State | null>(this, (use) => {
-    const status = use(this._model.status);
-    if (!use(this._isEnterpriseEdition) || !status) {
+    // "core" -- the opt-in state -- only applies when actually on Community.
+    // When we're on Full Grist but status hasn't loaded, return null so the
+    // section renders nothing rather than flashing an "Enable Full Grist"
+    // button.
+    if (!use(this._isEnterpriseEdition)) {
       return "core";
+    }
+    const status = use(this._model.status);
+    if (!status) {
+      return null;
     } else if (status.key) {
       return "activated";
     } else if (status.trial && status.trial.daysLeft > 0) {
@@ -75,16 +82,12 @@ export class ToggleEnterpriseWidget extends Disposable {
       testId("enterprise-content", this._isEnterpriseEdition),
       dom.domComputed(this._state, (state) => {
         switch (state) {
-          case "trial":
-            return this._trialCopy();
-          case "activated":
-            return this._activatedCopy();
-          case "no-key":
-            return this._noKeyCopy();
-          case "error":
-            return this._errorCopy();
-          default:
-            return this._coreCopy();
+          case "trial":    return this._trialCopy();
+          case "activated": return this._activatedCopy();
+          case "no-key":   return this._noKeyCopy();
+          case "error":    return this._errorCopy();
+          case "core":     return this._coreCopy();
+          default:         return null; // status not yet loaded
         }
       }),
       testId("enterprise-opt-in-section"),

--- a/app/client/ui/ToggleEnterpriseWidget.ts
+++ b/app/client/ui/ToggleEnterpriseWidget.ts
@@ -61,6 +61,15 @@ export class ToggleEnterpriseWidget extends Disposable {
     return this._isEnterpriseEdition;
   }
 
+  /**
+   * Observable for the install's installation ID. Populated by the existing
+   * enterprise activation-status fetch; null on community builds (where the
+   * `/api/activation/status` endpoint isn't mounted).
+   */
+  public getInstallationIdObservable() {
+    return this._model.installationId;
+  }
+
   public buildEnterpriseSection() {
     return cssSection(
       testId("enterprise-content", this._isEnterpriseEdition),
@@ -83,26 +92,10 @@ export class ToggleEnterpriseWidget extends Disposable {
   }
 
   private _buildPasteYourKey(show: BindableValue<boolean> = Observable.create(this, true)) {
-    const redactedInstallationId = Computed.create(this, this._model.installationId, (use, id) => {
-      // Leave only 6 first letter, rest convert to *.
-      return id ? id.slice(0, 6) + "*".repeat(id.length - 6) : "";
-    });
     return cssParagraph(
-      dom.autoDispose(redactedInstallationId),
       cssTextLine(
         dom("b", t(`Activation key`)),
-        cssInstallationId(
-          dom("span", t("Installation ID:")),
-          dom.text(redactedInstallationId),
-          copyHandler(() => this._model.installationId.get()!, t("Installation ID copied to clipboard")),
-          testId("installation-id"),
-          cssCopyButton(
-            icon("Copy"),
-          ),
-          hoverTooltip(t("Copy to clipboard"), {
-            key: TOOLTIP_KEY,
-          }),
-        ),
+        buildInstallationIdDisplay(this._model.installationId),
       ),
       cssInput(
         this._activationKey, { onInput: true }, { placeholder: t("Paste your activation key") },
@@ -129,12 +122,12 @@ export class ToggleEnterpriseWidget extends Disposable {
   private _trialCopy() {
     return [
       cssParagraph(
-        dom("b", t("You are currently trialing Grist Enterprise.")),
+        dom("b", t("You are currently trialing Full Grist.")),
       ),
       cssParagraph(
-        markdown(t(`An activation key is used to run Grist Enterprise after a trial period
+        markdown(t(`An activation key is used to run Full Grist after a trial period
 of 30 days has expired. Get an activation key by [contacting us]({{contactLink}}) today. You do
-not need an activation key to run Grist Core.
+not need an activation key to run Grist Community Edition.
 
 Learn more in our [Help Center]({{helpCenter}}).`, {
           contactLink: commonUrls.contact,
@@ -200,7 +193,7 @@ Learn more in our [Help Center]({{helpCenter}}).`, {
         dom.autoDispose(owner),
         cssRow(
           cssLabel(t("Plan name") + ":"),
-          dom("div", dom.text("Grist Enterprise")),
+          dom("div", dom.text("Full Grist")),
           testId("plan-name"),
         ),
         dom.maybe(expireAt, date => [
@@ -260,7 +253,7 @@ Learn more in our [Help Center]({{helpCenter}}).`, {
           testId("expired-info"),
           dom.domComputed(graceText, txt => cssParagraph(
             markdown((txt ? txt + " " : "") + t(
-              `To continue using Grist Enterprise, you need to
+              `To continue using Full Grist, you need to
                   [contact us]({{signupLink}}) to get your activation key.`, {
                 signupLink: commonUrls.contact,
               })),
@@ -277,7 +270,7 @@ Learn more in our [Help Center]({{helpCenter}}).`, {
       cssParagraph(
         enterpriseNotEnabledCopy(),
       ),
-      cssOptInButton(t("Enable Grist Enterprise"),
+      cssOptInButton(t("Enable Full Grist"),
         dom.on("click", () => this._isEnterpriseEdition.set(true)),
       ),
     ];
@@ -307,8 +300,8 @@ Learn more in our [Help Center]({{helpCenter}}).`, {
       dom.maybe(trialExpiredLocal, expireAt => [
         cssParagraph(
           markdown(t(
-            `Your trial period has expired on **{{expireAt}}**. To continue using Grist Enterprise, you need to
-[sign up for Grist Enterprise]({{signupLink}}) and paste your activation key below.`, {
+            `Your trial period has expired on **{{expireAt}}**. To continue using Full Grist, you need to
+[sign up for Full Grist]({{signupLink}}) and paste your activation key below.`, {
               signupLink: commonUrls.plans,
               expireAt,
             })),
@@ -317,8 +310,8 @@ Learn more in our [Help Center]({{helpCenter}}).`, {
       ]),
       dom.maybe(not(trialExpired), () => [
         cssParagraph(
-          markdown(t(`An active subscription is required to continue using Grist Enterprise. You can
-you activate your subscription by [signing up for Grist Enterprise ]({{signupLink}}) and pasting your
+          markdown(t(`An active subscription is required to continue using Full Grist. You can
+you activate your subscription by [signing up for Full Grist ]({{signupLink}}) and pasting your
 activation key below.`, {
             signupLink: commonUrls.plans,
           })),
@@ -344,10 +337,10 @@ activation key below.`, {
 function enterpriseNotEnabledCopy() {
   return [
     cssParagraph(
-      markdown(t(`An activation key is used to run Grist Enterprise after a trial period
+      markdown(t(`An activation key is used to run Full Grist after a trial period
         of 30 days has expired. Get an activation key by [signing up for Grist
         Enterprise]({{signupLink}}). You do not need an activation key to run
-        Grist Core.`, { signupLink: commonUrls.plans })),
+        Grist Community Edition.`, { signupLink: commonUrls.plans })),
     ),
     learnMoreLink(),
   ];
@@ -370,6 +363,23 @@ function copyHandler(value: () => string, confirmation: string) {
     });
     await copyToClipboard(value());
   });
+}
+
+/**
+ * Standard "Installation ID: <id> [copy]" row, shared by any admin-panel
+ * surface that surfaces the installation ID. Shows the full ID (this is
+ * an install-admin-only context) and copies it to clipboard on click.
+ * Rendered only once the ID has loaded; null renders nothing.
+ */
+export function buildInstallationIdDisplay(installationId: Observable<string | null>) {
+  return dom.maybe(installationId, id => cssInstallationId(
+    dom("span", t("Installation ID:")),
+    dom("span", id),
+    copyHandler(() => id, t("Installation ID copied to clipboard")),
+    testId("installation-id"),
+    cssCopyButton(icon("Copy")),
+    hoverTooltip(t("Copy to clipboard"), { key: TOOLTIP_KEY }),
+  ));
 }
 
 export const cssInput = styled(input, `

--- a/app/common/BootProbe.ts
+++ b/app/common/BootProbe.ts
@@ -18,13 +18,6 @@ export type BootProbeIds =
   "sandbox-providers"
 ;
 
-export interface HomeUrlBootProbeDetails {
-  // Effective APP_HOME_URL, or null if unset (server auto-detects from request).
-  value: string | null;
-  // Where the value came from: "env" (process.env), "db" (activation prefs), or null if unset.
-  source: "env" | "db" | null;
-}
-
 export interface BootProbeResult {
   verdict?: string;
   // Result of check.

--- a/app/common/BootProbe.ts
+++ b/app/common/BootProbe.ts
@@ -5,6 +5,7 @@ export type BootProbeIds =
   "admins" |
   "boot-key" |
   "health-check" |
+  "home-url" |
   "reachable" |
   "host-header" |
   "sandboxing" |
@@ -16,6 +17,13 @@ export type BootProbeIds =
   "backups" |
   "sandbox-providers"
 ;
+
+export interface HomeUrlBootProbeDetails {
+  // Effective APP_HOME_URL, or null if unset (server auto-detects from request).
+  value: string | null;
+  // Where the value came from: "env" (process.env), "db" (activation prefs), or null if unset.
+  source: "env" | "db" | null;
+}
 
 export interface BootProbeResult {
   verdict?: string;

--- a/app/common/ConfigAPI.ts
+++ b/app/common/ConfigAPI.ts
@@ -1,4 +1,5 @@
 import { BaseAPI, IOptions } from "app/common/BaseAPI";
+import { delay } from "app/common/delay";
 import { addCurrentOrgToPath } from "app/common/urlUtils";
 
 /**
@@ -47,6 +48,25 @@ export class ConfigAPI extends BaseAPI {
     if (!resp.ok) {
       throw new Error(await resp.text());
     }
+  }
+
+  /**
+   * Polls `healthcheck()` until it succeeds or `attempts` polls have elapsed.
+   * Returns true on success, false on timeout; callers decide how to surface
+   * the timeout (throw, silent, page reload, etc).
+   */
+  public async waitUntilReady({
+    attempts = 30,
+    intervalMs = 1000,
+  }: { attempts?: number; intervalMs?: number } = {}): Promise<boolean> {
+    for (let i = 0; i < attempts; i++) {
+      try {
+        await this.healthcheck();
+        return true;
+      } catch { /* not ready */ }
+      await delay(intervalMs);
+    }
+    return false;
   }
 
   /**

--- a/app/common/ConfigAPI.ts
+++ b/app/common/ConfigAPI.ts
@@ -18,6 +18,10 @@ export interface AuthProvider {
   metadata?: Record<string, any>; // Additional provide metadata.
 }
 
+export interface ServerConfig {
+  APP_HOME_URL: string | null;
+}
+
 /**
  * An API for accessing the internal Grist configuration, stored in
  * config.json.
@@ -86,6 +90,13 @@ export class ConfigAPI extends BaseAPI {
     const url = new URL(`${this._url}/api/config/auth-providers/config`);
     url.searchParams.append("provider", provider);
     return await this.requestJson(url.toString(), { method: "GET" });
+  }
+
+  /**
+   * Fetches the current server configuration (APP_HOME_URL).
+   */
+  public async getServerConfig(): Promise<ServerConfig> {
+    return await this.requestJson(`${this._url}/api/config/server`, { method: "GET" });
   }
 
   private get _url(): string {

--- a/app/common/ConfigAPI.ts
+++ b/app/common/ConfigAPI.ts
@@ -18,10 +18,6 @@ export interface AuthProvider {
   metadata?: Record<string, any>; // Additional provide metadata.
 }
 
-export interface ServerConfig {
-  APP_HOME_URL: string | null;
-}
-
 /**
  * An API for accessing the internal Grist configuration, stored in
  * config.json.
@@ -90,13 +86,6 @@ export class ConfigAPI extends BaseAPI {
     const url = new URL(`${this._url}/api/config/auth-providers/config`);
     url.searchParams.append("provider", provider);
     return await this.requestJson(url.toString(), { method: "GET" });
-  }
-
-  /**
-   * Fetches the current server configuration (APP_HOME_URL).
-   */
-  public async getServerConfig(): Promise<ServerConfig> {
-    return await this.requestJson(`${this._url}/api/config/server`, { method: "GET" });
   }
 
   private get _url(): string {

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -142,7 +142,7 @@ export const getCommonUrls = () => withAdminDefinedUrls({
   helpInstallAuditLogs: "https://support.getgrist.com/install/audit-log-overview/",
   helpTeamAuditLogs: "https://support.getgrist.com/install/audit-log-overview/",
   helpTelemetryLimited: "https://support.getgrist.com/telemetry-limited",
-  helpEnterpriseOptIn: "https://support.getgrist.com/self-managed/#how-do-i-enable-grist-enterprise",
+  helpEnterpriseOptIn: "https://support.getgrist.com/self-managed/#how-do-i-enable-the-full-edition-of-grist",
   helpCalendarWidget: "https://support.getgrist.com/widget-calendar",
   helpLinkKeys: "https://support.getgrist.com/examples/2021-04-link-keys",
   helpFilteringReferenceChoices: "https://support.getgrist.com/col-refs/#filtering-reference-choices-in-dropdown-lists",

--- a/app/server/lib/BootProbes.ts
+++ b/app/server/lib/BootProbes.ts
@@ -342,16 +342,14 @@ const _homeUrlProbe: Probe = {
   name: "Home URL",
   apply: async () => {
     const setting = appSettings.flag("homeUrl");
-    setting.readString({ envVar: "APP_HOME_URL" });
-    const described = setting.describe();
-    const value = (typeof described.value === "string" && described.value) ? described.value : null;
+    const value = setting.readString({ envVar: "APP_HOME_URL" }) || null;
     return {
       status: value ? "success" : "warning",
       verdict: value ? undefined :
         "APP_HOME_URL is not set; server auto-detects the URL from each request",
       details: {
         value,
-        source: described.source ?? null,
+        source: setting.describe().source ?? null,
       },
     };
   },

--- a/app/server/lib/BootProbes.ts
+++ b/app/server/lib/BootProbes.ts
@@ -61,6 +61,7 @@ export class BootProbes {
 
   private _addProbes() {
     this._probes.push(_homeUrlReachableProbe);
+    this._probes.push(_homeUrlProbe);
     this._probes.push(_statusCheckProbe);
     this._probes.push(_userProbe);
     this._probes.push(_bootKeyProbe);
@@ -325,6 +326,32 @@ const _sessionSecretProbe: Probe = {
       status: usingDefaultSessionSecret ? "warning" : "success",
       details: {
         GRIST_SESSION_SECRET: process.env.GRIST_SESSION_SECRET ? "set" : "not set",
+      },
+    };
+  },
+};
+
+// Reports whether APP_HOME_URL is configured, and whether it came from env or
+// from the activation prefs DB. Reads appSettings directly rather than the
+// memoized getHomeUrl() helper in gristSettings.ts, so that nested sections
+// (e.g. an admin re-reading this flag) see the same live view of env+DB state
+// that appSettings maintains. APP_HOME_URL is restart-required, so the DB
+// value that was loaded at boot is the value the rest of the server is using.
+const _homeUrlProbe: Probe = {
+  id: "home-url",
+  name: "Home URL",
+  apply: async () => {
+    const setting = appSettings.flag("homeUrl");
+    setting.readString({ envVar: "APP_HOME_URL" });
+    const described = setting.describe();
+    const value = (typeof described.value === "string" && described.value) ? described.value : null;
+    return {
+      status: value ? "success" : "warning",
+      verdict: value ? undefined :
+        "APP_HOME_URL is not set; server auto-detects the URL from each request",
+      details: {
+        value,
+        source: described.source ?? null,
       },
     };
   },

--- a/app/server/lib/ConfigBackendAPI.ts
+++ b/app/server/lib/ConfigBackendAPI.ts
@@ -95,6 +95,25 @@ export class ConfigBackendAPI {
       });
     }));
 
+    // GET /api/config/server
+    // Returns the persisted APP_HOME_URL, or null if unset (client falls
+    // back to auto-detecting from window.location). Reads directly from
+    // activation prefs + process.env rather than through the memoized
+    // gristSettings accessor -- APP_HOME_URL is restart-required, so the
+    // memoized value lags the DB until restart, which isn't what the admin
+    // panel wants to show after a write.
+    //
+    // Writes go through PATCH /api/install/prefs with
+    // `{ envVars: { APP_HOME_URL: ... } }` followed by a restart.
+    app.get("/api/config/server", requireInstallAdmin, expressWrap(async (req, resp) => {
+      const activation = await this._activations.current();
+      const fromDb = activation.prefs?.envVars?.APP_HOME_URL as string | undefined;
+      const fromEnv = process.env.APP_HOME_URL;
+      return sendOkReply(req, resp, {
+        APP_HOME_URL: fromDb || fromEnv || null,
+      });
+    }));
+
     app.get("/api/config/:key", requireInstallAdmin, expressWrap((req, resp) => {
       log.debug("config: requesting configuration", req.params);
 

--- a/app/server/lib/ConfigBackendAPI.ts
+++ b/app/server/lib/ConfigBackendAPI.ts
@@ -95,25 +95,6 @@ export class ConfigBackendAPI {
       });
     }));
 
-    // GET /api/config/server
-    // Returns the persisted APP_HOME_URL, or null if unset (client falls
-    // back to auto-detecting from window.location). Reads directly from
-    // activation prefs + process.env rather than through the memoized
-    // gristSettings accessor -- APP_HOME_URL is restart-required, so the
-    // memoized value lags the DB until restart, which isn't what the admin
-    // panel wants to show after a write.
-    //
-    // Writes go through PATCH /api/install/prefs with
-    // `{ envVars: { APP_HOME_URL: ... } }` followed by a restart.
-    app.get("/api/config/server", requireInstallAdmin, expressWrap(async (req, resp) => {
-      const activation = await this._activations.current();
-      const fromDb = activation.prefs?.envVars?.APP_HOME_URL as string | undefined;
-      const fromEnv = process.env.APP_HOME_URL;
-      return sendOkReply(req, resp, {
-        APP_HOME_URL: fromDb || fromEnv || null,
-      });
-    }));
-
     app.get("/api/config/:key", requireInstallAdmin, expressWrap((req, resp) => {
       log.debug("config: requesting configuration", req.params);
 

--- a/storybook/baseUrlSection.stories.ts
+++ b/storybook/baseUrlSection.stories.ts
@@ -1,0 +1,46 @@
+import { BaseUrlSection } from "app/client/ui/BaseUrlSection";
+
+import { styled } from "grainjs";
+
+export default {
+  title: "Admin panel/BaseUrlSection",
+  parameters: {
+    docs: { codePanel: true, source: { type: "code" } },
+  },
+};
+
+/**
+ * Base URL section. Used in the admin panel (`buildDom()`) and in the
+ * setup wizard (`buildWizardDom()`, which adds a "Leave automatic" button).
+ *
+ * The section does its own GET/PATCH against `/api/config/server` and
+ * `/api/install/prefs` at construction time, so these stories will hit
+ * whatever server the Storybook runner is pointed at. To preview pure
+ * visual states without a server, stub the APIs or run against a fixture.
+ */
+
+export const AdminPanelMode = {
+  render: (_args: any, { owner }: any) => {
+    const section = BaseUrlSection.create(owner, {});
+    return cssFrame(section.buildDom());
+  },
+};
+
+export const WizardMode = {
+  render: (_args: any, { owner }: any) => {
+    const section = BaseUrlSection.create(owner, {});
+    return cssFrame(section.buildWizardDom());
+  },
+};
+
+export const StatusDisplay = {
+  render: (_args: any, { owner }: any) => {
+    const section = BaseUrlSection.create(owner, {});
+    return cssFrame(section.buildStatusDisplay());
+  },
+};
+
+const cssFrame = styled("div", `
+  padding: 24px;
+  max-width: 520px;
+`);

--- a/storybook/baseUrlSection.stories.ts
+++ b/storybook/baseUrlSection.stories.ts
@@ -13,10 +13,11 @@ export default {
  * Base URL section. Used in the admin panel (`buildDom()`) and in the
  * setup wizard (`buildWizardDom()`, which adds a "Leave automatic" button).
  *
- * The section does its own GET/PATCH against `/api/config/server` and
- * `/api/install/prefs` at construction time, so these stories will hit
- * whatever server the Storybook runner is pointed at. To preview pure
- * visual states without a server, stub the APIs or run against a fixture.
+ * The section fetches the current URL via the `home-url` boot probe
+ * (`GET /api/probes/home-url`) and writes changes via
+ * `PATCH /api/install/prefs`, so these stories will hit whatever server
+ * the Storybook runner is pointed at. To preview pure visual states
+ * without a server, stub the APIs or run against a fixture.
  */
 
 export const AdminPanelMode = {

--- a/storybook/editionSection.stories.ts
+++ b/storybook/editionSection.stories.ts
@@ -1,0 +1,61 @@
+import { EditionSection } from "app/client/ui/EditionSection";
+
+import { styled } from "grainjs";
+
+export default {
+  title: "Admin panel/EditionSection",
+  parameters: {
+    docs: { codePanel: true, source: { type: "code" } },
+  },
+};
+
+/**
+ * Edition selector: Community vs Full Grist. The `availability` option
+ * lets stories drive which buttons are shown without depending on the
+ * enterprise build's `showEnterpriseToggle()` at runtime.
+ *
+ * Stories exercise only the wizard-mode selector; the admin-panel mode
+ * embeds the full `ToggleEnterpriseWidget` lifecycle, which needs a
+ * `Notifier` and live activation data to render meaningfully.
+ */
+
+export const CommunityOnly = {
+  render: (_args: any, { owner }: any) => {
+    const section = EditionSection.create(owner, {
+      availability: { fullGristAvailable: false, communityAvailable: true },
+    });
+    return cssFrame(section.buildWizardDom());
+  },
+};
+
+export const FullAndCommunity = {
+  render: (_args: any, { owner }: any) => {
+    const section = EditionSection.create(owner, {
+      availability: { fullGristAvailable: true, communityAvailable: true },
+    });
+    return cssFrame(section.buildWizardDom());
+  },
+};
+
+export const FullOnly = {
+  render: (_args: any, { owner }: any) => {
+    const section = EditionSection.create(owner, {
+      availability: { fullGristAvailable: true, communityAvailable: false },
+    });
+    return cssFrame(section.buildWizardDom());
+  },
+};
+
+export const StatusDisplay = {
+  render: (_args: any, { owner }: any) => {
+    const section = EditionSection.create(owner, {
+      availability: { fullGristAvailable: true, communityAvailable: true },
+    });
+    return cssFrame(section.buildStatusDisplay());
+  },
+};
+
+const cssFrame = styled("div", `
+  padding: 24px;
+  max-width: 520px;
+`);

--- a/storybook/editionSection.stories.ts
+++ b/storybook/editionSection.stories.ts
@@ -1,6 +1,8 @@
+import { Notifier } from "app/client/models/NotifyModel";
+import { AdminPanelControls } from "app/client/ui/AdminPanelCss";
 import { EditionSection } from "app/client/ui/EditionSection";
 
-import { styled } from "grainjs";
+import { Disposable, DomContents, Observable, styled } from "grainjs";
 
 export default {
   title: "Admin panel/EditionSection",
@@ -9,51 +11,116 @@ export default {
   },
 };
 
+// --- Helpers ----------------------------------------------------------------
+
+function createControls(owner: Disposable): AdminPanelControls {
+  return {
+    needsRestart: Observable.create(owner, false),
+    restartGrist: async () => { /* no-op in storybook */ },
+  };
+}
+
+// ToggleEnterpriseWidget reads `deploymentType` and `activation` straight
+// from window.gristConfig, so stories need to swap it to drive the widget
+// into specific visual states.
+function withGristConfig(owner: Disposable, config: Record<string, unknown>) {
+  const prev = (window as any).gristConfig;
+  (window as any).gristConfig = { ...prev, ...config };
+  owner.onDispose(() => { (window as any).gristConfig = prev; });
+}
+
+type EditionSectionOverrides =
+  NonNullable<Parameters<typeof EditionSection.create>[1]>["overrides"];
+
+interface AdminStoryArgs {
+  deploymentType?: "core" | "enterprise";
+  overrides: EditionSectionOverrides;
+  build?: (section: EditionSection) => DomContents;
+}
+
+function adminStory({ deploymentType, overrides, build }: AdminStoryArgs) {
+  return {
+    render: (_args: any, { owner }: any) => {
+      if (deploymentType) { withGristConfig(owner, { deploymentType }); }
+      const section = EditionSection.create(owner, {
+        controls: createControls(owner),
+        notifier: Notifier.create(owner),
+        overrides,
+      });
+      return cssFrame((build ?? (s => s.buildDom()))(section));
+    },
+  };
+}
+
+function wizardStory(overrides: EditionSectionOverrides) {
+  return {
+    render: (_args: any, { owner }: any) =>
+      cssFrame(EditionSection.create(owner, { overrides }).buildWizardDom()),
+  };
+}
+
+function statusStory(args: AdminStoryArgs) {
+  return adminStory({ ...args, build: s => s.buildStatusDisplay() });
+}
+
+// --- Admin-panel mode stories ----------------------------------------------
+
+/** Community-only build: no selector, just a note. */
+export const AdminCommunityOnly = adminStory({
+  overrides: { fullGristAvailable: false },
+});
+
 /**
- * Edition selector: Community vs Full Grist. The `availability` option
- * lets stories drive which buttons are shown without depending on the
- * enterprise build's `showEnterpriseToggle()` at runtime.
- *
- * Stories exercise only the wizard-mode selector; the admin-panel mode
- * embeds the full `ToggleEnterpriseWidget` lifecycle, which needs a
- * `Notifier` and live activation data to render meaningfully.
+ * Full Grist build, server currently running Community. Shows the selector;
+ * the legacy ToggleEnterpriseWidget is hidden to avoid duplicating its
+ * "Enable Full Grist" button.
  */
+export const AdminServerCore = adminStory({
+  deploymentType: "core",
+  overrides: { fullGristAvailable: true, initialServerEdition: "core" },
+});
 
-export const CommunityOnly = {
-  render: (_args: any, { owner }: any) => {
-    const section = EditionSection.create(owner, {
-      availability: { fullGristAvailable: false, communityAvailable: true },
-    });
-    return cssFrame(section.buildWizardDom());
-  },
-};
+/**
+ * Full Grist build, server currently running Full Grist. Shows the selector
+ * AND the ToggleEnterpriseWidget below (activation-key / trial / license
+ * UI). The widget's activation fetch fails silently in storybook and the
+ * widget renders its initial state.
+ */
+export const AdminServerFull = adminStory({
+  deploymentType: "enterprise",
+  overrides: { fullGristAvailable: true, initialServerEdition: "enterprise" },
+});
 
-export const FullAndCommunity = {
-  render: (_args: any, { owner }: any) => {
-    const section = EditionSection.create(owner, {
-      availability: { fullGristAvailable: true, communityAvailable: true },
-    });
-    return cssFrame(section.buildWizardDom());
+/** Edition forced via GRIST_FORCE_ENABLE_ENTERPRISE: no selector, env note. */
+export const AdminEditionForced = adminStory({
+  deploymentType: "enterprise",
+  overrides: {
+    fullGristAvailable: true,
+    editionForced: true,
+    initialServerEdition: "enterprise",
   },
-};
+});
 
-export const FullOnly = {
-  render: (_args: any, { owner }: any) => {
-    const section = EditionSection.create(owner, {
-      availability: { fullGristAvailable: true, communityAvailable: false },
-    });
-    return cssFrame(section.buildWizardDom());
-  },
-};
+// --- Status-pill stories ----------------------------------------------------
 
-export const StatusDisplay = {
-  render: (_args: any, { owner }: any) => {
-    const section = EditionSection.create(owner, {
-      availability: { fullGristAvailable: true, communityAvailable: true },
-    });
-    return cssFrame(section.buildStatusDisplay());
-  },
-};
+export const StatusCommunity = statusStory({
+  overrides: { fullGristAvailable: false },
+});
+
+export const StatusForced = statusStory({
+  overrides: { fullGristAvailable: true, editionForced: true },
+});
+
+export const StatusFull = statusStory({
+  deploymentType: "enterprise",
+  overrides: { fullGristAvailable: true, initialServerEdition: "enterprise" },
+});
+
+// --- Wizard-mode stories ----------------------------------------------------
+
+export const WizardCommunityOnly = wizardStory({ fullGristAvailable: false });
+
+export const WizardFullAndCommunity = wizardStory({ fullGristAvailable: true });
 
 const cssFrame = styled("div", `
   padding: 24px;

--- a/test/nbrowser/AdminPanelServer.ts
+++ b/test/nbrowser/AdminPanelServer.ts
@@ -81,7 +81,6 @@ describe("AdminPanelServer", function() {
         input,
       );
       await driver.sendKeys(`${server.getHost()}/`);
-      await driver.sleep(300);
 
       // Still in Test URL phase.
       assert.isTrue(await driver.findContent(".test-base-url-test", /Test URL/).isPresent());
@@ -221,25 +220,11 @@ describe("AdminPanelServer", function() {
         assert.isTrue(await confirmBtn.isDisplayed());
       });
 
-      it("should disable input after confirming", async function() {
-        const confirmBtn = await driver.findContent("button", /Confirm URL/);
-        await confirmBtn.click();
-        await driver.sleep(300);
+      it("should revert to Test URL when URL is changed after a passing test", async function() {
+        // Precondition: Confirm URL is visible (set by the previous test) and Test URL is not.
+        assert.isTrue(await driver.findContent(".test-base-url-save", /Confirm URL/).isPresent());
+        assert.isFalse(await driver.findContent(".test-base-url-test", /Test URL/).isPresent());
 
-        const input = await driver.find(".test-base-url-input");
-        assert.isNotNull(await input.getAttribute("disabled"));
-      });
-
-      it("should re-enable input after clicking edit", async function() {
-        const editBtn = await driver.find(".test-base-url-edit");
-        await editBtn.click();
-        await driver.sleep(300);
-
-        const input = await driver.find(".test-base-url-input");
-        assert.isNull(await input.getAttribute("disabled"));
-      });
-
-      it("should revert to Test URL when URL is changed", async function() {
         const input = await driver.find(".test-base-url-input");
         await input.click();
         await driver.executeScript(
@@ -248,11 +233,10 @@ describe("AdminPanelServer", function() {
           input,
         );
         await driver.sendKeys("http://nonexistent.invalid");
-        await driver.sleep(200);
 
-        // Should show Test URL again, not Confirm URL.
-        const testBtn = await driver.findContentWait("button", /Test URL/, 1000);
-        assert.isTrue(await testBtn.isDisplayed());
+        // Should revert to Test URL; Confirm URL should be gone.
+        await driver.findContentWait(".test-base-url-test", /Test URL/, 1000);
+        assert.isFalse(await driver.findContent(".test-base-url-save", /Confirm URL/).isPresent());
       });
 
       it("should show error when test fails", async function() {
@@ -261,6 +245,33 @@ describe("AdminPanelServer", function() {
         // BaseUrlSection._testUrl aborts after 10s; wait longer so a slow
         // DNS/network failure has time to surface.
         await driver.findContentWait(".test-base-url-test-status", /Could not reach/i, 15000);
+      });
+
+      it("should disable input after confirming", async function() {
+        // Restore a working URL and re-test so we have a Confirm URL button to click.
+        const input = await driver.find(".test-base-url-input");
+        await driver.executeScript(
+          `arguments[0].value = arguments[1];
+           arguments[0].dispatchEvent(new Event('input', { bubbles: true }));`,
+          input, server.getHost(),
+        );
+        const testBtn = await driver.findContent("button", /Test URL/);
+        await testBtn.click();
+        await driver.findContentWait(".test-base-url-test-status", /reachable/i, 5000);
+
+        const confirmBtn = await driver.findContentWait("button", /Confirm URL/, 3000);
+        await confirmBtn.click();
+
+        await driver.findWait(".test-base-url-confirmed-row", 2000);
+        assert.isNotNull(await driver.find(".test-base-url-input").getAttribute("disabled"));
+      });
+
+      it("should re-enable input after clicking edit", async function() {
+        const editBtn = await driver.find(".test-base-url-edit");
+        await editBtn.click();
+
+        await driver.wait(async () =>
+          (await driver.find(".test-base-url-input").getAttribute("disabled")) === null, 2000);
       });
     });
 

--- a/test/nbrowser/AdminPanelServer.ts
+++ b/test/nbrowser/AdminPanelServer.ts
@@ -98,6 +98,8 @@ describe("AdminPanelServer", function() {
       const confirmBtn = await driver.findContent(".test-base-url-save", /Confirm URL/);
       await confirmBtn.click();
       await driver.findWait(".test-base-url-confirmed-row", 2000);
+
+      await driver.findContentWait(".test-admin-panel-restart-button", /Restart Grist/, 2000);
     });
 
     it("should persist the URL via the API", async function() {

--- a/test/nbrowser/AdminPanelServer.ts
+++ b/test/nbrowser/AdminPanelServer.ts
@@ -1,0 +1,304 @@
+import * as gu from "test/nbrowser/gristUtils";
+import { server, setupTestSuite } from "test/nbrowser/testUtils";
+import * as testUtils from "test/server/testUtils";
+
+import { assert, driver } from "mocha-webdriver";
+
+/**
+ * Read activation install prefs from the running server. Requires the
+ * browser to be on a same-origin admin page so the fetch is authenticated.
+ */
+async function getInstallPrefs(): Promise<{ envVars?: Record<string, string | undefined> }> {
+  return driver.executeScript(
+    "return fetch('/api/install/prefs').then(r => r.json())",
+  );
+}
+
+/** PATCH activation envVars. Pass `null` for a key to clear it. */
+async function setEnvVars(envVars: Record<string, string | null>): Promise<void> {
+  const status = await driver.executeScript<number>(`
+    return fetch('/api/install/prefs', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: ${JSON.stringify(JSON.stringify({ envVars }))},
+    }).then(r => r.status);
+  `);
+  assert.equal(status, 200);
+}
+
+describe("AdminPanelServer", function() {
+  this.timeout(300000);
+  setupTestSuite();
+
+  let oldEnv: testUtils.EnvironmentSnapshot;
+  afterEach(() => gu.checkForErrors());
+
+  before(async function() {
+    oldEnv = new testUtils.EnvironmentSnapshot();
+    process.env.GRIST_TEST_SERVER_DEPLOYMENT_TYPE = "core";
+    process.env.GRIST_DEFAULT_EMAIL = gu.session().email;
+    await server.restart(true);
+  });
+
+  after(async function() {
+    oldEnv.restore();
+    await server.restart(true);
+  });
+
+  describe("Admin panel Server section", function() {
+    before(async function() {
+      await gu.session().personalSite.login();
+      await driver.get(`${server.getHost()}/admin`);
+      await gu.waitForAdminPanel();
+    });
+
+    it("should show Base URL item in the Server section", async function() {
+      const item = await driver.findWait(".test-admin-panel-item-base-url", 3000);
+      assert.equal(await item.isDisplayed(), true);
+      assert.match(await item.getText(), /Base URL/);
+    });
+
+    it("should show Edition item in the Server section", async function() {
+      const item = await driver.findWait(".test-admin-panel-item-edition", 3000);
+      assert.equal(await item.isDisplayed(), true);
+      assert.match(await item.getText(), /Edition/);
+    });
+
+    it("should not flag Base URL as dirty until Test + Confirm", async function() {
+      // Do everything in one expanded session so the item stays open.
+      const header = await driver.findWait(".test-admin-panel-item-name-base-url", 1000);
+      await header.click();
+      await driver.sleep(500);
+
+      // Edit the URL. Typing alone should NOT flag Base URL as dirty — the
+      // confirmed pill should stay hidden, the Confirm URL button should
+      // not appear, and the user should be in the Test URL phase.
+      const input = await driver.findWait(".test-base-url-input", 1000);
+      await input.click();
+      await driver.executeScript(
+        "arguments[0].value = '';" +
+        "arguments[0].dispatchEvent(new Event('input', { bubbles: true }));",
+        input,
+      );
+      await driver.sendKeys(`${server.getHost()}/`);
+      await driver.sleep(300);
+
+      // Still in Test URL phase.
+      assert.isTrue(await driver.findContent(".test-base-url-test", /Test URL/).isPresent());
+      assert.isFalse(await driver.findContent(".test-base-url-save", /Confirm URL/).isPresent());
+      assert.isFalse(await driver.find(".test-base-url-confirmed-row").isPresent());
+
+      // Click Test URL — still no confirmed row, just validation result.
+      const testBtn = await driver.find(".test-base-url-test");
+      await testBtn.click();
+      await driver.findContentWait(".test-base-url-test-status", /reachable/i, 5000);
+      assert.isFalse(await driver.find(".test-base-url-confirmed-row").isPresent());
+
+      // Click Confirm URL — NOW the confirmed row appears.
+      const confirmBtn = await driver.findContent(".test-base-url-save", /Confirm URL/);
+      await confirmBtn.click();
+      await driver.findWait(".test-base-url-confirmed-row", 2000);
+    });
+
+    it("should persist the URL via the API", async function() {
+      // We can't actually click "Restart Grist" here because it would
+      // restart and reload, so verify persistence via the endpoint that
+      // the Apply and Continue button uses.
+      await setEnvVars({ APP_HOME_URL: "http://test.example.com" });
+      const prefs = await getInstallPrefs();
+      assert.equal(prefs.envVars?.APP_HOME_URL, "http://test.example.com");
+    });
+
+    after(async function() {
+      // Undo the URL set by the persistence test so the wizard suite
+      // below starts from an unset APP_HOME_URL.
+      await setEnvVars({ APP_HOME_URL: null });
+    });
+  });
+
+  describe("Setup wizard Server step", function() {
+    before(async function() {
+      await gu.session().personalSite.login();
+    });
+
+    it("should show the Server step with Base URL and Edition", async function() {
+      await driver.get(`${server.getHost()}/admin/setup`);
+      await gu.waitForAdminPanel();
+
+      await driver.findContentWait("div", /Server/, 3000);
+      await driver.findContentWait("h3", /Base URL/, 3000);
+      await driver.findContentWait("h3", /Edition/, 3000);
+    });
+
+    it("should show disabled continue button initially", async function() {
+      const btn = await driver.findWait(".test-quick-setup-server-continue", 3000);
+      // disabled attribute is either "" (grainjs boolAttr) or "true" depending on setter.
+      assert.isNotNull(await btn.getAttribute("disabled"));
+      // Wait for the Computed-driven button text to resolve.
+      await driver.findContentWait(".test-quick-setup-server-continue",
+        /Confirm.*base URL.*edition/i, 3000);
+    });
+
+    describe("getting through without changes", function() {
+      // APP_HOME_URL is not set in this test env, so "Leave automatic"
+      // produces no change and the Continue button offers Continue (not
+      // Apply). When APP_HOME_URL is set, the same choice would be dirty
+      // and would clear the URL via PATCH /install/prefs instead.
+      it("should allow leaving Base URL automatic", async function() {
+        const skipUrl = await driver.findContentWait("button", /Leave automatic/, 3000);
+        await skipUrl.click();
+        await driver.sleep(300);
+
+        assert.isTrue(await driver.findContent(".test-base-url-confirmed-row", /Automatic/).isDisplayed());
+      });
+
+      it("should allow confirming Community Edition", async function() {
+        // Explicitly pick Community first: on builds where Full Grist is
+        // available the default selection is "enterprise", which would mark
+        // Edition dirty (server is "core") and flip the button text.
+        const community = await driver.findContentWait(".test-edition-community", /Community/, 3000);
+        await community.click();
+        await driver.sleep(100);
+
+        const confirmEdition = await driver.findContentWait("button", /Confirm edition/, 3000);
+        await confirmEdition.click();
+        await driver.sleep(300);
+
+        assert.isTrue(await driver.findContent(".test-edition-confirmed-row", /Confirmed/).isDisplayed());
+      });
+
+      it("should show Continue (not Apply) when nothing changed", async function() {
+        const btn = await driver.find(".test-quick-setup-server-continue");
+        assert.equal(await btn.getAttribute("disabled"), null);
+        assert.equal(await btn.getText(), "Continue");
+      });
+
+      it("should advance to the next step on Continue", async function() {
+        const btn = await driver.find(".test-quick-setup-server-continue");
+        await btn.click();
+        await driver.sleep(500);
+
+        assert.equal(await driver.find(".test-base-url-section").isPresent(), false);
+      });
+    });
+
+    describe("Test URL flow", function() {
+      before(async function() {
+        await driver.get(`${server.getHost()}/admin/setup`);
+        await gu.waitForAdminPanel();
+      });
+
+      it("should show Test URL button initially", async function() {
+        await driver.findContentWait(".test-base-url-test", /Test URL/, 3000);
+        // In wizard mode the save button is the "Confirm URL" button, shown only after testing.
+        // It should not be present initially (before testing).
+        assert.isFalse(await driver.findContent(".test-base-url-save", /Confirm URL/).isPresent());
+      });
+
+      it("should test the URL and show success", async function() {
+        // Set input to the actual server host so the test fetch succeeds.
+        const input = await driver.find(".test-base-url-input");
+        await driver.executeScript(
+          `arguments[0].value = arguments[1];
+           arguments[0].dispatchEvent(new Event('input', { bubbles: true }));`,
+          input, server.getHost(),
+        );
+        const testBtn = await driver.findContentWait("button", /Test URL/, 3000);
+        await testBtn.click();
+        // Wait for the test result.
+        await driver.findWait(".test-base-url-test-status", 5000);
+        await driver.sleep(500);
+
+        // Should show reachable message.
+        const status = await driver.find(".test-base-url-test-status").getText();
+        assert.match(status, /reachable/i);
+      });
+
+      it("should show Confirm URL after successful test", async function() {
+        const confirmBtn = await driver.findContentWait("button", /Confirm URL/, 3000);
+        assert.isTrue(await confirmBtn.isDisplayed());
+      });
+
+      it("should disable input after confirming", async function() {
+        const confirmBtn = await driver.findContent("button", /Confirm URL/);
+        await confirmBtn.click();
+        await driver.sleep(300);
+
+        const input = await driver.find(".test-base-url-input");
+        assert.isNotNull(await input.getAttribute("disabled"));
+      });
+
+      it("should re-enable input after clicking edit", async function() {
+        const editBtn = await driver.find(".test-base-url-edit");
+        await editBtn.click();
+        await driver.sleep(300);
+
+        const input = await driver.find(".test-base-url-input");
+        assert.isNull(await input.getAttribute("disabled"));
+      });
+
+      it("should revert to Test URL when URL is changed", async function() {
+        const input = await driver.find(".test-base-url-input");
+        await input.click();
+        await driver.executeScript(
+          "arguments[0].value = '';" +
+          "arguments[0].dispatchEvent(new Event('input', { bubbles: true }));",
+          input,
+        );
+        await driver.sendKeys("http://nonexistent.invalid");
+        await driver.sleep(200);
+
+        // Should show Test URL again, not Confirm URL.
+        const testBtn = await driver.findContentWait("button", /Test URL/, 1000);
+        assert.isTrue(await testBtn.isDisplayed());
+      });
+
+      it("should show error when test fails", async function() {
+        const testBtn = await driver.findContent("button", /Test URL/);
+        await testBtn.click();
+        // BaseUrlSection._testUrl aborts after 10s; wait longer so a slow
+        // DNS/network failure has time to surface.
+        await driver.findContentWait(".test-base-url-test-status", /Could not reach/i, 15000);
+      });
+    });
+
+    describe("Apply and Continue", function() {
+      before(async function() {
+        await driver.get(`${server.getHost()}/admin/setup`);
+        await gu.waitForAdminPanel();
+      });
+
+      it("should show Apply and Continue when URL differs from server", async function() {
+        // Test and confirm the URL (use the actual server host so the test passes).
+        const input = await driver.findWait(".test-base-url-input", 3000);
+        await input.click();
+        await driver.executeScript(
+          "arguments[0].value = '';" +
+          "arguments[0].dispatchEvent(new Event('input', { bubbles: true }));",
+          input,
+        );
+        await driver.sendKeys(`${server.getHost()}`);
+        await driver.sleep(200);
+
+        // Test it first.
+        const testBtn = await driver.find(".test-base-url-test");
+        await testBtn.click();
+        await driver.findContentWait(".test-base-url-test-status", /reachable/i, 5000);
+
+        // Confirm URL.
+        const confirmUrl = await driver.find(".test-base-url-save");
+        await confirmUrl.click();
+        await driver.sleep(300);
+
+        // Confirm edition.
+        const confirmEdition = await driver.find(".test-edition-confirm");
+        await confirmEdition.click();
+        await driver.sleep(300);
+
+        // Button should say "Apply and Continue".
+        await driver.findContentWait(".test-quick-setup-server-continue",
+          /Apply and Continue/, 3000);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fills in the Server piece of the `/admin/setup` wizard and its
admin-panel counterpart -- Base URL and Edition -- plus the shared
apply/restart plumbing the other wizard steps can plug into.

Highlights:

- `BaseUrlSection` with a Test-URL-then-Confirm flow.
- `EditionSection` reusing the existing `ToggleEnterpriseWidget` in
  admin-panel mode; a simple Community vs Full Grist picker in wizard
  mode.
- `PendingChangesManager` + `PartialApplyError`: sections implement a
  small `ConfigSection` interface, the manager batches apply()s,
  restarts the server once at the end when needed.
