### PR TITLE
Ignoring empty actions in webhook's API

### DIFF
--- a/app/server/lib/WebhookQueue.ts
+++ b/app/server/lib/WebhookQueue.ts
@@ -1,5 +1,6 @@
 import { MapWithTTL } from "app/common/AsyncCreate";
 import { WebhookMessageType } from "app/common/CommTypes";
+import { safeJsonParse } from "app/common/gutil";
 import {
   EmailAction,
   TriggerAction,
@@ -197,7 +198,7 @@ export class WebhookQueue implements ActionQueue<WebhookActionPayload> {
     // Go through all triggers int the document that we have.
     for (const t of triggersTable.getRecords()) {
       // Each trigger has associated table and a bunch of trigger actions (currently only 1 that is webhook).
-      const actions = JSON.parse(t.actions) as TriggerAction[];
+      const actions = safeJsonParse(t.actions, []) as TriggerAction[];
       // Get only webhooks for this trigger.
       const webhookActions = actions.filter(act => act.type === "webhook");
       for (const act of webhookActions) {

--- a/test/server/lib/docapi/DocApiTriggers.ts
+++ b/test/server/lib/docapi/DocApiTriggers.ts
@@ -128,6 +128,9 @@ function addTriggersTests(getCtx: () => TestContext) {
     assert.equal(actions[0].to, "test@example.com");
     assert.equal(actions[0].subject, "Hello");
     assert.equal(actions[0].body, "World");
+
+    const webhooksRes = await docApi.getWebhooks();
+    assert.deepEqual(webhooksRes.webhooks, []);
   });
 
   it("should update trigger with webhook action and store secrets", async function() {
@@ -241,5 +244,15 @@ function addTriggersTests(getCtx: () => TestContext) {
     const updatedActions = JSON.parse(updated.records.find(r => r.id === id)!.fields.actions!);
     assert.equal(updatedActions[0].subject, "Updated");
     assert.equal(updatedActions[1].url, "https://example.com/w");
+  });
+
+  it("GET /webhooks ignores triggers with no actions", async function() {
+    const tableRef = await getTableRef(docApi, "Table1");
+    await docApi.addTriggers({
+      records: [{ fields: { tableRef, label: "no-actions trigger" } }],
+    });
+
+    const res = await docApi.getWebhooks();
+    assert.deepEqual(res.webhooks, []);
   });
 }


### PR DESCRIPTION
## Context

Webhook's API didn't handle empty action column well as other endpoints do.

## Proposed solution

Reusing the same pattern as in other places, that check if actions are filled before parsing it.

## Has this been tested?

- [X] 👍 yes, I added tests to the test suite