### PR TITLE
Final step in Quick Setup Wizard

### DIFF
--- a/app/client/ui/PermissionsSetupSection.ts
+++ b/app/client/ui/PermissionsSetupSection.ts
@@ -275,7 +275,7 @@ Grist is now in service and available to users.")),
 
 const PRESETS: Record<string, Record<string, boolean>> = {
   locked: { teamSites: false, personalSites: false, anonAccess: false, playground: false },
-  recommended: { teamSites: false, personalSites: false, anonAccess: true,  playground: false },
+  recommended: { teamSites: false, personalSites: true, anonAccess: true,  playground: false },
   open: { teamSites: true,  personalSites: true,  anonAccess: true,  playground: true },
 };
 

--- a/app/client/ui/PermissionsSetupSection.ts
+++ b/app/client/ui/PermissionsSetupSection.ts
@@ -1,0 +1,542 @@
+import { makeT } from "app/client/lib/localization";
+import { getHomeUrl } from "app/client/models/homeUrl";
+import { bigBasicButton, bigPrimaryButton } from "app/client/ui2018/buttons";
+import { theme, vars } from "app/client/ui2018/cssVars";
+import { loadingSpinner } from "app/client/ui2018/loaders";
+import { toggleSwitch } from "app/client/ui2018/toggleSwitch";
+import { ConfigAPI } from "app/common/ConfigAPI";
+import { delay } from "app/common/delay";
+import { not } from "app/common/gutil";
+import { InstallAPIImpl, PermissionsStatus } from "app/common/InstallAPI";
+import { tokens } from "app/common/ThemePrefs";
+import { getGristConfig } from "app/common/urlUtils";
+
+import { Computed, Disposable, dom, DomContents, makeTestId, Observable, styled } from "grainjs";
+
+const t = makeT("PermissionsSetupSection");
+const testId = makeTestId("test-permissions-setup-");
+
+/**
+ * Renders the "Apply & Restart" step of the setup wizard.
+ *
+ * Shows default permission toggles with preset modes (Locked down / Recommended / Open),
+ * a "Go Live" button that saves settings and restarts the server, and a success state
+ * after restart completes.
+ */
+export class PermissionsSetupSection extends Disposable {
+  // Needed to read and update settings.
+  private _installAPI = new InstallAPIImpl(getHomeUrl());
+  // Needed for restarts.
+  private _configAPI = new ConfigAPI(getHomeUrl());
+  // Data received from the server about current permissions status.
+  private _status = Observable.create<PermissionsStatus | null>(this, null);
+  // Error message holder.
+  private _error = Observable.create<string>(this, "");
+  // Loading state.
+  private _saving = Observable.create<boolean>(this, false);
+  // Whether the server has been restarted after saving. Used to switch to the success page.
+  private _restarted = Observable.create<boolean>(this, false);
+
+  // Dirty state for the things being toggled. Default values are set to those that
+  // are in grist-core, but it doesn't matter, they are replaced when the real status is loaded.
+  private _toggles: Record<string, Observable<boolean>> = {
+    teamSites: Observable.create<boolean>(this, false), // values are not important
+    personalSites: Observable.create<boolean>(this, false),
+    anonAccess: Observable.create<boolean>(this, false),
+    playground: Observable.create<boolean>(this, false),
+  };
+
+  // Preset detector. Checks state of toggles, and if they match it shows which preset is active.
+  // Env-locked toggles are excluded from matching — they can't be changed, so they shouldn't
+  // prevent a preset from being recognized.
+  private _presetDetector = Computed.create(this, (use) => {
+    const status = use(this._status);
+    for (const [name, values] of Object.entries(PRESETS)) {
+      if (Object.entries(values).every(([k, v]) => {
+        if (status && this._isEnvLocked(status, k)) { return true; }
+        return use(this._toggles[k]) === v;
+      })) {
+        return name;
+      }
+    }
+    return null;
+  });
+
+  constructor() {
+    super();
+    void this._load();
+  }
+
+  public buildDom(): DomContents {
+    return dom("div",
+      testId("section"),
+      dom.domComputed(this._restarted, (done) => {
+        // If we are restarted, show the success page.
+        if (done) { return this._buildSuccessPage(); }
+
+        // Otherwise show the permissions setup page, with error/loading states.
+        return dom("div",
+          dom.maybe(this._error, err => cssError(err)),
+          dom.domComputed(this._status, (s) => {
+            if (!s) { return cssLoading(loadingSpinner(), t("Loading permissions…")); }
+            return this._buildContent(s);
+          }),
+        );
+      }),
+    );
+  }
+
+  private async _load() {
+    try {
+      const s = await this._installAPI.getPermissionsStatus();
+      if (this.isDisposed()) { return; }
+      this._status.set(s);
+      // Initialize all toggles from current server values.
+      this._toggles.teamSites.set(s.orgCreationAnyone.value ?? true);
+      this._toggles.personalSites.set(s.personalOrgs.value ?? true);
+      this._toggles.anonAccess.set(!(s.forceLogin.value ?? false));
+      this._toggles.playground.set(s.anonPlayground.value ?? true);
+      // Apply recommended preset — skips env-locked toggles, so their
+      // server values above are preserved.
+      this._applyPreset("recommended");
+      // When GRIST_SINGLE_ORG=docs, the personal org is the only org —
+      // disabling personal sites would make Grist non-functional.
+      if (getGristConfig().singleOrg === "docs") {
+        this._toggles.personalSites.set(true);
+      }
+    } catch (e) {
+      if (this.isDisposed()) { return; }
+      this._error.set(String(e));
+    }
+  }
+
+  private _applyPreset(preset: string) {
+    const status = this._status.get();
+    for (const [toggleName, toggleValue] of Object.entries(PRESETS[preset])) {
+      // Don't override toggles locked by environment variables.
+      if (status && this._isEnvLocked(status, toggleName)) { continue; }
+      this._toggles[toggleName].set(toggleValue);
+    }
+  }
+
+  private _isEnvLocked(status: PermissionsStatus, toggleKey: string): boolean {
+    const def = TOGGLE_DEFS.find(d => d.key === toggleKey);
+    return !!def && status[def.permKey].source === "environment-variable";
+  }
+
+  private async _handleGoLive() {
+    // Simple way for preventing multiple clicks.
+    if (this._saving.get()) { return; }
+    this._saving.set(true);
+    this._error.set("");
+    try {
+      await this._installAPI.updateInstallPrefs({ envVars: {
+        GRIST_ORG_CREATION_ANYONE: String(this._toggles.teamSites.get()),
+        GRIST_PERSONAL_ORGS: String(this._toggles.personalSites.get()),
+        GRIST_FORCE_LOGIN: String(!this._toggles.anonAccess.get()),
+        GRIST_ANON_PLAYGROUND: String(this._toggles.playground.get()),
+        GRIST_IN_SERVICE: "true",
+      } });
+      await this._configAPI.restartServer();
+      await this._waitForReady();
+      if (this.isDisposed()) { return; }
+      this._saving.set(false);
+      this._restarted.set(true);
+    } catch (e) {
+      if (this.isDisposed()) { return; }
+      this._error.set(String(e));
+    } finally {
+      if (!this.isDisposed()) { this._saving.set(false); }
+    }
+  }
+
+  private async _waitForReady(maxAttempts = 30) {
+    for (let i = 0; i < maxAttempts; i++) {
+      await delay(1000);
+      if (this.isDisposed()) { return; }
+      try {
+        await this._configAPI.healthcheck();
+        return;
+      } catch {
+        // Server not ready yet, keep polling.
+      }
+    }
+    throw new Error(t("Server did not restart in time. Please refresh the page."));
+  }
+
+  private _goHome() {
+    window.location.href = getHomeUrl(); // avoid using urlState here, as it is meant for team navigation.
+  }
+
+  private _buildContent(status: PermissionsStatus): DomContents {
+    return dom("div",
+      cssStepTitle(t("Apply & Restart")),
+      cssStepDescription(
+        t("Review these defaults before going live. \
+You can change them later from the admin panel."),
+      ),
+      cssPermissionsSection(
+        dom.cls("disabled", this._saving),
+        cssSectionLabel(t("DEFAULT PERMISSIONS")),
+        cssPresetBar(
+          ...([
+            ["locked", t("Locked down")] as const,
+            ["recommended", t("Recommended")] as const,
+            ["open", t("Open")] as const,
+          ].map(([key, label]) =>
+            cssPresetButton(
+              label,
+              dom.cls("active", use => use(this._presetDetector) === key),
+              dom.on("click", () => this._applyPreset(key)),
+              testId(`preset-${key}`),
+            ),
+          )),
+        ),
+
+        // Toggle rows.
+        ...TOGGLE_DEFS.map(({ key, permKey, label, description }) => {
+          const locked = status[permKey].source === "environment-variable";
+          const conflict = key === "personalSites" && getGristConfig().singleOrg === "docs";
+          return cssPermissionRow(
+            cssPermissionToggle(
+              toggleSwitch(this._toggles[key], {
+                args: [locked ? dom.cls("disabled") : null],
+                inputArgs: locked ? [dom.prop("disabled", true)] : [],
+              }),
+            ),
+            cssPermissionInfo(
+              cssPermissionLabelRow(
+                cssPermissionLabel(label()),
+                locked ? cssBadge(cssBadge.cls("-warning"), t("Environment"), testId("env-badge")) : null,
+                conflict ? cssBadge(cssBadge.cls("-error"), t("Conflict"), testId("conflict-badge")) : null,
+              ),
+              cssPermissionDescription(description()),
+            ),
+            testId(`perm-${permKey}`),
+          );
+        }),
+
+        // Warning when some settings are locked by environment variables.
+        hasEnvLocked(status) ? cssWarningWell(
+          t("Some settings are controlled by environment variables and cannot be \
+changed here: {{vars}}. To modify them, update the corresponding variables \
+in your server configuration and restart.",
+          { vars: getEnvLockedVars(status).join(", ") }),
+          testId("env-warning"),
+        ) : null,
+
+        // GRIST_SINGLE_ORG warning.
+        getGristConfig().singleOrg ? cssWarningWell(
+          t("You have GRIST_SINGLE_ORG={{value}} set. With this, users only see one \
+site — but personal sites and team creation still work behind the \
+scenes. Worth locking down unless you have a specific reason to keep them.",
+          { value: getGristConfig().singleOrg! }),
+          getGristConfig().singleOrg === "docs" ? dom("div",
+            dom.style("margin-top", "8px"),
+            t("The personal org is the only org available — personal sites must \
+stay enabled or Grist will be non-functional."),
+          ) : null,
+          testId("single-org-warning"),
+        ) : null,
+      ),
+
+      // Bottom area: Go Live / Loading states.
+      dom.maybe(this._saving, () =>
+        cssRestartingRow(
+          loadingSpinner(),
+          t("Applying settings and restarting…"),
+        ),
+      ),
+      dom.maybe(not(this._saving), () =>
+        cssBottomRow(
+          bigPrimaryButton(t("Apply and Go Live!"),
+            cssGoLiveButton.cls(""),
+            dom.on("click", () => this._handleGoLive()),
+            testId("go-live"),
+          ),
+        ),
+      ),
+    );
+  }
+
+  private _buildSuccessPage(): DomContents {
+    return cssSuccessPage(
+      cssSparks(),
+      cssSuccessTitle(t("Grist is live!")),
+      cssSuccessSubtitle(t("Your configuration changes have been applied and the server has been restarted. \
+Grist is now in service and available to users.")),
+      bigBasicButton(t("Back to installation"),
+        dom.on("click", () => this._goHome()),
+        testId("back-to-install"),
+      ),
+    );
+  }
+}
+
+const PRESETS: Record<string, Record<string, boolean>> = {
+  locked: { teamSites: false, personalSites: false, anonAccess: false, playground: false },
+  recommended: { teamSites: false, personalSites: false, anonAccess: true,  playground: false },
+  open: { teamSites: true,  personalSites: true,  anonAccess: true,  playground: true },
+};
+
+function hasEnvLocked(status: PermissionsStatus): boolean {
+  return TOGGLE_DEFS.some(({ permKey }) => status[permKey].source === "environment-variable");
+}
+
+function getEnvLockedVars(status: PermissionsStatus): string[] {
+  return TOGGLE_DEFS
+    .filter(({ permKey }) => status[permKey].source === "environment-variable")
+    .map(({ envVar }) => envVar);
+}
+
+type PermissionKey = keyof Omit<PermissionsStatus, "singleOrg">;
+
+const TOGGLE_DEFS: {
+  key: string;
+  permKey: PermissionKey;
+  envVar: string;
+  label: () => string;
+  description: () => string;
+}[] = [
+  {
+    key: "teamSites",
+    permKey: "orgCreationAnyone",
+    envVar: "GRIST_ORG_CREATION_ANYONE",
+    label: () => t("Allow anyone to create team sites"),
+    description: () => t("Any logged-in user can create new team sites. \
+Turn off to restrict team creation to admins only."),
+  },
+  {
+    key: "personalSites",
+    permKey: "personalOrgs",
+    envVar: "GRIST_PERSONAL_ORGS",
+    label: () => t("Allow personal sites"),
+    description: () => t("Users can create their own personal sites with documents. \
+Turn off to restrict all documents to team sites managed by admins."),
+  },
+  {
+    key: "anonAccess",
+    permKey: "forceLogin",
+    envVar: "GRIST_FORCE_LOGIN",
+    label: () => t("Allow anonymous access"),
+    description: () => t("Visitors who aren't signed in can view publicly shared documents. \
+This is needed for link sharing and published forms."),
+  },
+  {
+    key: "playground",
+    permKey: "anonPlayground",
+    envVar: "GRIST_ANON_PLAYGROUND",
+    label: () => t("Allow anonymous playground"),
+    description: () => t("Visitors who aren't signed in can create and edit documents \
+in a temporary playground. Turn off to require sign-in before creating any documents."),
+  },
+];
+
+const cssLoading = styled("div", `
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 48px 32px;
+  color: ${theme.lightText};
+`);
+
+const cssError = styled("div", `
+  background: ${theme.toastErrorBg};
+  border-radius: 8px;
+  color: white;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+`);
+
+const cssStepTitle = styled("div", `
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 8px;
+`);
+
+const cssStepDescription = styled("div", `
+  font-size: 14px;
+  color: ${theme.lightText};
+  line-height: 1.5;
+  margin-bottom: 20px;
+`);
+
+const cssPermissionsSection = styled("div", `
+  border: 1px solid ${theme.pagePanelsBorder};
+  border-radius: 8px;
+  padding: 16px 20px;
+  transition: opacity 0.2s;
+
+  &.disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+`);
+
+const cssSectionLabel = styled("div", `
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+  color: ${theme.lightText};
+`);
+
+const cssPresetBar = styled("div", `
+  display: flex;
+  background: ${tokens.bgTertiary};
+  border-radius: 8px;
+  padding: 3px;
+  margin-bottom: 20px;
+`);
+
+const cssPresetButton = styled("div", `
+  flex: 1;
+  text-align: center;
+  padding: 6px 12px;
+  border-radius: 8px;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: ${theme.lightText};
+  cursor: pointer;
+  user-select: none;
+  transition: all 0.15s ease;
+
+  &.active {
+    color: ${theme.text};
+    font-weight: 600;
+    background: ${theme.mainPanelBg};
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(0, 0, 0, 0.1);
+  }
+`);
+
+const cssPermissionRow = styled("div", `
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 0;
+  border-bottom: 1px solid ${theme.pagePanelsBorder};
+`);
+
+const cssPermissionToggle = styled("div", `
+  flex: none;
+  padding-top: 2px;
+
+  & .disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+`);
+
+const cssPermissionInfo = styled("div", `
+  flex: 1;
+  min-width: 0;
+`);
+
+const cssPermissionLabelRow = styled("div", `
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+`);
+
+const cssPermissionLabel = styled("div", `
+  font-size: 14px;
+  font-weight: 600;
+  color: ${theme.text};
+`);
+
+const cssBadge = styled("span", `
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: ${vars.smallFontSize};
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  color: white;
+
+  &-warning {
+    background-color: ${theme.toastWarningBg};
+  }
+  &-error {
+    background-color: ${theme.toastErrorBg};
+  }
+`);
+
+const cssPermissionDescription = styled("div", `
+  font-size: 13px;
+  color: ${theme.lightText};
+  line-height: 1.4;
+`);
+
+const cssWarningWell = styled("div", `
+  border: 2px solid ${theme.toastWarningBg};
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin-top: 16px;
+  font-size: ${vars.smallFontSize};
+  line-height: 1.4;
+  color: ${theme.text};
+`);
+
+const cssBottomRow = styled("div", `
+  display: flex;
+  justify-content: stretch;
+  margin-top: 24px;
+  & > * {
+    flex: 1;
+  }
+`);
+
+const cssRestartingRow = styled("div", `
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 16px;
+  padding: 14px 16px;
+  border: 1px solid ${theme.pagePanelsBorder};
+  border-radius: 8px;
+  color: ${theme.lightText};
+  font-size: 14px;
+`);
+
+const cssGoLiveButton = styled("div", `
+  background-color: ${theme.toastSuccessBg};
+  border-color: ${theme.toastSuccessBg};
+  &:hover {
+    background-color: ${theme.toastSuccessBg};
+    filter: brightness(0.95);
+  }
+`);
+
+const cssSuccessPage = styled("div", `
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 48px 32px;
+  gap: 12px;
+`);
+
+const cssSparks = styled("div", `
+  height: 48px;
+  width: 48px;
+  background-image: var(--icon-Sparks);
+  display: inline-block;
+  background-repeat: no-repeat;
+`);
+
+const cssSuccessTitle = styled("div", `
+  font-size: 18px;
+  font-weight: 600;
+  color: ${theme.text};
+`);
+
+const cssSuccessSubtitle = styled("div", `
+  font-size: 14px;
+  color: ${theme.lightText};
+  margin-bottom: 16px;
+`);

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -4,6 +4,7 @@ import { reportError } from "app/client/models/errors";
 import { getHomeUrl } from "app/client/models/homeUrl";
 import { cssFadeUp, cssFadeUpGristLogo, cssFadeUpHeading, cssFadeUpSubHeading } from "app/client/ui/AdminPanelCss";
 import { BackupsSection } from "app/client/ui/BackupsSection";
+import { PermissionsSetupSection } from "app/client/ui/PermissionsSetupSection";
 import { bigPrimaryButton } from "app/client/ui2018/buttons";
 import { Stepper } from "app/client/ui2018/Stepper";
 import { InstallAPIImpl } from "app/common/InstallAPI";
@@ -49,7 +50,8 @@ export class QuickSetup extends Disposable {
     {
       label: t("Apply & restart"),
       completed: observable(false),
-      buildDom: () => null,
+      plain: true,
+      buildDom: () => this._buildApplyStep(),
     },
   ];
 
@@ -90,6 +92,13 @@ export class QuickSetup extends Disposable {
           ),
         ),
       );
+    });
+  }
+
+  private _buildApplyStep(): DomContents {
+    return dom.create((owner) => {
+      const section = PermissionsSetupSection.create(owner);
+      return section.buildDom();
     });
   }
 }

--- a/app/client/ui2018/Stepper.ts
+++ b/app/client/ui2018/Stepper.ts
@@ -3,7 +3,9 @@ import { unstyledButton } from "app/client/ui2018/unstyled";
 import { inlineStyle } from "app/common/gutil";
 import { tokens } from "app/common/ThemePrefs";
 
-import { BindableValue, Disposable, dom, DomContents, Observable, styled } from "grainjs";
+import { BindableValue, Disposable, dom, DomContents, makeTestId, Observable, styled } from "grainjs";
+
+const testId = makeTestId("test-stepper-");
 
 export interface StepperProps {
   activeStep: Observable<number>;
@@ -39,6 +41,7 @@ export class Stepper extends Disposable {
           cssStep.cls("-active", use => use(this._activeStep) === i),
           cssStep.cls("-completed", completed),
           dom.on("click", () => this._activeStep.set(i)),
+          testId(`step-${i}`),
           cssStepIcon(
             dom.domComputed(completed, c => c ? cssIcon("Tick") : String(i + 1)),
           ),

--- a/app/common/InstallAPI.ts
+++ b/app/common/InstallAPI.ts
@@ -27,6 +27,18 @@ export interface PrefWithSource<T> {
 
 export type PrefSource = "environment-variable" | "preferences";
 
+export interface PermissionSetting {
+  value: boolean | undefined;
+  source: PrefSource | undefined;
+}
+
+export interface PermissionsStatus {
+  orgCreationAnyone: PermissionSetting;
+  personalOrgs: PermissionSetting;
+  forceLogin: PermissionSetting;
+  anonPlayground: PermissionSetting;
+}
+
 export interface InstallAPI {
   getInstallPrefs(): Promise<InstallPrefsWithSources>;
   updateInstallPrefs(prefs: Partial<InstallPrefs>): Promise<void>;
@@ -36,6 +48,7 @@ export interface InstallAPI {
   checkUpdates(): Promise<LatestVersionAvailable>;
   getChecks(): Promise<{ probes: BootProbeInfo[] }>;
   runCheck(id: string): Promise<BootProbeResult>;
+  getPermissionsStatus(): Promise<PermissionsStatus>;
 }
 
 export class InstallAPIImpl extends BaseAPI implements InstallAPI {
@@ -64,6 +77,10 @@ export class InstallAPIImpl extends BaseAPI implements InstallAPI {
 
   public runCheck(id: string): Promise<BootProbeResult> {
     return this.requestJson(`${this._url}/api/probes/${id}`, { method: "GET" });
+  }
+
+  public async getPermissionsStatus(): Promise<PermissionsStatus> {
+    return this.requestJson(`${this._url}/api/install/permissions`, { method: "GET" });
   }
 
   private get _url(): string {

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -8,6 +8,7 @@ import {
 import { AdminPageConfig } from "app/common/gristUrls";
 import { isAffirmative } from "app/common/gutil";
 import { InstallPrefs } from "app/common/Install";
+import { PermissionsStatus, PrefSource } from "app/common/InstallAPI";
 import { getOrgKey } from "app/gen-server/ApiServer";
 import { Config } from "app/gen-server/entity/Config";
 import {
@@ -19,7 +20,13 @@ import { RequestWithLogin } from "app/server/lib/Authorizer";
 import { BootProbes } from "app/server/lib/BootProbes";
 import { expressWrap } from "app/server/lib/expressWrap";
 import { GristServer } from "app/server/lib/GristServer";
-import { invalidateReloadableSettings } from "app/server/lib/gristSettings";
+import {
+  getAnonPlaygroundEnabled, getAnonPlaygroundEnabledSource,
+  getCanAnyoneCreateOrgs, getCanAnyoneCreateOrgsSource,
+  getForceLogin, getForceLoginSource,
+  getPersonalOrgsEnabled, getPersonalOrgsEnabledSource,
+  invalidateReloadableSettings,
+} from "app/server/lib/gristSettings";
 import log from "app/server/lib/log";
 import {
   getScope,
@@ -138,6 +145,22 @@ export function attachEarlyEndpoints(options: AttachOptions) {
     expressWrap(async (_req, res) => {
       const prefs = await gristServer.getActivations().getPrefsWithSources();
       return sendOkReply(null, res, prefs);
+    }),
+  );
+
+  // Returns current default permission settings with their sources.
+  app.get(
+    "/api/install/permissions",
+    expressWrap(async (_req, res) => {
+      const toPrefSource = (s: "env" | "db" | undefined): PrefSource | undefined =>
+        s === "env" ? "environment-variable" : s === "db" ? "preferences" : undefined;
+      const status: PermissionsStatus = {
+        orgCreationAnyone: { value: getCanAnyoneCreateOrgs(), source: toPrefSource(getCanAnyoneCreateOrgsSource()) },
+        personalOrgs: { value: getPersonalOrgsEnabled(), source: toPrefSource(getPersonalOrgsEnabledSource()) },
+        forceLogin: { value: getForceLogin(), source: toPrefSource(getForceLoginSource()) },
+        anonPlayground: { value: getAnonPlaygroundEnabled(), source: toPrefSource(getAnonPlaygroundEnabledSource()) },
+      };
+      return sendOkReply(null, res, status);
     }),
   );
 

--- a/app/server/lib/gristSettings.ts
+++ b/app/server/lib/gristSettings.ts
@@ -100,6 +100,12 @@ export const getAnonPlaygroundEnabled = memoize(() =>
   }),
 );
 
+/** Returns where the `GRIST_ANON_PLAYGROUND` value came from ("env" or "db"), or undefined if using the default. */
+export function getAnonPlaygroundEnabledSource(): AppSettingSource | undefined {
+  getAnonPlaygroundEnabled(); // ensure the flag is read/initialized
+  return appSettings.section("orgs").flag("enableAnonPlayground").describe().source;
+}
+
 /**
  * Returns the value of `GRIST_FORCE_LOGIN` from {@link appSettings}.
  *
@@ -112,6 +118,12 @@ export const getForceLogin = memoize(() =>
     defaultValue: false,
   }),
 );
+
+/** Returns where the `GRIST_FORCE_LOGIN` value came from ("env" or "db"), or undefined if using the default. */
+export function getForceLoginSource(): AppSettingSource | undefined {
+  getForceLogin(); // ensure the flag is read/initialized
+  return appSettings.section("login").flag("forced").describe().source;
+}
 
 /**
  * Returns the value of `GRIST_ONBOARDING_TUTORIAL_DOC_ID` from {@link appSettings}.
@@ -138,6 +150,12 @@ export const getCanAnyoneCreateOrgs = memoize(() =>
   }),
 );
 
+/** Returns where the `GRIST_ORG_CREATION_ANYONE` value came from ("env" or "db"), or undefined if using the default. */
+export function getCanAnyoneCreateOrgsSource(): AppSettingSource | undefined {
+  getCanAnyoneCreateOrgs(); // ensure the flag is read/initialized
+  return appSettings.section("orgs").flag("canAnyoneCreateOrgs").describe().source;
+}
+
 /**
  * Returns the value of `GRIST_PERSONAL_ORGS` from {@link appSettings}.
  *
@@ -150,6 +168,12 @@ export const getPersonalOrgsEnabled = memoize(() =>
     defaultValue: getCanAnyoneCreateOrgs(),
   }),
 );
+
+/** Returns where the `GRIST_PERSONAL_ORGS` value came from ("env" or "db"), or undefined if using the default. */
+export function getPersonalOrgsEnabledSource(): AppSettingSource | undefined {
+  getPersonalOrgsEnabled(); // ensure the flag is read/initialized
+  return appSettings.section("orgs").flag("enablePersonalOrgs").describe().source;
+}
 
 /**
  * Returns the value of `GRIST_SANDBOX_FLAVOR` from {@link appSettings}.

--- a/test/nbrowser/PermissionsStep.ts
+++ b/test/nbrowser/PermissionsStep.ts
@@ -36,7 +36,7 @@ describe("PermissionsStep", function() {
     // Should start with "Recommended" preset active.
     assert.isTrue(await isPresetActive("recommended"));
     assert.isFalse(await isToggleChecked("orgCreationAnyone"));
-    assert.isFalse(await isToggleChecked("personalOrgs"));
+    assert.isTrue(await isToggleChecked("personalOrgs"));
     assert.isTrue(await isToggleChecked("forceLogin"));
     assert.isFalse(await isToggleChecked("anonPlayground"));
 

--- a/test/nbrowser/PermissionsStep.ts
+++ b/test/nbrowser/PermissionsStep.ts
@@ -149,6 +149,41 @@ describe("PermissionsStep", function() {
     await server.restart();
   });
 
+  it("should show warning when GRIST_SINGLE_ORG is a non-docs value", async function() {
+    process.env.GRIST_SINGLE_ORG = "myteam";
+    await server.restart();
+    session = await gu.session().personalSite.login();
+    await navigateToStep();
+
+    // Single-org warning should be shown with the value.
+    const warning = await driver.find(".test-permissions-setup-single-org-warning");
+    assert.isTrue(await warning.isDisplayed());
+    assert.include(await warning.getText(), "GRIST_SINGLE_ORG=myteam");
+
+    // No conflict badge — conflict only applies to docs.
+    assert.isFalse(await hasConflictBadge("personalOrgs"));
+    assert.isFalse(await hasConflictBadge("orgCreationAnyone"));
+    assert.isFalse(await hasConflictBadge("forceLogin"));
+    assert.isFalse(await hasConflictBadge("anonPlayground"));
+
+    // No env badges.
+    assert.lengthOf(await driver.findAll(".test-permissions-setup-env-badge"), 0);
+    assert.isFalse(await driver.find(".test-permissions-setup-env-warning").isPresent());
+
+    // All toggles should be enabled (not disabled).
+    assert.isFalse(await isToggleDisabled("orgCreationAnyone"));
+    assert.isFalse(await isToggleDisabled("personalOrgs"));
+    assert.isFalse(await isToggleDisabled("forceLogin"));
+    assert.isFalse(await isToggleDisabled("anonPlayground"));
+
+    // Recommended preset should still be active.
+    assert.isTrue(await isPresetActive("recommended"));
+
+    // Restore and restart for subsequent tests.
+    delete process.env.GRIST_SINGLE_ORG;
+    await server.restart();
+  });
+
   it("should save permissions and show restart error", async function() {
     await (await gu.session().personalSite.login()).loadDocMenu("/");
     // Before saving, all permissions should be at defaults (no source).

--- a/test/nbrowser/PermissionsStep.ts
+++ b/test/nbrowser/PermissionsStep.ts
@@ -1,0 +1,227 @@
+import { InstallAPIImpl } from "app/common/InstallAPI";
+import * as gu from "test/nbrowser/gristUtils";
+import { server, setupTestSuite } from "test/nbrowser/testUtils";
+import * as testUtils from "test/server/testUtils";
+
+import { assert, driver } from "mocha-webdriver";
+
+describe("PermissionsStep", function() {
+  this.timeout(process.env.DEBUG ? "10m" : "20s");
+  setupTestSuite();
+  gu.bigScreen();
+
+  let oldEnv: testUtils.EnvironmentSnapshot;
+  let session: gu.Session;
+  let installApi: InstallAPIImpl;
+
+  afterEach(() => gu.checkForErrors());
+
+  before(async function() {
+    oldEnv = new testUtils.EnvironmentSnapshot();
+    process.env.GRIST_TEST_SERVER_DEPLOYMENT_TYPE = "core";
+    process.env.GRIST_DEFAULT_EMAIL = gu.session().email;
+    await server.restart(true); // clear database
+    session = await gu.session().personalSite.login();
+    installApi = session.createApi(InstallAPIImpl);
+  });
+
+  after(async function() {
+    oldEnv.restore();
+    await server.restart(true);
+  });
+
+  it("should default to Recommended preset and apply presets correctly", async function() {
+    await navigateToStep();
+
+    // Should start with "Recommended" preset active.
+    assert.isTrue(await isPresetActive("recommended"));
+    assert.isFalse(await isToggleChecked("orgCreationAnyone"));
+    assert.isFalse(await isToggleChecked("personalOrgs"));
+    assert.isTrue(await isToggleChecked("forceLogin"));
+    assert.isFalse(await isToggleChecked("anonPlayground"));
+
+    // No env badges, env warning, or single-org warning should be visible.
+    assert.isFalse(await driver.find(".test-permissions-setup-env-warning").isPresent());
+    assert.isFalse(await driver.find(".test-permissions-setup-single-org-warning").isPresent());
+    assert.lengthOf(await driver.findAll(".test-permissions-setup-env-badge"), 0);
+
+    // Click "Open" preset — all toggles should be on.
+    await driver.find(".test-permissions-setup-preset-open").click();
+    assert.isTrue(await isToggleChecked("orgCreationAnyone"));
+    assert.isTrue(await isToggleChecked("personalOrgs"));
+    assert.isTrue(await isToggleChecked("forceLogin"));
+    assert.isTrue(await isToggleChecked("anonPlayground"));
+
+    // Click "Locked down" preset — all toggles should be off.
+    await driver.find(".test-permissions-setup-preset-locked").click();
+    assert.isFalse(await isToggleChecked("orgCreationAnyone"));
+    assert.isFalse(await isToggleChecked("personalOrgs"));
+    assert.isFalse(await isToggleChecked("forceLogin"));
+    assert.isFalse(await isToggleChecked("anonPlayground"));
+  });
+
+  it("should return defaults before any permissions are saved", async function() {
+    const status = await installApi.getPermissionsStatus();
+    assert.equal(status.orgCreationAnyone.value, true);
+    assert.equal(status.orgCreationAnyone.source, undefined);
+    assert.equal(status.personalOrgs.value, true);
+    assert.equal(status.personalOrgs.source, undefined);
+    assert.equal(status.forceLogin.value, false);
+    assert.equal(status.forceLogin.source, undefined);
+    assert.equal(status.anonPlayground.value, true);
+    assert.equal(status.anonPlayground.source, undefined);
+  });
+
+  it("should report env-locked toggles via API and disable them in UI", async function() {
+    // Set some vars via real environment and restart.
+    process.env.GRIST_FORCE_LOGIN = "true";
+    process.env.GRIST_ANON_PLAYGROUND = "false";
+    await server.restart();
+    session = await gu.session().personalSite.login();
+
+    // API should report those as environment-variable source.
+    const status = await installApi.getPermissionsStatus();
+    assert.equal(status.forceLogin.value, true);
+    assert.equal(status.forceLogin.source, "environment-variable");
+    assert.equal(status.anonPlayground.value, false);
+    assert.equal(status.anonPlayground.source, "environment-variable");
+    // The others should still be defaults (no source).
+    assert.equal(status.orgCreationAnyone.source, undefined);
+    assert.equal(status.personalOrgs.source, undefined);
+
+    // UI should show env-locked toggles as disabled with "Environment" badges.
+    await navigateToStep();
+    assert.isTrue(await isToggleDisabled("forceLogin"));
+    assert.isTrue(await isToggleDisabled("anonPlayground"));
+    assert.isFalse(await isToggleDisabled("orgCreationAnyone"));
+    assert.isFalse(await isToggleDisabled("personalOrgs"));
+
+    // Should show "Environment" badges on locked toggles only.
+    assert.lengthOf(await driver.findAll(".test-permissions-setup-env-badge"), 2);
+    assert.isTrue(await hasBadge("forceLogin"));
+    assert.isTrue(await hasBadge("anonPlayground"));
+    assert.isFalse(await hasBadge("orgCreationAnyone"));
+    assert.isFalse(await hasBadge("personalOrgs"));
+
+    // Should show the env warning well.
+    assert.isTrue(await driver.find(".test-permissions-setup-env-warning").isPresent());
+
+    // Restore env and restart for subsequent tests.
+    delete process.env.GRIST_FORCE_LOGIN;
+    delete process.env.GRIST_ANON_PLAYGROUND;
+    await server.restart();
+  });
+
+  it("should show conflict when GRIST_SINGLE_ORG=docs", async function() {
+    process.env.GRIST_SINGLE_ORG = "docs";
+    await server.restart();
+    await navigateToStep();
+
+    // personalOrgs should be forced ON — the personal org is the only org
+    // when GRIST_SINGLE_ORG=docs. The toggle stays enabled so the user can
+    // change it, but the Conflict badge and warning well inform them.
+    assert.isTrue(await isToggleChecked("personalOrgs"));
+    assert.isFalse(await isToggleDisabled("personalOrgs"));
+
+    // Should show a "Conflict" badge on personalOrgs only.
+    assert.isTrue(await hasConflictBadge("personalOrgs"));
+    assert.isFalse(await hasConflictBadge("orgCreationAnyone"));
+    assert.isFalse(await hasConflictBadge("forceLogin"));
+    assert.isFalse(await hasConflictBadge("anonPlayground"));
+
+    // Other toggles should remain normal (not disabled, no badges).
+    assert.isFalse(await isToggleDisabled("orgCreationAnyone"));
+    assert.isFalse(await isToggleDisabled("forceLogin"));
+    assert.isFalse(await isToggleDisabled("anonPlayground"));
+    assert.lengthOf(await driver.findAll(".test-permissions-setup-env-badge"), 0);
+
+    // Single-org warning should explain the conflict.
+    const warning = await driver.find(".test-permissions-setup-single-org-warning");
+    assert.isTrue(await warning.isDisplayed());
+    assert.include(await warning.getText(), "GRIST_SINGLE_ORG=docs");
+    assert.include(await warning.getText(), "personal");
+
+    // No env warning (singleOrg is not an env-locked toggle).
+    assert.isFalse(await driver.find(".test-permissions-setup-env-warning").isPresent());
+
+    // Restore and restart for subsequent tests.
+    delete process.env.GRIST_SINGLE_ORG;
+    await server.restart();
+  });
+
+  it("should save permissions and show restart error", async function() {
+    await (await gu.session().personalSite.login()).loadDocMenu("/");
+    // Before saving, all permissions should be at defaults (no source).
+    const before = await installApi.getPermissionsStatus();
+    assert.isUndefined(before.orgCreationAnyone.source);
+    assert.isUndefined(before.personalOrgs.source);
+    assert.isUndefined(before.forceLogin.source);
+    assert.isUndefined(before.anonPlayground.source);
+
+    await navigateToStep();
+
+    // Select "Open" preset (differs from defaults) and click Go Live.
+    await driver.find(".test-permissions-setup-preset-open").click();
+    await driver.find(".test-permissions-setup-go-live").click();
+
+    // In test mode the server can't auto-restart, so the UI shows the error.
+    await gu.waitToPass(async () => {
+      assert.include(
+        await driver.find(".test-permissions-setup-section").getText(),
+        "Cannot automatically restart",
+      );
+    }, 5000);
+
+    // Do manual restart to apply settings for subsequent tests.
+    await server.restart();
+    session = await gu.session().personalSite.login();
+    installApi = session.createApi(InstallAPIImpl);
+
+    // Even though restart failed, settings should have been persisted to DB.
+    const status = await installApi.getPermissionsStatus();
+    assert.equal(status.orgCreationAnyone.value, true);
+    assert.equal(status.orgCreationAnyone.source, "preferences");
+    assert.equal(status.personalOrgs.value, true);
+    assert.equal(status.personalOrgs.source, "preferences");
+    assert.equal(status.forceLogin.value, false);
+    assert.equal(status.forceLogin.source, "preferences");
+    assert.equal(status.anonPlayground.value, true);
+    assert.equal(status.anonPlayground.source, "preferences");
+  });
+
+  async function navigateToStep() {
+    await driver.get(`${server.getHost()}/admin/setup`);
+    await driver.findWait(".test-stepper-step-4", 1000);
+    await driver.find(".test-stepper-step-4").click();
+    await gu.waitToPass(async () => {
+      assert.include(
+        await driver.find(".test-permissions-setup-section").getText(),
+        "Apply & Restart",
+      );
+    }, 1000);
+  }
+
+  async function isPresetActive(preset: string): Promise<boolean> {
+    const cls = await driver.find(`.test-permissions-setup-preset-${preset}`).getAttribute("class");
+    return cls.includes("active");
+  }
+
+  async function isToggleChecked(permKey: string): Promise<boolean> {
+    const el = await driver.find(`.test-permissions-setup-perm-${permKey} label`);
+    const cls = await el.getAttribute("class");
+    return cls.includes("--checked");
+  }
+
+  async function isToggleDisabled(permKey: string): Promise<boolean> {
+    const input = await driver.find(`.test-permissions-setup-perm-${permKey} input`);
+    return input.getAttribute("disabled").then(v => v !== null);
+  }
+
+  async function hasBadge(permKey: string): Promise<boolean> {
+    return driver.find(`.test-permissions-setup-perm-${permKey} .test-permissions-setup-env-badge`).isPresent();
+  }
+
+  async function hasConflictBadge(permKey: string): Promise<boolean> {
+    return driver.find(`.test-permissions-setup-perm-${permKey} .test-permissions-setup-conflict-badge`).isPresent();
+  }
+});


### PR DESCRIPTION
## Context
Final step in the QuickSetup wizard

## Proposed solution
Final step in the wizard. Allows to set 4 variables into the database
GRIST_ORG_CREATION_ANYONE
GRIST_PERSONAL_ORGS
GRIST_FORCE_LOGIN
GRIST_ANON_PLAYGROUND

Offers 3 presents locked, recommended, and open.
Locked - all are off (GRIST_FORCE_LOGIN is reverted so in locked it is set to true)
Recommended - only anonymous users are turned on
Open - all are on.

Shows environment badges when toggles are locked by env vars, and a conflict                                        
badge when `GRIST_SINGLE_ORG=docs` conflicts with personal orgs settings or is set
to any other team.
                                                                                         
"Go Live" button persists settings to DB and triggers a server restart. This restart
behavior is tested manually

## Has this been tested?
New test added

Bot assisted work.