### PR TITLE
return cleanly to quick setup from getgrist.com registration

### DIFF
--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -35,6 +35,7 @@ import { BootKeyStatus } from "app/client/ui/BootKeyStatus";
 import { InstallConfigsAPI } from "app/client/ui/ConfigsAPI";
 import { DraftChangesManager } from "app/client/ui/DraftChanges";
 import { EditionSection } from "app/client/ui/EditionSection";
+import { peekSetupReturnFromGetGristCom } from "app/client/ui/GetGristComProvider";
 import { pagePanels } from "app/client/ui/PagePanels";
 import {
   buildPermissionsCard,
@@ -135,6 +136,12 @@ export class AdminPanel extends Disposable {
   constructor(private _appModel: AppModel, private _appObj: App) {
     super();
     document.title = getAdminPanelName() + getPageTitleSuffix(getGristConfig());
+    // Full-page replace (not pushUrl) so /admin/setup loads with the
+    // wizard chrome instead of the admin panel's left sidebar.
+    if (this._page.get() === "admin" && peekSetupReturnFromGetGristCom()) {
+      window.location.replace(urlState().makeUrl({ adminPanel: "setup" }));
+      return;
+    }
   }
 
   public buildDom() {

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -12,7 +12,13 @@ import {
   cssWellTitle,
 } from "app/client/ui/AdminPanelCss";
 import { ChangeAdminModal } from "app/client/ui/ChangeAdminModal";
-import { GetGristComProviderInfoModal, getGristComProviderMeta } from "app/client/ui/GetGristComProvider";
+import {
+  armSetupReturnFromGetGristCom,
+  clearSetupReturnFromGetGristCom,
+  GetGristComProviderInfoModal,
+  getGristComProviderMeta,
+  peekSetupReturnFromGetGristCom,
+} from "app/client/ui/GetGristComProvider";
 import { ApplyResult } from "app/client/ui/QuickSetupContinueButton";
 import { quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
 import { cssCardSurface } from "app/client/ui/SettingsLayout";
@@ -138,6 +144,13 @@ export class AuthenticationSection extends Disposable {
 
     this._fetchProviders().catch(reportError);
     this._fetchPrefsPendingChanges().catch(reportError);
+
+    // Don't clear the breadcrumb here -- the AppModel re-initializes
+    // during boot and may dispose+re-mount this section, and we want
+    // the new mount to also reopen the modal.
+    if (!this._inAdminPanel && peekSetupReturnFromGetGristCom() === "auth") {
+      this._openGetGristComModal();
+    }
   }
 
   /**
@@ -303,14 +316,28 @@ authentication system.",
     );
   }
 
+  private _openGetGristComModal() {
+    const m = new GetGristComProviderInfoModal();
+    if (!this._inAdminPanel) {
+      armSetupReturnFromGetGristCom("auth");
+    }
+    const onUserClose = () => {
+      if (!this._inAdminPanel) { clearSetupReturnFromGetGristCom(); }
+    };
+    m.show({
+      onConfigure: () => {
+        this._recentlyConfigured.add(GETGRIST_COM_PROVIDER_KEY);
+        this._fetchProviders().catch(reportError);
+        onUserClose();
+      },
+      onCancel: onUserClose,
+    });
+    this.onDispose(() => m.isDisposed() ? void 0 : m.dispose());
+  }
+
   private _configureProvider(provider: AuthProvider) {
     if (provider.key === GETGRIST_COM_PROVIDER_KEY) {
-      const m = new GetGristComProviderInfoModal();
-      m.show(() => {
-        this._recentlyConfigured.add(provider.key);
-        this._fetchProviders().catch(reportError);
-      });
-      this.onDispose(() => m.isDisposed() ? void 0 : m.dispose());
+      this._openGetGristComModal();
     } else if (PROVIDER_META_BUILDERS[provider.key]) {
       const m = new InformationModal(provider);
       m.show();

--- a/app/client/ui/GetGristComProvider.ts
+++ b/app/client/ui/GetGristComProvider.ts
@@ -1,5 +1,6 @@
 import { makeT } from "app/client/lib/localization";
 import { inlineMarkdown } from "app/client/lib/markdown";
+import { getStorage } from "app/client/lib/storage";
 import { getHomeUrl, reportError } from "app/client/models/AppModel";
 import { cssTextArea } from "app/client/ui/AdminPanelCss";
 import { bigBasicButton, bigPrimaryButton } from "app/client/ui2018/buttons";
@@ -32,11 +33,45 @@ Users sign in with their getgrist.com account."),
   };
 }
 
+// localStorage breadcrumb that carries the user from getgrist.com's
+// "Return to Admin Panel" button (which hard-codes /admin) back into the
+// wizard at the step they were on, with the configure modal reopened.
+//
+// Read by AdminPanel, QuickSetup, and AuthenticationSection during page
+// boot. Cleared only on user-driven dismissal of the modal -- not on
+// plain disposal -- so a transient re-mount (the AppModel reinitializes
+// during boot) leaves it intact for the next mount to act on.
+export const SETUP_RETURN_KEY = "grist:getgristComSetupReturn";
+
+/** Currently always "auth", typed for future steps. */
+export type SetupReturnStep = "auth";
+
+export function armSetupReturnFromGetGristCom(step: SetupReturnStep): void {
+  getStorage().setItem(SETUP_RETURN_KEY, step);
+}
+
+export function peekSetupReturnFromGetGristCom(): SetupReturnStep | null {
+  const value = getStorage().getItem(SETUP_RETURN_KEY);
+  return value === "auth" ? value : null;
+}
+
+export function clearSetupReturnFromGetGristCom(): void {
+  getStorage().removeItem(SETUP_RETURN_KEY);
+}
+
 /**
  * Modal for configuring "Sign in with getgrist.com" login system.
  */
+export interface GetGristComProviderInfoModalOptions {
+  /** Called when the user clicks Configure and the secret is accepted. */
+  onConfigure?: () => void;
+  /** Called when the user dismisses the modal (Cancel / Esc / click-away). */
+  onCancel?: () => void;
+}
+
 export class GetGristComProviderInfoModal extends Disposable {
   private _onConfigure: (() => void) | undefined;
+  private _onCancel: (() => void) | undefined;
   private readonly _configKey: Observable<string> = Observable.create(this, "");
   private readonly _working: Observable<boolean> = Observable.create(this, false);
   private readonly _error: Observable<boolean> = Observable.create(this, false);
@@ -55,10 +90,9 @@ export class GetGristComProviderInfoModal extends Disposable {
     }));
   }
 
-  public show(
-    onConfigure?: () => void,
-  ): void {
-    this._onConfigure = onConfigure;
+  public show(opts: GetGristComProviderInfoModalOptions = {}): void {
+    this._onConfigure = opts.onConfigure;
+    this._onCancel = opts.onCancel;
     modal((ctl, owner) => {
       this.onDispose(() => ctl.close());
       const registerUrlObs: Observable<string> = Observable.create<string>(owner, "");
@@ -123,7 +157,7 @@ getgrist.com and paste the configuration key you receive below.", {
         cssModalButtons(
           bigBasicButton(
             t("Cancel"),
-            dom.on("click", () => this.dispose()),
+            dom.on("click", () => this._handleCancel()),
             testId("modal-cancel"),
           ),
           bigPrimaryButton(
@@ -134,7 +168,18 @@ getgrist.com and paste the configuration key you receive below.", {
           ),
         ),
       ];
+    }, {
+      // Esc / click-away close the modal via `ctl.close()` without disposing
+      // `this` -- route them through the same cleanup path as the Cancel
+      // button so `onCancel` (e.g. clearing the setup-return breadcrumb) runs.
+      onCancel: () => this._handleCancel(),
     });
+  }
+
+  private _handleCancel(): void {
+    if (this.isDisposed()) { return; }
+    this._onCancel?.();
+    this.dispose();
   }
 
   private async _handleConfigure() {

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -7,6 +7,7 @@ import { buildAdminAccessDeniedCard } from "app/client/ui/AdminAccessDeniedCard"
 import { cssFadeUp, cssFadeUpGristLogo, cssFadeUpHeading, cssFadeUpSubHeading } from "app/client/ui/AdminPanelCss";
 import { AuthenticationSection } from "app/client/ui/AuthenticationSection";
 import { BackupsSection } from "app/client/ui/BackupsSection";
+import { peekSetupReturnFromGetGristCom, SetupReturnStep } from "app/client/ui/GetGristComProvider";
 import { PermissionsSetupSection } from "app/client/ui/PermissionsSetupSection";
 import { quickSetupContinueButton } from "app/client/ui/QuickSetupContinueButton";
 import { QuickSetupServerStep } from "app/client/ui/QuickSetupServerStep";
@@ -19,7 +20,10 @@ import { Disposable, dom, DomContents, makeTestId, observable, Observable, style
 const t = makeT("QuickSetup");
 const testId = makeTestId("test-quick-setup-");
 
+type StepId = SetupReturnStep | "server" | "sandbox" | "backups" | "apply";
+
 interface Step {
+  id: StepId;
   completed: Observable<boolean>;
   label: string;
   buildDom(): DomContents;
@@ -33,26 +37,31 @@ export class QuickSetup extends Disposable {
   private _checksLoaded = Observable.create<boolean>(this, false);
   private _steps: Step[] = [
     {
+      id: "server",
       label: t("Server"),
       completed: Observable.create(this, false),
       buildDom: () => this._buildServerStep(),
     },
     {
+      id: "sandbox",
       label: t("Sandboxing"),
       completed: observable(false),
       buildDom: () => this._buildSandboxStep(),
     },
     {
+      id: "auth",
       label: t("Authentication"),
       completed: observable(false),
       buildDom: () => this._buildAuthStep(),
     },
     {
+      id: "backups",
       label: t("Backups"),
       completed: observable(false),
       buildDom: () => this._buildBackupsStep(),
     },
     {
+      id: "apply",
       label: t("Apply & restart"),
       completed: observable(false),
       buildDom: () => this._buildApplyStep(),
@@ -61,6 +70,8 @@ export class QuickSetup extends Disposable {
 
   constructor(private _appModel: AppModel) {
     super();
+    const returnStep = peekSetupReturnFromGetGristCom();
+    if (returnStep) { this._jumpToStep(returnStep); }
   }
 
   public buildDom() {
@@ -93,6 +104,15 @@ export class QuickSetup extends Disposable {
         this._steps[i].buildDom(),
       )),
     );
+  }
+
+  private _jumpToStep(id: StepId) {
+    const target = this._steps.findIndex(s => s.id === id);
+    if (target < 0) { return; }
+    for (let i = 0; i < target; i++) {
+      this._steps[i].completed.set(true);
+    }
+    this._activeStep.set(target);
   }
 
   private _buildServerStep(): DomContents {

--- a/test/client/ui/GetGristComProvider.ts
+++ b/test/client/ui/GetGristComProvider.ts
@@ -1,0 +1,47 @@
+import { getStorage } from "app/client/lib/storage";
+import {
+  armSetupReturnFromGetGristCom,
+  clearSetupReturnFromGetGristCom,
+  peekSetupReturnFromGetGristCom,
+  SETUP_RETURN_KEY,
+} from "app/client/ui/GetGristComProvider";
+import { setTmpMochaGlobals } from "test/client/clientUtil";
+
+import { assert } from "chai";
+
+describe("GetGristComProvider setup-return breadcrumb", function() {
+  setTmpMochaGlobals();
+
+  beforeEach(() => {
+    getStorage().removeItem(SETUP_RETURN_KEY);
+  });
+
+  it("should not be armed by default", function() {
+    assert.strictEqual(peekSetupReturnFromGetGristCom(), null);
+  });
+
+  it("arm() sets the breadcrumb and peek() reads it without consuming", function() {
+    armSetupReturnFromGetGristCom("auth");
+    assert.strictEqual(peekSetupReturnFromGetGristCom(), "auth");
+    assert.strictEqual(peekSetupReturnFromGetGristCom(), "auth");
+  });
+
+  it("clear() removes the breadcrumb", function() {
+    armSetupReturnFromGetGristCom("auth");
+    clearSetupReturnFromGetGristCom();
+    assert.strictEqual(peekSetupReturnFromGetGristCom(), null);
+  });
+
+  it("peek() returns null when storage holds an unrecognized value", function() {
+    // Defensive: stale/forward-compat values in storage should not be
+    // surfaced as valid steps.
+    getStorage().setItem(SETUP_RETURN_KEY, "something-else");
+    assert.strictEqual(peekSetupReturnFromGetGristCom(), null);
+  });
+
+  it("re-arming overwrites the previous value", function() {
+    armSetupReturnFromGetGristCom("auth");
+    armSetupReturnFromGetGristCom("auth");
+    assert.strictEqual(peekSetupReturnFromGetGristCom(), "auth");
+  });
+});

--- a/test/nbrowser/QuickSetupAuth.ts
+++ b/test/nbrowser/QuickSetupAuth.ts
@@ -1,10 +1,56 @@
+import { SETUP_RETURN_KEY } from "app/client/ui/GetGristComProvider";
 import { FORWARD_AUTH_PROVIDER_KEY } from "app/common/loginProviders";
+import { toggleItem } from "test/nbrowser/AdminPanelTools";
 import * as gu from "test/nbrowser/gristUtils";
 import { startMockOIDCIssuer } from "test/nbrowser/oidcMockServer";
 import { server, setupTestSuite } from "test/nbrowser/testUtils";
 import * as testUtils from "test/server/testUtils";
 
 import { assert, driver } from "mocha-webdriver";
+
+async function readBreadcrumb(): Promise<string | null> {
+  return driver.executeScript<string | null>(
+    `return window.localStorage.getItem(${JSON.stringify(SETUP_RETURN_KEY)});`,
+  );
+}
+
+async function writeBreadcrumb(value: string): Promise<void> {
+  await driver.executeScript(
+    `window.localStorage.setItem(${JSON.stringify(SETUP_RETURN_KEY)}, ${JSON.stringify(value)});`,
+  );
+}
+
+async function clearBreadcrumb(): Promise<void> {
+  await driver.executeScript(
+    `window.localStorage.removeItem(${JSON.stringify(SETUP_RETURN_KEY)});`,
+  );
+}
+
+async function isModalOpen(): Promise<boolean> {
+  return (await driver.findAll(".test-admin-auth-modal-header")).length > 0;
+}
+
+async function openConfigureModal(): Promise<void> {
+  // Provider rows are only in the DOM when the list is expanded.
+  const header = await driver.findWait(".test-admin-auth-provider-list-header", 4000);
+  if (await header.getAttribute("aria-expanded") === "false") {
+    await header.click();
+  }
+  // Retry the row lookup and click together: AuthenticationSection's
+  // buildDom domComputes over async `_providers` and `_loginSystemId`,
+  // so the row subtree can be replaced between the find and the click.
+  await gu.waitToPass(async () => {
+    const row = await driver.findContent(".test-admin-auth-provider-row",
+      /Sign in with getgrist/);
+    await row.find(".test-admin-auth-configure-button").click();
+  }, 2000);
+  await driver.findWait(".test-admin-auth-modal-header", 2000);
+}
+
+async function cancelConfigureModal(): Promise<void> {
+  await driver.find(".test-admin-auth-modal-cancel").click();
+  await driver.wait(async () => !(await isModalOpen()), 2000);
+}
 
 describe("QuickSetupAuth", function() {
   this.timeout("2m");
@@ -259,5 +305,113 @@ describe("QuickSetupAuth", function() {
     } finally {
       await server.removeLogin();
     }
+  });
+
+  // The "Return to Admin Panel" button on getgrist.com's registration page
+  // hard-codes /admin. A localStorage breadcrumb causes /admin to bounce
+  // back into /admin/setup at the auth step and reopen the configure
+  // modal so the user can paste the secret they have on the clipboard.
+  // The breadcrumb is set only while the wizard's modal is alive and is
+  // cleared on dispose, so abandoning the flow does not hijack later
+  // /admin visits.
+  describe("getgrist.com setup-return breadcrumb", function() {
+    let oldEnv: testUtils.EnvironmentSnapshot;
+
+    before(async function() {
+      oldEnv = new testUtils.EnvironmentSnapshot();
+      delete process.env.GRIST_OIDC_IDP_ISSUER;
+      delete process.env.GRIST_OIDC_IDP_CLIENT_ID;
+      delete process.env.GRIST_OIDC_IDP_CLIENT_SECRET;
+      delete process.env.GRIST_OIDC_IDP_SKIP_END_SESSION_ENDPOINT;
+      delete process.env.GRIST_OIDC_SP_HOST;
+      await server.restart();
+    });
+
+    after(async function() {
+      oldEnv.restore();
+      await server.restart();
+    });
+
+    it("arms when the wizard's configure modal opens, clears when it closes", async function() {
+      await navigateToAuthStep();
+      await clearBreadcrumb();
+      assert.isNull(await readBreadcrumb(), "should start unarmed");
+
+      await openConfigureModal();
+      assert.equal(await readBreadcrumb(), "auth",
+        "opening from the wizard should arm the breadcrumb");
+
+      await cancelConfigureModal();
+      assert.isNull(await readBreadcrumb(),
+        "closing the modal should clear the breadcrumb");
+    });
+
+    it("does NOT arm when the configure modal is opened from the admin panel", async function() {
+      await driver.get(`${server.getHost()}/admin`);
+      await gu.waitForAdminPanel();
+      await toggleItem("authentication");
+      await clearBreadcrumb();
+
+      await openConfigureModal();
+      assert.isNull(await readBreadcrumb(),
+        "admin-panel-launched modal must not arm the breadcrumb");
+
+      await cancelConfigureModal();
+    });
+
+    it("/admin bounces to /admin/setup, jumps to auth, and reopens the modal", async function() {
+      // Land on the same origin so we can seed localStorage, then arm and
+      // navigate to /admin to trigger the bounce.
+      await driver.get(`${server.getHost()}/admin/setup`);
+      await writeBreadcrumb("auth");
+
+      await driver.get(`${server.getHost()}/admin`);
+
+      // Bounced to /admin/setup with the configure modal reopened.
+      await driver.findWait(".test-admin-auth-modal-header", 4000);
+      assert.match(await driver.getCurrentUrl(), /\/admin\/setup($|\?|#)/);
+
+      // Stepper landed on the Authentication step (index 2).
+      const activeStep = await driver.findWait(".test-stepper-step-2", 2000);
+      assert.match(await activeStep.getAttribute("class"), /-active/);
+
+      // The reopened modal is itself wizard-launched and re-arms the
+      // breadcrumb so a second round-trip through registration still works.
+      assert.equal(await readBreadcrumb(), "auth");
+
+      // Closing the reopened modal clears the breadcrumb.
+      await cancelConfigureModal();
+      assert.isNull(await readBreadcrumb());
+    });
+
+    it("/admin does not bounce when the breadcrumb is unset", async function() {
+      await driver.get(`${server.getHost()}/admin/setup`);
+      await clearBreadcrumb();
+
+      await driver.get(`${server.getHost()}/admin`);
+      await gu.waitForAdminPanel();
+
+      assert.match(await driver.getCurrentUrl(), /\/admin($|\?|#)/);
+      assert.notMatch(await driver.getCurrentUrl(), /\/admin\/setup/);
+      assert.isFalse(await isModalOpen());
+    });
+
+    it("/admin/setup honors the breadcrumb without needing the bounce", async function() {
+      await driver.get(`${server.getHost()}/admin/setup`);
+      await writeBreadcrumb("auth");
+
+      // Direct navigation -- AdminPanel does not need to bounce, but
+      // QuickSetup should still jump to auth and the AuthenticationSection
+      // should still reopen the modal.
+      await driver.get(`${server.getHost()}/admin/setup`);
+      await driver.findWait(".test-admin-auth-modal-header", 4000);
+
+      const activeStep = await driver.findWait(".test-stepper-step-2", 2000);
+      assert.match(await activeStep.getAttribute("class"), /-active/);
+      // Reopened modal re-arms; closing it clears.
+      assert.equal(await readBreadcrumb(), "auth");
+      await cancelConfigureModal();
+      assert.isNull(await readBreadcrumb());
+    });
   });
 });


### PR DESCRIPTION
When the configure-getgrist.com modal opens from the quick setup wizard, getgrist.com's registration page offers a "Return to Admin Panel" button that hard-codes /admin -- which used to dump wizard users on the admin panel mid-flow. A small localStorage breadcrumb, set while the modal is alive and cleared on dispose, now bounces /admin back to /admin/setup, jumps the wizard to the auth step, and reopens the configure modal so the secret on the user's clipboard is one paste away from done.

The breadcrumb is wizard-only (admin-panel launches don't arm it) and self-healing: closing the modal at any time -- Cancel, success, route change, tab teardown -- clears the flag, so deliberately abandoning the flow never hijacks a later /admin visit. The bounce uses a full-page replace rather than an SPA push so /admin/setup loads with the wizard chrome instead of carrying the admin sidebar across.

Tests cover arming and clearing in the unit layer plus the end-to-end bounce, the no-bounce case, and direct /admin/setup navigation in nbrowser.
