### PR TITLE
"Add new record" experiment fine-tuning

### DIFF
--- a/app/client/ui/NewRecordButton.ts
+++ b/app/client/ui/NewRecordButton.ts
@@ -62,4 +62,10 @@ const cssNewRecordButton = styled(primaryButton, `
   display: flex;
   align-items: center;
   gap: 6px;
+
+  @media print {
+    & {
+      display: none;
+    }
+  }
 `);

--- a/app/client/ui/NewRecordButton.ts
+++ b/app/client/ui/NewRecordButton.ts
@@ -1,10 +1,12 @@
 import BaseView from "app/client/components/BaseView";
+import DetailView from "app/client/components/DetailView";
+import GridView from "app/client/components/GridView";
 import { makeT } from "app/client/lib/localization";
 import { primaryButton } from "app/client/ui2018/buttons";
 import { testId, zIndexes } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
 
-import { dom, styled } from "grainjs";
+import { dom, DomArg, styled } from "grainjs";
 
 const t = makeT("NewRecordButton");
 
@@ -18,7 +20,10 @@ const translationStrings = {
  *
  * It only renders when the experiment is enabled and the view has focus.
  */
-export function maybeShowNewRecordExperiment(view: BaseView) {
+export function maybeShowNewRecordExperiment(view: BaseView): DomArg {
+  if (!(view instanceof GridView || view instanceof DetailView)) {
+    return undefined;
+  }
   const experimentIsEnabled = view.gristDoc.appModel.experiments?.isEnabled("newRecordButton");
   return dom.maybe(
     use => (experimentIsEnabled && use(view.viewSection.hasFocus) && use(view.enableAddRow)),


### PR DESCRIPTION
## Context

(Very late) follow-up to https://github.com/gristlabs/grist-core/pull/1431, this fixes a few oversights on the first implementation that were reported by users testing the experiment. Very sorry for the delay…

This is about the "New record" button that appears at the bottom left of widgets. The feature is hidden by default, behind an "experiment" flag. You can enable it (and also disable it later) by appending in your URL `?experiment=newRecordButton`.

## Proposed solution

- only show the button in tables, cards, and card lists widgets
- do not render the button when printing

## Related issues

https://github.com/gristlabs/grist-core/pull/1431 and https://github.com/gristlabs/grist-core/issues/366

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
