### PR TITLE
Add BackupsSection to QuickSetup and AdminPanel

### DIFF
--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -15,7 +15,10 @@ import {
   AdminPanelControls,
   AdminSection,
   AdminSectionItem,
+  cssDangerText,
+  cssErrorText,
   cssFlexSpace,
+  cssHappyText,
   cssIconWrapper as cssWellIcon,
   cssSection,
   cssSectionTitle,
@@ -29,6 +32,7 @@ import { getAdminPanelName } from "app/client/ui/AdminPanelName";
 import { App } from "app/client/ui/App";
 import { AuditLogStreamingConfig, getDestinationDisplayName } from "app/client/ui/AuditLogStreamingConfig";
 import { AuthenticationSection } from "app/client/ui/AuthenticationSection";
+import { BackupsSection } from "app/client/ui/BackupsSection";
 import { BootKeyStatus } from "app/client/ui/BootKeyStatus";
 import { InstallConfigsAPI } from "app/client/ui/ConfigsAPI";
 import { pagePanels } from "app/client/ui/PagePanels";
@@ -345,6 +349,7 @@ Please log in as an administrator.`)),
           expandedContent: this._buildSessionSecretNotice(),
         }),
       ]),
+      this._buildBackupsSection(),
       this._buildAuditLogsSection(),
       dom.create(AdminSection, t("Version"), [
         dom.create(AdminSectionItem, {
@@ -863,6 +868,7 @@ Set the environment variable GRIST_ALLOW_AUTOMATIC_VERSION_CHECKING to "true" to
             "authentication",
             "session-secret",
             "service-status",
+            "backups",
           ].includes(probe.id);
           const show = isRedundant ? options.showRedundant : options.showNovel;
           if (!show) { return null; }
@@ -936,6 +942,19 @@ Set the environment variable GRIST_ALLOW_AUTOMATIC_VERSION_CHECKING to "true" to
         // should not arrive here
         return "??";
     }
+  }
+
+  private _buildBackupsSection() {
+    const backups = BackupsSection.create(this, { checks: this._checks, hideTitle: true });
+    return dom.create(AdminSection, t("Storage"), [
+      dom.create(AdminSectionItem, {
+        id: "backups",
+        name: t("Backups"),
+        description: t("Back up documents externally"),
+        value: backups.buildStatusDisplay(),
+        expandedContent: backups.buildDom(),
+      }),
+    ]);
   }
 
   private _buildAuditLogsSection() {
@@ -1076,18 +1095,6 @@ const cssCheckNowButton = styled(basicButton, `
 
 const cssGrayed = styled("span", `
   color: ${theme.lightText};
-`);
-
-const cssErrorText = styled("span", `
-  color: ${theme.errorText};
-`);
-
-const cssDangerText = styled("div", `
-  color: ${theme.dangerText};
-`);
-
-const cssHappyText = styled("span", `
-  color: ${theme.controlFg};
 `);
 
 const cssLabel = styled("div", `

--- a/app/client/ui/AdminPanelCss.ts
+++ b/app/client/ui/AdminPanelCss.ts
@@ -260,6 +260,18 @@ export const cssValueLabel = styled("div", `
   border-radius: ${vars.controlBorderRadius};
 `);
 
+export const cssErrorText = styled("span", `
+  color: ${theme.errorText};
+`);
+
+export const cssDangerText = styled("div", `
+  color: ${theme.dangerText};
+`);
+
+export const cssHappyText = styled("span", `
+  color: ${theme.controlFg};
+`);
+
 export const cssTextArea = styled(textarea, `
   color: ${theme.inputFg};
   background-color: ${theme.inputBg};

--- a/app/client/ui/BackupsSection.ts
+++ b/app/client/ui/BackupsSection.ts
@@ -28,7 +28,6 @@ const STORAGE_BACKENDS: Record<BackendName, BackendInfo> = {
   minio: {
     label: () => t("S3 (MinIO client)"),
     description: () => t("AWS S3-compatible service via MinIO client library. Works with AWS S3, MinIO, and others."),
-    disabledTag: () => t("Available in full edition"),
   },
   s3: {
     label: () => t("S3 (AWS client)"),
@@ -48,7 +47,7 @@ const STORAGE_BACKENDS: Record<BackendName, BackendInfo> = {
 
 export interface BackupsSectionProps {
   checks: AdminChecks;
-  /** Default: `false`. */
+  /** Hides the "Backups" title above the list of available backends (default: `false`). */
   hideTitle?: boolean;
 }
 

--- a/app/client/ui/BackupsSection.ts
+++ b/app/client/ui/BackupsSection.ts
@@ -150,7 +150,7 @@ export class BackupsSection extends Disposable {
       cssBackendBody(
         cssBackendNameRow(
           cssBackendName(STORAGE_BACKENDS[name].label),
-          dom.maybe(use => use(this._activeBackend) ?? "none" === name, () =>
+          dom.maybe(use => (use(this._activeBackend) ?? "none") === name, () =>
             cssBackendTag(cssBackendTag.cls("-active"), t("Active")),
           ),
           disabled ? cssBackendTag(cssBackendTag.cls("-disabled"), STORAGE_BACKENDS[name].disabledTag?.()) : null,
@@ -183,7 +183,7 @@ export class BackupsSection extends Disposable {
             ),
           );
         }
-        case "azure": {
+        case "s3": {
           return cssInstructions(
             dom("div", t("Set these environment variables and restart Grist to enable S3 storage:")),
             cssCodeBlock(
@@ -198,7 +198,7 @@ export class BackupsSection extends Disposable {
             ),
           );
         }
-        case "s3": {
+        case "azure": {
           return cssInstructions(
             dom("div", t("Set these environment variables and restart Grist to enable Azure storage:")),
             cssCodeBlock(

--- a/app/client/ui/BackupsSection.ts
+++ b/app/client/ui/BackupsSection.ts
@@ -6,16 +6,17 @@ import { icon } from "app/client/ui2018/icons";
 import { cssLink } from "app/client/ui2018/links";
 import { loadingSpinner } from "app/client/ui2018/loaders";
 import { BackupsBootProbeDetails } from "app/common/BootProbe";
+import { StorageBackendName } from "app/common/ExternalStorage";
 import { commonUrls } from "app/common/gristUrls";
+import { StringUnion } from "app/common/StringUnion";
 import { components, tokens } from "app/common/ThemePrefs";
 
 import { Computed, Disposable, dom, DomContents, Observable, styled, UseCBOwner } from "grainjs";
 
 const t = makeT("BackupsSection");
 
-type BackendName = "minio" | "s3" | "azure";
-
-type OptionalBackendName = BackendName | "none";
+const BackendName = StringUnion(...StorageBackendName.values, "none");
+type BackendName = typeof BackendName.type;
 
 interface BackendInfo {
   label: () => DomContents;
@@ -23,7 +24,7 @@ interface BackendInfo {
   disabledTag?: () => DomContents;
 }
 
-const STORAGE_BACKENDS: Record<BackendName | "none", BackendInfo> = {
+const STORAGE_BACKENDS: Record<BackendName, BackendInfo> = {
   minio: {
     label: () => t("S3 (MinIO client)"),
     description: () => t("AWS S3-compatible service via MinIO client library. Works with AWS S3, MinIO, and others."),
@@ -69,14 +70,9 @@ export class BackupsSection extends Disposable {
   public readonly canProceed: Computed<boolean>;
 
   private readonly _backupsProbeDetails = Computed.create(this, use => this._getBackupsProbeDetails(use));
-
-  private readonly _activeBackend = Computed.create(this, use =>
-    use(this._backupsProbeDetails)?.backend as BackendName | undefined);
-
-  private readonly _availableBackends = Computed.create(this, use =>
-    use(this._backupsProbeDetails)?.availableBackends as BackendName[] | undefined);
-
-  private readonly _selectedBackend = Observable.create<OptionalBackendName | undefined>(this, undefined);
+  private readonly _activeBackend = Computed.create(this, use => use(this._backupsProbeDetails)?.backend);
+  private readonly _availableBackends = Computed.create(this, use => use(this._backupsProbeDetails)?.availableBackends);
+  private readonly _selectedBackend = Observable.create<BackendName | undefined>(this, undefined);
 
   constructor(private _props: BackupsSectionProps) {
     super();
@@ -119,10 +115,8 @@ export class BackupsSection extends Disposable {
         );
       }
 
-      const enabledBackends = Object.keys(STORAGE_BACKENDS)
-        .filter((name): name is BackendName => availableBackends.includes(name as BackendName));
-      const disabledBackends = Object.keys(STORAGE_BACKENDS)
-        .filter((name): name is BackendName => !availableBackends.includes(name as BackendName) && name !== "none");
+      const enabledBackends = StorageBackendName.values.filter(name => availableBackends.includes(name));
+      const disabledBackends = StorageBackendName.values.filter(name => !availableBackends.includes(name));
       return [
         cssBackendCards(
           enabledBackends.map(name => this._buildBackendCard(name)),
@@ -134,7 +128,7 @@ export class BackupsSection extends Disposable {
     });
   }
 
-  private _buildBackendCard(name: OptionalBackendName, disabled = false) {
+  private _buildBackendCard(name: BackendName, disabled = false) {
     return cssBackendCard(
       cssBackendCard.cls("-selected", use => use(this._selectedBackend) === name),
       cssBackendCard.cls("-disabled", disabled),

--- a/app/client/ui/BackupsSection.ts
+++ b/app/client/ui/BackupsSection.ts
@@ -365,7 +365,7 @@ const cssInstructions = styled("div", `
 const cssCodeBlock = styled("pre", `
   margin: 0;
   padding: 10px 14px;
-  background-color: ${tokens.white};
+  background-color: ${tokens.bg};
   border: 1px solid ${tokens.decorationTertiary};
   border-radius: 6px;
   font-size: 12px;

--- a/app/client/ui/BackupsSection.ts
+++ b/app/client/ui/BackupsSection.ts
@@ -1,0 +1,375 @@
+import { makeT } from "app/client/lib/localization";
+import { AdminChecks } from "app/client/models/AdminChecks";
+import { cssDangerText, cssHappyText, cssValueLabel } from "app/client/ui/AdminPanelCss";
+import { colors } from "app/client/ui2018/cssVars";
+import { icon } from "app/client/ui2018/icons";
+import { cssLink } from "app/client/ui2018/links";
+import { loadingSpinner } from "app/client/ui2018/loaders";
+import { BackupsBootProbeDetails } from "app/common/BootProbe";
+import { commonUrls } from "app/common/gristUrls";
+import { components, tokens } from "app/common/ThemePrefs";
+
+import { Computed, Disposable, dom, DomContents, Observable, styled, UseCBOwner } from "grainjs";
+
+const t = makeT("BackupsSection");
+
+type BackendName = "minio" | "s3" | "azure";
+
+type OptionalBackendName = BackendName | "none";
+
+interface BackendInfo {
+  label: () => DomContents;
+  description: () => DomContents;
+  disabledTag?: () => DomContents;
+}
+
+const STORAGE_BACKENDS: Record<BackendName | "none", BackendInfo> = {
+  minio: {
+    label: () => t("S3 (MinIO client)"),
+    description: () => t("AWS S3-compatible service via MinIO client library. Works with AWS S3, MinIO, and others."),
+    disabledTag: () => t("Available in full edition"),
+  },
+  s3: {
+    label: () => t("S3 (AWS client)"),
+    description: () => t("AWS S3 via native AWS SDK. Supports IAM roles and AWS-native auth."),
+    disabledTag: () => t("Available in full edition"),
+  },
+  azure: {
+    label: () => t("Azure Blob Storage"),
+    description: () => t("Microsoft Azure Blob Storage via native Azure SDK."),
+    disabledTag: () => t("Available in full edition"),
+  },
+  none: {
+    label: () => t("No external storage"),
+    description: () => t("Documents stored on local disk only."),
+  },
+};
+
+export interface BackupsSectionProps {
+  checks: AdminChecks;
+  /** Default: `false`. */
+  hideTitle?: boolean;
+}
+
+/**
+ * Renders a list of storage backends for document backups.
+ *
+ * Enumerates {@link STORAGE_BACKENDS} and builds a selectable card for each backend, showing instructions
+ * on how to enable the selected backend. If backups are enabled, the active backend will be marked with an
+ * "Active" tag. If a backend is unavailable in the current edition of Grist, it will be disabled and
+ * marked with an upgrade required tag (e.g. "Only available in full edition").
+ *
+ * At this point in time, the list of backends is purely informational: the operator is expected to manually
+ * complete the steps to enable a particular backend based on the instructions shown. Typically, this involves
+ * setting some environment variables and restarting the Grist server for them to take effect.
+ *
+ * This component is shared by both AdminPanel and QuickSetup.
+ */
+export class BackupsSection extends Disposable {
+  public readonly canProceed: Computed<boolean>;
+
+  private readonly _backupsProbeDetails = Computed.create(this, use => this._getBackupsProbeDetails(use));
+
+  private readonly _activeBackend = Computed.create(this, use =>
+    use(this._backupsProbeDetails)?.backend as BackendName | undefined);
+
+  private readonly _availableBackends = Computed.create(this, use =>
+    use(this._backupsProbeDetails)?.availableBackends as BackendName[] | undefined);
+
+  private readonly _selectedBackend = Observable.create<OptionalBackendName | undefined>(this, undefined);
+
+  constructor(private _props: BackupsSectionProps) {
+    super();
+
+    this.canProceed = Computed.create(this, this._selectedBackend, (_use, backend) => !!backend);
+  }
+
+  public buildDom() {
+    return cssSection(
+      this._props.hideTitle ? null : cssTitle(
+        icon("Database"),
+        cssTitleText(t("Backups")),
+      ),
+      cssDescription(
+        t("Store document backups on an external service like S3 or Azure. \
+          This protects against data loss if the server's disk fails."),
+      ),
+      this._buildBackendCards(),
+    );
+  }
+
+  public buildStatusDisplay() {
+    return dom.domComputed((use) => {
+      const backend = use(this._activeBackend);
+      if (backend) {
+        return cssValueLabel(cssHappyText(STORAGE_BACKENDS[backend].label));
+      } else {
+        return cssValueLabel(cssDangerText(t("Off")));
+      }
+    });
+  }
+
+  private _buildBackendCards() {
+    return dom.domComputed((use) => {
+      const availableBackends = use(this._availableBackends);
+      if (availableBackends === undefined) {
+        return cssLoading(
+          loadingSpinner(),
+          t("Loading backup providers..."),
+        );
+      }
+
+      const enabledBackends = Object.keys(STORAGE_BACKENDS)
+        .filter((name): name is BackendName => availableBackends.includes(name as BackendName));
+      const disabledBackends = Object.keys(STORAGE_BACKENDS)
+        .filter((name): name is BackendName => !availableBackends.includes(name as BackendName) && name !== "none");
+      return [
+        cssBackendCards(
+          enabledBackends.map(name => this._buildBackendCard(name)),
+          disabledBackends.map(name => this._buildBackendCard(name, true)),
+          this._buildBackendCard("none"),
+        ),
+        this._buildBackendInstructions(),
+      ];
+    });
+  }
+
+  private _buildBackendCard(name: OptionalBackendName, disabled = false) {
+    return cssBackendCard(
+      cssBackendCard.cls("-selected", use => use(this._selectedBackend) === name),
+      cssBackendCard.cls("-disabled", disabled),
+      disabled ? null : dom.on("click", () => this._selectedBackend.set(name)),
+      cssRadio(
+        dom.attr("type", "radio"),
+        dom.attr("name", "backend"),
+        dom.attr("value", name),
+        dom.prop("disabled", disabled),
+        dom.prop("checked", use => use(this._selectedBackend) === name),
+        disabled ? null : dom.on("change", () => this._selectedBackend.set(name)),
+      ),
+      cssBackendBody(
+        cssBackendNameRow(
+          cssBackendName(STORAGE_BACKENDS[name].label),
+          dom.maybe(use => use(this._activeBackend) ?? "none" === name, () =>
+            cssBackendTag(cssBackendTag.cls("-active"), t("Active")),
+          ),
+          disabled ? cssBackendTag(cssBackendTag.cls("-disabled"), STORAGE_BACKENDS[name].disabledTag?.()) : null,
+        ),
+        cssBackendDescription(STORAGE_BACKENDS[name].description),
+      ),
+    );
+  }
+
+  private _buildBackendInstructions() {
+    return dom.domComputed((use) => {
+      const selected = use(this._selectedBackend);
+      if (!selected) { return null; }
+
+      switch (selected) {
+        case "minio": {
+          return cssInstructions(
+            dom("div", t("Set these environment variables and restart Grist to enable MinIO storage:")),
+            cssCodeBlock(
+              "GRIST_DOCS_MINIO_BUCKET=my-grist-docs\n" +
+              "GRIST_DOCS_MINIO_ENDPOINT=s3.amazonaws.com\n" +
+              "GRIST_DOCS_MINIO_ACCESS_KEY=...\n" +
+              "GRIST_DOCS_MINIO_SECRET_KEY=...",
+            ),
+            dom("div",
+              cssLink(
+                { href: commonUrls.helpCloudStorage, target: "_blank" },
+                t("Learn more."),
+              ),
+            ),
+          );
+        }
+        case "azure": {
+          return cssInstructions(
+            dom("div", t("Set these environment variables and restart Grist to enable S3 storage:")),
+            cssCodeBlock(
+              "GRIST_DOCS_S3_BUCKET=my-grist-docs\n" +
+              "GRIST_DOCS_S3_PREFIX=v1/\n",
+            ),
+            dom("div",
+              cssLink(
+                { href: commonUrls.helpCloudStorage, target: "_blank" },
+                t("Learn more."),
+              ),
+            ),
+          );
+        }
+        case "s3": {
+          return cssInstructions(
+            dom("div", t("Set these environment variables and restart Grist to enable Azure storage:")),
+            cssCodeBlock(
+              "AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...\n" +
+              "GRIST_AZURE_CONTAINER=my-grist-docs\n" +
+              "GRIST_AZURE_PREFIX=v1/\n",
+            ),
+            dom("div",
+              cssLink(
+                { href: commonUrls.helpCloudStorage, target: "_blank" },
+                t("Learn more."),
+              ),
+            ),
+          );
+        }
+      }
+    });
+  }
+
+  private _getBackupsProbeDetails(use: UseCBOwner): BackupsBootProbeDetails | undefined {
+    const req = this._props.checks.requestCheckById(use, "backups");
+    const result = req ? use(req.result) : undefined;
+    if (!result) { return undefined; }
+
+    return result.details as BackupsBootProbeDetails | undefined;
+  }
+}
+
+const cssSection = styled("div", `
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`);
+
+const cssTitle = styled("div", `
+  --icon-color: ${tokens.primary};
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  margin-bottom: 4px;
+`);
+
+const cssTitleText = styled("div", `
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.2px;
+`);
+
+const cssDescription = styled("div", `
+  color: ${tokens.secondary};
+  line-height: 1.55;
+  margin-bottom: 16px;
+`);
+
+const cssLoading = styled("div", `
+  align-items: center;
+  color: ${tokens.secondary};
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  justify-content: center;
+  padding: 48px 32px;
+`);
+
+const cssBackendCards = styled("div", `
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`);
+
+const cssBackendCard = styled("div", `
+  align-items: flex-start;
+  border: 1px solid ${tokens.decoration};
+  border-radius: 8px;
+  cursor: pointer;
+  display: flex;
+  gap: 12px;
+  padding: 14px 18px;
+  transition: border-color 0.2s, background-color 0.2s, box-shadow 0.2s;
+
+  &:hover {
+    border-color: ${tokens.primary};
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  }
+  &-selected {
+    background-color: ${components.lightHover};
+    border-color: ${tokens.primary};
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  }
+  &-disabled {
+    border-color: ${tokens.decorationSecondary};
+    cursor: not-allowed;
+  }
+  &-disabled:hover {
+    border-color: ${tokens.decorationSecondary};
+    box-shadow: none;
+  }
+`);
+
+const cssRadio = styled("input", `
+  cursor: pointer;
+  flex-shrink: 0;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+`);
+
+const cssBackendBody = styled("div", `
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+`);
+
+const cssBackendNameRow = styled("div", `
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+`);
+
+const cssBackendName = styled("span", `
+  font-weight: 600;
+
+  .${cssBackendCard.className}-disabled & {
+    color: ${tokens.secondary};
+  }
+`);
+
+const cssBackendTag = styled("span", `
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: ${tokens.smallFontSize};
+  font-weight: 600;
+  letter-spacing: 0.2px;
+
+  &-active {
+    background-color: ${tokens.primary};
+    color: ${tokens.white};
+  }
+  &-disabled {
+    background-color: ${colors.orange};
+    color: white;
+  }
+`);
+
+const cssBackendDescription = styled("div", `
+  color: ${tokens.secondary};
+  font-size: ${tokens.smallFontSize};
+`);
+
+const cssInstructions = styled("div", `
+  padding: 14px 18px;
+  background-color: ${components.lightHover};
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  line-height: 1.5;
+`);
+
+const cssCodeBlock = styled("pre", `
+  margin: 0;
+  padding: 10px 14px;
+  background-color: ${tokens.white};
+  border: 1px solid ${tokens.decorationTertiary};
+  border-radius: 6px;
+  font-size: 12px;
+  font-family: "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace;
+  overflow-x: auto;
+  line-height: 1.5;
+`);

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -1,6 +1,12 @@
 import { makeT } from "app/client/lib/localization";
+import { AdminChecks } from "app/client/models/AdminChecks";
+import { reportError } from "app/client/models/errors";
+import { getHomeUrl } from "app/client/models/homeUrl";
 import { cssFadeUp, cssFadeUpGristLogo, cssFadeUpHeading, cssFadeUpSubHeading } from "app/client/ui/AdminPanelCss";
+import { BackupsSection } from "app/client/ui/BackupsSection";
+import { bigPrimaryButton } from "app/client/ui2018/buttons";
 import { Stepper } from "app/client/ui2018/Stepper";
+import { InstallAPIImpl } from "app/common/InstallAPI";
 import { tokens } from "app/common/ThemePrefs";
 
 import { Disposable, dom, DomContents, observable, Observable, styled } from "grainjs";
@@ -10,11 +16,14 @@ const t = makeT("QuickSetup");
 interface Step {
   completed: Observable<boolean>;
   label: string;
+  /** When true, step content card has no border or padding. */
+  plain?: boolean;
   buildDom(): DomContents;
 }
 
 export class QuickSetup extends Disposable {
   private _activeStep = Observable.create<number>(this, 0);
+  private _checks = new AdminChecks(this, new InstallAPIImpl(getHomeUrl()));
   private _steps: Step[] = [
     {
       label: t("Server"),
@@ -34,7 +43,8 @@ export class QuickSetup extends Disposable {
     {
       label: t("Backups"),
       completed: observable(false),
-      buildDom: () => null,
+      plain: true,
+      buildDom: () => this._buildBackupsStep(),
     },
     {
       label: t("Apply & restart"),
@@ -45,6 +55,7 @@ export class QuickSetup extends Disposable {
 
   constructor() {
     super();
+    this._checks.fetchAvailableChecks().catch(reportError);
   }
 
   public buildDom() {
@@ -56,9 +67,30 @@ export class QuickSetup extends Disposable {
         dom.create(Stepper, { activeStep: this._activeStep, steps: this._steps }),
       ),
       dom.domComputed(this._activeStep, i => cssStepContent(
+        cssStepContent.cls("-plain", Boolean(this._steps[i].plain)),
         this._steps[i].buildDom(),
       )),
     );
+  }
+
+  private _buildBackupsStep(): DomContents {
+    return dom.create((owner) => {
+      const section = BackupsSection.create(owner, { checks: this._checks });
+      return dom("div",
+        section.buildDom(),
+        cssContinueRow(
+          bigPrimaryButton(
+            t("Continue"),
+            dom.boolAttr("disabled", use => !use(section.canProceed)),
+            dom.on("click", () => {
+              const activeStepIndex = this._activeStep.get();
+              this._steps[activeStepIndex].completed.set(true);
+              this._activeStep.set(activeStepIndex + 1);
+            }),
+          ),
+        ),
+      );
+    });
   }
 }
 
@@ -84,4 +116,16 @@ const cssStepContent = styled("div", `
   margin: 24px auto;
   max-width: 520px;
   padding: 28px 32px;
+  &-plain {
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    background: none;
+  }
+`);
+
+const cssContinueRow = styled("div", `
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 24px;
 `);

--- a/app/common/BootProbe.ts
+++ b/app/common/BootProbe.ts
@@ -1,3 +1,4 @@
+import { StorageBackendName } from "app/common/ExternalStorage";
 import { SandboxInfo } from "app/common/SandboxInfo";
 
 export type BootProbeIds =
@@ -35,6 +36,6 @@ export type SandboxingBootProbeDetails = SandboxInfo;
 
 export interface BackupsBootProbeDetails {
   active: boolean;
-  backend?: string;
-  availableBackends: string[];
+  availableBackends: StorageBackendName[];
+  backend?: StorageBackendName;
 }

--- a/app/common/BootProbe.ts
+++ b/app/common/BootProbe.ts
@@ -11,7 +11,8 @@ export type BootProbeIds =
   "authentication" |
   "websockets" |
   "session-secret" |
-  "service-status"
+  "service-status" |
+  "backups"
 ;
 
 export interface BootProbeResult {
@@ -31,3 +32,9 @@ export interface BootProbeInfo {
 }
 
 export type SandboxingBootProbeDetails = SandboxInfo;
+
+export interface BackupsBootProbeDetails {
+  active: boolean;
+  backend?: string;
+  availableBackends: string[];
+}

--- a/app/common/ExternalStorage.ts
+++ b/app/common/ExternalStorage.ts
@@ -1,0 +1,8 @@
+import { StringUnion } from "app/common/StringUnion";
+
+export const StorageBackendName = StringUnion(
+  "minio",
+  "s3",
+  "azure",
+);
+export type StorageBackendName = typeof StorageBackendName.type;

--- a/app/common/ICommonUrls-ti.ts
+++ b/app/common/ICommonUrls-ti.ts
@@ -38,6 +38,7 @@ export const ICommonUrls = t.iface([], {
   "helpFiddleMode": "string",
   "helpFormUrlValues": "string",
   "helpAirtableIntegration": "string",
+  "helpCloudStorage": "string",
   "freeCoachingCall": "string",
   "contactSupport": "string",
   "termsOfService": t.union("string", "undefined"),

--- a/app/common/ICommonUrls.ts
+++ b/app/common/ICommonUrls.ts
@@ -35,6 +35,7 @@ export interface ICommonUrls {
   helpFiddleMode: string;
   helpFormUrlValues: string;
   helpAirtableIntegration: string;
+  helpCloudStorage: string;
 
   freeCoachingCall: string; // Link to the human help (example: email adress or meeting scheduling tool)
   contactSupport: string; // Link to contact support on error pages (example: email adress or online form).

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -155,6 +155,7 @@ export const getCommonUrls = () => withAdminDefinedUrls({
   helpSharing: "https://support.getgrist.com/sharing",
   helpFormUrlValues: "https://support.getgrist.com/widget-form/#accept-value-from-url",
   helpAirtableIntegration: "https://support.getgrist.com/install/integrations/airtable",
+  helpCloudStorage: "https://support.getgrist.com/install/cloud-storage",
   freeCoachingCall: getFreeCoachingCallUrl(),
   contactSupport: getContactSupportUrl(),
   termsOfService: getTermsOfServiceUrl(),

--- a/app/server/lib/BootProbes.ts
+++ b/app/server/lib/BootProbes.ts
@@ -70,6 +70,7 @@ export class BootProbes {
     this._probes.push(_sessionSecretProbe);
     this._probes.push(_admins);
     this._probes.push(_serviceStatusProbe);
+    this._probes.push(_backupsProbe);
     this._probeById = new Map(this._probes.map(p => [p.id, p]));
   }
 }
@@ -336,6 +337,28 @@ const _serviceStatusProbe: Probe = {
       status: inService ? "success" : "warning",
       verdict: inService ? undefined : "Server is out of service for maintenance",
       details: { inService, source },
+    };
+  },
+};
+
+const _backupsProbe: Probe = {
+  id: "backups",
+  name: "Backups",
+  apply: async (server) => {
+    const externalStorage = appSettings.section("externalStorage");
+    const active = externalStorage.flag("active").getAsBool();
+    const backend = Object.values(externalStorage.nested)
+      .find(storage => storage.flag("active").getAsBool())
+      ?.name;
+    const availableBackends = server.create.getAvailableStorageBackends();
+    return {
+      status: active ? "success" : "warning",
+      verdict: active ? undefined : "Backups are disabled",
+      details: {
+        active,
+        backend,
+        availableBackends,
+      },
     };
   },
 };

--- a/app/server/lib/BootProbes.ts
+++ b/app/server/lib/BootProbes.ts
@@ -347,17 +347,17 @@ const _backupsProbe: Probe = {
   apply: async (server) => {
     const externalStorage = appSettings.section("externalStorage");
     const active = externalStorage.flag("active").getAsBool();
+    const availableBackends = server.create.getAvailableStorageBackends();
     const backend = Object.values(externalStorage.nested)
       .find(storage => storage.flag("active").getAsBool())
       ?.name;
-    const availableBackends = server.create.getAvailableStorageBackends();
     return {
       status: active ? "success" : "warning",
-      verdict: active ? undefined : "Backups are disabled",
+      verdict: active ? undefined : "Backups are not enabled",
       details: {
         active,
-        backend,
         availableBackends,
+        backend,
       },
     };
   },

--- a/app/server/lib/ICreate.ts
+++ b/app/server/lib/ICreate.ts
@@ -1,3 +1,4 @@
+import { StorageBackendName } from "app/common/ExternalStorage";
 import { GristDeploymentType } from "app/common/gristUrls";
 import { getThemeBackgroundSnippet } from "app/common/Themes";
 import { HomeDBManager } from "app/gen-server/lib/homedb/HomeDBManager";
@@ -88,7 +89,7 @@ export interface ICreate {
   // Return a string containing 1 or more HTML tags to insert into the head element of every
   // static page.
   getExtraHeadHtml?(): string;
-  getAvailableStorageBackends(): string[];
+  getAvailableStorageBackends(): StorageBackendName[];
   getStorageOptions?(name: string): ICreateStorageOptions | undefined;
   getAttachmentStoreOptions(): { [key: string]: ICreateAttachmentStoreOptions | undefined };
   getSqliteVariant?(): SqliteVariant;
@@ -105,7 +106,7 @@ export interface ICreate {
 type StopCallback = () => void;
 
 export interface ICreateStorageOptions {
-  name: string;
+  name: StorageBackendName;
   check(): boolean;
   checkBackend?(): Promise<void>;
   create(purpose: "doc" | "meta" | "attachments", extraPrefix: string): ExternalStorage | undefined;

--- a/app/server/lib/ICreate.ts
+++ b/app/server/lib/ICreate.ts
@@ -88,6 +88,7 @@ export interface ICreate {
   // Return a string containing 1 or more HTML tags to insert into the head element of every
   // static page.
   getExtraHeadHtml?(): string;
+  getAvailableStorageBackends(): string[];
   getStorageOptions?(name: string): ICreateStorageOptions | undefined;
   getAttachmentStoreOptions(): { [key: string]: ICreateAttachmentStoreOptions | undefined };
   getSqliteVariant?(): SqliteVariant;
@@ -193,6 +194,10 @@ export class BaseCreate implements ICreate {
     }
     elements.push(getThemeBackgroundSnippet());
     return elements.join("\n");
+  }
+
+  public getAvailableStorageBackends() {
+    return this._storage.map(s => s.name);
   }
 
   public getStorageOptions(name: string) {


### PR DESCRIPTION
## Context

The Admin Panel currently doesn't surface information about backups and snapshots.

## Proposed solution

Add an informational section about document backups to the Admin Panel.

The section is built using a new boot probe that returns whether external storage is enabled, the storage backend (if enabled), and the list of available storage backends.

The section lists all of the available storage backends, reports which one is currently active, and shows instructions on how to enable each backend.

The section is also shown in one of the quick setup steps (not yet released).

## Has this been tested?

Tested manually on Admin Panel with community and full editions of Grist.
