### PR TITLE
clearer error when personal orgs are disabled

### DIFF
--- a/app/client/ui/AppUI.ts
+++ b/app/client/ui/AppUI.ts
@@ -67,7 +67,7 @@ function createMainPage(appModel: AppModel, appObj: App) {
   if (!appModel.currentOrg && appModel.needsOrg.get()) {
     const err = appModel.orgError;
     if (err?.status === 404) {
-      return createNotFoundPage(appModel);
+      return createNotFoundPage(appModel, err.error);
     } else if (err && (err.status === 401 || err.status === 403)) {
       // Generally give access denied error.
       // The exception is for document pages, where we want to allow access to documents

--- a/app/gen-server/ApiServer.ts
+++ b/app/gen-server/ApiServer.ts
@@ -25,7 +25,7 @@ import { expressWrap } from "app/server/lib/expressWrap";
 import { RequestWithOrg } from "app/server/lib/extractOrg";
 import { GristServer } from "app/server/lib/GristServer";
 import { getCookieDomain } from "app/server/lib/gristSessions";
-import { getCanAnyoneCreateOrgs, getTemplateOrg } from "app/server/lib/gristSettings";
+import { getCanAnyoneCreateOrgs, getPersonalOrgsEnabled, getTemplateOrg } from "app/server/lib/gristSettings";
 import log from "app/server/lib/log";
 import { clearSessionCacheIfNeeded, getDocScope, getScope, integerParam,
   isParameterOn, optStringParam, sendOkReply, sendReply, stringParam } from "app/server/lib/requestUtils";
@@ -582,7 +582,10 @@ export class ApiServer {
       const org = domain ? (await this._withPrivilegedViewForUser(
         domain, req, scope => this._dbManager.getOrg(scope, domain),
       )) : null;
-      const orgError = (org?.errMessage) ? { error: org.errMessage, status: org.status } : undefined;
+      let orgError = (org?.errMessage) ? { error: org.errMessage, status: org.status } : undefined;
+      if (!domain && !fullUser.anonymous && !getPersonalOrgsEnabled()) {
+        orgError = { error: "Personal orgs are disabled and no team site is available", status: 404 };
+      }
       if (org?.data?.billingAccount) {
       // Flatten features into single object for client side code that is using BillingAccount client side model.
         org.data.billingAccount.features = org.data.billingAccount.getEffectiveFeatures();

--- a/app/gen-server/lib/homedb/HomeDBManager.ts
+++ b/app/gen-server/lib/homedb/HomeDBManager.ts
@@ -656,6 +656,11 @@ export class HomeDBManager implements HomeDBAuth {
       };
       return { status: 200, data: anonOrg as any };
     }
+    // If the request is for the user's personal org but personal orgs are disabled,
+    // surface a clear message rather than silently producing an empty query result.
+    if (this.isMergedOrg(orgKey) && !getPersonalOrgsEnabled()) {
+      return { status: 404, errMessage: "Personal orgs are disabled" };
+    }
     let qb = this.org(scope, orgKey, {
       ...(options?.requirePermissions ? {
         markPermissions: options.requirePermissions,

--- a/test/gen-server/ApiSession.ts
+++ b/test/gen-server/ApiSession.ts
@@ -1,5 +1,6 @@
 import { UserProfile } from "app/common/LoginSessionAPI";
 import { AccessOptionWithRole } from "app/gen-server/entity/Organization";
+import { getCanAnyoneCreateOrgs, getPersonalOrgsEnabled } from "app/server/lib/gristSettings";
 import { TestServer } from "test/gen-server/apiUtils";
 import * as testUtils from "test/server/testUtils";
 
@@ -131,6 +132,52 @@ describe("ApiSession", function() {
     assert.deepEqual(resp.data.orgError, {
       status: 404,
       error: "organization not found",
+    });
+  });
+
+  describe("with personal orgs disabled", function() {
+    let oldEnv: testUtils.EnvironmentSnapshot;
+
+    before(async function() {
+      oldEnv = new testUtils.EnvironmentSnapshot();
+      process.env.GRIST_PERSONAL_ORGS = "false";
+      getPersonalOrgsEnabled.cache.clear();
+      getCanAnyoneCreateOrgs.cache.clear();
+    });
+
+    after(async function() {
+      oldEnv.restore();
+      getPersonalOrgsEnabled.cache.clear();
+      getCanAnyoneCreateOrgs.cache.clear();
+    });
+
+    it("returns orgErr for /o/docs when personal orgs are disabled", async function() {
+      const cookie = await server.getCookieLogin("nasa", { email: regular, name: "Chimpy" });
+      const resp = await axios.get(`${serverUrl}/o/docs/api/session/access/active`, cookie);
+      assert.equal(resp.status, 200);
+      assert.equal(resp.data.org, null);
+      assert.deepEqual(resp.data.orgError, {
+        status: 404,
+        error: "Personal orgs are disabled",
+      });
+    });
+
+    it("returns orgErr when no org in URL and personal orgs are disabled", async function() {
+      const cookie = await server.getCookieLogin("nasa", { email: regular, name: "Chimpy" });
+      const resp = await axios.get(`${serverUrl}/api/session/access/active`, cookie);
+      assert.equal(resp.status, 200);
+      assert.equal(resp.data.org, null);
+      assert.deepEqual(resp.data.orgError, {
+        status: 404,
+        error: "Personal orgs are disabled and no team site is available",
+      });
+    });
+
+    it("does not set orgErr for anonymous users with no org in URL", async function() {
+      const resp = await axios.get(`${serverUrl}/api/session/access/active`, nobody);
+      assert.equal(resp.status, 200);
+      assert.equal(resp.data.org, null);
+      assert.isUndefined(resp.data.orgError);
     });
   });
 


### PR DESCRIPTION
Previously visiting a personal-org URL while logged in with personal orgs disabled would show a vague "Something went wrong" or a generic "Page not found". Now there are clearer messages.
