### PR TITLE
Fix padded checkboxes: anchor border/tick to the input element.

### DIFF
--- a/app/client/ui/ColumnFilterMenu.ts
+++ b/app/client/ui/ColumnFilterMenu.ts
@@ -312,7 +312,6 @@ export function columnFilterMenu(owner: IDisposableOwner, opts: IFilterMenuOptio
                   }
                 }),
                 (elem) => { elem.checked = columnFilter.includes(key); checkboxMap.set(key, elem); },
-                dom.style("position", "relative"),
               ),
               dom("span", renderValue(key, value), testId("value")),
               cssItemCount(value.count.toLocaleString(), testId("count")),

--- a/app/client/ui2018/checkbox.ts
+++ b/app/client/ui2018/checkbox.ts
@@ -42,6 +42,8 @@ export const cssCheckboxSquare = styled("input", `
   margin: 0 !important;
   padding: 0;
 
+  /* Positioning context for the ::before/::after pseudos (border + tick) painted below. */
+  position: relative;
   flex-shrink: 0;
 
   display: inline-block;
@@ -194,8 +196,6 @@ export const cssRadioCheckboxOptions = styled("div", `
   gap: 10px;
 `);
 
-// We need to reset top and left of ::before element, as it is wrongly set
-// on the inline checkbox.
 // To simulate radio button behavior, we will block user input after option is selected, because
 // checkbox doesn't support two-way binding.
 const cssBlockCheckbox = styled("div", `
@@ -204,10 +204,6 @@ const cssBlockCheckbox = styled("div", `
   border: 1px solid ${theme.controlSecondaryDisabledFg};
   border-radius: 3px;
   cursor: pointer;
-  & input::before, & input::after  {
-    top: unset;
-    left: unset;
-  }
   &:hover {
     border-color: ${theme.controlFg};
   }

--- a/storybook/checkboxes.stories.ts
+++ b/storybook/checkboxes.stories.ts
@@ -117,6 +117,29 @@ export const RadioOptions = {
 };
 
 /**
+ * Checkboxes with a padded, bordered wrapper — the kind of box-style affordance used
+ * for radio-style options or settings groups. Extend any checkbox builder with
+ * `styled(squareCheckbox, …)` (or `styled(labeledSquareCheckbox, …)`) to add padding,
+ * border, hover styles, etc. directly on the surrounding `cssLabel`.
+ *
+ * `radioCheckboxOption` is the built-in helper that follows this pattern; it composes
+ * `labeledCircleCheckbox` with `cssBlockCheckbox` (padding + border + radio-like
+ * pointer-events) and ties a group of options to a shared observable.
+ */
+export const PaddedWrapper = {
+  render: (_args: any, { owner }: any) => {
+    const a = Observable.create(owner, true);
+    const b = Observable.create(owner, false);
+    const role = Observable.create<"a" | "b">(owner, "a");
+    return cssColumn(
+      cssPaddedSquareCheckbox(a),
+      cssPaddedLabeledSquareCheckbox(b, "labeledSquareCheckbox with padding"),
+      radioCheckboxOption(role, "a", dom("span", "radioCheckboxOption")),
+    );
+  },
+};
+
+/**
  * Toggle switch with animated slide transition.
  * Pass an `Observable<boolean>` and optional `{ label }`.
  */
@@ -152,3 +175,11 @@ const cssColumn = styled("div", `
   align-items: flex-start;
   gap: 12px;
 `);
+
+const cssPadded = `
+  padding: 10px 8px;
+  border: 1px solid #888;
+  border-radius: 3px;
+`;
+const cssPaddedSquareCheckbox = styled(squareCheckbox, cssPadded);
+const cssPaddedLabeledSquareCheckbox = styled(labeledSquareCheckbox, cssPadded);


### PR DESCRIPTION
Small CSS fix in the checkbox component: the border and tick are now positioned relative to the input itself rather than an outer ancestor. Also remove two callers' workarounds for the same issue.

Adds a Storybook example for checkboxes inside a padded wrapper, the case where the misalignment was visible.

## Context

If a component like `labeledSquareCheckbox` is styled to include padding, its rendering has been broken: the tick is misplaced. This PR fixes it.

## Proposed solution

Adds `position: relative` to the checkbox input element.

## Has this been tested?

No automated test for this css-only change, but a storybook example is added, which looks wrong without the change, and is fixed by it.

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

Storybook example before the fix (note the radio workaround that's corrects it):
<img width="1604" height="316" alt="image" src="https://github.com/user-attachments/assets/9311088c-6889-469c-8cd7-fe7758ccc0ea" />

Storybook with the fix (the radio workaround removed, but is still correct):
<img width="1604" height="316" alt="image" src="https://github.com/user-attachments/assets/b9a93413-5f68-40ef-91c4-6da000f8e8b4" />

