### PR TITLE
show the default-permission toggles in the admin panel

### DIFF
--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -34,6 +34,11 @@ import { InstallConfigsAPI } from "app/client/ui/ConfigsAPI";
 import { DraftChangesManager } from "app/client/ui/DraftChanges";
 import { EditionSection } from "app/client/ui/EditionSection";
 import { pagePanels } from "app/client/ui/PagePanels";
+import {
+  buildPermissionsCard,
+  buildPermissionsStatusDisplay,
+} from "app/client/ui/PermissionsSetupSection";
+import { PermissionsToggleModel } from "app/client/ui/PermissionsToggleModel";
 import { QuickSetup } from "app/client/ui/QuickSetup";
 import { ServiceStatus } from "app/client/ui/ServiceStatus";
 import {
@@ -204,6 +209,8 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
     notifier: this._appModel.notifier,
   });
 
+  private _permissionsModel = PermissionsToggleModel.create(this);
+
   private _drafts = DraftChangesManager.create(this);
 
   private _checks: AdminChecks;
@@ -226,6 +233,7 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
     this._checks = new AdminChecks(this, this._installAPI);
     this._drafts.addSection(this._baseUrlSection);
     this._drafts.addSection(this._editionSection);
+    this._drafts.addSection(this._permissionsModel);
 
     // Mirror visibility into the shared controller so the left-panel entry
     // appears/disappears with the banner.
@@ -485,6 +493,13 @@ Please log in as an administrator.`)),
           description: t("Key to sign sessions with"),
           value: this._buildSessionSecretDisplay(),
           expandedContent: this._buildSessionSecretNotice(),
+        }),
+        SectionItem({
+          id: "default-permissions",
+          name: t("Default permissions"),
+          description: t("Who can create sites, log in, and use the playground"),
+          value: buildPermissionsStatusDisplay(this._permissionsModel),
+          expandedContent: buildPermissionsCard(this._permissionsModel),
         }),
       ]),
       this._buildBackupsSection(),

--- a/app/client/ui/PermissionsSetupSection.ts
+++ b/app/client/ui/PermissionsSetupSection.ts
@@ -1,18 +1,25 @@
 import { makeT } from "app/client/lib/localization";
 import { getHomeUrl } from "app/client/models/homeUrl";
+import { cssWell, cssWellContent } from "app/client/ui/AdminPanelCss";
+import {
+  getEnvLockedVars,
+  hasEnvLocked,
+  PermissionsToggleModel,
+  PresetName,
+  TOGGLE_DEFS,
+} from "app/client/ui/PermissionsToggleModel";
 import { quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
-import { cssQuickSetupCard, cssShadowedPrimaryButton } from "app/client/ui/SettingsLayout";
+import { cssQuickSetupCard, cssShadowedPrimaryButton, cssValueLabel } from "app/client/ui/SettingsLayout";
 import { bigBasicButton } from "app/client/ui2018/buttons";
 import { theme, vars } from "app/client/ui2018/cssVars";
 import { loadingSpinner } from "app/client/ui2018/loaders";
 import { toggleSwitch } from "app/client/ui2018/toggleSwitch";
 import { ConfigAPI } from "app/common/ConfigAPI";
 import { not } from "app/common/gutil";
-import { InstallAPIImpl, PermissionsStatus } from "app/common/InstallAPI";
 import { tokens } from "app/common/ThemePrefs";
 import { getGristConfig } from "app/common/urlUtils";
 
-import { Computed, Disposable, dom, DomContents, makeTestId, Observable, styled } from "grainjs";
+import { Disposable, dom, DomContents, makeTestId, Observable, styled } from "grainjs";
 
 const t = makeT("PermissionsSetupSection");
 const testId = makeTestId("test-permissions-setup-");
@@ -25,43 +32,12 @@ const testId = makeTestId("test-permissions-setup-");
  * after restart completes.
  */
 export class PermissionsSetupSection extends Disposable {
-  // Needed to read and update settings.
-  private _installAPI = new InstallAPIImpl(getHomeUrl());
-  // Needed for restarts.
+  private _model = PermissionsToggleModel.create(this);
   private _configAPI = new ConfigAPI(getHomeUrl());
-  // Data received from the server about current permissions status.
-  private _status = Observable.create<PermissionsStatus | null>(this, null);
-  // Error message holder.
   private _error = Observable.create<string>(this, "");
-  // Loading state.
   private _saving = Observable.create<boolean>(this, false);
   // Whether the server has been restarted after saving. Used to switch to the success page.
   private _restarted = Observable.create<boolean>(this, false);
-
-  // Dirty state for the things being toggled. Default values are set to those that
-  // are in grist-core, but it doesn't matter, they are replaced when the real status is loaded.
-  private _toggles: Record<string, Observable<boolean>> = {
-    teamSites: Observable.create<boolean>(this, false), // values are not important
-    personalSites: Observable.create<boolean>(this, false),
-    anonAccess: Observable.create<boolean>(this, false),
-    playground: Observable.create<boolean>(this, false),
-  };
-
-  // Preset detector. Checks state of toggles, and if they match it shows which preset is active.
-  // Env-locked toggles are excluded from matching — they can't be changed, so they shouldn't
-  // prevent a preset from being recognized.
-  private _presetDetector = Computed.create(this, (use) => {
-    const status = use(this._status);
-    for (const [name, values] of Object.entries(PRESETS)) {
-      if (Object.entries(values).every(([k, v]) => {
-        if (status && this._isEnvLocked(status, k)) { return true; }
-        return use(this._toggles[k]) === v;
-      })) {
-        return name;
-      }
-    }
-    return null;
-  });
 
   constructor() {
     super();
@@ -72,16 +48,10 @@ export class PermissionsSetupSection extends Disposable {
     return dom("div",
       testId("section"),
       dom.domComputed(this._restarted, (done) => {
-        // If we are restarted, show the success page.
         if (done) { return this._buildSuccessPage(); }
-
-        // Otherwise show the permissions setup page, with error/loading states.
         return dom("div",
           dom.maybe(this._error, err => cssError(err)),
-          dom.domComputed(this._status, (s) => {
-            if (!s) { return cssLoading(loadingSpinner(), t("Loading permissions…")); }
-            return this._buildContent(s);
-          }),
+          this._buildContent(),
         );
       }),
     );
@@ -89,21 +59,15 @@ export class PermissionsSetupSection extends Disposable {
 
   private async _load() {
     try {
-      const s = await this._installAPI.getPermissionsStatus();
+      await this._model.loaded;
       if (this.isDisposed()) { return; }
-      this._status.set(s);
-      // Initialize all toggles from current server values.
-      this._toggles.teamSites.set(s.orgCreationAnyone.value ?? true);
-      this._toggles.personalSites.set(s.personalOrgs.value ?? true);
-      this._toggles.anonAccess.set(!(s.forceLogin.value ?? false));
-      this._toggles.playground.set(s.anonPlayground.value ?? true);
-      // Apply recommended preset — skips env-locked toggles, so their
-      // server values above are preserved.
-      this._applyPreset("recommended");
-      // When GRIST_SINGLE_ORG=docs, the personal org is the only org —
-      // disabling personal sites would make Grist non-functional.
+      // Recommended is the wizard default; applyPreset skips env-locked
+      // toggles, so their server values from load() are preserved.
+      this._model.applyPreset("recommended");
+      // GRIST_SINGLE_ORG=docs makes the personal org the only org —
+      // disabling personal sites would brick Grist.
       if (getGristConfig().singleOrg === "docs") {
-        this._toggles.personalSites.set(true);
+        this._model.toggles.personalSites.set(true);
       }
     } catch (e) {
       if (this.isDisposed()) { return; }
@@ -111,37 +75,15 @@ export class PermissionsSetupSection extends Disposable {
     }
   }
 
-  private _applyPreset(preset: string) {
-    const status = this._status.get();
-    for (const [toggleName, toggleValue] of Object.entries(PRESETS[preset])) {
-      // Don't override toggles locked by environment variables.
-      if (status && this._isEnvLocked(status, toggleName)) { continue; }
-      this._toggles[toggleName].set(toggleValue);
-    }
-  }
-
-  private _isEnvLocked(status: PermissionsStatus, toggleKey: string): boolean {
-    const def = TOGGLE_DEFS.find(d => d.key === toggleKey);
-    return !!def && status[def.permKey].source === "environment-variable";
-  }
-
   private async _handleGoLive() {
-    // Simple way for preventing multiple clicks.
     if (this._saving.get()) { return; }
     this._saving.set(true);
     this._error.set("");
     try {
-      await this._installAPI.updateInstallPrefs({ envVars: {
-        GRIST_ORG_CREATION_ANYONE: String(this._toggles.teamSites.get()),
-        GRIST_PERSONAL_ORGS: String(this._toggles.personalSites.get()),
-        GRIST_FORCE_LOGIN: String(!this._toggles.anonAccess.get()),
-        GRIST_ANON_PLAYGROUND: String(this._toggles.playground.get()),
-        GRIST_IN_SERVICE: "true",
-      } });
+      await this._model.apply();
       await this._configAPI.restartServer();
       await this._waitForReady();
       if (this.isDisposed()) { return; }
-      this._saving.set(false);
       this._restarted.set(true);
     } catch (e) {
       if (this.isDisposed()) { return; }
@@ -162,7 +104,7 @@ export class PermissionsSetupSection extends Disposable {
     window.location.href = getHomeUrl(); // avoid using urlState here, as it is meant for team navigation.
   }
 
-  private _buildContent(status: PermissionsStatus): DomContents {
+  private _buildContent(): DomContents {
     return dom("div",
       quickSetupStepHeader({
         icon: "Settings",
@@ -170,72 +112,8 @@ export class PermissionsSetupSection extends Disposable {
         description: t("Review these defaults before going live. " +
           "You can change them later from the admin panel."),
       }),
-      cssPermissionsSection(
-        dom.cls("disabled", this._saving),
-        cssSectionLabel(t("DEFAULT PERMISSIONS")),
-        cssPresetBar(
-          ...([
-            ["locked", t("Locked down")] as const,
-            ["recommended", t("Recommended")] as const,
-            ["open", t("Open")] as const,
-          ].map(([key, label]) =>
-            cssPresetButton(
-              label,
-              dom.cls("active", use => use(this._presetDetector) === key),
-              dom.on("click", () => this._applyPreset(key)),
-              testId(`preset-${key}`),
-            ),
-          )),
-        ),
+      buildPermissionsCard(this._model, { disabled: this._saving }),
 
-        // Toggle rows.
-        ...TOGGLE_DEFS.map(({ key, permKey, label, description }) => {
-          const locked = status[permKey].source === "environment-variable";
-          const conflict = key === "personalSites" && getGristConfig().singleOrg === "docs";
-          return cssPermissionRow(
-            cssPermissionToggle(
-              toggleSwitch(this._toggles[key], {
-                args: [locked ? dom.cls("disabled") : null],
-                inputArgs: locked ? [dom.prop("disabled", true)] : [],
-              }),
-            ),
-            cssPermissionInfo(
-              cssPermissionLabelRow(
-                cssPermissionLabel(label()),
-                locked ? cssBadge(cssBadge.cls("-warning"), t("Environment"), testId("env-badge")) : null,
-                conflict ? cssBadge(cssBadge.cls("-error"), t("Conflict"), testId("conflict-badge")) : null,
-              ),
-              cssPermissionDescription(description()),
-            ),
-            testId(`perm-${permKey}`),
-          );
-        }),
-
-        // Warning when some settings are locked by environment variables.
-        hasEnvLocked(status) ? cssWarningWell(
-          t("Some settings are controlled by environment variables and cannot be \
-changed here: {{vars}}. To modify them, update the corresponding variables \
-in your server configuration and restart.",
-          { vars: getEnvLockedVars(status).join(", ") }),
-          testId("env-warning"),
-        ) : null,
-
-        // GRIST_SINGLE_ORG warning.
-        getGristConfig().singleOrg ? cssWarningWell(
-          t("You have GRIST_SINGLE_ORG={{value}} set. With this, users only see one \
-site — but personal sites and team creation still work behind the \
-scenes. Worth locking down unless you have a specific reason to keep them.",
-          { value: getGristConfig().singleOrg! }),
-          getGristConfig().singleOrg === "docs" ? dom("div",
-            dom.style("margin-top", "8px"),
-            t("The personal org is the only org available — personal sites must \
-stay enabled or Grist will be non-functional."),
-          ) : null,
-          testId("single-org-warning"),
-        ) : null,
-      ),
-
-      // Bottom area: Go Live / Loading states.
       dom.maybe(this._saving, () =>
         cssRestartingRow(
           loadingSpinner(),
@@ -267,64 +145,103 @@ Grist is now in service and available to users.")),
   }
 }
 
-const PRESETS: Record<string, Record<string, boolean>> = {
-  locked: { teamSites: false, personalSites: false, anonAccess: false, playground: false },
-  recommended: { teamSites: false, personalSites: true, anonAccess: true,  playground: false },
-  open: { teamSites: true,  personalSites: true,  anonAccess: true,  playground: true },
+const PRESET_LABELS: Record<PresetName, () => string> = {
+  locked: () => t("Locked down"),
+  recommended: () => t("Recommended"),
+  open: () => t("Open"),
 };
 
-function hasEnvLocked(status: PermissionsStatus): boolean {
-  return TOGGLE_DEFS.some(({ permKey }) => status[permKey].source === "environment-variable");
+/**
+ * Renders the shared "Default Permissions" card: preset bar, the four
+ * permission toggle rows, and warning wells for env-locked toggles and
+ * GRIST_SINGLE_ORG. Used by both the QuickSetup wizard's "Apply & Restart"
+ * step and the admin panel's grouped permissions item so the two surfaces
+ * stay visually identical. Shows a spinner until the model's status loads.
+ *
+ * Pass `options.disabled` to grey out and lock the card (the wizard does
+ * this while the Go Live restart is in flight).
+ */
+export function buildPermissionsCard(
+  model: PermissionsToggleModel,
+  options: { disabled?: Observable<boolean> } = {},
+): DomContents {
+  return dom.domComputed(model.status, (status) => {
+    if (!status) { return cssLoading(loadingSpinner(), t("Loading permissions…")); }
+    return cssPermissionsSection(
+      options.disabled ? dom.cls("disabled", options.disabled) : null,
+      cssSectionLabel(t("DEFAULT PERMISSIONS")),
+      cssPresetBar(
+        ...(Object.keys(PRESET_LABELS) as PresetName[]).map(key =>
+          cssPresetButton(
+            PRESET_LABELS[key](),
+            dom.cls("active", use => use(model.presetDetector) === key),
+            dom.on("click", () => model.applyPreset(key)),
+            testId(`preset-${key}`),
+          ),
+        ),
+      ),
+
+      ...TOGGLE_DEFS.map(({ key, permKey, label, description }) => {
+        const locked = status[permKey].source === "environment-variable";
+        const conflict = model.hasConflict(key);
+        return cssPermissionRow(
+          cssPermissionToggle(
+            toggleSwitch(model.toggles[key], {
+              args: [locked ? dom.cls("disabled") : null],
+              inputArgs: locked ? [dom.prop("disabled", true)] : [],
+            }),
+          ),
+          cssPermissionInfo(
+            cssPermissionLabelRow(
+              cssPermissionLabel(label()),
+              locked ? cssBadge(cssBadge.cls("-warning"), t("Environment"), testId("env-badge")) : null,
+              conflict ? cssBadge(cssBadge.cls("-error"), t("Conflict"), testId("conflict-badge")) : null,
+            ),
+            cssPermissionDescription(description()),
+          ),
+          testId(`perm-${permKey}`),
+        );
+      }),
+
+      hasEnvLocked(status) ? cssWell(cssWell.cls("-warning"),
+        cssWellContent(
+          t("Some settings are controlled by environment variables and cannot be \
+changed here: {{vars}}. To modify them, update the corresponding variables \
+in your server configuration and restart.",
+          { vars: getEnvLockedVars(status).join(", ") }),
+        ),
+        testId("env-warning"),
+      ) : null,
+
+      getGristConfig().singleOrg ? cssWell(cssWell.cls("-warning"),
+        cssWellContent(
+          dom("p", t("You have GRIST_SINGLE_ORG={{value}} set. With this, users only see one \
+site — but personal sites and team creation still work behind the \
+scenes. Worth locking down unless you have a specific reason to keep them.",
+          { value: getGristConfig().singleOrg! })),
+          getGristConfig().singleOrg === "docs" ? dom("p",
+            t("The personal org is the only org available — personal sites must \
+stay enabled or Grist will be non-functional."),
+          ) : null,
+        ),
+        testId("single-org-warning"),
+      ) : null,
+    );
+  });
 }
 
-function getEnvLockedVars(status: PermissionsStatus): string[] {
-  return TOGGLE_DEFS
-    .filter(({ permKey }) => status[permKey].source === "environment-variable")
-    .map(({ envVar }) => envVar);
+/**
+ * Compact status for the admin-panel item's collapsed row, naming the
+ * active preset (or "Custom" when toggles match no preset). Mirrors
+ * {@link EditionSection.buildStatusDisplay} on neighbouring items.
+ */
+export function buildPermissionsStatusDisplay(model: PermissionsToggleModel): DomContents {
+  return dom.domComputed((use) => {
+    if (!use(model.status)) { return cssValueLabel(t("loading…")); }
+    const preset = use(model.presetDetector);
+    return cssValueLabel(preset ? PRESET_LABELS[preset]() : t("Custom"));
+  });
 }
-
-type PermissionKey = keyof Omit<PermissionsStatus, "singleOrg">;
-
-const TOGGLE_DEFS: {
-  key: string;
-  permKey: PermissionKey;
-  envVar: string;
-  label: () => string;
-  description: () => string;
-}[] = [
-  {
-    key: "teamSites",
-    permKey: "orgCreationAnyone",
-    envVar: "GRIST_ORG_CREATION_ANYONE",
-    label: () => t("Allow anyone to create team sites"),
-    description: () => t("Any logged-in user can create new team sites. \
-Turn off to restrict team creation to admins only."),
-  },
-  {
-    key: "personalSites",
-    permKey: "personalOrgs",
-    envVar: "GRIST_PERSONAL_ORGS",
-    label: () => t("Allow personal sites"),
-    description: () => t("Users can create their own personal sites with documents. \
-Turn off to restrict all documents to team sites managed by admins."),
-  },
-  {
-    key: "anonAccess",
-    permKey: "forceLogin",
-    envVar: "GRIST_FORCE_LOGIN",
-    label: () => t("Allow anonymous access"),
-    description: () => t("Visitors who aren't signed in can view publicly shared documents. \
-This is needed for link sharing and published forms."),
-  },
-  {
-    key: "playground",
-    permKey: "anonPlayground",
-    envVar: "GRIST_ANON_PLAYGROUND",
-    label: () => t("Allow anonymous playground"),
-    description: () => t("Visitors who aren't signed in can create and edit documents \
-in a temporary playground. Turn off to require sign-in before creating any documents."),
-  },
-];
 
 const cssLoading = styled("div", `
   display: flex;
@@ -447,16 +364,6 @@ const cssPermissionDescription = styled("div", `
   font-size: 13px;
   color: ${theme.lightText};
   line-height: 1.4;
-`);
-
-const cssWarningWell = styled("div", `
-  border: 2px solid ${theme.toastWarningBg};
-  border-radius: 8px;
-  padding: 12px 16px;
-  margin-top: 16px;
-  font-size: ${vars.smallFontSize};
-  line-height: 1.4;
-  color: ${theme.text};
 `);
 
 const cssBottomRow = styled("div", `

--- a/app/client/ui/PermissionsSetupSection.ts
+++ b/app/client/ui/PermissionsSetupSection.ts
@@ -16,6 +16,7 @@ import { loadingSpinner } from "app/client/ui2018/loaders";
 import { toggleSwitch } from "app/client/ui2018/toggleSwitch";
 import { ConfigAPI } from "app/common/ConfigAPI";
 import { not } from "app/common/gutil";
+import { InstallAPIImpl } from "app/common/InstallAPI";
 import { tokens } from "app/common/ThemePrefs";
 import { getGristConfig } from "app/common/urlUtils";
 
@@ -34,6 +35,7 @@ const testId = makeTestId("test-permissions-setup-");
 export class PermissionsSetupSection extends Disposable {
   private _model = PermissionsToggleModel.create(this);
   private _configAPI = new ConfigAPI(getHomeUrl());
+  private _installAPI = new InstallAPIImpl(getHomeUrl());
   private _error = Observable.create<string>(this, "");
   private _saving = Observable.create<boolean>(this, false);
   // Whether the server has been restarted after saving. Used to switch to the success page.
@@ -81,6 +83,10 @@ export class PermissionsSetupSection extends Disposable {
     this._error.set("");
     try {
       await this._model.apply();
+      // The wizard's Go Live step is what clears the post-setup gate;
+      // service status is its own concern, so set it via a separate call
+      // rather than bundling it into the permissions write.
+      await this._installAPI.updateInstallPrefs({ envVars: { GRIST_IN_SERVICE: "true" } });
       await this._configAPI.restartServer();
       await this._waitForReady();
       if (this.isDisposed()) { return; }

--- a/app/client/ui/PermissionsToggleModel.ts
+++ b/app/client/ui/PermissionsToggleModel.ts
@@ -123,7 +123,6 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
         GRIST_PERSONAL_ORGS: String(this.toggles.personalSites.get()),
         GRIST_FORCE_LOGIN: String(!this.toggles.anonAccess.get()),
         GRIST_ANON_PLAYGROUND: String(this.toggles.playground.get()),
-        GRIST_IN_SERVICE: "true",
       },
     });
     if (this.isDisposed()) { return; }

--- a/app/client/ui/PermissionsToggleModel.ts
+++ b/app/client/ui/PermissionsToggleModel.ts
@@ -1,0 +1,234 @@
+import { makeT } from "app/client/lib/localization";
+import { reportError } from "app/client/models/AppModel";
+import { getHomeUrl } from "app/client/models/homeUrl";
+import { ConfigSection, DraftChangeDescription } from "app/client/ui/DraftChanges";
+import { InstallAPI, InstallAPIImpl, PermissionsStatus } from "app/common/InstallAPI";
+import { getGristConfig } from "app/common/urlUtils";
+
+import { Computed, Disposable, Observable } from "grainjs";
+
+const t = makeT("PermissionsToggleModel");
+
+/**
+ * Shared model for the four install-wide permission toggles
+ * (team sites / personal sites / anon access / playground).
+ *
+ * Used by both QuickSetup's "Apply & Restart" card and the admin
+ * panel's Security Settings rows. Owns loading from the server,
+ * dirty tracking against server values, env-locked detection,
+ * preset application, and the `apply()` that persists changes.
+ *
+ * Implements ConfigSection so it can be registered with the admin
+ * panel's DraftChangesManager and participate in the unified
+ * Apply + Restart banner.
+ */
+export class PermissionsToggleModel extends Disposable implements ConfigSection {
+  /** Toggle env-var changes only take effect after a restart. */
+  public readonly needsRestart = true;
+
+  /** Current loading status. */
+  public readonly status = Observable.create<PermissionsStatus | null>(this, null);
+
+  /** Live toggle values (what the UI binds to). */
+  public readonly toggles: Record<ToggleKey, Observable<boolean>> = {
+    teamSites: Observable.create<boolean>(this, false),
+    personalSites: Observable.create<boolean>(this, false),
+    anonAccess: Observable.create<boolean>(this, false),
+    playground: Observable.create<boolean>(this, false),
+  };
+
+  /** True when any toggle has drifted from its server value. */
+  public readonly isDirty: Computed<boolean>;
+
+  /** Which preset, if any, the current toggle state matches. Null if none. */
+  public readonly presetDetector: Computed<PresetName | null>;
+
+  /** Resolves after the initial server fetch lands in `status`. */
+  public readonly loaded: Promise<void>;
+
+  // Last known server value for each toggle. Used for dirty tracking and
+  // for `describeChange()` so the banner shows the new value, not the old.
+  private _serverValues: Record<ToggleKey, Observable<boolean>> = {
+    teamSites: Observable.create<boolean>(this, false),
+    personalSites: Observable.create<boolean>(this, false),
+    anonAccess: Observable.create<boolean>(this, false),
+    playground: Observable.create<boolean>(this, false),
+  };
+
+  private _installAPI: InstallAPI;
+
+  constructor(opts: { installAPI?: InstallAPI } = {}) {
+    super();
+    this._installAPI = opts.installAPI ?? new InstallAPIImpl(getHomeUrl());
+
+    this.loaded = this._load();
+    this.loaded.catch(reportError);
+
+    this.isDirty = Computed.create(this, (use) => {
+      const status = use(this.status);
+      if (!status) { return false; }
+      return TOGGLE_DEFS.some(({ key }) => {
+        if (this._isEnvLocked(status, key)) { return false; }
+        return use(this.toggles[key]) !== use(this._serverValues[key]);
+      });
+    });
+
+    this.presetDetector = Computed.create(this, (use) => {
+      const status = use(this.status);
+      for (const [name, values] of PRESET_ENTRIES) {
+        if (values.every(([k, v]) => {
+          if (status && this._isEnvLocked(status, k)) { return true; }
+          return use(this.toggles[k]) === v;
+        })) {
+          return name;
+        }
+      }
+      return null;
+    });
+  }
+
+  /** Apply a named preset, skipping env-locked toggles (they can't change). */
+  public applyPreset(preset: PresetName): void {
+    const status = this.status.get();
+    for (const [toggleName, toggleValue] of Object.entries(PRESETS[preset])) {
+      const key = toggleName as ToggleKey;
+      if (status && this._isEnvLocked(status, key)) { continue; }
+      this.toggles[key].set(toggleValue);
+    }
+  }
+
+  public isEnvLocked(key: ToggleKey): boolean {
+    const status = this.status.get();
+    return !!status && this._isEnvLocked(status, key);
+  }
+
+  /**
+   * Whether the given toggle is forced-on by a deployment constraint
+   * (currently: GRIST_SINGLE_ORG=docs makes the personal org load-bearing).
+   */
+  public hasConflict(key: ToggleKey): boolean {
+    return key === "personalSites" && getGristConfig().singleOrg === "docs";
+  }
+
+  // Always persists the current toggle values, even when they match the
+  // current server state. The QuickSetup "Go Live" flow calls this with
+  // whatever preset the user picked, which may be identical to defaults
+  // but should still be committed as an explicit preference. The admin
+  // panel routes through DraftChangesManager, which only calls apply()
+  // on dirty sections, so the unconditional write is harmless there.
+  public async apply(): Promise<void> {
+    await this._installAPI.updateInstallPrefs({
+      envVars: {
+        GRIST_ORG_CREATION_ANYONE: String(this.toggles.teamSites.get()),
+        GRIST_PERSONAL_ORGS: String(this.toggles.personalSites.get()),
+        GRIST_FORCE_LOGIN: String(!this.toggles.anonAccess.get()),
+        GRIST_ANON_PLAYGROUND: String(this.toggles.playground.get()),
+        GRIST_IN_SERVICE: "true",
+      },
+    });
+    if (this.isDisposed()) { return; }
+    for (const { key } of TOGGLE_DEFS) {
+      this._serverValues[key].set(this.toggles[key].get());
+    }
+  }
+
+  public describeChange(): DraftChangeDescription {
+    const changed = TOGGLE_DEFS
+      .filter(({ key }) => !this.isEnvLocked(key))
+      .filter(({ key }) => this.toggles[key].get() !== this._serverValues[key].get())
+      .map(({ key, label }) => `${label()}: ${this.toggles[key].get() ? t("on") : t("off")}`);
+    return { label: t("Permissions"), value: changed.join(", ") };
+  }
+
+  private async _load(): Promise<void> {
+    const s = await this._installAPI.getPermissionsStatus();
+    if (this.isDisposed()) { return; }
+    this._setBoth("teamSites", s.orgCreationAnyone.value ?? true);
+    this._setBoth("personalSites", s.personalOrgs.value ?? true);
+    this._setBoth("anonAccess", !(s.forceLogin.value ?? false));
+    this._setBoth("playground", s.anonPlayground.value ?? true);
+    this.status.set(s);
+  }
+
+  private _setBoth(key: ToggleKey, value: boolean): void {
+    if (this.toggles[key].get() !== value) { this.toggles[key].set(value); }
+    if (this._serverValues[key].get() !== value) { this._serverValues[key].set(value); }
+  }
+
+  private _isEnvLocked(status: PermissionsStatus, toggleKey: ToggleKey): boolean {
+    const def = TOGGLE_DEF_BY_KEY.get(toggleKey);
+    return !!def && status[def.permKey].source === "environment-variable";
+  }
+}
+
+export type ToggleKey = "teamSites" | "personalSites" | "anonAccess" | "playground";
+export type PresetName = "locked" | "recommended" | "open";
+export type PermissionKey = keyof Omit<PermissionsStatus, "singleOrg">;
+
+export interface ToggleDef {
+  key: ToggleKey;
+  permKey: PermissionKey;
+  envVar: string;
+  label: () => string;
+  description: () => string;
+}
+
+export const PRESETS: Record<PresetName, Record<ToggleKey, boolean>> = {
+  locked: { teamSites: false, personalSites: false, anonAccess: false, playground: false },
+  recommended: { teamSites: false, personalSites: true, anonAccess: true, playground: false },
+  open: { teamSites: true, personalSites: true, anonAccess: true, playground: true },
+};
+
+// Pre-typed entries so the presetDetector Computed doesn't widen back to
+// `string` via Object.entries on every recomputation.
+const PRESET_ENTRIES: readonly (readonly [PresetName, readonly (readonly [ToggleKey, boolean])[]])[] =
+  (Object.entries(PRESETS) as [PresetName, Record<ToggleKey, boolean>][]).map(
+    ([name, values]) => [name, Object.entries(values) as [ToggleKey, boolean][]],
+  );
+
+export const TOGGLE_DEFS: ToggleDef[] = [
+  {
+    key: "teamSites",
+    permKey: "orgCreationAnyone",
+    envVar: "GRIST_ORG_CREATION_ANYONE",
+    label: () => t("Allow anyone to create team sites"),
+    description: () => t("Any logged-in user can create new team sites. \
+Turn off to restrict team creation to admins only."),
+  },
+  {
+    key: "personalSites",
+    permKey: "personalOrgs",
+    envVar: "GRIST_PERSONAL_ORGS",
+    label: () => t("Allow personal sites"),
+    description: () => t("Users can create their own personal sites with documents. \
+Turn off to restrict all documents to team sites managed by admins."),
+  },
+  {
+    key: "anonAccess",
+    permKey: "forceLogin",
+    envVar: "GRIST_FORCE_LOGIN",
+    label: () => t("Allow anonymous access"),
+    description: () => t("Visitors who aren't signed in can view publicly shared documents. \
+This is needed for link sharing and published forms."),
+  },
+  {
+    key: "playground",
+    permKey: "anonPlayground",
+    envVar: "GRIST_ANON_PLAYGROUND",
+    label: () => t("Allow anonymous playground"),
+    description: () => t("Visitors who aren't signed in can create and edit documents \
+in a temporary playground. Turn off to require sign-in before creating any documents."),
+  },
+];
+
+const TOGGLE_DEF_BY_KEY = new Map<ToggleKey, ToggleDef>(TOGGLE_DEFS.map(d => [d.key, d]));
+
+export function hasEnvLocked(status: PermissionsStatus): boolean {
+  return TOGGLE_DEFS.some(({ permKey }) => status[permKey].source === "environment-variable");
+}
+
+export function getEnvLockedVars(status: PermissionsStatus): string[] {
+  return TOGGLE_DEFS
+    .filter(({ permKey }) => status[permKey].source === "environment-variable")
+    .map(({ envVar }) => envVar);
+}

--- a/test/nbrowser/AdminPanelPermissions.ts
+++ b/test/nbrowser/AdminPanelPermissions.ts
@@ -1,0 +1,142 @@
+import { InstallAPIImpl } from "app/common/InstallAPI";
+import * as gu from "test/nbrowser/gristUtils";
+import { server, setupTestSuite } from "test/nbrowser/testUtils";
+import * as testUtils from "test/server/testUtils";
+
+import { assert, driver } from "mocha-webdriver";
+
+describe("AdminPanelPermissions", function() {
+  this.timeout(process.env.DEBUG ? "10m" : "30s");
+  setupTestSuite();
+  gu.bigScreen();
+
+  let oldEnv: testUtils.EnvironmentSnapshot;
+  let session: gu.Session;
+  let installApi: InstallAPIImpl;
+
+  afterEach(() => gu.checkForErrors());
+
+  before(async function() {
+    oldEnv = new testUtils.EnvironmentSnapshot();
+    process.env.GRIST_TEST_SERVER_DEPLOYMENT_TYPE = "core";
+    process.env.GRIST_DEFAULT_EMAIL = gu.session().email;
+    await server.restart(true); // clear database
+    session = await gu.session().personalSite.login();
+    installApi = session.createApi(InstallAPIImpl);
+  });
+
+  after(async function() {
+    oldEnv.restore();
+    await server.restart(true);
+  });
+
+  // The grouped Default-permissions row reuses QuickSetup's card, so its
+  // inner toggles render with the same `.test-permissions-setup-*` selectors
+  // as the wizard. We expand the row first so getText() / clicks land on
+  // visible elements (SectionItem uses a max-height transition).
+  async function expandPermissionsItem() {
+    await driver.findWait(".test-admin-panel-item-default-permissions", 3000);
+    await driver.find(".test-admin-panel-item-name-default-permissions").click();
+    // SectionItem uses a max-height transition; wait for the toggle label
+    // to be visible (isDisplayed implies present) before interacting.
+    await driver.wait(
+      async () => driver.find(".test-permissions-setup-perm-orgCreationAnyone label").isDisplayed(),
+      3000,
+    );
+  }
+
+  it("groups the four toggles under one Default-permissions row", async function() {
+    await driver.get(`${server.getHost()}/admin`);
+    await gu.waitForAdminPanel();
+    const item = await driver.findWait(".test-admin-panel-item-default-permissions", 3000);
+    assert.equal(await item.isDisplayed(), true);
+    // Status display should name a preset once loaded. With a clean DB
+    // and no env overrides, all four defaults are on → preset = Open.
+    // (The wizard applies "Recommended" on load; the admin panel shows
+    // the actual server state.)
+    await gu.waitToPass(async () => {
+      assert.match(await item.getText(), /\b(Open|Recommended|Locked down|Custom)\b/);
+    }, 3000);
+  });
+
+  it("flags a draft change and persists via apply-without-restart", async function() {
+    await expandPermissionsItem();
+
+    // Default for orgCreationAnyone is `true`. Flip it off.
+    assert.isTrue(await isToggleChecked("orgCreationAnyone"));
+    await driver.find(".test-permissions-setup-perm-orgCreationAnyone label").click();
+    assert.isFalse(await isToggleChecked("orgCreationAnyone"));
+
+    // Restart banner should now show a Permissions entry naming the change.
+    // The banner uses a grid-template-rows reveal transition, so wait for
+    // text to become visible (zero-height during the transition makes
+    // getText() return '').
+    const banner = await driver.findWait(".test-admin-panel-draft-changes", 2000);
+    await gu.waitToPass(async () => {
+      const text = await banner.getText();
+      assert.match(text, /Permissions/);
+      assert.match(text, /Allow anyone to create team sites/);
+    }, 3000);
+
+    // In test mode the server can't auto-restart, so the manual-restart
+    // button is exposed. Clicking it routes through DraftChangesManager,
+    // which calls the model's apply() — the path we want to verify.
+    await driver.findWait(".test-admin-panel-apply-no-restart", 3000);
+    await gu.waitToPass(async () => {
+      await driver.find(".test-admin-panel-apply-no-restart").click();
+    }, 3000);
+
+    // After apply, the draft list should clear (the change is committed
+    // to install prefs in the DB).
+    await gu.waitToPass(async () => {
+      assert.isFalse(await driver.find(".test-admin-panel-draft-changes").isPresent());
+    }, 5000);
+
+    // Install prefs only land in process.env on the next server start, so
+    // a restart is required before getPermissionsStatus reflects them.
+    await server.restart();
+    session = await gu.session().personalSite.login();
+    installApi = session.createApi(InstallAPIImpl);
+
+    const status = await installApi.getPermissionsStatus();
+    assert.equal(status.orgCreationAnyone.value, false);
+    assert.equal(status.orgCreationAnyone.source, "preferences");
+  });
+
+  it("disables env-locked toggles and shows the env-var warning well", async function() {
+    process.env.GRIST_FORCE_LOGIN = "true";
+    await server.restart();
+    session = await gu.session().personalSite.login();
+    installApi = session.createApi(InstallAPIImpl);
+
+    await driver.get(`${server.getHost()}/admin`);
+    await gu.waitForAdminPanel();
+    await expandPermissionsItem();
+
+    // The forceLogin toggle should be disabled and carry the Environment badge.
+    const input = await driver.find(".test-permissions-setup-perm-forceLogin input");
+    assert.isNotNull(await input.getAttribute("disabled"));
+    assert.isTrue(await driver
+      .find(".test-permissions-setup-perm-forceLogin .test-permissions-setup-env-badge")
+      .isPresent());
+
+    // The env-warning well should mention the locked env var.
+    const warning = await driver.find(".test-permissions-setup-env-warning");
+    await gu.waitToPass(async () => {
+      assert.match(await warning.getText(), /GRIST_FORCE_LOGIN/);
+    }, 3000);
+
+    // Other toggles should still be enabled.
+    const teamInput = await driver.find(".test-permissions-setup-perm-orgCreationAnyone input");
+    assert.isNull(await teamInput.getAttribute("disabled"));
+
+    delete process.env.GRIST_FORCE_LOGIN;
+    await server.restart();
+  });
+
+  async function isToggleChecked(permKey: string): Promise<boolean> {
+    const el = await driver.find(`.test-permissions-setup-perm-${permKey} label`);
+    const cls = await el.getAttribute("class");
+    return cls.includes("--checked");
+  }
+});

--- a/test/nbrowser/AdminPanelPermissions.ts
+++ b/test/nbrowser/AdminPanelPermissions.ts
@@ -60,6 +60,8 @@ describe("AdminPanelPermissions", function() {
   });
 
   it("flags a draft change and persists via apply-without-restart", async function() {
+    await driver.get(`${server.getHost()}/admin`);
+    await gu.waitForAdminPanel();
     await expandPermissionsItem();
 
     // Default for orgCreationAnyone is `true`. Flip it off.


### PR DESCRIPTION
The Apply & Restart step of the setup wizard has a nice card with toggles for the four install-wide defaults (team sites, personal sites, anonymous access, anonymous playground). Once the wizard is done, those toggles disappear -- you'd have to re-run the wizard to flip one.

This adds the same card to the admin panel, under Security Settings, as a single grouped row labelled "Default permissions". The collapsed row shows which preset the toggles match (Locked down / Recommended / Open / Custom); expanding it reveals the same card the wizard uses.

To avoid duplicating the rendering, the card and its little status display are now exported helpers in PermissionsSetupSection. The state behind them lives in a new PermissionsToggleModel that implements ConfigSection, so the admin panel's existing draft-changes manager and restart banner pick up toggle changes for free -- flip a toggle, the banner appears with a "Permissions: ..." entry, click Apply and the new values land in install prefs ready for the next restart.
