### PR TITLE
start harmonizing the quick setup tabs

### DIFF
--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -1122,7 +1122,7 @@ Set the environment variable GRIST_ALLOW_AUTOMATIC_VERSION_CHECKING to "true" to
   }
 
   private _buildBackupsSection() {
-    const backups = BackupsSection.create(this, { checks: this._checks, hideTitle: true });
+    const backups = BackupsSection.create(this, { checks: this._checks, controls: this });
     return SectionCard(t("Storage"), [
       SectionItem({
         id: "backups",

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -49,11 +49,16 @@ const noAuthAcknowledged = localStorageBoolObs(
 interface AuthenticationSectionOptions {
   appModel: AppModel;
   loginSystemId?: Observable<string | undefined>;
+  /**
+   * Present when this section is rendered inside the admin panel. Absent in the
+   * setup wizard. The single signal for "am I in the admin panel?" -- also the
+   * channel through which the section reports needsRestart.
+   *
+   * When absent, the per-section restart warning is suppressed (the wizard
+   * handles continuation via its own Continue button).
+   */
   controls?: AdminPanelControls;
   installAPI?: InstallAPI;
-  /** When false, suppress the restart warning banner and needsRestart signal.
-   *  Used by the setup wizard where a single restart happens at the end. */
-  showRestartWarning?: boolean;
 }
 
 export class AuthenticationSection extends Disposable {
@@ -65,6 +70,8 @@ export class AuthenticationSection extends Disposable {
 
   private _appModel = this._options.appModel;
   private _installAPI = this._options.installAPI ?? new InstallAPIImpl(getHomeUrl());
+  /** True when embedded in the admin panel (vs. the setup wizard). */
+  private _inAdminPanel = Boolean(this._options.controls);
   private _controls = this._options.controls ?? {
     needsRestart: Observable.create(this, false),
     restartGrist: async () => { await new ConfigAPI(getHomeUrl()).restartServer(); },
@@ -117,7 +124,7 @@ export class AuthenticationSection extends Disposable {
         const loginSystemId = use(this._loginSystemId);
         return this._buildSection(providers, loginSystemId);
       }),
-      this._options.showRestartWarning !== false ?
+      this._inAdminPanel ?
         dom.maybe(this._hasActiveOnRestartProvider, () => this._buildAuthenticationChangeWarning()) : null,
     ];
   }
@@ -328,7 +335,7 @@ authentication system.",
   };
 
   private _checkIfRestartNeeded() {
-    if (this._options.showRestartWarning === false) { return; }
+    if (!this._inAdminPanel) { return; }
 
     const hasActiveOnRestartProvider = this._hasActiveOnRestartProvider.get();
 

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -14,6 +14,7 @@ import { ChangeAdminModal } from "app/client/ui/ChangeAdminModal";
 import { GetGristComProviderInfoModal, getGristComProviderMeta } from "app/client/ui/GetGristComProvider";
 import { quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
 import { cssCardSurface } from "app/client/ui/SettingsLayout";
+import { cssHeroCard } from "app/client/ui/SetupCard";
 import { basicButton, bigBasicButton, bigPrimaryButton, textButton } from "app/client/ui2018/buttons";
 import { labeledSquareCheckbox } from "app/client/ui2018/checkbox";
 import { theme, vars } from "app/client/ui2018/cssVars";
@@ -76,9 +77,9 @@ export class AuthenticationSection extends Disposable {
    * deferred install-prefs (admin email changes). Drives the QuickSetup
    * "Apply and Continue" / "Continue" button label.
    */
-  public hasPendingChanges: Computed<boolean>;
+  public isDirty: Computed<boolean>;
 
-  /** True while {@link applyPendingChanges} is in flight. */
+  /** True while {@link apply} is in flight. */
   public isApplying = Observable.create<boolean>(this, false);
 
   private _appModel = this._options.appModel;
@@ -126,7 +127,7 @@ export class AuthenticationSection extends Disposable {
       return !!loginSystemId && isRealProvider(loginSystemId);
     });
 
-    this.hasPendingChanges = Computed.create(this, (use) => {
+    this.isDirty = Computed.create(this, (use) => {
       if (use(this._hasActiveOnRestartProvider)) { return true; }
       const prefs = use(this._prefsPendingChanges);
       return Boolean(prefs?.onRestartSetAdminEmail || prefs?.onRestartReplaceEmailWithAdmin);
@@ -145,8 +146,8 @@ export class AuthenticationSection extends Disposable {
    *
    * No-op when there are no pending changes. Throws on restart timeout.
    */
-  public async applyPendingChanges(): Promise<void> {
-    if (!this.hasPendingChanges.get()) { return; }
+  public async apply(): Promise<void> {
+    if (!this.isDirty.get()) { return; }
     if (this.isApplying.get()) { return; }
     this.isApplying.set(true);
     try {
@@ -155,9 +156,7 @@ export class AuthenticationSection extends Disposable {
         throw new Error("Timed out waiting for Grist server to restart");
       }
       if (this.isDisposed()) { return; }
-      await this._fetchProviders();
-      if (this.isDisposed()) { return; }
-      await this._fetchPrefsPendingChanges();
+      await Promise.all([this._fetchProviders(), this._fetchPrefsPendingChanges()]);
     } finally {
       if (!this.isDisposed()) { this.isApplying.set(false); }
     }
@@ -852,25 +851,6 @@ function buildProviderList(
     dom.maybe(use => !use(collapsed), buildCards),
   );
 }
-
-const cssHeroCard = styled(cssCardSurface, `
-  padding: 16px 20px;
-  border-left-width: 4px;
-  margin-bottom: 24px;
-
-  &-success {
-    border-left-color: ${theme.toastSuccessBg};
-  }
-  &-pending {
-    border-left-color: ${theme.controlPrimaryBg};
-  }
-  &-warning {
-    border-left-color: ${theme.toastWarningBg};
-  }
-  &-error {
-    border-left-color: ${theme.errorText};
-  }
-`);
 
 const cssHeroHeader = styled("div", `
   display: flex;

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -12,6 +12,8 @@ import {
 } from "app/client/ui/AdminPanelCss";
 import { ChangeAdminModal } from "app/client/ui/ChangeAdminModal";
 import { GetGristComProviderInfoModal, getGristComProviderMeta } from "app/client/ui/GetGristComProvider";
+import { quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
+import { cssCardSurface } from "app/client/ui/SettingsLayout";
 import { basicButton, bigBasicButton, bigPrimaryButton, textButton } from "app/client/ui2018/buttons";
 import { labeledSquareCheckbox } from "app/client/ui2018/checkbox";
 import { theme, vars } from "app/client/ui2018/cssVars";
@@ -68,6 +70,17 @@ export class AuthenticationSection extends Disposable {
    */
   public canProceed: Computed<boolean>;
 
+  /**
+   * True when there are saved changes that won't take effect until the
+   * server restarts: a provider that will be active on next boot, or
+   * deferred install-prefs (admin email changes). Drives the QuickSetup
+   * "Apply and Continue" / "Continue" button label.
+   */
+  public hasPendingChanges: Computed<boolean>;
+
+  /** True while {@link applyPendingChanges} is in flight. */
+  public isApplying = Observable.create<boolean>(this, false);
+
   private _appModel = this._options.appModel;
   private _installAPI = this._options.installAPI ?? new InstallAPIImpl(getHomeUrl());
   /** True when embedded in the admin panel (vs. the setup wizard). */
@@ -113,12 +126,50 @@ export class AuthenticationSection extends Disposable {
       return !!loginSystemId && isRealProvider(loginSystemId);
     });
 
+    this.hasPendingChanges = Computed.create(this, (use) => {
+      if (use(this._hasActiveOnRestartProvider)) { return true; }
+      const prefs = use(this._prefsPendingChanges);
+      return Boolean(prefs?.onRestartSetAdminEmail || prefs?.onRestartReplaceEmailWithAdmin);
+    });
+
     this._fetchProviders().catch(reportError);
     this._fetchPrefsPendingChanges().catch(reportError);
   }
 
+  /**
+   * Apply pending auth changes by restarting the server and waiting until
+   * it's ready again. The relevant config writes have already happened
+   * inline (via the configuration modals); this is purely the restart so
+   * the new config takes effect. After restart, re-fetches providers and
+   * prefs so the section reflects the post-restart state.
+   *
+   * No-op when there are no pending changes. Throws on restart timeout.
+   */
+  public async applyPendingChanges(): Promise<void> {
+    if (!this.hasPendingChanges.get()) { return; }
+    if (this.isApplying.get()) { return; }
+    this.isApplying.set(true);
+    try {
+      await this._configAPI.restartServer();
+      if (!await this._configAPI.waitUntilReady()) {
+        throw new Error("Timed out waiting for Grist server to restart");
+      }
+      if (this.isDisposed()) { return; }
+      await this._fetchProviders();
+      if (this.isDisposed()) { return; }
+      await this._fetchPrefsPendingChanges();
+    } finally {
+      if (!this.isDisposed()) { this.isApplying.set(false); }
+    }
+  }
+
   public buildDom() {
     return [
+      this._inAdminPanel ? null : quickSetupStepHeader({
+        icon: "AddUser",
+        title: t("Authentication"),
+        description: t("Choose how users sign in to Grist."),
+      }),
       dom.domComputed((use) => {
         const providers = use(this._providers);
         const loginSystemId = use(this._loginSystemId);
@@ -802,10 +853,8 @@ function buildProviderList(
   );
 }
 
-const cssHeroCard = styled("div", `
+const cssHeroCard = styled(cssCardSurface, `
   padding: 16px 20px;
-  border-radius: 8px;
-  border: 1px solid ${theme.menuBorder};
   border-left-width: 4px;
   margin-bottom: 24px;
 
@@ -905,11 +954,9 @@ const cssCollapseIcon = styled(icon, `
   --icon-color: ${theme.lightText};
 `);
 
-const cssMethodsContainer = styled("div", `
+const cssMethodsContainer = styled(cssCardSurface, `
   display: flex;
   flex-direction: column;
-  border: 1px solid ${theme.menuBorder};
-  border-radius: 8px;
   overflow: hidden;
 `);
 

--- a/app/client/ui/BackupsSection.ts
+++ b/app/client/ui/BackupsSection.ts
@@ -1,9 +1,9 @@
 import { makeT } from "app/client/lib/localization";
 import { AdminChecks } from "app/client/models/AdminChecks";
 import { AdminPanelControls, cssDangerText, cssHappyText } from "app/client/ui/AdminPanelCss";
-import { cssValueLabel } from "app/client/ui/SettingsLayout";
+import { quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
+import { cssCardSurface, cssValueLabel } from "app/client/ui/SettingsLayout";
 import { colors } from "app/client/ui2018/cssVars";
-import { icon } from "app/client/ui2018/icons";
 import { cssLink } from "app/client/ui2018/links";
 import { loadingSpinner } from "app/client/ui2018/loaders";
 import { BackupsBootProbeDetails } from "app/common/BootProbe";
@@ -76,6 +76,15 @@ export interface BackupsSectionProps {
 export class BackupsSection extends Disposable {
   public readonly canProceed: Computed<boolean>;
 
+  /**
+   * Backups is currently informational -- enabling a backend is done out of
+   * band by setting env vars and restarting. So nothing is ever pending here
+   * and {@link applyPendingChanges} is a no-op. Both are kept as part of the
+   * shared {@link QuickSetupSection} shape across all setup steps.
+   */
+  public readonly hasPendingChanges = Computed.create(this, () => false);
+  public readonly isApplying = Observable.create<boolean>(this, false);
+
   private readonly _backupsProbeDetails = Computed.create(this, use => this._getBackupsProbeDetails(use));
   private readonly _activeBackend = Computed.create(this, use => use(this._backupsProbeDetails)?.backend);
   private readonly _availableBackends = Computed.create(this, use => use(this._backupsProbeDetails)?.availableBackends);
@@ -87,16 +96,19 @@ export class BackupsSection extends Disposable {
     this.canProceed = Computed.create(this, this._selectedBackend, (_use, backend) => !!backend);
   }
 
+  public async applyPendingChanges(): Promise<void> { /* no-op */ }
+
   public buildDom() {
     return cssSection(
-      this._props.controls ? null : cssTitle(
-        icon("Database"),
-        cssTitleText(t("Backups")),
-      ),
-      cssDescription(
+      this._props.controls ? cssDescription(
         t("Store document backups on an external service like S3 or Azure. \
           This protects against data loss if the server's disk fails."),
-      ),
+      ) : quickSetupStepHeader({
+        icon: "Database",
+        title: t("Backups"),
+        description: t("Store document backups on an external service like S3 or Azure. " +
+          "This protects against data loss if the server's disk fails."),
+      }),
       this._buildBackendCards(),
     );
   }
@@ -234,20 +246,6 @@ const cssSection = styled("div", `
   gap: 12px;
 `);
 
-const cssTitle = styled("div", `
-  --icon-color: ${tokens.primary};
-  align-items: center;
-  display: flex;
-  gap: 10px;
-  margin-bottom: 4px;
-`);
-
-const cssTitleText = styled("div", `
-  font-size: 17px;
-  font-weight: 700;
-  letter-spacing: -0.2px;
-`);
-
 const cssDescription = styled("div", `
   color: ${tokens.secondary};
   line-height: 1.55;
@@ -270,24 +268,20 @@ const cssBackendCards = styled("div", `
   gap: 8px;
 `);
 
-const cssBackendCard = styled("div", `
+const cssBackendCard = styled(cssCardSurface, `
   align-items: flex-start;
-  border: 1px solid ${tokens.decoration};
-  border-radius: 8px;
   cursor: pointer;
   display: flex;
   gap: 12px;
   padding: 14px 18px;
-  transition: border-color 0.2s, background-color 0.2s, box-shadow 0.2s;
+  transition: border-color 0.2s, background-color 0.2s;
 
   &:hover {
     border-color: ${tokens.primary};
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
   }
   &-selected {
     background-color: ${components.lightHover};
     border-color: ${tokens.primary};
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
   }
   &-disabled {
     border-color: ${tokens.decorationSecondary};

--- a/app/client/ui/BackupsSection.ts
+++ b/app/client/ui/BackupsSection.ts
@@ -79,10 +79,10 @@ export class BackupsSection extends Disposable {
   /**
    * Backups is currently informational -- enabling a backend is done out of
    * band by setting env vars and restarting. So nothing is ever pending here
-   * and {@link applyPendingChanges} is a no-op. Both are kept as part of the
+   * and {@link apply} is a no-op. Both are kept as part of the
    * shared {@link QuickSetupSection} shape across all setup steps.
    */
-  public readonly hasPendingChanges = Computed.create(this, () => false);
+  public readonly isDirty = Computed.create(this, () => false);
   public readonly isApplying = Observable.create<boolean>(this, false);
 
   private readonly _backupsProbeDetails = Computed.create(this, use => this._getBackupsProbeDetails(use));
@@ -96,7 +96,7 @@ export class BackupsSection extends Disposable {
     this.canProceed = Computed.create(this, this._selectedBackend, (_use, backend) => !!backend);
   }
 
-  public async applyPendingChanges(): Promise<void> { /* no-op */ }
+  public async apply(): Promise<void> { /* no-op */ }
 
   public buildDom() {
     return cssSection(

--- a/app/client/ui/BackupsSection.ts
+++ b/app/client/ui/BackupsSection.ts
@@ -1,6 +1,6 @@
 import { makeT } from "app/client/lib/localization";
 import { AdminChecks } from "app/client/models/AdminChecks";
-import { cssDangerText, cssHappyText } from "app/client/ui/AdminPanelCss";
+import { AdminPanelControls, cssDangerText, cssHappyText } from "app/client/ui/AdminPanelCss";
 import { cssValueLabel } from "app/client/ui/SettingsLayout";
 import { colors } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
@@ -48,8 +48,15 @@ const STORAGE_BACKENDS: Record<BackendName, BackendInfo> = {
 
 export interface BackupsSectionProps {
   checks: AdminChecks;
-  /** Hides the "Backups" title above the list of available backends (default: `false`). */
-  hideTitle?: boolean;
+  /**
+   * Present when this section is rendered inside the admin panel. Absent in the
+   * setup wizard. Sections use this as the single signal for "am I in the admin
+   * panel?" -- it's also the channel through which they report needsRestart.
+   *
+   * BackupsSection has no restart-required settings of its own, but accepts the
+   * option so all sections share one mode flag.
+   */
+  controls?: AdminPanelControls;
 }
 
 /**
@@ -82,7 +89,7 @@ export class BackupsSection extends Disposable {
 
   public buildDom() {
     return cssSection(
-      this._props.hideTitle ? null : cssTitle(
+      this._props.controls ? null : cssTitle(
         icon("Database"),
         cssTitleText(t("Backups")),
       ),

--- a/app/client/ui/PermissionsSetupSection.ts
+++ b/app/client/ui/PermissionsSetupSection.ts
@@ -1,6 +1,7 @@
 import { makeT } from "app/client/lib/localization";
 import { getHomeUrl } from "app/client/models/homeUrl";
-import { cssQuickSetupCard, cssShadowedPrimaryButton, quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
+import { quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
+import { cssQuickSetupCard, cssShadowedPrimaryButton } from "app/client/ui/SettingsLayout";
 import { bigBasicButton } from "app/client/ui2018/buttons";
 import { theme, vars } from "app/client/ui2018/cssVars";
 import { loadingSpinner } from "app/client/ui2018/loaders";

--- a/app/client/ui/PermissionsSetupSection.ts
+++ b/app/client/ui/PermissionsSetupSection.ts
@@ -1,6 +1,7 @@
 import { makeT } from "app/client/lib/localization";
 import { getHomeUrl } from "app/client/models/homeUrl";
-import { bigBasicButton, bigPrimaryButton } from "app/client/ui2018/buttons";
+import { cssQuickSetupCard, cssShadowedPrimaryButton, quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
+import { bigBasicButton } from "app/client/ui2018/buttons";
 import { theme, vars } from "app/client/ui2018/cssVars";
 import { loadingSpinner } from "app/client/ui2018/loaders";
 import { toggleSwitch } from "app/client/ui2018/toggleSwitch";
@@ -162,11 +163,12 @@ export class PermissionsSetupSection extends Disposable {
 
   private _buildContent(status: PermissionsStatus): DomContents {
     return dom("div",
-      cssStepTitle(t("Apply & Restart")),
-      cssStepDescription(
-        t("Review these defaults before going live. \
-You can change them later from the admin panel."),
-      ),
+      quickSetupStepHeader({
+        icon: "Settings",
+        title: t("Apply & Restart"),
+        description: t("Review these defaults before going live. " +
+          "You can change them later from the admin panel."),
+      }),
       cssPermissionsSection(
         dom.cls("disabled", this._saving),
         cssSectionLabel(t("DEFAULT PERMISSIONS")),
@@ -241,8 +243,7 @@ stay enabled or Grist will be non-functional."),
       ),
       dom.maybe(not(this._saving), () =>
         cssBottomRow(
-          bigPrimaryButton(t("Apply and Go Live!"),
-            cssGoLiveButton.cls(""),
+          cssGoLiveButton(t("Apply and Go Live!"),
             dom.on("click", () => this._handleGoLive()),
             testId("go-live"),
           ),
@@ -342,23 +343,7 @@ const cssError = styled("div", `
   margin-bottom: 16px;
 `);
 
-const cssStepTitle = styled("div", `
-  font-size: 18px;
-  font-weight: 600;
-  margin-bottom: 8px;
-`);
-
-const cssStepDescription = styled("div", `
-  font-size: 14px;
-  color: ${theme.lightText};
-  line-height: 1.5;
-  margin-bottom: 20px;
-`);
-
-const cssPermissionsSection = styled("div", `
-  border: 1px solid ${theme.pagePanelsBorder};
-  border-radius: 8px;
-  padding: 16px 20px;
+const cssPermissionsSection = styled(cssQuickSetupCard, `
   transition: opacity 0.2s;
 
   &.disabled {
@@ -494,7 +479,7 @@ const cssRestartingRow = styled("div", `
   font-size: 14px;
 `);
 
-const cssGoLiveButton = styled("div", `
+const cssGoLiveButton = styled(cssShadowedPrimaryButton, `
   background-color: ${theme.toastSuccessBg};
   border-color: ${theme.toastSuccessBg};
   &:hover {

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -106,7 +106,6 @@ export class QuickSetup extends Disposable {
     return dom.create((owner) => {
       const section = AuthenticationSection.create(owner, {
         appModel: this._appModel,
-        showRestartWarning: false,
       });
       return dom("div",
         section.buildDom(),

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -7,12 +7,11 @@ import { cssFadeUp, cssFadeUpGristLogo, cssFadeUpHeading, cssFadeUpSubHeading } 
 import { AuthenticationSection } from "app/client/ui/AuthenticationSection";
 import { BackupsSection } from "app/client/ui/BackupsSection";
 import { PermissionsSetupSection } from "app/client/ui/PermissionsSetupSection";
+import { quickSetupContinueButton } from "app/client/ui/QuickSetupContinueButton";
 import { QuickSetupServerStep } from "app/client/ui/QuickSetupServerStep";
 import { SandboxSetupSection } from "app/client/ui/SandboxSection";
-import { bigPrimaryButton } from "app/client/ui2018/buttons";
 import { Stepper } from "app/client/ui2018/Stepper";
 import { InstallAPIImpl } from "app/common/InstallAPI";
-import { tokens } from "app/common/ThemePrefs";
 
 import { Disposable, dom, DomContents, makeTestId, observable, Observable, styled } from "grainjs";
 
@@ -22,8 +21,6 @@ const testId = makeTestId("test-quick-setup-");
 interface Step {
   completed: Observable<boolean>;
   label: string;
-  /** When true, step content card has no border or padding. */
-  plain?: boolean;
   buildDom(): DomContents;
 }
 
@@ -39,30 +36,21 @@ export class QuickSetup extends Disposable {
     {
       label: t("Sandboxing"),
       completed: observable(false),
-      plain: true,
-      buildDom: () => {
-        const section = SandboxSetupSection.create(
-          this, () => this._activeStep.set(this._activeStep.get() + 1),
-        );
-        return section.buildDom();
-      },
+      buildDom: () => this._buildSandboxStep(),
     },
     {
       label: t("Authentication"),
       completed: observable(false),
-      plain: true,
       buildDom: () => this._buildAuthStep(),
     },
     {
       label: t("Backups"),
       completed: observable(false),
-      plain: true,
       buildDom: () => this._buildBackupsStep(),
     },
     {
       label: t("Apply & restart"),
       completed: observable(false),
-      plain: true,
       buildDom: () => this._buildApplyStep(),
     },
   ];
@@ -83,7 +71,6 @@ export class QuickSetup extends Disposable {
         dom.create(Stepper, { activeStep: this._activeStep, steps: this._steps }),
       ),
       dom.domComputed(this._activeStep, i => cssStepContent(
-        cssStepContent.cls("-plain", Boolean(this._steps[i].plain)),
         this._steps[i].buildDom(),
       )),
     );
@@ -102,25 +89,22 @@ export class QuickSetup extends Disposable {
     this._activeStep.set(i + 1);
   }
 
-  private _buildAuthStep(): DomContents {
+  private _buildSandboxStep(): DomContents {
     return dom.create((owner) => {
-      const section = AuthenticationSection.create(owner, {
-        appModel: this._appModel,
-      });
+      const section = SandboxSetupSection.create(owner);
       return dom("div",
         section.buildDom(),
-        cssContinueRow(
-          bigPrimaryButton(
-            t("Continue"),
-            dom.boolAttr("disabled", use => !use(section.canProceed)),
-            dom.on("click", () => {
-              const activeStepIndex = this._activeStep.get();
-              this._steps[activeStepIndex].completed.set(true);
-              this._activeStep.set(activeStepIndex + 1);
-            }),
-            testId("auth-continue"),
-          ),
-        ),
+        quickSetupContinueButton(section, () => this._advanceStep(), testId("sandbox-continue")),
+      );
+    });
+  }
+
+  private _buildAuthStep(): DomContents {
+    return dom.create((owner) => {
+      const section = AuthenticationSection.create(owner, { appModel: this._appModel });
+      return dom("div",
+        section.buildDom(),
+        quickSetupContinueButton(section, () => this._advanceStep(), testId("auth-continue")),
       );
     });
   }
@@ -130,17 +114,7 @@ export class QuickSetup extends Disposable {
       const section = BackupsSection.create(owner, { checks: this._checks });
       return dom("div",
         section.buildDom(),
-        cssContinueRow(
-          bigPrimaryButton(
-            t("Continue"),
-            dom.boolAttr("disabled", use => !use(section.canProceed)),
-            dom.on("click", () => {
-              const activeStepIndex = this._activeStep.get();
-              this._steps[activeStepIndex].completed.set(true);
-              this._activeStep.set(activeStepIndex + 1);
-            }),
-          ),
-        ),
+        quickSetupContinueButton(section, () => this._advanceStep(), testId("backups-continue")),
       );
     });
   }
@@ -166,25 +140,6 @@ const cssStepper = styled("div", `
 
 const cssStepContent = styled("div", `
   animation: ${cssFadeUp} 0.5s ease 0.24s both;
-  background: ${tokens.bg};
-  border: 1px solid ${tokens.decorationSecondary};
-  border-radius: 12px;
-  box-shadow:
-    0 1px 3px rgba(0, 0, 0, 0.04),
-    0 8px 24px rgba(0, 0, 0, 0.06);
   margin: 24px auto;
   max-width: 520px;
-  padding: 28px 32px;
-  &-plain {
-    border: none;
-    box-shadow: none;
-    padding: 0;
-    background: none;
-  }
-`);
-
-const cssContinueRow = styled("div", `
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 24px;
 `);

--- a/app/client/ui/QuickSetupContinueButton.ts
+++ b/app/client/ui/QuickSetupContinueButton.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared "Continue" / "Apply and Continue" button for QuickSetup steps.
+ *
+ * Each step's section conforms to {@link QuickSetupSection} so the button's
+ * label and click behaviour can be driven uniformly:
+ *
+ *   - Nothing dirty             -> "Continue", advance on click.
+ *   - Pending changes           -> "Apply and Continue", apply (which may
+ *                                  restart the server) and then advance.
+ *   - Applying                  -> "Applying...", disabled.
+ *
+ * Sections may override the label for step-specific cases (e.g. sandbox's
+ * "Skip and Continue" when env-locked, or server's "Confirm base URL to
+ * continue" pre-confirmation messages) by implementing `customLabel`.
+ */
+import { makeT } from "app/client/lib/localization";
+import { reportError } from "app/client/models/errors";
+import { cssShadowedPrimaryButton } from "app/client/ui/QuickSetupStepHeader";
+
+import { Computed, dom, DomElementArg, Observable, styled, UseCBOwner } from "grainjs";
+
+const t = makeT("QuickSetupContinueButton");
+
+export interface QuickSetupSection {
+  /** True when the step's content is in a state the user can move past. */
+  canProceed: Computed<boolean>;
+  /** True when there are saved-but-not-yet-effective changes (e.g. waiting on a restart). */
+  hasPendingChanges: Computed<boolean>;
+  /** True while {@link applyPendingChanges} is in flight. */
+  isApplying: Observable<boolean>;
+  /**
+   * Persist any pending changes and (if needed) restart the server.
+   * No-op if nothing is pending. Owns its own `isApplying` flag.
+   */
+  applyPendingChanges(): Promise<void>;
+  /** Optional per-step label override. Return null/undefined to use the default labels. */
+  customLabel?(use: UseCBOwner): string | null | undefined;
+}
+
+/**
+ * Renders the standard QuickSetup continue button. After a successful
+ * apply, calls `onAfter` to let the wizard advance.
+ */
+export function quickSetupContinueButton(
+  section: QuickSetupSection,
+  onAfter: () => void,
+  ...args: DomElementArg[]
+) {
+  return cssQuickSetupContinueRow(
+    cssShadowedPrimaryButton(
+      dom.text((use) => {
+        if (use(section.isApplying)) { return t("Applying..."); }
+        const override = section.customLabel?.(use);
+        if (override) { return override; }
+        return use(section.hasPendingChanges) ? t("Apply and Continue") : t("Continue");
+      }),
+      dom.boolAttr("disabled", use => !use(section.canProceed) || use(section.isApplying)),
+      dom.on("click", async () => {
+        if (section.isApplying.get()) { return; }
+        try {
+          await section.applyPendingChanges();
+        } catch (err) {
+          reportError(err as Error);
+          return;
+        }
+        onAfter();
+      }),
+      ...args,
+    ),
+  );
+}
+
+const cssQuickSetupContinueRow = styled("div", `
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 24px;
+`);

--- a/app/client/ui/QuickSetupContinueButton.ts
+++ b/app/client/ui/QuickSetupContinueButton.ts
@@ -15,7 +15,7 @@
  */
 import { makeT } from "app/client/lib/localization";
 import { reportError } from "app/client/models/errors";
-import { cssShadowedPrimaryButton } from "app/client/ui/QuickSetupStepHeader";
+import { cssShadowedPrimaryButton } from "app/client/ui/SettingsLayout";
 
 import { Computed, dom, DomElementArg, Observable, styled, UseCBOwner } from "grainjs";
 
@@ -25,14 +25,14 @@ export interface QuickSetupSection {
   /** True when the step's content is in a state the user can move past. */
   canProceed: Computed<boolean>;
   /** True when there are saved-but-not-yet-effective changes (e.g. waiting on a restart). */
-  hasPendingChanges: Computed<boolean>;
-  /** True while {@link applyPendingChanges} is in flight. */
+  isDirty: Computed<boolean>;
+  /** True while {@link apply} is in flight. */
   isApplying: Observable<boolean>;
   /**
    * Persist any pending changes and (if needed) restart the server.
    * No-op if nothing is pending. Owns its own `isApplying` flag.
    */
-  applyPendingChanges(): Promise<void>;
+  apply(): Promise<void>;
   /** Optional per-step label override. Return null/undefined to use the default labels. */
   customLabel?(use: UseCBOwner): string | null | undefined;
 }
@@ -52,13 +52,13 @@ export function quickSetupContinueButton(
         if (use(section.isApplying)) { return t("Applying..."); }
         const override = section.customLabel?.(use);
         if (override) { return override; }
-        return use(section.hasPendingChanges) ? t("Apply and Continue") : t("Continue");
+        return use(section.isDirty) ? t("Apply and Continue") : t("Continue");
       }),
       dom.boolAttr("disabled", use => !use(section.canProceed) || use(section.isApplying)),
       dom.on("click", async () => {
         if (section.isApplying.get()) { return; }
         try {
-          await section.applyPendingChanges();
+          await section.apply();
         } catch (err) {
           reportError(err as Error);
           return;

--- a/app/client/ui/QuickSetupServerStep.ts
+++ b/app/client/ui/QuickSetupServerStep.ts
@@ -1,116 +1,80 @@
 import { makeT } from "app/client/lib/localization";
-import { reportError } from "app/client/models/errors";
 import { BaseUrlSection } from "app/client/ui/BaseUrlSection";
 import { DraftChangesManager } from "app/client/ui/DraftChanges";
 import { EditionSection } from "app/client/ui/EditionSection";
-import { bigPrimaryButton } from "app/client/ui2018/buttons";
-import { theme } from "app/client/ui2018/cssVars";
-import { icon } from "app/client/ui2018/icons";
+import { quickSetupContinueButton, QuickSetupSection } from "app/client/ui/QuickSetupContinueButton";
+import { cssQuickSetupCard, quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
 
-import { Computed, Disposable, dom, DomContents, makeTestId, styled } from "grainjs";
+import { Computed, Disposable, dom, DomContents, makeTestId, Observable, styled, UseCBOwner } from "grainjs";
 
 const t = makeT("QuickSetupServerStep");
 const testId = makeTestId("test-quick-setup-");
 
 /**
- * First step of the setup wizard: Base URL + Edition. Collects draft
- * changes and applies them in a single batch when the user clicks Continue.
+ * First step of QuickSetup: Base URL + Edition. Collects draft changes
+ * across two sections and applies them in a single batch via the shared
+ * QuickSetup continue button.
  *
- * Extracted into its own file to keep QuickSetup.ts focused on step
- * navigation; the other setup steps (sandboxing, backups, etc.) live in
- * their own modules too.
+ * Implements {@link QuickSetupSection} directly -- the step is itself
+ * the unit the QuickSetup continue button drives, just composed of two
+ * underlying sections via {@link DraftChangesManager}.
  */
-export class QuickSetupServerStep extends Disposable {
+export class QuickSetupServerStep extends Disposable implements QuickSetupSection {
+  public canProceed: Computed<boolean>;
+  public hasPendingChanges: Computed<boolean>;
+  public isApplying: Observable<boolean>;
+
   private _baseUrl = BaseUrlSection.create(this);
   private _edition = EditionSection.create(this);
   private _drafts = DraftChangesManager.create(this);
-
-  private _canProceed: Computed<boolean>;
 
   constructor(private _onComplete: () => void) {
     super();
     this._drafts.addSection(this._baseUrl);
     this._drafts.addSection(this._edition);
-    this._canProceed = Computed.create(this, use =>
+    this.canProceed = Computed.create(this, use =>
       use(this._baseUrl.canProceed) && use(this._edition.canProceed),
     );
+    this.hasPendingChanges = this._drafts.hasDraftChanges;
+    this.isApplying = this._drafts.isApplying;
+  }
+
+  /** Pre-confirm message when the user hasn't yet confirmed URL/edition. */
+  public customLabel(use: UseCBOwner): string | null {
+    const urlOk = use(this._baseUrl.canProceed);
+    const edOk = use(this._edition.canProceed);
+    if (!urlOk && !edOk) { return t("Confirm base URL and edition to continue"); }
+    if (!urlOk) { return t("Confirm base URL to continue"); }
+    if (!edOk) { return t("Confirm edition to continue"); }
+    return null;
+  }
+
+  public async applyPendingChanges(): Promise<void> {
+    await this._drafts.applyAll();
   }
 
   public buildDom(): DomContents {
     return dom("div",
-      cssStepHeading(
-        cssStepHeadingIcon(icon("Home")),
-        t("Server"),
-      ),
-      cssStepDescription(
-        t("Set your server's base URL and choose which edition of Grist to run."),
-      ),
-      cssStepSection(
+      quickSetupStepHeader({
+        icon: "Home",
+        title: t("Server"),
+        description: t("Set your server's base URL and choose which edition of Grist to run."),
+      }),
+      cssQuickSetupCard(
         cssStepSectionTitle(t("Base URL")),
         this._baseUrl.buildWizardDom(),
       ),
-      cssStepSection(
+      cssQuickSetupCard(
         cssStepSectionTitle(t("Edition")),
         this._edition.buildWizardDom(),
       ),
-      cssContinueRow(
-        bigPrimaryButton(
-          dom.text((use) => {
-            const urlOk = use(this._baseUrl.canProceed);
-            const edOk = use(this._edition.canProceed);
-            if (!urlOk && !edOk) { return t("Confirm base URL and edition to continue"); }
-            if (!urlOk) { return t("Confirm base URL to continue"); }
-            if (!edOk) { return t("Confirm edition to continue"); }
-            return use(this._drafts.hasDraftChanges) ? t("Apply and Continue") : t("Continue");
-          }),
-          dom.boolAttr("disabled", use => !use(this._canProceed) || use(this._drafts.isApplying)),
-          dom.on("click", async () => {
-            try {
-              await this._drafts.applyAll();
-              this._onComplete();
-            } catch (err) {
-              reportError(err as Error);
-            }
-          }),
-          testId("server-continue"),
-        ),
-      ),
+      quickSetupContinueButton(this, () => this._onComplete(), testId("server-continue")),
     );
   }
 }
-
-const cssStepHeading = styled("div", `
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 18px;
-  font-weight: 600;
-  margin-bottom: 4px;
-`);
-
-const cssStepHeadingIcon = styled("div", `
-  display: flex;
-  --icon-color: ${theme.controlPrimaryBg};
-`);
-
-const cssStepDescription = styled("div", `
-  font-size: 14px;
-  line-height: 1.5;
-  margin-bottom: 20px;
-`);
-
-const cssStepSection = styled("div", `
-  margin-bottom: 24px;
-`);
 
 const cssStepSectionTitle = styled("h3", `
   font-size: 14px;
   font-weight: 600;
   margin: 0 0 8px 0;
-`);
-
-const cssContinueRow = styled("div", `
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 24px;
 `);

--- a/app/client/ui/QuickSetupServerStep.ts
+++ b/app/client/ui/QuickSetupServerStep.ts
@@ -3,7 +3,8 @@ import { BaseUrlSection } from "app/client/ui/BaseUrlSection";
 import { DraftChangesManager } from "app/client/ui/DraftChanges";
 import { EditionSection } from "app/client/ui/EditionSection";
 import { quickSetupContinueButton, QuickSetupSection } from "app/client/ui/QuickSetupContinueButton";
-import { cssQuickSetupCard, quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
+import { quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
+import { cssQuickSetupCard } from "app/client/ui/SettingsLayout";
 
 import { Computed, Disposable, dom, DomContents, makeTestId, Observable, styled, UseCBOwner } from "grainjs";
 
@@ -21,7 +22,7 @@ const testId = makeTestId("test-quick-setup-");
  */
 export class QuickSetupServerStep extends Disposable implements QuickSetupSection {
   public canProceed: Computed<boolean>;
-  public hasPendingChanges: Computed<boolean>;
+  public isDirty: Computed<boolean>;
   public isApplying: Observable<boolean>;
 
   private _baseUrl = BaseUrlSection.create(this);
@@ -35,7 +36,7 @@ export class QuickSetupServerStep extends Disposable implements QuickSetupSectio
     this.canProceed = Computed.create(this, use =>
       use(this._baseUrl.canProceed) && use(this._edition.canProceed),
     );
-    this.hasPendingChanges = this._drafts.hasDraftChanges;
+    this.isDirty = this._drafts.hasDraftChanges;
     this.isApplying = this._drafts.isApplying;
   }
 
@@ -49,7 +50,7 @@ export class QuickSetupServerStep extends Disposable implements QuickSetupSectio
     return null;
   }
 
-  public async applyPendingChanges(): Promise<void> {
+  public async apply(): Promise<void> {
     await this._drafts.applyAll();
   }
 

--- a/app/client/ui/QuickSetupStepHeader.ts
+++ b/app/client/ui/QuickSetupStepHeader.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared header for QuickSetup steps: an optional icon, a title, and a
+ * description. Each step uses this to keep type, spacing, and tone
+ * consistent across the wizard.
+ */
+import { cardSurfaceShadow, cssCardSurface } from "app/client/ui/SettingsLayout";
+import { bigPrimaryButton } from "app/client/ui2018/buttons";
+import { theme, vars } from "app/client/ui2018/cssVars";
+import { IconName } from "app/client/ui2018/IconList";
+import { icon } from "app/client/ui2018/icons";
+
+import { dom, DomContents, styled } from "grainjs";
+
+export interface QuickSetupStepHeaderOptions {
+  /** Optional icon shown before the title. */
+  icon?: IconName;
+  /** Step title (already translated by the caller). */
+  title: string;
+  /** Short description shown below the title (already translated). */
+  description: string;
+}
+
+export function quickSetupStepHeader(opts: QuickSetupStepHeaderOptions): DomContents {
+  return [
+    cssQuickSetupStepTitle(
+      opts.icon ? cssQuickSetupStepIcon(icon(opts.icon)) : null,
+      dom("span", opts.title),
+    ),
+    cssQuickSetupStepDescription(opts.description),
+  ];
+}
+
+const cssQuickSetupStepTitle = styled("div", `
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 4px;
+`);
+
+const cssQuickSetupStepIcon = styled("div", `
+  display: flex;
+  --icon-color: ${theme.controlPrimaryBg};
+`);
+
+const cssQuickSetupStepDescription = styled("div", `
+  font-size: ${vars.mediumFontSize};
+  color: ${theme.lightText};
+  line-height: 1.5;
+  margin-bottom: 20px;
+`);
+
+/**
+ * Bordered card used to wrap a sub-section of a QuickSetup step
+ * (e.g. Base URL or Edition inside the Server step, the toggle list
+ * inside the Apply & Restart step). Inherits the shared bordered look
+ * (border, radius, drop shadow, solid background) from
+ * {@link cssCardSurface} so it tracks the admin panel's outer cards.
+ */
+export const cssQuickSetupCard = styled(cssCardSurface, `
+  padding: 16px 20px;
+  margin-bottom: 16px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`);
+
+/**
+ * Big primary button with the shared card-surface drop shadow, so
+ * "Continue" / "Apply and Continue" / "Go Live" all sit at the same
+ * visual depth as the bordered cards on the page. The shadow drops
+ * when the button is disabled.
+ */
+export const cssShadowedPrimaryButton = styled(bigPrimaryButton, `
+  box-shadow: ${cardSurfaceShadow};
+  &:disabled, &[disabled] {
+    box-shadow: none;
+  }
+`);

--- a/app/client/ui/QuickSetupStepHeader.ts
+++ b/app/client/ui/QuickSetupStepHeader.ts
@@ -3,8 +3,6 @@
  * description. Each step uses this to keep type, spacing, and tone
  * consistent across the wizard.
  */
-import { cardSurfaceShadow, cssCardSurface } from "app/client/ui/SettingsLayout";
-import { bigPrimaryButton } from "app/client/ui2018/buttons";
 import { theme, vars } from "app/client/ui2018/cssVars";
 import { IconName } from "app/client/ui2018/IconList";
 import { icon } from "app/client/ui2018/icons";
@@ -49,33 +47,4 @@ const cssQuickSetupStepDescription = styled("div", `
   color: ${theme.lightText};
   line-height: 1.5;
   margin-bottom: 20px;
-`);
-
-/**
- * Bordered card used to wrap a sub-section of a QuickSetup step
- * (e.g. Base URL or Edition inside the Server step, the toggle list
- * inside the Apply & Restart step). Inherits the shared bordered look
- * (border, radius, drop shadow, solid background) from
- * {@link cssCardSurface} so it tracks the admin panel's outer cards.
- */
-export const cssQuickSetupCard = styled(cssCardSurface, `
-  padding: 16px 20px;
-  margin-bottom: 16px;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-`);
-
-/**
- * Big primary button with the shared card-surface drop shadow, so
- * "Continue" / "Apply and Continue" / "Go Live" all sit at the same
- * visual depth as the bordered cards on the page. The shadow drops
- * when the button is disabled.
- */
-export const cssShadowedPrimaryButton = styled(bigPrimaryButton, `
-  box-shadow: ${cardSurfaceShadow};
-  &:disabled, &[disabled] {
-    box-shadow: none;
-  }
 `);

--- a/app/client/ui/SandboxSection.ts
+++ b/app/client/ui/SandboxSection.ts
@@ -28,6 +28,13 @@ abstract class SandboxSectionBase extends Disposable {
   // Observable for user selection.
   protected _selected = Observable.create<string | null>(this, null);
 
+  /** True when a different flavor is selected than what's currently active and not env-locked. */
+  protected readonly _needsRestart: Computed<boolean> =
+    Computed.create(this, this._model, this._selected, (_, model, selected) => {
+      if (model?.flavorInEnv) { return false; }
+      return !!selected && selected !== model?.current;
+    });
+
   constructor() {
     super();
     this._loadStatus().catch((e) => {
@@ -52,14 +59,6 @@ abstract class SandboxSectionBase extends Disposable {
 
   protected _isLockedByEnv() {
     return !!this._model.get()?.flavorInEnv;
-  }
-
-  /** Computed: true when a different flavor is selected than currently active and not env-locked. */
-  protected _needsRestart(): Computed<boolean> {
-    return Computed.create(this, this._model, this._selected, (_, model, selected) => {
-      if (model?.flavorInEnv) { return false; }
-      return !!selected && selected !== model?.current;
-    });
   }
 
   protected async _save() {
@@ -211,23 +210,23 @@ export class SandboxSetupSection extends SandboxSectionBase {
   public readonly canProceed: Computed<boolean> = Computed.create(this, this._selected, (_, s) => !!s);
 
   /** True when a different flavor is selected than what's currently active (and not env-locked). */
-  public readonly hasPendingChanges = this._needsRestart();
+  public readonly isDirty = this._needsRestart;
 
-  /** True while {@link applyPendingChanges} is in flight. */
+  /** True while {@link apply} is in flight. */
   public readonly isApplying: Observable<boolean> = Observable.create(this, false);
 
   /** Persist the selected flavor and restart the server. No-op when env-locked or unchanged. */
-  public async applyPendingChanges(): Promise<void> {
+  public async apply(): Promise<void> {
     if (this.isApplying.get()) { return; }
-    const willRestart = this.hasPendingChanges.get();
+    const willRestart = this.isDirty.get();
     this.isApplying.set(true);
     try {
       await this._save();
       if (willRestart) {
         await this._configAPI.restartServer();
         // Brief delay so we don't catch the server before it's begun
-        // restarting; waitUntilReady then polls for ~30s.
-        await delay(2000);
+        // restarting; waitUntilReady then polls.
+        await delay(500);
         await this._configAPI.waitUntilReady();
       }
     } finally {

--- a/app/client/ui/SandboxSection.ts
+++ b/app/client/ui/SandboxSection.ts
@@ -1,8 +1,7 @@
 import { makeT } from "app/client/lib/localization";
 import { getHomeUrl } from "app/client/models/AppModel";
-import { reportError } from "app/client/models/errors";
+import { quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
 import { BadgeConfig, buildCardList, buildHeroCard, buildItemCard } from "app/client/ui/SetupCard";
-import { bigPrimaryButton } from "app/client/ui2018/buttons";
 import { theme, vars } from "app/client/ui2018/cssVars";
 import { loadingSpinner } from "app/client/ui2018/loaders";
 import { ConfigAPI } from "app/common/ConfigAPI";
@@ -10,7 +9,7 @@ import { delay } from "app/common/delay";
 import { InstallAPIImpl } from "app/common/InstallAPI";
 import { SandboxInfo, SandboxingStatus } from "app/common/SandboxInfo";
 
-import { Disposable, dom, DomContents, makeTestId, Observable, styled, UseCB } from "grainjs";
+import { Computed, Disposable, dom, DomContents, makeTestId, Observable, styled, UseCB, UseCBOwner } from "grainjs";
 
 const t = makeT("SandboxSection");
 const testId = makeTestId("test-sandbox-section-");
@@ -55,10 +54,12 @@ abstract class SandboxSectionBase extends Disposable {
     return !!this._model.get()?.flavorInEnv;
   }
 
-  protected _needsRestart() {
-    if (this._isLockedByEnv()) { return false; }
-    const selected = this._selected.get();
-    return !!selected && selected !== this._model.get()?.current;
+  /** Computed: true when a different flavor is selected than currently active and not env-locked. */
+  protected _needsRestart(): Computed<boolean> {
+    return Computed.create(this, this._model, this._selected, (_, model, selected) => {
+      if (model?.flavorInEnv) { return false; }
+      return !!selected && selected !== model?.current;
+    });
   }
 
   protected async _save() {
@@ -148,11 +149,12 @@ abstract class SandboxSectionBase extends Disposable {
     });
 
     return dom("div",
-      cssStepTitle(t("Sandboxing")),
-      cssStepDescription(
-        t("Grist runs user formulas as Python code. Sandboxing isolates this execution " +
+      quickSetupStepHeader({
+        icon: "Lock",
+        title: t("Sandboxing"),
+        description: t("Grist runs user formulas as Python code. Sandboxing isolates this execution " +
           "to protect your server. Without it, document formulas can access the full system."),
-      ),
+      }),
 
       isLockedByEnv ? cssEnvWarning(
         t("Sandbox type is set via the GRIST_SANDBOX_FLAVOR environment variable " +
@@ -201,53 +203,41 @@ abstract class SandboxSectionBase extends Disposable {
 }
 
 /**
- * Sandbox section for the Setup wizard. Includes a Continue button that
- * saves the selection and advances to the next step.
+ * Sandbox section for QuickSetup. Conforms to {@link QuickSetupSection} so
+ * the QuickSetup step builder can drop in a shared continue button.
  */
 export class SandboxSetupSection extends SandboxSectionBase {
-  private _saving = Observable.create(this, false);
+  /** Always true once the model has loaded — there's always a default selection. */
+  public readonly canProceed: Computed<boolean> = Computed.create(this, this._selected, (_, s) => !!s);
 
-  constructor(private _onContinue: () => void) {
-    super();
-  }
+  /** True when a different flavor is selected than what's currently active (and not env-locked). */
+  public readonly hasPendingChanges = this._needsRestart();
 
-  protected _buildFooter(): DomContents {
-    return cssContinueRow(
-      bigPrimaryButton(
-        dom.domComputed((use) => {
-          if (use(this._saving)) { return cssInlineSpinner(cssSmallSpinner(), t("Applying...")); }
-          const s = use(this._model);
-          if (s?.flavorInEnv) { return t("Skip and Continue"); }
-          const selected = use(this._selected);
-          return selected && selected !== s?.current ?
-            t("Apply and Continue") : t("Continue");
-        }),
-        dom.boolAttr("disabled", this._saving),
-        dom.on("click", () => this._saveAndContinue()),
-        testId("continue"),
-      ),
-    );
-  }
+  /** True while {@link applyPendingChanges} is in flight. */
+  public readonly isApplying: Observable<boolean> = Observable.create(this, false);
 
-  private async _saveAndContinue() {
-    if (this._saving.get()) { return; }
-    this._saving.set(true);
+  /** Persist the selected flavor and restart the server. No-op when env-locked or unchanged. */
+  public async applyPendingChanges(): Promise<void> {
+    if (this.isApplying.get()) { return; }
+    const willRestart = this.hasPendingChanges.get();
+    this.isApplying.set(true);
     try {
       await this._save();
-      if (this._needsRestart()) {
+      if (willRestart) {
         await this._configAPI.restartServer();
         // Brief delay so we don't catch the server before it's begun
         // restarting; waitUntilReady then polls for ~30s.
         await delay(2000);
         await this._configAPI.waitUntilReady();
       }
-    } catch (e) {
-      reportError(e);
-      this._saving.set(false);
-      return;
+    } finally {
+      if (!this.isDisposed()) { this.isApplying.set(false); }
     }
-    this._saving.set(false);
-    this._onContinue();
+  }
+
+  /** Returns "Skip and Continue" when env-locked; otherwise null to use shared defaults. */
+  public customLabel(use: UseCBOwner): string | null {
+    return use(this._model)?.flavorInEnv ? t("Skip and Continue") : null;
   }
 }
 
@@ -278,42 +268,6 @@ function sandboxDescription(key: string): string {
       return "";
   }
 }
-
-const cssStepTitle = styled("div", `
-  font-size: 18px;
-  font-weight: 600;
-  margin-bottom: 8px;
-`);
-
-const cssStepDescription = styled("div", `
-  font-size: 14px;
-  color: ${theme.lightText};
-  line-height: 1.5;
-  margin-bottom: 20px;
-`);
-
-const cssContinueRow = styled("div", `
-  display: flex;
-  justify-content: stretch;
-  margin-top: 24px;
-  gap: 12px;
-  & > * {
-    flex: 1;
-  }
-`);
-
-const cssInlineSpinner = styled("div", `
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-`);
-
-const cssSmallSpinner = styled(loadingSpinner, `
-  width: 16px;
-  height: 16px;
-  border-width: 2px;
-`);
 
 const cssLoading = styled("div", `
   display: flex;

--- a/app/client/ui/SandboxSection.ts
+++ b/app/client/ui/SandboxSection.ts
@@ -1,11 +1,11 @@
 import { makeT } from "app/client/lib/localization";
 import { getHomeUrl } from "app/client/models/AppModel";
+import { ConfigSection, DraftChangesManager } from "app/client/ui/DraftChanges";
 import { quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
 import { BadgeConfig, buildCardList, buildHeroCard, buildItemCard } from "app/client/ui/SetupCard";
 import { theme, vars } from "app/client/ui2018/cssVars";
 import { loadingSpinner } from "app/client/ui2018/loaders";
 import { ConfigAPI } from "app/common/ConfigAPI";
-import { delay } from "app/common/delay";
 import { InstallAPIImpl } from "app/common/InstallAPI";
 import { SandboxInfo, SandboxingStatus } from "app/common/SandboxInfo";
 
@@ -202,36 +202,36 @@ abstract class SandboxSectionBase extends Disposable {
 }
 
 /**
- * Sandbox section for QuickSetup. Conforms to {@link QuickSetupSection} so
- * the QuickSetup step builder can drop in a shared continue button.
+ * Sandbox section for QuickSetup. Conforms to {@link QuickSetupSection}
+ * by delegating dirty/apply/restart through a {@link DraftChangesManager}
+ * with a single registered {@link ConfigSection} adapter for the sandbox
+ * flavor pref. This keeps the apply pipeline (persist + restart + wait,
+ * with shared failure handling) the same as the Server step.
  */
 export class SandboxSetupSection extends SandboxSectionBase {
   /** Always true once the model has loaded — there's always a default selection. */
   public readonly canProceed: Computed<boolean> = Computed.create(this, this._selected, (_, s) => !!s);
 
-  /** True when a different flavor is selected than what's currently active (and not env-locked). */
-  public readonly isDirty = this._needsRestart;
+  public readonly isDirty: Computed<boolean>;
+  public readonly isApplying: Observable<boolean>;
 
-  /** True while {@link apply} is in flight. */
-  public readonly isApplying: Observable<boolean> = Observable.create(this, false);
+  private readonly _drafts = DraftChangesManager.create(this);
+  private readonly _draftSection: ConfigSection = {
+    isDirty: this._needsRestart,
+    needsRestart: true,
+    apply: () => this._save(),
+    describeChange: () => ({ label: t("Sandbox"), value: sandboxLabel(this._selected.get() ?? "") }),
+  };
 
-  /** Persist the selected flavor and restart the server. No-op when env-locked or unchanged. */
+  constructor() {
+    super();
+    this._drafts.addSection(this._draftSection);
+    this.isDirty = this._drafts.hasDraftChanges;
+    this.isApplying = this._drafts.isApplying;
+  }
+
   public async apply(): Promise<void> {
-    if (this.isApplying.get()) { return; }
-    const willRestart = this.isDirty.get();
-    this.isApplying.set(true);
-    try {
-      await this._save();
-      if (willRestart) {
-        await this._configAPI.restartServer();
-        // Brief delay so we don't catch the server before it's begun
-        // restarting; waitUntilReady then polls.
-        await delay(500);
-        await this._configAPI.waitUntilReady();
-      }
-    } finally {
-      if (!this.isDisposed()) { this.isApplying.set(false); }
-    }
+    await this._drafts.applyAll();
   }
 
   /** Returns "Skip and Continue" when env-locked; otherwise null to use shared defaults. */

--- a/app/client/ui/SettingsLayout.ts
+++ b/app/client/ui/SettingsLayout.ts
@@ -187,15 +187,40 @@ export const cssPageTitle = styled("h1", `
   font-weight: ${tokens.headerControlTextWeight};
 `);
 
-export const cssSection = styled("div", `
+/**
+ * Soft drop shadow shared by bordered cards and prominent buttons in the
+ * admin panel and QuickSetup, so both surfaces sit at the same visual depth.
+ * Use as a CSS value: `box-shadow: ${cardSurfaceShadow};`.
+ */
+export const cardSurfaceShadow = `2px 2px 12px 0px ${theme.widgetPickerShadow}`;
+
+/**
+ * Shared visual "card" surface: bordered, rounded, soft drop shadow,
+ * solid background. Used by the admin panel's outer section card and by
+ * the inner cards inside QuickSetup steps so both share the same look.
+ *
+ * Nested instances drop the shadow -- a card-inside-a-card would
+ * otherwise stack two shadows and look heavy. This handles the case
+ * where a section (e.g. AuthenticationSection) renders the same cards
+ * both standalone in QuickSetup and inside the admin panel's outer
+ * SectionCard.
+ */
+export const cssCardSurface = styled("div", `
+  border: 1px solid ${theme.widgetBorder};
+  border-radius: 12px;
+  box-shadow: ${cardSurfaceShadow};
+  background-color: ${tokens.bg};
+
+  & & {
+    box-shadow: none;
+  }
+`);
+
+export const cssSection = styled(cssCardSurface, `
   padding: 16px 32px 24px 32px;
   max-width: 750px;
   width: 100%;
   margin: 0 auto;
-  border: 1px solid ${theme.widgetBorder};
-  border-radius: 12px;
-  box-shadow: 2px 2px 12px 0px ${theme.widgetPickerShadow};
-  background-color: ${tokens.bg};
   &-bare {
     border: none;
     padding: 0px;

--- a/app/client/ui/SettingsLayout.ts
+++ b/app/client/ui/SettingsLayout.ts
@@ -1,5 +1,6 @@
 import { hoverTooltip } from "app/client/ui/tooltips";
 import { transition } from "app/client/ui/transitions";
+import { bigPrimaryButton } from "app/client/ui2018/buttons";
 import { mediaSmall, testId, theme, vars } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
 import { tokens } from "app/common/ThemePrefs";
@@ -234,6 +235,34 @@ export const cssSection = styled(cssCardSurface, `
     & {
       padding: 12px;
     }
+  }
+`);
+
+/**
+ * Bordered card used to wrap a sub-section of a QuickSetup step
+ * (e.g. Base URL or Edition inside the Server step, the toggle list
+ * inside the Apply & Restart step). Inherits the shared bordered look
+ * from {@link cssCardSurface} so it tracks the admin panel's outer cards.
+ */
+export const cssQuickSetupCard = styled(cssCardSurface, `
+  padding: 16px 20px;
+  margin-bottom: 16px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`);
+
+/**
+ * Big primary button with the shared card-surface drop shadow, so
+ * "Continue" / "Apply and Continue" / "Go Live" all sit at the same
+ * visual depth as the bordered cards on the page. The shadow drops
+ * when the button is disabled.
+ */
+export const cssShadowedPrimaryButton = styled(bigPrimaryButton, `
+  box-shadow: ${cardSurfaceShadow};
+  &:disabled, &[disabled] {
+    box-shadow: none;
   }
 `);
 

--- a/app/client/ui/SetupCard.ts
+++ b/app/client/ui/SetupCard.ts
@@ -6,6 +6,7 @@
  *
  * All options are data-driven: plain values or Bindable<T> for reactivity.
  */
+import { cssCardSurface } from "app/client/ui/SettingsLayout";
 import { basicButton } from "app/client/ui2018/buttons";
 import { theme, vars } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
@@ -358,10 +359,8 @@ const cssTag = styled("span", `
   margin-left: 6px;
 `);
 
-const cssHeroCard = styled("div", `
+const cssHeroCard = styled(cssCardSurface, `
   padding: 16px 20px;
-  border-radius: 8px;
-  border: 1px solid ${theme.menuBorder};
   border-left-width: 4px;
   margin-bottom: 24px;
 
@@ -420,11 +419,9 @@ const cssHeroFooter = styled("div", `
   color: ${theme.lightText};
 `);
 
-const cssItemsContainer = styled("div", `
+const cssItemsContainer = styled(cssCardSurface, `
   display: flex;
   flex-direction: column;
-  border: 1px solid ${theme.menuBorder};
-  border-radius: 8px;
   overflow: hidden;
 `);
 

--- a/app/client/ui/SetupCard.ts
+++ b/app/client/ui/SetupCard.ts
@@ -359,7 +359,13 @@ const cssTag = styled("span", `
   margin-left: 6px;
 `);
 
-const cssHeroCard = styled(cssCardSurface, `
+/**
+ * Hero card with a colored 4px left border indicating state. Shared by
+ * the sandbox setup card and the authentication section's hero. Use
+ * `cssHeroCard.cls("-success" | "-pending" | "-warning" | "-error")` to
+ * pick the left-border color.
+ */
+export const cssHeroCard = styled(cssCardSurface, `
   padding: 16px 20px;
   border-left-width: 4px;
   margin-bottom: 24px;

--- a/app/common/ConfigAPI.ts
+++ b/app/common/ConfigAPI.ts
@@ -54,11 +54,18 @@ export class ConfigAPI extends BaseAPI {
    * Polls `healthcheck()` until it succeeds or `attempts` polls have elapsed.
    * Returns true on success, false on timeout; callers decide how to surface
    * the timeout (throw, silent, page reload, etc).
+   *
+   * All callers invoke this after `restartServer()`. The server returns from
+   * `restartServer` before tearing down its listener, so the very first poll
+   * can otherwise hit the still-up old process and return true immediately.
+   * A brief initial delay lets the server begin its restart first.
    */
   public async waitUntilReady({
     attempts = 30,
     intervalMs = 1000,
-  }: { attempts?: number; intervalMs?: number } = {}): Promise<boolean> {
+    initialDelayMs = 500,
+  }: { attempts?: number; intervalMs?: number; initialDelayMs?: number } = {}): Promise<boolean> {
+    await delay(initialDelayMs);
     for (let i = 0; i < attempts; i++) {
       try {
         await this.healthcheck();

--- a/test/nbrowser/QuickSetupApply.ts
+++ b/test/nbrowser/QuickSetupApply.ts
@@ -5,7 +5,7 @@ import * as testUtils from "test/server/testUtils";
 
 import { assert, driver } from "mocha-webdriver";
 
-describe("PermissionsStep", function() {
+describe("QuickSetupApply", function() {
   this.timeout(process.env.DEBUG ? "10m" : "20s");
   setupTestSuite();
   gu.bigScreen();

--- a/test/nbrowser/QuickSetupSandbox.ts
+++ b/test/nbrowser/QuickSetupSandbox.ts
@@ -326,7 +326,7 @@ describe("QuickSetupSandbox", function() {
 
   /** Returns the continue button text. */
   async function buttonText() {
-    return driver.find(".test-sandbox-section-continue").getText();
+    return driver.find(".test-quick-setup-sandbox-continue").getText();
   }
 
   /** Returns whether the env-lock warning is visible. */

--- a/test/nbrowser/QuickSetupSandbox.ts
+++ b/test/nbrowser/QuickSetupSandbox.ts
@@ -173,7 +173,7 @@ const FIXTURE_ONLY_UNSANDBOXED: BootProbeResult = {
   },
 };
 
-describe("SandboxStep", function() {
+describe("QuickSetupSandbox", function() {
   this.timeout(process.env.DEBUG ? "10m" : "20s");
   setupTestSuite();
   gu.bigScreen();


### PR DESCRIPTION
The `/admin/setup` wizard grew up over a flurry of independent PRs, one tab at a time, and inherited five different card styles, four different ways of asking "am I in the wizard or the admin panel?", and three different apply-and-restart loops. This branch trims that into a shape, although there's more to do.

## Commit 1 -- one mode signal

Four sections had four different ways of asking the same question. `BackupsSection` looked at `hideTitle`, `AuthenticationSection` at `showRestartWarning`, the Server pair at a `controls?: AdminPanelControls` option, and `SandboxSection` cheated with a separate subclass. The first commit picks `controls?` as canonical -- present means admin panel, absent means wizard -- and rewrites the others to match. The redundant flags go away. The same commit renames the diverging step test files (`SandboxStep.ts`, `PermissionsStep.ts`) into the `QuickSetup<Step>.ts` shape that `QuickSetupAuth.ts` already used.

## Commit 2 -- a shared step shape

Where the wizard actually starts to feel like a wizard. A new `QuickSetupSection` interface declares the surface every step exposes; a new `quickSetupContinueButton` helper renders the standard "Continue" / "Apply and Continue" / "Applying..." button driven by it. All four steps conform. The Server step keeps its pre-confirm labels and Sandbox keeps its env-locked "Skip and Continue" via a `customLabel` hook. Auth gains real "Apply and Continue" semantics for the first time. A `quickSetupStepHeader` helper gives all five steps the same icon-title-description header, including one Auth was missing. On the visual side, `cssCardSurface` is factored out of the admin panel's `cssSection` so the bordered, shadowed look is one source of truth, and a single `& &` rule means any nested `cssCardSurface` automatically drops its shadow -- which is how Auth and Backups in the admin panel flatten without per-component plumbing.

## Commit 3 -- the simplify pass

What came out of running `/simplify` over commit 2. A duplicate `cssHeroCard` is hoisted, two misplaced styled components move to a sensible home, a method that allocated a fresh `Computed` per call becomes a field, Auth's two post-restart fetches parallelize, and `QuickSetupSection`'s `hasPendingChanges`/`applyPendingChanges` rename to `isDirty`/`apply` so the interface reads as a strict superset of `DraftChanges.ConfigSection`.

## Commit 4 -- Sandbox folds into the apply pipeline

`SandboxSetupSection` now owns a `DraftChangesManager`, registers a small `ConfigSection` adapter, and deletes its local `restartServer + delay + waitUntilReady` block. There's now a single restart-and-wait implementation in the codebase, and Sandbox failures use the same aggregation path the Server step already used. The local `delay(500)` was a workaround for a real race where `waitUntilReady`'s first poll hit the still-up old server; fixed at the source by giving `waitUntilReady` an `initialDelayMs` so every caller benefits. Server needed no changes -- already on this pattern. Auth deferred: its config is saved by modals before Continue, so its `apply()` would be a no-op marker, which doesn't fit `ConfigSection` cleanly enough yet.

## Where this leaves things

The five steps share one mode signal, one button helper, one step header, one card surface, one apply pipeline for the four that persist, one restart-and-wait, and one test-naming convention. Auth's eventual unification is the obvious next move, but a small diff from here rather than a structural rewrite.

Heavy use of bot assistance.
