### PR TITLE
Fixes opaque origin handling in trustOrigin for CORS requests

### DIFF
--- a/app/server/lib/requestUtils.ts
+++ b/app/server/lib/requestUtils.ts
@@ -89,15 +89,13 @@ export function getOrgUrl(req: Request, path: string = "/") {
  * Parse a request's origin header safely into a URL.
  * Handles Opaque Origins (https://developer.mozilla.org/en-US/docs/Glossary/Origin#opaque_origin)
  * and malformed URLs safely.
- * @returns {URL | "null" | undefined} - A URL if a valid URL was provided,
- *                                       undefined if origin was falsey (e.g. empty) or undefined,
- *                                       and an Opaque Origin otherwise.
+ *
+ * Throws an ApiError if origin is invalid (not a valid URL or "null")
  */
-export function parseOrigin(origin: string | undefined): URL | "null" | undefined {
-  if (!origin) { return undefined; }
+export function parseOrigin(origin: string): { raw: string, url: URL } | "null" {
   if (origin === "null") { return "null" as const; }
   try {
-    return new URL(origin);
+    return { raw: origin, url: new URL(origin) };
   } catch {
     throw new ApiError(`Invalid origin: ${origin}`, 400);
   }
@@ -112,15 +110,16 @@ export function parseOrigin(origin: string | undefined): URL | "null" | undefine
 export function trustOrigin(req: IncomingMessage, resp?: Response): boolean {
   // TODO: We may want to consider changing allowed origin values in the future.
   // Note that the request origin is undefined for non-CORS requests.
-  const originUrl = parseOrigin(req.headers.origin);
-  if (originUrl === undefined) { return true; } // Not a CORS request.
+  if (!req.headers.origin) { return true; } // Not a CORS request
+  const origin = parseOrigin(req.headers.origin);
   // Opaque origin: https://developer.mozilla.org/en-US/docs/Glossary/Origin#opaque_origin
-  if (originUrl === "null") { return false; }
-  if (!allowHost(req, originUrl)) { return false; }
+  if (origin === "null") { return false; }
+  if (!allowHost(req, origin.url)) { return false; }
 
   if (resp) {
     // For a request to a custom domain, the full hostname must match.
-    resp.header("Access-Control-Allow-Origin", originUrl.origin);
+    // Access-Control-Allow-Origin should match the Origin value exactly (https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin)
+    resp.header("Access-Control-Allow-Origin", origin.raw);
     resp.header("Vary", "Origin");
   }
   return true;

--- a/app/server/lib/requestUtils.ts
+++ b/app/server/lib/requestUtils.ts
@@ -113,15 +113,15 @@ export function parseOrigin(origin: string | undefined): URL | "null" | undefine
 export function trustOrigin(req: IncomingMessage, resp?: Response): boolean {
   // TODO: We may want to consider changing allowed origin values in the future.
   // Note that the request origin is undefined for non-CORS requests.
-  const origin = parseOrigin(req.headers.origin);
-  if (origin === undefined) { return true; } // Not a CORS request.
+  const originUrl = parseOrigin(req.headers.origin);
+  if (originUrl === undefined) { return true; } // Not a CORS request.
   // Opaque origin: https://developer.mozilla.org/en-US/docs/Glossary/Origin#opaque_origin
-  if (origin === "null") { return false; }
-  if (!allowHost(req, origin)) { return false; }
+  if (originUrl === "null") { return false; }
+  if (!allowHost(req, originUrl)) { return false; }
 
   if (resp) {
     // For a request to a custom domain, the full hostname must match.
-    resp.header("Access-Control-Allow-Origin", origin.toString());
+    resp.header("Access-Control-Allow-Origin", originUrl.origin);
     resp.header("Vary", "Origin");
   }
   return true;

--- a/app/server/lib/requestUtils.ts
+++ b/app/server/lib/requestUtils.ts
@@ -90,11 +90,11 @@ export function getOrgUrl(req: Request, path: string = "/") {
  * Handles Opaque Origins (https://developer.mozilla.org/en-US/docs/Glossary/Origin#opaque_origin)
  * and malformed URLs safely.
  * @returns {URL | "null" | undefined} - A URL if a valid URL was provided,
- *                                       undefined if no URL was provided,
+ *                                       undefined if origin was falsey (e.g. empty) or undefined,
  *                                       and an Opaque Origin otherwise.
  */
 export function parseOrigin(origin: string | undefined): URL | "null" | undefined {
-  if (origin === undefined) { return undefined; }
+  if (!origin) { return undefined; }
   if (origin === "null") { return "null" as const; }
   try {
     return new URL(origin);

--- a/app/server/lib/requestUtils.ts
+++ b/app/server/lib/requestUtils.ts
@@ -86,6 +86,25 @@ export function getOrgUrl(req: Request, path: string = "/") {
 }
 
 /**
+ * Parse a request's origin header safely into a URL.
+ * Handles Opaque Origins (https://developer.mozilla.org/en-US/docs/Glossary/Origin#opaque_origin)
+ * and malformed URLs safely.
+ * @returns {URL | "null" | undefined} - A URL if a valid URL was provided,
+ *                                       undefined if no URL was provided,
+ *                                       and an Opaque Origin otherwise.
+ */
+export function parseOrigin(origin: string | undefined): URL | "null" | undefined {
+  if (origin === undefined) { return undefined; }
+  if (origin.toLowerCase() === "null") { return "null" as const; }
+  try {
+    return new URL(origin);
+  } catch {
+    // Malformed origin URL - treat it as an Opaque Origin (which cannot be safely used for security checks)
+    return "null" as const;
+  }
+}
+
+/**
  * Returns true for requests from permitted origins.  For such requests, if
  * a Response object is provided, an "Access-Control-Allow-Origin" header is added
  * to the response.  Vary: Origin is also set to reflect the fact that the headers
@@ -94,13 +113,15 @@ export function getOrgUrl(req: Request, path: string = "/") {
 export function trustOrigin(req: IncomingMessage, resp?: Response): boolean {
   // TODO: We may want to consider changing allowed origin values in the future.
   // Note that the request origin is undefined for non-CORS requests.
-  const origin = req.headers.origin;
-  if (!origin) { return true; } // Not a CORS request.
-  if (!allowHost(req, new URL(origin))) { return false; }
+  const origin = parseOrigin(req.headers.origin);
+  if (origin === undefined) { return true; } // Not a CORS request.
+  // Opaque origin: https://developer.mozilla.org/en-US/docs/Glossary/Origin#opaque_origin
+  if (origin === "null") { return false; }
+  if (!allowHost(req, origin)) { return false; }
 
   if (resp) {
     // For a request to a custom domain, the full hostname must match.
-    resp.header("Access-Control-Allow-Origin", origin);
+    resp.header("Access-Control-Allow-Origin", origin.toString());
     resp.header("Vary", "Origin");
   }
   return true;

--- a/app/server/lib/requestUtils.ts
+++ b/app/server/lib/requestUtils.ts
@@ -99,8 +99,7 @@ export function parseOrigin(origin: string | undefined): URL | "null" | undefine
   try {
     return new URL(origin);
   } catch {
-    // Malformed origin URL - treat it as an Opaque Origin (which cannot be safely used for security checks)
-    return "null" as const;
+    throw new ApiError(`Invalid origin: ${origin}`, 400);
   }
 }
 

--- a/app/server/lib/requestUtils.ts
+++ b/app/server/lib/requestUtils.ts
@@ -95,7 +95,7 @@ export function getOrgUrl(req: Request, path: string = "/") {
  */
 export function parseOrigin(origin: string | undefined): URL | "null" | undefined {
   if (origin === undefined) { return undefined; }
-  if (origin.toLowerCase() === "null") { return "null" as const; }
+  if (origin === "null") { return "null" as const; }
   try {
     return new URL(origin);
   } catch {

--- a/test/server/lib/requestUtils.ts
+++ b/test/server/lib/requestUtils.ts
@@ -28,12 +28,13 @@ describe("requestUtils", function() {
       });
     }
 
-    [
+    const apiErrorTestCases = [
       "invalid url",
-    ].forEach((origin) => {
+    ];
+    for (const origin of apiErrorTestCases) {
       it(`throws an ApiError on invalid origin '${origin}'`, function() {
         assert.throws(() => trustOrigin({ headers: { origin } } as any));
       });
-    });
+    }
   });
 });

--- a/test/server/lib/requestUtils.ts
+++ b/test/server/lib/requestUtils.ts
@@ -17,7 +17,6 @@ describe("requestUtils", function() {
       ["https://nasa.efc-r.com", "docs.efc-r.com", true],
       ["https://nasa.efc-r.com", "api.efc-r.com", true],
       ["null", "docs.getgrist.com", false],
-      ["some invalid URL", "docs.getgrist.com", false],
     ];
     for (const [origin, host, permitted] of combinations) {
       it(`${origin} can${permitted ? "" : "not"} access ${host} in browser`, function() {
@@ -27,5 +26,14 @@ describe("requestUtils", function() {
         );
       });
     }
+
+    [
+      "",
+      "invalid url",
+    ].forEach((origin) => {
+      it(`throws an ApiError on invalid origin '${origin}'`, function() {
+        assert.throws(() => trustOrigin({ headers: { origin } } as any));
+      });
+    });
   });
 });

--- a/test/server/lib/requestUtils.ts
+++ b/test/server/lib/requestUtils.ts
@@ -16,6 +16,8 @@ describe("requestUtils", function() {
       ["https://nasa.efc-r.com", "docs.getgrist.com", false],
       ["https://nasa.efc-r.com", "docs.efc-r.com", true],
       ["https://nasa.efc-r.com", "api.efc-r.com", true],
+      ["null", "docs.getgrist.com", false],
+      ["some invalid URL", "docs.getgrist.com", false],
     ];
     for (const [origin, host, permitted] of combinations) {
       it(`${origin} can${permitted ? "" : "not"} access ${host} in browser`, function() {

--- a/test/server/lib/requestUtils.ts
+++ b/test/server/lib/requestUtils.ts
@@ -17,9 +17,10 @@ describe("requestUtils", function() {
       ["https://nasa.efc-r.com", "docs.efc-r.com", true],
       ["https://nasa.efc-r.com", "api.efc-r.com", true],
       ["null", "docs.getgrist.com", false],
+      ["", "docs.getgrist.com", true],
     ];
     for (const [origin, host, permitted] of combinations) {
-      it(`${origin} can${permitted ? "" : "not"} access ${host} in browser`, function() {
+      it(`'${origin}' can${permitted ? "" : "not"} access '${host}' in browser`, function() {
         assert.equal(
           trustOrigin({ headers: { origin, host } } as any, { header: (a: string, b: string) => true } as any),
           permitted,
@@ -28,7 +29,6 @@ describe("requestUtils", function() {
     }
 
     [
-      "",
       "invalid url",
     ].forEach((origin) => {
       it(`throws an ApiError on invalid origin '${origin}'`, function() {


### PR DESCRIPTION
## Context

In certain contexts, the browser is permitted to use "null" as an [Opaque Origin](https://developer.mozilla.org/en-US/docs/Glossary/Origin#opaque_origin) value in the "Origin" header. 

This isn't handled well by `trustOrigin` currently, resulting in an internal server error unnecessarily.

This can manifest in specific situations, such as when using a `https://` widget in a `http://` hosted site (e.g. local development). 

## Proposed solution

This tightens up the parsing of the `Origin` header, forcing the Opaque Origin (`"null"`) to be handled explicitly, as well as falling back on it for invalid origin values. 

The Opaque Origin is safe to fall back on for invalid values, as [it cannot be safely used for security checks](https://developer.mozilla.org/en-US/docs/Glossary/Origin#:~:text=cannot%20be%20safely%20used%20for%20security%20checks), so should always be treated as an unsafe CORS request with the lowest possible level of access. 

## Related issues

Manifested while exploring this issue, and fixes this problem specifically for local development on Firefox:

https://community.getgrist.com/t/attachment-viewer-widget-on-self-hosted-grist-doesnt-work/13856

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [X] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

