### PR TITLE
unify handling of auth changes with other pending config changes

### DIFF
--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -702,11 +702,14 @@ class AdminInstallationPanel extends Disposable {
         const req = this._checks.requestCheckById(use, "service-status");
         const result = req ? use(req.result) : undefined;
 
-        if (result?.details?.inService) {
+        // Until the probe lands, show a neutral placeholder rather than the
+        // alarming default. Otherwise a real admin (and our tests) see
+        // "out of service" briefly on every page load.
+        if (!result) { return cssValueLabel(t("checking")); }
+        if (result.details?.inService) {
           return cssValueLabel(cssHappyText(t("in service")));
-        } else {
-          return cssValueLabel(cssDangerText(t("out of service")));
         }
+        return cssValueLabel(cssDangerText(t("out of service")));
       },
     );
   }
@@ -761,11 +764,11 @@ class AdminInstallationPanel extends Disposable {
         const req = this._checks.requestCheckById(use, "boot-key");
         const result = req ? use(req.result) : undefined;
 
-        if (result?.details?.disabled) {
+        if (!result) { return cssValueLabel(t("checking")); }
+        if (result.details?.disabled) {
           return cssValueLabel(cssHappyText(t("disabled")));
-        } else {
-          return cssValueLabel(cssDangerText(t("enabled")));
         }
+        return cssValueLabel(cssDangerText(t("enabled")));
       },
     );
   }

--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -12,7 +12,6 @@ import { buildAdminAccessDeniedCard } from "app/client/ui/AdminAccessDeniedCard"
 import { buildAdminData } from "app/client/ui/AdminControls";
 import { buildAdminLeftPanel, getPageNames } from "app/client/ui/AdminLeftPanel";
 import {
-  AdminPanelControls,
   cssDangerText,
   cssErrorText,
   cssFlexSpace,
@@ -204,20 +203,16 @@ export class AdminPanel extends Disposable {
   }
 }
 
-class AdminInstallationPanel extends Disposable implements AdminPanelControls {
-  // Legacy `needsRestart` channel kept for any remaining non-draft sections
-  // that signal a restart imperatively. Auth no longer uses it (it's now a
-  // ConfigSection registered with `_drafts`).
-  public needsRestart = Observable.create(this, false);
+class AdminInstallationPanel extends Disposable {
   // Sticky flag: true after the user has applied changes without a restart
   // in an environment that doesn't support auto-restart. Keeps the manual
   // restart reminder on screen until the user reloads the page. Cleared only
   // by a full page reload (see reloadSafe at the bottom of this file).
   private _awaitingManualRestart = Observable.create<boolean>(this, false);
   private _supportsRestart = !!getAdminConfig().runningUnderSupervisor;
-  private _baseUrlSection = BaseUrlSection.create(this, { controls: this });
+  private _baseUrlSection = BaseUrlSection.create(this, { inAdminPanel: true });
   private _editionSection = EditionSection.create(this, {
-    controls: this,
+    inAdminPanel: true,
     notifier: this._appModel.notifier,
   });
 
@@ -237,12 +232,10 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
   // alternative content that doesn't need the section anyway.
   private _authSection: AuthenticationSection | undefined;
 
-  // Banner visibility: shown when draft-tracked sections have pending
-  // changes, or a legacy section has flagged that a restart is required,
+  // Banner visibility: shown when any tracked section has pending changes,
   // or the user has applied changes without a restart and still owes us one.
   private _showRestartBanner = Computed.create(this, use =>
     use(this._drafts.needsRestart) ||
-    use(this.needsRestart) ||
     use(this._awaitingManualRestart),
   );
 
@@ -317,13 +310,9 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
 
   private async _performRestart() {
     // When a section needs a restart, DraftChangesManager handles the
-    // apply+restart+wait cycle. Otherwise the banner was shown for another
-    // reason (e.g. a section saved inline) and we restart directly.
-    //
-    // Note: individual sections never call `configAPI.restartServer()` on
-    // their own. They only mark themselves `needsRestart` and route through
-    // here, so a single user click always produces exactly one restart even
-    // when several sections are dirty at once.
+    // apply+restart+wait cycle. Otherwise the banner was shown because the
+    // user previously applied without restart and still owes us one, so we
+    // restart directly.
     if (this._drafts.needsRestart.get()) {
       const result = await this._drafts.applyAll();
       // A section's afterApply may have already navigated us elsewhere
@@ -1157,7 +1146,7 @@ Set the environment variable GRIST_ALLOW_AUTOMATIC_VERSION_CHECKING to "true" to
   }
 
   private _buildBackupsSection() {
-    const backups = BackupsSection.create(this, { checks: this._checks, controls: this });
+    const backups = BackupsSection.create(this, { checks: this._checks, inAdminPanel: true });
     return SectionCard(t("Storage"), [
       SectionItem({
         id: "backups",

--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -2,7 +2,6 @@ import { buildHomeBanners } from "app/client/components/Banners";
 import { makeT } from "app/client/lib/localization";
 import { markdown } from "app/client/lib/markdown";
 import { getTimeFromNow } from "app/client/lib/timeUtils";
-import { redirectToLogin } from "app/client/lib/urlUtils";
 import { AdminCheckRequest, AdminChecks, probeDetails, ProbeDetails } from "app/client/models/AdminChecks";
 import { AppModel, getHomeUrl, reportError } from "app/client/models/AppModel";
 import { AuditLogsModel, AuditLogsModelImpl } from "app/client/models/AuditLogsModel";
@@ -206,14 +205,10 @@ export class AdminPanel extends Disposable {
 }
 
 class AdminInstallationPanel extends Disposable implements AdminPanelControls {
-  // Signal from legacy sections (e.g. AuthenticationSection) that their own
-  // state change now requires a restart. Draft-tracked sections contribute
-  // separately via `_drafts.needsRestart`; both are combined into
-  // `_showRestartBanner`.
+  // Legacy `needsRestart` channel kept for any remaining non-draft sections
+  // that signal a restart imperatively. Auth no longer uses it (it's now a
+  // ConfigSection registered with `_drafts`).
   public needsRestart = Observable.create(this, false);
-  // Set when a pending change will sign the admin out on apply. Read
-  // after restart to route through /login.
-  public needsLogin = Observable.create(this, false);
   // Sticky flag: true after the user has applied changes without a restart
   // in an environment that doesn't support auto-restart. Keeps the manual
   // restart reminder on screen until the user reloads the page. Cleared only
@@ -235,6 +230,12 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
   private readonly _configAPI: ConfigAPI = new ConfigAPI(getHomeUrl());
   private _authCheck: Observable<AdminCheckRequest | undefined>;
   private _loginProvider: Observable<string | undefined>;
+  // Created in the constructor body since it depends on `_loginProvider`,
+  // which is itself initialized after `_checks`. Undefined when there is
+  // no signed-in admin user -- the section reads the user's email at
+  // construction time and the "no valid user" admin path renders
+  // alternative content that doesn't need the section anyway.
+  private _authSection: AuthenticationSection | undefined;
 
   // Banner visibility: shown when draft-tracked sections have pending
   // changes, or a legacy section has flagged that a restart is required,
@@ -248,19 +249,32 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
   constructor(private _appModel: AppModel, private _restartBanner: RestartBannerController) {
     super();
     this._checks = new AdminChecks(this, this._installAPI);
-    this._drafts.addSection(this._baseUrlSection);
-    this._drafts.addSection(this._editionSection);
-    this._drafts.addSection(this._permissionsModel);
-
-    // Mirror visibility into the shared controller so the left-panel entry
-    // appears/disappears with the banner.
-    this._restartBanner.isVisible.set(this._showRestartBanner.get());
-    this.autoDispose(this._showRestartBanner.addListener(v => this._restartBanner.isVisible.set(v)));
 
     this._authCheck = Computed.create(this, (use) => {
       return this._checks.requestCheckById(use, "authentication");
     });
     this._loginProvider = this._checks.buildLoginProviderObs(this);
+
+    if (this._appModel.currentValidUser) {
+      this._authSection = AuthenticationSection.create(this, {
+        appModel: this._appModel,
+        loginSystemId: this._loginProvider,
+        inAdminPanel: true,
+        installAPI: this._installAPI,
+      });
+    }
+
+    this._drafts.addSection(this._baseUrlSection);
+    this._drafts.addSection(this._editionSection);
+    this._drafts.addSection(this._permissionsModel);
+    if (this._authSection) {
+      this._drafts.addSection(this._authSection);
+    }
+
+    // Mirror visibility into the shared controller so the left-panel entry
+    // appears/disappears with the banner.
+    this._restartBanner.isVisible.set(this._showRestartBanner.get());
+    this.autoDispose(this._showRestartBanner.addListener(v => this._restartBanner.isVisible.set(v)));
   }
 
   public buildDom() {
@@ -310,21 +324,18 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
     // their own. They only mark themselves `needsRestart` and route through
     // here, so a single user click always produces exactly one restart even
     // when several sections are dirty at once.
-    // Snapshot before applying: the restart clears it.
-    const willInvalidateSession = this.needsLogin.get();
-
     if (this._drafts.needsRestart.get()) {
-      await this._drafts.applyAll();
+      const result = await this._drafts.applyAll();
+      // A section's afterApply may have already navigated us elsewhere
+      // (e.g. auth changes redirect through sign-in). Don't clobber that
+      // with a reload.
+      if (result?.redirected) { return; }
     } else {
       await this._configAPI.restartServer();
       if (!await this._configAPI.waitUntilReady()) {
         await reloadSafe();
         return;
       }
-    }
-    if (willInvalidateSession) {
-      redirectToLogin();
-      return;
     }
     await reloadSafe();
   }
@@ -807,12 +818,7 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
   }
 
   private _buildAuthenticationPanelExtraContent() {
-    return dom.create(AuthenticationSection, {
-      appModel: this._appModel,
-      loginSystemId: this._loginProvider,
-      controls: this,
-      installAPI: this._installAPI,
-    });
+    return this._authSection?.buildDom();
   }
 
   private _buildSessionSecretDisplay() {

--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -57,7 +57,7 @@ import { buildInstallationIdDisplay } from "app/client/ui/ToggleEnterpriseWidget
 import { createTopBarHome } from "app/client/ui/TopBar";
 import { createUserImage } from "app/client/ui/UserImage";
 import { fullBreadcrumbs } from "app/client/ui2018/breadcrumbs";
-import { basicButton, bigBasicButton, bigPrimaryButton, bigPrimaryButtonLink } from "app/client/ui2018/buttons";
+import { basicButton, bigBasicButton, bigPrimaryButton } from "app/client/ui2018/buttons";
 import { testId, theme } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
 import { cssLink, makeLinks } from "app/client/ui2018/links";

--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -57,7 +57,7 @@ import { buildInstallationIdDisplay } from "app/client/ui/ToggleEnterpriseWidget
 import { createTopBarHome } from "app/client/ui/TopBar";
 import { createUserImage } from "app/client/ui/UserImage";
 import { fullBreadcrumbs } from "app/client/ui2018/breadcrumbs";
-import { basicButton, bigPrimaryButton } from "app/client/ui2018/buttons";
+import { basicButton, bigBasicButton, bigPrimaryButton, bigPrimaryButtonLink } from "app/client/ui2018/buttons";
 import { testId, theme } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
 import { cssLink, makeLinks } from "app/client/ui2018/links";
@@ -232,8 +232,9 @@ class AdminInstallationPanel extends Disposable {
   // alternative content that doesn't need the section anyway.
   private _authSection: AuthenticationSection | undefined;
 
-  // Banner visibility: shown when any tracked section has pending changes,
-  // or the user has applied changes without a restart and still owes us one.
+  // Banner visibility: shown when a tracked section has restart-required
+  // pending changes, or the user has applied changes without a restart and
+  // still owes us one. Non-restart drafts don't surface the banner.
   private _showRestartBanner = Computed.create(this, use =>
     use(this._drafts.needsRestart) ||
     use(this._awaitingManualRestart),
@@ -339,6 +340,24 @@ class AdminInstallationPanel extends Disposable {
     }
   }
 
+  private async _dismissChanges() {
+    if (!this._drafts.hasDraftChanges.get()) { return; }
+    confirmModal(
+      t("Dismiss pending changes?"),
+      t("Dismiss"),
+      async () => {
+        try {
+          await spinnerModal(t("Dismissing..."), this._drafts.dismissAll());
+        } catch (err) {
+          reportError(err as Error);
+        }
+      },
+      {
+        explanation: dom("p", t("Any pending changes will be cleared.")),
+      },
+    );
+  }
+
   /**
    * Show something helpful to those without access to the panel,
    * which could include a legit administrator if auth is misconfigured.
@@ -410,11 +429,20 @@ class AdminInstallationPanel extends Disposable {
             ),
             dom.hide(this._supportsRestart),
           ),
-          bigPrimaryButton(
-            t("Restart Grist"),
-            dom.on("click", () => this.restartGrist()),
-            testId("admin-panel-restart-button"),
-            dom.show(this._supportsRestart),
+          cssRestartButtonRow(
+            bigPrimaryButton(
+              t("Restart Grist"),
+              dom.on("click", () => this.restartGrist()),
+              testId("admin-panel-restart-button"),
+              dom.show(this._supportsRestart),
+            ),
+            dom.maybe(this._drafts.hasDraftChanges, () =>
+              bigBasicButton(
+                t("Dismiss changes"),
+                dom.on("click", () => this._dismissChanges()),
+                testId("admin-panel-dismiss-button"),
+              ),
+            ),
           ),
         ),
       )),
@@ -1292,6 +1320,13 @@ const cssDraftChangesList = styled("ul", `
 
 const cssDraftChangeLabel = styled("span", `
   font-weight: 600;
+`);
+
+const cssRestartButtonRow = styled("div", `
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
 `);
 
 const cssExpandedContent = styled("div", `

--- a/app/client/ui/AdminPanelCss.ts
+++ b/app/client/ui/AdminPanelCss.ts
@@ -12,10 +12,6 @@ import { dom, IDisposableOwner, keyframes, Observable, styled } from "grainjs";
 export interface AdminPanelControls {
   // Pending changes need a restart to take effect; drives the banner.
   needsRestart: Observable<boolean>;
-  // Pending changes will sign the admin out on apply, so route through
-  // /login afterwards instead of reloading. Today this matches needsRestart,
-  // but they're conceptually distinct.
-  needsLogin: Observable<boolean>;
   restartGrist: () => Promise<void>;
 }
 

--- a/app/client/ui/AdminPanelCss.ts
+++ b/app/client/ui/AdminPanelCss.ts
@@ -9,12 +9,6 @@ import { components, tokens } from "app/common/ThemePrefs";
 
 import { dom, IDisposableOwner, keyframes, Observable, styled } from "grainjs";
 
-export interface AdminPanelControls {
-  // Pending changes need a restart to take effect; drives the banner.
-  needsRestart: Observable<boolean>;
-  restartGrist: () => Promise<void>;
-}
-
 export function HidableToggle(
   owner: IDisposableOwner,
   value: Observable<boolean | null>,

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -492,7 +492,7 @@ effect after you restart Grist."),
     saveModal((_ctl, owner) => {
       const changeAdminModal = ChangeAdminModal.create(owner, {
         currentUserEmail,
-        defaultEmail: this._getgristLoginOwner.get().email,
+        defaultEmail: this._getgristLoginOwner.get()?.email,
         onSave: async ({ email, replace }) => {
           await this._setInstallAdmin(email, replace);
         },

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -85,9 +85,6 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
    */
   public isDirty: Computed<boolean>;
 
-  /** True while {@link apply} is in flight. */
-  public isApplying = Observable.create<boolean>(this, false);
-
   /** Auth changes always require a restart to take effect. */
   public readonly needsRestart = true;
 
@@ -142,6 +139,18 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
     return providers.some(p => p.willBeActive);
   });
 
+  // Server-side state that needs a restart to settle: a provider switch
+  // or a queued admin-email change. Distinct from `isDirty`, which also
+  // counts purely local drafts.
+  private _hasPersistedRestartChange = Computed.create(
+    this, this._hasActiveOnRestartProvider, this._prefsPendingChanges,
+    (_use, hasActive, prefs) => {
+      return hasActive ||
+        Boolean(prefs?.onRestartSetAdminEmail) ||
+        Boolean(prefs?.onRestartReplaceEmailWithAdmin);
+    },
+  );
+
   private _getgristLoginOwner = Computed.create(this, this._providers, (_use, providers) => {
     const getgristLogin = providers.find(p => p.key === GETGRIST_COM_PROVIDER_KEY);
     return getgristLogin?.metadata?.owner ?? null;
@@ -159,12 +168,13 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
       return !!loginSystemId && isRealProvider(loginSystemId);
     });
 
+    // Evaluate every branch: short-circuit returns drop subscriptions to
+    // later deps, leaving `isDirty` stale once an early truthy branch flips.
     this.isDirty = Computed.create(this, (use) => {
-      if (use(this._draftConfigs).size > 0) { return true; }
-      if (use(this._draftActiveProvider) !== null) { return true; }
-      if (use(this._hasActiveOnRestartProvider)) { return true; }
-      const prefs = use(this._prefsPendingChanges);
-      return Boolean(prefs?.onRestartSetAdminEmail || prefs?.onRestartReplaceEmailWithAdmin);
+      const hasDraftConfigs = use(this._draftConfigs).size > 0;
+      const hasDraftActive = use(this._draftActiveProvider) !== null;
+      const hasPersistedRestartChange = use(this._hasPersistedRestartChange);
+      return hasDraftConfigs || hasDraftActive || hasPersistedRestartChange;
     });
 
     this._fetchProviders().catch(reportError);
@@ -213,29 +223,60 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
     return { redirected: true };
   }
 
-  public describeChange(): DraftChangeDescription {
+  /**
+   * Drop every contribution this section makes to the draft list:
+   *   - clear local provider-config and active-provider drafts
+   *   - null both on-restart admin-email prefs server-side
+   * `willBeActive`/`willBeDisabled` rooted in env-var deltas aren't
+   * cleared here -- the user can reverse those via the per-provider
+   * controls in the section itself.
+   */
+  public async dismiss(): Promise<void> {
+    if (!this.isDirty.get()) { return; }
+    this._draftConfigs.set(new Map());
+    this._draftActiveProvider.set(null);
+    this._recentlyConfigured.clear();
+    const prefs = this._prefsPendingChanges.get();
+    if (prefs?.onRestartSetAdminEmail || prefs?.onRestartReplaceEmailWithAdmin) {
+      await this._installAPI.updateInstallPrefs({
+        onRestartSetAdminEmail: null,
+        onRestartReplaceEmailWithAdmin: null,
+      });
+      if (this.isDisposed()) { return; }
+      await this._fetchPrefsPendingChanges();
+    }
+  }
+
+  public describeChange(): DraftChangeDescription[] {
+    const entries: DraftChangeDescription[] = [];
     const providers = this._displayProviders.get();
     const willBeActive = providers.find(p => p.willBeActive);
-    if (willBeActive) {
-      return { label: t("Authentication"), value: willBeActive.name };
-    }
     const willBeDisabled = providers.find(p => p.willBeDisabled);
-    if (willBeDisabled) {
-      return { label: t("Authentication"), value: t("disabled") };
+    if (willBeActive) {
+      entries.push({ label: t("Authentication"), value: willBeActive.name });
+    } else if (willBeDisabled) {
+      entries.push({ label: t("Authentication"), value: t("disabled") });
+    } else if (this._draftConfigs.get().size > 0) {
+      entries.push({ label: t("Authentication"), value: t("configuration updated") });
     }
-    if (this._draftConfigs.get().size > 0) {
-      return { label: t("Authentication"), value: t("configuration updated") };
-    }
+
     const prefs = this._prefsPendingChanges.get();
     if (prefs?.onRestartSetAdminEmail) {
-      return { label: t("Admin user"), value: prefs.onRestartSetAdminEmail };
+      entries.push({ label: t("New admin email"), value: prefs.onRestartSetAdminEmail });
     }
     if (prefs?.onRestartReplaceEmailWithAdmin) {
-      return { label: t("Admin user"), value: t("updated") };
+      entries.push({
+        label: t("Reassign login to admin"),
+        value: prefs.onRestartReplaceEmailWithAdmin,
+      });
     }
+
     // describeChange is only consulted when isDirty is true; one of the
     // above branches should have hit. Fall back rather than throw.
-    return { label: t("Authentication"), value: "" };
+    if (entries.length === 0) {
+      entries.push({ label: t("Authentication"), value: "" });
+    }
+    return entries;
   }
 
   public buildDom() {
@@ -251,7 +292,7 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
         return this._buildSection(providers, loginSystemId);
       }),
       this._inAdminPanel ?
-        dom.maybe(this._hasActiveOnRestartProvider, () => this._buildAuthenticationChangeWarning()) : null,
+        dom.maybe(this._hasPersistedRestartChange, () => this._buildAuthenticationChangeWarning()) : null,
     ];
   }
 

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -209,6 +209,12 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
       this._draftActiveProvider.set(null);
       this._recentlyConfigured.add(activeChoice);
     }
+
+    // Refresh `_providers` here so `isDirty` survives a restart failure --
+    // `afterApply` only runs on success.
+    if (!this.isDisposed()) {
+      await this._fetchProviders();
+    }
   }
 
   /**

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -5,13 +5,13 @@ import { redirectToLogin } from "app/client/lib/urlUtils";
 import { AdminChecks } from "app/client/models/AdminChecks";
 import { AppModel, getHomeUrl, reportError } from "app/client/models/AppModel";
 import {
-  AdminPanelControls,
   cssIconWrapper,
   cssWell,
   cssWellContent,
   cssWellTitle,
 } from "app/client/ui/AdminPanelCss";
 import { ChangeAdminModal } from "app/client/ui/ChangeAdminModal";
+import { ConfigSection, DraftChangeDescription } from "app/client/ui/DraftChanges";
 import {
   armSetupReturnFromGetGristCom,
   clearSetupReturnFromGetGristCom,
@@ -61,18 +61,16 @@ interface AuthenticationSectionOptions {
   appModel: AppModel;
   loginSystemId?: Observable<string | undefined>;
   /**
-   * Present when this section is rendered inside the admin panel. Absent in the
-   * setup wizard. The single signal for "am I in the admin panel?" -- also the
-   * channel through which the section reports needsRestart.
-   *
-   * When absent, the per-section restart warning is suppressed (the wizard
-   * handles continuation via its own Continue button).
+   * True when rendered inside the admin panel; false in the setup wizard.
+   * Controls admin-only affordances (the in-panel "Restart required"
+   * warning with Change-admin-user controls). Restart routing happens
+   * via the parent's DraftChangesManager regardless.
    */
-  controls?: AdminPanelControls;
+  inAdminPanel?: boolean;
   installAPI?: InstallAPI;
 }
 
-export class AuthenticationSection extends Disposable {
+export class AuthenticationSection extends Disposable implements ConfigSection {
   /**
    * True when authentication is in a state the user can proceed with:
    * a real provider is active, configured, or pending — or the user acknowledged no-auth.
@@ -90,15 +88,13 @@ export class AuthenticationSection extends Disposable {
   /** True while {@link apply} is in flight. */
   public isApplying = Observable.create<boolean>(this, false);
 
+  /** Auth changes always require a restart to take effect. */
+  public readonly needsRestart = true;
+
   private _appModel = this._options.appModel;
   private _installAPI = this._options.installAPI ?? new InstallAPIImpl(getHomeUrl());
   /** True when embedded in the admin panel (vs. the setup wizard). */
-  private _inAdminPanel = Boolean(this._options.controls);
-  private _controls = this._options.controls ?? {
-    needsRestart: Observable.create(this, false),
-    needsLogin: Observable.create(this, false),
-    restartGrist: async () => { await new ConfigAPI(getHomeUrl()).restartServer(); },
-  };
+  private _inAdminPanel = Boolean(this._options.inAdminPanel);
 
   private _loginSystemId = this._options.loginSystemId ?? this._makeLoginSystemId();
 
@@ -154,31 +150,44 @@ export class AuthenticationSection extends Disposable {
   }
 
   /**
-   * Apply pending auth changes by restarting the server and waiting until
-   * it's ready again. The relevant config writes have already happened
-   * inline (via the configuration modals); this is purely the restart so
-   * the new config takes effect.
+   * No-op for now: the configure / set-active / deactivate modals persist
+   * their changes inline, so by the time `apply()` runs the server already
+   * has the env-var updates queued for restart. We're declared dirty
+   * because of the server-side `willBeActive`, not because of any
+   * client-side draft. The DraftChangesManager fires the actual restart;
+   * `afterApply()` then routes the now-signed-out admin through sign-in.
    *
-   * On success, fires a top-level navigation through sign-in (the admin's
-   * session is gone after the restart) and returns `{ redirected: true }`
-   * so the caller knows not to run any post-apply step. No-op when there
-   * are no pending changes. Throws on restart timeout.
+   * Phase 3 of the migration will move the inline mutations into true
+   * drafts that this method persists.
    */
-  public async apply(): Promise<ApplyResult> {
+  public async apply(): Promise<void> {
     if (!this.isDirty.get()) { return; }
-    if (this.isApplying.get()) { return; }
-    this.isApplying.set(true);
-    try {
-      await this._configAPI.restartServer();
-      if (!await this._configAPI.waitUntilReady()) {
-        throw new Error("Timed out waiting for Grist server to restart");
-      }
-    } finally {
-      if (!this.isDisposed()) { this.isApplying.set(false); }
-    }
+  }
+
+  /**
+   * Auth changes invalidate the admin's session, so once the manager has
+   * restarted we redirect through sign-in rather than trying to refetch
+   * (the API would 401 anyway). Returning `{ redirected: true }` tells the
+   * manager and its caller to skip any post-apply work.
+   */
+  public async afterApply(): Promise<ApplyResult> {
     if (this.isDisposed()) { return; }
     redirectToLogin();
     return { redirected: true };
+  }
+
+  public describeChange(): DraftChangeDescription {
+    const provider = this._providers.get().find(p => p.willBeActive);
+    if (provider) {
+      return { label: t("Authentication"), value: provider.name };
+    }
+    const prefs = this._prefsPendingChanges.get();
+    if (prefs?.onRestartSetAdminEmail) {
+      return { label: t("Admin user"), value: prefs.onRestartSetAdminEmail };
+    }
+    // describeChange is only consulted when isDirty is true; one of the
+    // above branches should have hit. Fall back rather than throw.
+    return { label: t("Authentication"), value: "" };
   }
 
   public buildDom() {
@@ -210,7 +219,6 @@ export class AuthenticationSection extends Disposable {
       return;
     }
     this._providers.set(providers);
-    this._checkIfRestartNeeded();
   }
 
   private async _fetchPrefsPendingChanges() {
@@ -404,7 +412,6 @@ authentication system.",
     if (this.isDisposed()) { return; }
 
     await this._fetchPrefsPendingChanges();
-    this._checkIfRestartNeeded();
   };
 
   private async _revertSetInstallAdmin() {
@@ -416,23 +423,6 @@ authentication system.",
 
     await this._fetchPrefsPendingChanges();
   };
-
-  private _checkIfRestartNeeded() {
-    if (!this._inAdminPanel) { return; }
-
-    const hasActiveOnRestartProvider = this._hasActiveOnRestartProvider.get();
-
-    const prefsPendingChanges = this._prefsPendingChanges.get();
-    const hasUnappliedRestartPrefs = Boolean(
-      prefsPendingChanges?.onRestartSetAdminEmail ||
-      prefsPendingChanges?.onRestartReplaceEmailWithAdmin,
-    );
-    const needsRestart = hasActiveOnRestartProvider || hasUnappliedRestartPrefs;
-    if (needsRestart) {
-      this._controls.needsRestart.set(true);
-      this._controls.needsLogin.set(true);
-    }
-  }
 }
 
 /**

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -111,7 +111,34 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
    */
   private _recentlyConfigured = new Set<string>();
 
-  private _hasActiveOnRestartProvider = Computed.create(this, this._providers, (_use, providers) => {
+  /**
+   * Per-provider configuration drafts (currently only the getgrist.com
+   * secret). The map's value is the body that will be PATCHed to
+   * `/api/config/auth-providers` on apply. Drafts disappear once apply
+   * has persisted them.
+   */
+  private _draftConfigs = Observable.create<Map<string, Record<string, string>>>(this, new Map());
+
+  /**
+   * Pending choice for the active authentication provider. `null` means
+   * the user has not chosen one in this session; otherwise it is a
+   * provider key (or `FALLBACK_PROVIDER_KEY` for "deactivate").
+   */
+  private _draftActiveProvider = Observable.create<string | null>(this, null);
+
+  /**
+   * Server providers merged with local drafts. Drafts win over server
+   * state, so the user sees their pending choices reflected in the
+   * hero card and the provider list before they apply.
+   */
+  private _displayProviders = Computed.create(
+    this, this._providers, this._draftConfigs, this._draftActiveProvider,
+    (_use, providers, draftConfigs, draftActive) => {
+      return providers.map(p => mergeProviderWithDrafts(p, draftConfigs, draftActive));
+    },
+  );
+
+  private _hasActiveOnRestartProvider = Computed.create(this, this._displayProviders, (_use, providers) => {
     return providers.some(p => p.willBeActive);
   });
 
@@ -126,13 +153,15 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
     this.canProceed = Computed.create(this, (use) => {
       if (use(noAuthAcknowledged)) { return true; }
       if (use(this._hasActiveOnRestartProvider)) { return true; }
-      const providers = use(this._providers);
+      const providers = use(this._displayProviders);
       if (providers.some(p => (p.isActive || p.isConfigured) && isRealProvider(p.key))) { return true; }
       const loginSystemId = use(this._loginSystemId);
       return !!loginSystemId && isRealProvider(loginSystemId);
     });
 
     this.isDirty = Computed.create(this, (use) => {
+      if (use(this._draftConfigs).size > 0) { return true; }
+      if (use(this._draftActiveProvider) !== null) { return true; }
       if (use(this._hasActiveOnRestartProvider)) { return true; }
       const prefs = use(this._prefsPendingChanges);
       return Boolean(prefs?.onRestartSetAdminEmail || prefs?.onRestartReplaceEmailWithAdmin);
@@ -150,18 +179,26 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
   }
 
   /**
-   * No-op for now: the configure / set-active / deactivate modals persist
-   * their changes inline, so by the time `apply()` runs the server already
-   * has the env-var updates queued for restart. We're declared dirty
-   * because of the server-side `willBeActive`, not because of any
-   * client-side draft. The DraftChangesManager fires the actual restart;
-   * `afterApply()` then routes the now-signed-out admin through sign-in.
-   *
-   * Phase 3 of the migration will move the inline mutations into true
-   * drafts that this method persists.
+   * Persist drafts to the server. Configure calls go first because a
+   * provider must be configured server-side before it can be set active.
+   * Each draft is cleared once its API call succeeds, so a partial
+   * failure leaves the remaining drafts in place for a retry. The
+   * DraftChangesManager fires the restart afterwards; `afterApply` then
+   * routes the now-signed-out admin through sign-in.
    */
   public async apply(): Promise<void> {
-    if (!this.isDirty.get()) { return; }
+    for (const [providerKey, config] of this._draftConfigs.get()) {
+      await this._configAPI.configureProvider(providerKey, config);
+      this._updateDraftConfigs(draft => draft.delete(providerKey));
+      this._recentlyConfigured.add(providerKey);
+    }
+
+    const activeChoice = this._draftActiveProvider.get();
+    if (activeChoice !== null) {
+      await this._configAPI.setActiveAuthProvider(activeChoice);
+      this._draftActiveProvider.set(null);
+      this._recentlyConfigured.add(activeChoice);
+    }
   }
 
   /**
@@ -177,13 +214,24 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
   }
 
   public describeChange(): DraftChangeDescription {
-    const provider = this._providers.get().find(p => p.willBeActive);
-    if (provider) {
-      return { label: t("Authentication"), value: provider.name };
+    const providers = this._displayProviders.get();
+    const willBeActive = providers.find(p => p.willBeActive);
+    if (willBeActive) {
+      return { label: t("Authentication"), value: willBeActive.name };
+    }
+    const willBeDisabled = providers.find(p => p.willBeDisabled);
+    if (willBeDisabled) {
+      return { label: t("Authentication"), value: t("disabled") };
+    }
+    if (this._draftConfigs.get().size > 0) {
+      return { label: t("Authentication"), value: t("configuration updated") };
     }
     const prefs = this._prefsPendingChanges.get();
     if (prefs?.onRestartSetAdminEmail) {
       return { label: t("Admin user"), value: prefs.onRestartSetAdminEmail };
+    }
+    if (prefs?.onRestartReplaceEmailWithAdmin) {
+      return { label: t("Admin user"), value: t("updated") };
     }
     // describeChange is only consulted when isDirty is true; one of the
     // above branches should have hit. Fall back rather than throw.
@@ -198,13 +246,20 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
         description: t("Choose how users sign in to Grist."),
       }),
       dom.domComputed((use) => {
-        const providers = use(this._providers);
+        const providers = use(this._displayProviders);
         const loginSystemId = use(this._loginSystemId);
         return this._buildSection(providers, loginSystemId);
       }),
       this._inAdminPanel ?
         dom.maybe(this._hasActiveOnRestartProvider, () => this._buildAuthenticationChangeWarning()) : null,
     ];
+  }
+
+  /** Apply a mutation to the draft-configs map immutably. */
+  private _updateDraftConfigs(mutate: (draft: Map<string, Record<string, string>>) => void) {
+    const next = new Map(this._draftConfigs.get());
+    mutate(next);
+    this._draftConfigs.set(next);
   }
 
   private _makeLoginSystemId(): Observable<string | undefined> {
@@ -301,15 +356,11 @@ authentication system.",
     );
   }
 
-  private async _setActiveProvider(provider: AuthProvider) {
+  private _setActiveProvider(provider: AuthProvider) {
     confirmModal(
       t("Set as active method?"),
       t("Confirm"),
-      async () => {
-        await this._configAPI.setActiveAuthProvider(provider.key);
-        this._recentlyConfigured.add(provider.key);
-        await this._fetchProviders();
-      },
+      async () => { this._draftActiveProvider.set(provider.key); },
       {
         explanation: dom("div",
           cssMarkdownSpan(
@@ -317,7 +368,8 @@ authentication system.",
               { name: provider.name }),
           ),
           dom("p",
-            t("The new method will go into effect after you restart Grist."),
+            t("The change will be saved when you apply pending changes, and will go into \
+effect after you restart Grist."),
           ),
         ),
       },
@@ -333,9 +385,18 @@ authentication system.",
       if (!this._inAdminPanel) { clearSetupReturnFromGetGristCom(); }
     };
     m.show({
-      onConfigure: () => {
+      onSubmit: (key: string) => {
+        this._updateDraftConfigs(draft =>
+          draft.set(GETGRIST_COM_PROVIDER_KEY, { GRIST_GETGRISTCOM_SECRET: key }));
+        // Mirror the server's "first configured provider wins" behavior:
+        // if nothing is currently active and the user has not chosen one
+        // yet in this session, treat the just-configured provider as the
+        // pending active. Saves the user an explicit "Set as active"
+        // click in the simple zero-config-to-getgrist.com path.
+        if (this._draftActiveProvider.get() === null && !this._providers.get().some(p => p.isActive)) {
+          this._draftActiveProvider.set(GETGRIST_COM_PROVIDER_KEY);
+        }
         this._recentlyConfigured.add(GETGRIST_COM_PROVIDER_KEY);
-        this._fetchProviders().catch(reportError);
         onUserClose();
       },
       onCancel: onUserClose,
@@ -357,11 +418,7 @@ authentication system.",
     confirmModal(
       t("Deactivate authentication?"),
       t("Deactivate"),
-      async () => {
-        await this._configAPI.setActiveAuthProvider(FALLBACK_PROVIDER_KEY);
-        this._recentlyConfigured.add(provider.key);
-        await this._fetchProviders();
-      },
+      async () => { this._draftActiveProvider.set(FALLBACK_PROVIDER_KEY); },
       {
         explanation: dom("div",
           cssMarkdownSpan(
@@ -371,7 +428,8 @@ authentication system.",
             t("Your configuration will be preserved. You can reactivate it later without reconfiguring."),
           ),
           dom("p",
-            t("The change will take effect after you restart Grist."),
+            t("The change will be saved when you apply pending changes, and will take \
+effect after you restart Grist."),
           ),
         ),
       },
@@ -423,6 +481,53 @@ authentication system.",
 
     await this._fetchPrefsPendingChanges();
   };
+}
+
+/**
+ * Merge a server-reported provider with any client-side drafts so the UI
+ * reflects the user's pending choices.
+ *
+ * - A draft secret marks the provider as configured and (if the server
+ *   has not pinned the active provider via env) able to be activated.
+ * - A draft active-provider choice flips `willBeActive` on the chosen
+ *   provider and `willBeDisabled` on the currently-active one. Choosing
+ *   the fallback (deactivate) just sets `willBeDisabled` on the
+ *   currently-active provider.
+ */
+function mergeProviderWithDrafts(
+  provider: AuthProvider,
+  draftConfigs: Map<string, Record<string, string>>,
+  draftActive: string | null,
+): AuthProvider {
+  const merged: AuthProvider = { ...provider };
+
+  if (draftConfigs.has(provider.key)) {
+    merged.isConfigured = true;
+    merged.configError = undefined;
+    if (!provider.isSelectedByEnv) {
+      merged.canBeActivated = !provider.isActive;
+    }
+  }
+
+  if (draftActive !== null) {
+    const wasActive = !!provider.isActive;
+    // Mirror the server's `isActive = key === active && key === next` so
+    // the ACTIVE badge clears on the outgoing provider as soon as the
+    // user picks a new one.
+    merged.isActive = wasActive && provider.key === draftActive;
+    if (provider.key === draftActive) {
+      merged.willBeActive = !wasActive;
+      merged.willBeDisabled = false;
+      merged.canBeActivated = false;
+    } else {
+      merged.willBeActive = false;
+      if (wasActive) {
+        merged.willBeDisabled = true;
+        merged.canBeActivated = !provider.isSelectedByEnv;
+      }
+    }
+  }
+  return merged;
 }
 
 /**

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -85,6 +85,14 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
    */
   public isDirty: Computed<boolean>;
 
+  /**
+   * Per-section description shown in the restart banner. Reactive on
+   * `_displayProviders`, `_draftConfigs`, and `_prefsPendingChanges`, so
+   * a second sub-change while already-dirty (e.g. a queued admin email
+   * change after a provider switch) refreshes the displayed bullets.
+   */
+  public describeChange: Computed<DraftChangeDescription[]>;
+
   /** Auth changes always require a restart to take effect. */
   public readonly needsRestart = true;
 
@@ -177,6 +185,38 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
       return hasDraftConfigs || hasDraftActive || hasPersistedRestartChange;
     });
 
+    this.describeChange = Computed.create(this, (use) => {
+      const entries: DraftChangeDescription[] = [];
+      const providers = use(this._displayProviders);
+      const willBeActive = providers.find(p => p.willBeActive);
+      const willBeDisabled = providers.find(p => p.willBeDisabled);
+      if (willBeActive) {
+        entries.push({ label: t("Authentication"), value: willBeActive.name });
+      } else if (willBeDisabled) {
+        entries.push({ label: t("Authentication"), value: t("disabled") });
+      } else if (use(this._draftConfigs).size > 0) {
+        entries.push({ label: t("Authentication"), value: t("configuration updated") });
+      }
+
+      const prefs = use(this._prefsPendingChanges);
+      if (prefs?.onRestartSetAdminEmail) {
+        entries.push({ label: t("New admin email"), value: prefs.onRestartSetAdminEmail });
+      }
+      if (prefs?.onRestartReplaceEmailWithAdmin) {
+        entries.push({
+          label: t("Reassign login to admin"),
+          value: prefs.onRestartReplaceEmailWithAdmin,
+        });
+      }
+
+      // describeChange is only consulted when isDirty is true; one of the
+      // above branches should have hit. Fall back rather than throw.
+      if (entries.length === 0) {
+        entries.push({ label: t("Authentication"), value: "" });
+      }
+      return entries;
+    });
+
     this._fetchProviders().catch(reportError);
     this._fetchPrefsPendingChanges().catch(reportError);
 
@@ -251,38 +291,6 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
       if (this.isDisposed()) { return; }
       await this._fetchPrefsPendingChanges();
     }
-  }
-
-  public describeChange(): DraftChangeDescription[] {
-    const entries: DraftChangeDescription[] = [];
-    const providers = this._displayProviders.get();
-    const willBeActive = providers.find(p => p.willBeActive);
-    const willBeDisabled = providers.find(p => p.willBeDisabled);
-    if (willBeActive) {
-      entries.push({ label: t("Authentication"), value: willBeActive.name });
-    } else if (willBeDisabled) {
-      entries.push({ label: t("Authentication"), value: t("disabled") });
-    } else if (this._draftConfigs.get().size > 0) {
-      entries.push({ label: t("Authentication"), value: t("configuration updated") });
-    }
-
-    const prefs = this._prefsPendingChanges.get();
-    if (prefs?.onRestartSetAdminEmail) {
-      entries.push({ label: t("New admin email"), value: prefs.onRestartSetAdminEmail });
-    }
-    if (prefs?.onRestartReplaceEmailWithAdmin) {
-      entries.push({
-        label: t("Reassign login to admin"),
-        value: prefs.onRestartReplaceEmailWithAdmin,
-      });
-    }
-
-    // describeChange is only consulted when isDirty is true; one of the
-    // above branches should have hit. Fall back rather than throw.
-    if (entries.length === 0) {
-      entries.push({ label: t("Authentication"), value: "" });
-    }
-    return entries;
   }
 
   public buildDom() {

--- a/app/client/ui/BackupsSection.ts
+++ b/app/client/ui/BackupsSection.ts
@@ -1,6 +1,6 @@
 import { makeT } from "app/client/lib/localization";
 import { AdminChecks } from "app/client/models/AdminChecks";
-import { AdminPanelControls, cssDangerText, cssHappyText } from "app/client/ui/AdminPanelCss";
+import { cssDangerText, cssHappyText } from "app/client/ui/AdminPanelCss";
 import { quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
 import { cssCardSurface, cssValueLabel } from "app/client/ui/SettingsLayout";
 import { colors } from "app/client/ui2018/cssVars";
@@ -48,15 +48,8 @@ const STORAGE_BACKENDS: Record<BackendName, BackendInfo> = {
 
 export interface BackupsSectionProps {
   checks: AdminChecks;
-  /**
-   * Present when this section is rendered inside the admin panel. Absent in the
-   * setup wizard. Sections use this as the single signal for "am I in the admin
-   * panel?" -- it's also the channel through which they report needsRestart.
-   *
-   * BackupsSection has no restart-required settings of its own, but accepts the
-   * option so all sections share one mode flag.
-   */
-  controls?: AdminPanelControls;
+  /** True when rendered in the admin panel; false / absent in the wizard. */
+  inAdminPanel?: boolean;
 }
 
 /**
@@ -100,7 +93,7 @@ export class BackupsSection extends Disposable {
 
   public buildDom() {
     return cssSection(
-      this._props.controls ? cssDescription(
+      this._props.inAdminPanel ? cssDescription(
         t("Store document backups on an external service like S3 or Azure. \
           This protects against data loss if the server's disk fails."),
       ) : quickSetupStepHeader({

--- a/app/client/ui/BaseUrlSection.ts
+++ b/app/client/ui/BaseUrlSection.ts
@@ -7,6 +7,7 @@ import {
   cssSectionContainer,
   cssSectionDescription,
 } from "app/client/ui/AdminPanelCss";
+import { DraftChangeDescription } from "app/client/ui/DraftChanges";
 import { cssValueLabel } from "app/client/ui/SettingsLayout";
 import { basicButton, primaryButton } from "app/client/ui2018/buttons";
 import { theme, vars } from "app/client/ui2018/cssVars";
@@ -37,6 +38,8 @@ export class BaseUrlSection extends Disposable {
 
   /** True when current state differs from what the server has. */
   public isDirty: Computed<boolean>;
+
+  public describeChange: Computed<DraftChangeDescription[]>;
 
   /** Base URL changes require a server restart to take effect safely. */
   public readonly needsRestart = true;
@@ -73,6 +76,11 @@ export class BaseUrlSection extends Disposable {
       if (current === use(this._serverUrl)) { return false; }
       return true;
     });
+    this.describeChange = Computed.create(this, use =>
+      use(this._urlSkipped) ?
+        [{ label: t("Base URL"), value: t("automatic") }] :
+        [{ label: t("Base URL"), value: use(this._editedUrl).trim() }],
+    );
 
     this._editedUrl.addListener((url) => {
       if (this._testResult.get() === "passed" && url.trim() !== this._testedUrlValue) {
@@ -91,13 +99,6 @@ export class BaseUrlSection extends Disposable {
     const url = skipped ? null : this._editedUrl.get().trim();
     await this._persist(url);
     this._serverUrl.set(skipped ? "" : url!);
-  }
-
-  public describeChange() {
-    if (this._urlSkipped.get()) {
-      return [{ label: t("Base URL"), value: t("automatic") }];
-    }
-    return [{ label: t("Base URL"), value: this._editedUrl.get().trim() }];
   }
 
   public async dismiss(): Promise<void> {

--- a/app/client/ui/BaseUrlSection.ts
+++ b/app/client/ui/BaseUrlSection.ts
@@ -1,7 +1,6 @@
 import { makeT } from "app/client/lib/localization";
 import { getHomeUrl, reportError } from "app/client/models/AppModel";
 import {
-  AdminPanelControls,
   buildConfirmedRow,
   cssHappyText,
   cssSectionButtonRow,
@@ -25,7 +24,8 @@ type UrlStatus = "loading" | "loaded" | "saving" | "saved" | "error";
 type TestResult = "idle" | "testing" | "passed" | "failed";
 
 interface BaseUrlSectionOptions {
-  controls?: AdminPanelControls;
+  /** True when rendered in the admin panel; false / absent in the wizard. */
+  inAdminPanel?: boolean;
 }
 
 export class BaseUrlSection extends Disposable {

--- a/app/client/ui/BaseUrlSection.ts
+++ b/app/client/ui/BaseUrlSection.ts
@@ -14,7 +14,7 @@ import { icon } from "app/client/ui2018/icons";
 import { unstyledButton } from "app/client/ui2018/unstyled";
 import { InstallAPIImpl } from "app/common/InstallAPI";
 
-import { Computed, Disposable, dom, DomContents, input, makeTestId,
+import { bundleChanges, Computed, Disposable, dom, DomContents, input, makeTestId,
   Observable, styled } from "grainjs";
 
 const t = makeT("BaseUrlSection");
@@ -100,6 +100,14 @@ export class BaseUrlSection extends Disposable {
     return [{ label: t("Base URL"), value: this._editedUrl.get().trim() }];
   }
 
+  public async dismiss(): Promise<void> {
+    if (!this.isDirty.get()) { return; }
+    bundleChanges(() => {
+      this._resetEdits();
+      this._editedUrl.set(this._serverUrl.get());
+    });
+  }
+
   public buildStatusDisplay(): DomContents {
     return dom.domComputed((use) => {
       if (use(this._status) === "loading") {
@@ -115,16 +123,27 @@ export class BaseUrlSection extends Disposable {
   public buildDom(): DomContents { return this._buildSection({ allowSkip: false }); }
   public buildWizardDom(): DomContents { return this._buildSection({ allowSkip: true }); }
 
+  /**
+   * Reset draft state back to "not yet confirmed" with a clean test slate.
+   * Called both from dismiss and from the Edit button on the confirmed row.
+   * Does not touch `_editedUrl` -- the Edit-row case wants to keep what the
+   * user typed.
+   */
+  private _resetEdits() {
+    this._urlConfirmed.set(false);
+    this._urlSkipped.set(false);
+    this._testResult.set("idle");
+    this._testError.set("");
+    this._testDetailOpen.set(false);
+  }
+
   // allowSkip=true shows a "Leave automatic" button alongside Confirm;
   // in admin-panel mode we don't offer it.
   private _buildSection(opts: { allowSkip: boolean }): DomContents {
     return cssSectionContainer(
       this._buildCore(),
-      buildConfirmedRow(this._urlConfirmed, () => {
-        this._urlConfirmed.set(false);
-        this._urlSkipped.set(false);
-        this._testResult.set("idle");
-      }, { skipped: this._urlSkipped, skippedLabel: t("Automatic"), testPrefix: "base-url" }),
+      buildConfirmedRow(this._urlConfirmed, () => this._resetEdits(),
+        { skipped: this._urlSkipped, skippedLabel: t("Automatic"), testPrefix: "base-url" }),
       dom.maybe(use => !use(this._urlConfirmed), () => [
         dom.domComputed(this._testResult, result => this._buildTestStatus(result)),
         cssSectionButtonRow(

--- a/app/client/ui/BaseUrlSection.ts
+++ b/app/client/ui/BaseUrlSection.ts
@@ -95,9 +95,9 @@ export class BaseUrlSection extends Disposable {
 
   public describeChange() {
     if (this._urlSkipped.get()) {
-      return { label: t("Base URL"), value: t("automatic") };
+      return [{ label: t("Base URL"), value: t("automatic") }];
     }
-    return { label: t("Base URL"), value: this._editedUrl.get().trim() };
+    return [{ label: t("Base URL"), value: this._editedUrl.get().trim() }];
   }
 
   public buildStatusDisplay(): DomContents {

--- a/app/client/ui/DraftChanges.ts
+++ b/app/client/ui/DraftChanges.ts
@@ -61,12 +61,25 @@ export interface ConfigSection {
    */
   afterApply?(): Promise<ApplyResult>;
   /**
-   * Describe the draft change for display in the restart banner.
-   * Only called when isDirty is true. Re-read whenever any section's
-   * `isDirty` fires -- sections whose described value can drift while
-   * `isDirty` stays true should toggle `isDirty` to trigger a refresh.
+   * Describe the draft change(s) for display in the restart banner.
+   * Returning multiple entries lets a section surface several distinct
+   * pending sub-changes (e.g. a new admin email and a separate login
+   * rename) as separate bullets. Only called when isDirty is true.
+   * Re-read whenever any section's `isDirty` fires -- sections whose
+   * described value can drift while `isDirty` stays true should toggle
+   * `isDirty` to trigger a refresh.
    */
-  describeChange(): DraftChangeDescription;
+  describeChange(): DraftChangeDescription[];
+  /**
+   * Optional. Discard whatever made this section dirty: clear local
+   * drafts, and -- if the section reads server-side state that
+   * contributes to `isDirty` -- delete that state. Called by the
+   * manager's `dismissAll()` for the "Dismiss changes" path. Sections
+   * whose dirty state is purely session-local can omit this; the
+   * manager already filters to dirty sections, so an implementation
+   * can additionally choose to no-op when there's nothing to undo.
+   */
+  dismiss?(): Promise<void>;
 }
 
 export class DraftChangesManager extends Disposable {
@@ -84,7 +97,7 @@ export class DraftChangesManager extends Disposable {
   constructor() {
     super();
     this.changes = Computed.create(this, use =>
-      use(this._sections).filter(s => use(s.isDirty)).map(s => s.describeChange()),
+      use(this._sections).filter(s => use(s.isDirty)).flatMap(s => s.describeChange()),
     );
     this.hasDraftChanges = Computed.create(this, use => use(this.changes).length > 0);
     this.needsRestart = Computed.create(this, use =>
@@ -103,6 +116,19 @@ export class DraftChangesManager extends Disposable {
   }
 
   /**
+   * Discard all pending draft changes. Sections without a `dismiss` or
+   * not currently dirty are skipped; the first failure propagates and
+   * remaining sections stay dirty for a retry.
+   */
+  public async dismissAll(): Promise<void> {
+    for (const section of this._sections.get()) {
+      if (section.isDirty.get() && section.dismiss) {
+        await section.dismiss();
+      }
+    }
+  }
+
+  /**
    * Persist all draft changes without restarting. Use when the server
    * can't auto-restart (no supervisor); the user restarts manually.
    */
@@ -118,7 +144,10 @@ export class DraftChangesManager extends Disposable {
       // it applies, and we want the error message to name the change the
       // user asked for, not whatever it looks like after the attempt.
       const dirty = this._sections.get().filter(s => s.isDirty.get());
-      const labels = new Map(dirty.map(s => [s, s.describeChange().label]));
+      const labels = new Map(dirty.map((s) => {
+        const entries = s.describeChange();
+        return [s, entries.map(e => e.label).join(", ")] as const;
+      }));
 
       const failures: { label: string; error: Error }[] = [];
       for (const section of dirty) {

--- a/app/client/ui/DraftChanges.ts
+++ b/app/client/ui/DraftChanges.ts
@@ -44,6 +44,19 @@ export interface ConfigSection {
   /** True when the section's changes require a server restart to take effect. */
   needsRestart: boolean;
   /**
+   * Describe the draft change(s) for display in the restart banner.
+   * Only consulted when `isDirty` is true (the manager filters first).
+   * Returning multiple entries lets a section surface several distinct
+   * pending sub-changes (e.g. a new admin email and a separate login
+   * rename) as separate bullets.
+   *
+   * A Computed (not a plain method) so the banner re-reads when a
+   * section's described value drifts while `isDirty` stays true --
+   * e.g. an auth section that's already dirty from a provider switch
+   * gains a queued admin-email change.
+   */
+  describeChange: Computed<DraftChangeDescription[]>;
+  /**
    * Persist the section's changes to the server and update its own view of
    * the server state so `isDirty` goes false. No-op if not dirty. On error,
    * throws without updating; `isDirty` stays true.
@@ -60,16 +73,6 @@ export interface ConfigSection {
    * should run.
    */
   afterApply?(): Promise<ApplyResult>;
-  /**
-   * Describe the draft change(s) for display in the restart banner.
-   * Returning multiple entries lets a section surface several distinct
-   * pending sub-changes (e.g. a new admin email and a separate login
-   * rename) as separate bullets. Only called when isDirty is true.
-   * Re-read whenever any section's `isDirty` fires -- sections whose
-   * described value can drift while `isDirty` stays true should toggle
-   * `isDirty` to trigger a refresh.
-   */
-  describeChange(): DraftChangeDescription[];
   /**
    * Optional. Discard whatever made this section dirty: clear local
    * drafts, and -- if the section reads server-side state that
@@ -97,7 +100,7 @@ export class DraftChangesManager extends Disposable {
   constructor() {
     super();
     this.changes = Computed.create(this, use =>
-      use(this._sections).filter(s => use(s.isDirty)).flatMap(s => s.describeChange()),
+      use(this._sections).filter(s => use(s.isDirty)).flatMap(s => use(s.describeChange)),
     );
     this.hasDraftChanges = Computed.create(this, use => use(this.changes).length > 0);
     this.needsRestart = Computed.create(this, use =>
@@ -145,7 +148,7 @@ export class DraftChangesManager extends Disposable {
       // user asked for, not whatever it looks like after the attempt.
       const dirty = this._sections.get().filter(s => s.isDirty.get());
       const labels = new Map(dirty.map((s) => {
-        const entries = s.describeChange();
+        const entries = s.describeChange.get();
         return [s, entries.map(e => e.label).join(", ")] as const;
       }));
 

--- a/app/client/ui/DraftChanges.ts
+++ b/app/client/ui/DraftChanges.ts
@@ -23,6 +23,7 @@
  * is the server-side durable list of on-restart directives.
  */
 import { getHomeUrl } from "app/client/models/AppModel";
+import { ApplyResult } from "app/client/ui/QuickSetupContinueButton";
 import { ConfigAPI } from "app/common/ConfigAPI";
 
 import { Computed, Disposable, Observable } from "grainjs";
@@ -48,6 +49,17 @@ export interface ConfigSection {
    * throws without updating; `isDirty` stays true.
    */
   apply(): Promise<void>;
+  /**
+   * Optional post-restart hook. Called by the manager after `restartServer`
+   * and `waitUntilReady` complete -- a chance for sections whose persisted
+   * state only becomes visible to the API post-restart (e.g. auth, where
+   * `willBeActive` flips to `isActive`) to refetch and clear `isDirty`.
+   * Errors are logged but do not fail the apply. May return
+   * `{ redirected: true }` to tell the manager (and its caller) that a
+   * top-level navigation has been fired, so no further post-apply work
+   * should run.
+   */
+  afterApply?(): Promise<ApplyResult>;
   /**
    * Describe the draft change for display in the restart banner.
    * Only called when isDirty is true. Re-read whenever any section's
@@ -86,19 +98,19 @@ export class DraftChangesManager extends Disposable {
 
   public get isApplying() { return this._applying; }
 
-  public async applyAll(): Promise<void> {
-    await this._apply({ restart: true });
+  public async applyAll(): Promise<ApplyResult> {
+    return this._apply({ restart: true });
   }
 
   /**
    * Persist all draft changes without restarting. Use when the server
    * can't auto-restart (no supervisor); the user restarts manually.
    */
-  public async applyWithoutRestart(): Promise<void> {
-    await this._apply({ restart: false });
+  public async applyWithoutRestart(): Promise<ApplyResult> {
+    return this._apply({ restart: false });
   }
 
-  private async _apply({ restart }: { restart: boolean }): Promise<void> {
+  private async _apply({ restart }: { restart: boolean }): Promise<ApplyResult> {
     if (this._applying.get()) { return; }
     this._applying.set(true);
     try {
@@ -120,10 +132,21 @@ export class DraftChangesManager extends Disposable {
       // Only restart when every dirty section succeeded -- a half-applied
       // set would either strand changes behind another restart or look
       // complete when it wasn't.
+      let redirected = false;
       if (restart && failures.length === 0 && dirty.some(s => s.needsRestart)) {
         await this._configAPI.restartServer();
         if (!await this._configAPI.waitUntilReady()) {
           throw new Error("Timed out waiting for Grist server to restart");
+        }
+        for (const section of dirty) {
+          try {
+            const result = await section.afterApply?.();
+            if (result?.redirected) { redirected = true; }
+          } catch (err) {
+            // Best-effort: log and continue. The section may show stale
+            // state but won't block the rest of the apply from finishing.
+            console.warn("afterApply failed:", err);
+          }
         }
       }
 
@@ -131,6 +154,7 @@ export class DraftChangesManager extends Disposable {
         const parts = failures.map(f => `${f.label}: ${f.error.message || String(f.error)}`);
         throw new Error(`Could not apply: ${parts.join("; ")}`);
       }
+      if (redirected) { return { redirected: true }; }
     } finally {
       if (!this.isDisposed()) { this._applying.set(false); }
     }

--- a/app/client/ui/EditionSection.ts
+++ b/app/client/ui/EditionSection.ts
@@ -185,6 +185,11 @@ export class EditionSection extends Disposable implements ConfigSection {
     }];
   }
 
+  public async dismiss(): Promise<void> {
+    if (!this.isDirty.get()) { return; }
+    this._selectedEdition.set(this._serverEdition.get());
+  }
+
   /**
    * Shared core: description, edition selector tabs, per-selection text.
    * Used by both admin panel and wizard.

--- a/app/client/ui/EditionSection.ts
+++ b/app/client/ui/EditionSection.ts
@@ -3,7 +3,6 @@ import { getHomeUrl } from "app/client/models/AppModel";
 import { Notifier } from "app/client/models/NotifyModel";
 import { showEnterpriseToggle } from "app/client/ui/ActivationPage";
 import {
-  AdminPanelControls,
   buildConfirmedRow,
   cssHappyText,
   cssSectionButtonRow,
@@ -30,7 +29,8 @@ const testId = makeTestId("test-edition-");
 type Edition = "enterprise" | "core";
 
 interface EditionSectionOptions {
-  controls?: AdminPanelControls;
+  /** True when rendered in the admin panel; false / absent in the wizard. */
+  inAdminPanel?: boolean;
   notifier?: Notifier;
   /**
    * Optional overrides for state that's normally derived from globals
@@ -65,7 +65,7 @@ export class EditionSection extends Disposable implements ConfigSection {
   private _selectedEdition = Observable.create<Edition | null>(this, null);
   private _serverEdition = Observable.create<Edition>(this, "core");
   // Pre-confirmed in admin-panel mode so the confirm/edit flow only runs in the wizard.
-  private _editionConfirmed = Observable.create<boolean>(this, !!this._options.controls);
+  private _editionConfirmed = Observable.create<boolean>(this, !!this._options.inAdminPanel);
 
   // Only created in admin-panel mode (requires a notifier).
   private _toggleEnterprise: ToggleEnterpriseWidget | null;
@@ -92,7 +92,7 @@ export class EditionSection extends Disposable implements ConfigSection {
     // the section isn't dirty before the user acts. In wizard mode, default to
     // Full Grist when available; the user can change it via the buttons.
     // Done here rather than in `_buildSelector` so a re-render can't reset it.
-    this._selectedEdition.set(this._options.controls ?
+    this._selectedEdition.set(this._options.inAdminPanel ?
       this._serverEdition.get() :
       this.fullGristAvailable ? "enterprise" : "core",
     );

--- a/app/client/ui/EditionSection.ts
+++ b/app/client/ui/EditionSection.ts
@@ -179,10 +179,10 @@ export class EditionSection extends Disposable implements ConfigSection {
 
   public describeChange() {
     const selected = this._selectedEdition.get();
-    return {
+    return [{
       label: t("Edition"),
       value: selected === "enterprise" ? t("Full Grist") : t("Community Edition"),
-    };
+    }];
   }
 
   /**

--- a/app/client/ui/EditionSection.ts
+++ b/app/client/ui/EditionSection.ts
@@ -9,7 +9,7 @@ import {
   cssSectionContainer,
   cssSectionDescription,
 } from "app/client/ui/AdminPanelCss";
-import { ConfigSection } from "app/client/ui/DraftChanges";
+import { ConfigSection, DraftChangeDescription } from "app/client/ui/DraftChanges";
 import { cssValueLabel } from "app/client/ui/SettingsLayout";
 import { ToggleEnterpriseWidget } from "app/client/ui/ToggleEnterpriseWidget";
 import { primaryButton } from "app/client/ui2018/buttons";
@@ -57,6 +57,7 @@ export class EditionSection extends Disposable implements ConfigSection {
 
   public canProceed: Computed<boolean>;
   public isDirty: Computed<boolean>;
+  public describeChange: Computed<DraftChangeDescription[]>;
 
   public readonly fullGristAvailable: boolean;
   public readonly editionForced: boolean;
@@ -104,6 +105,10 @@ export class EditionSection extends Disposable implements ConfigSection {
       if (selected === null) { return false; }
       return selected !== use(this._serverEdition);
     });
+    this.describeChange = Computed.create(this, use => [{
+      label: t("Edition"),
+      value: use(this._selectedEdition) === "enterprise" ? t("Full Grist") : t("Community Edition"),
+    }]);
   }
 
   public buildStatusDisplay(): DomContents {
@@ -175,14 +180,6 @@ export class EditionSection extends Disposable implements ConfigSection {
     if (!selected) { return; }
     await this._configAPI.setValue({ edition: selected });
     this._serverEdition.set(selected);
-  }
-
-  public describeChange() {
-    const selected = this._selectedEdition.get();
-    return [{
-      label: t("Edition"),
-      value: selected === "enterprise" ? t("Full Grist") : t("Community Edition"),
-    }];
   }
 
   public async dismiss(): Promise<void> {

--- a/app/client/ui/GetGristComProvider.ts
+++ b/app/client/ui/GetGristComProvider.ts
@@ -14,6 +14,39 @@ import { GETGRIST_COM_PROVIDER_KEY } from "app/common/loginProviders";
 import { components } from "app/common/ThemePrefs";
 import { getGristConfig } from "app/common/urlUtils";
 
+/**
+ * Validate a getgrist.com configuration key at the level the server's
+ * `readGetGristComConfigFromSettings` does: must be base64 of a JSON
+ * object containing `oidcClientId`, `oidcClientSecret`, and `oidcIssuer`.
+ * Returns null when valid, or a short reason string when not.
+ *
+ * Apply-time still revalidates server-side, so this only catches the
+ * obvious paste mistakes (truncation, wrong format) early.
+ */
+export function validateGetGristComKey(key: string): string | null {
+  let decoded: string;
+  try {
+    decoded = atob(key);
+  } catch {
+    return "Configuration key is not valid base64";
+  }
+  let parsed: any;
+  try {
+    parsed = JSON.parse(decoded);
+  } catch {
+    return "Configuration key does not decode to JSON";
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return "Configuration key is not a JSON object";
+  }
+  for (const field of ["oidcClientId", "oidcClientSecret", "oidcIssuer"]) {
+    if (typeof parsed[field] !== "string" || !parsed[field]) {
+      return `Configuration key is missing ${field}`;
+    }
+  }
+  return null;
+}
+
 import { Disposable, dom, makeTestId, Observable, styled } from "grainjs";
 
 const t = makeT("GetGristComProvider");
@@ -60,20 +93,27 @@ export function clearSetupReturnFromGetGristCom(): void {
 }
 
 /**
- * Modal for configuring "Sign in with getgrist.com" login system.
+ * Modal for configuring "Sign in with getgrist.com". Validates the pasted
+ * key client-side, then hands it to the caller's `onSubmit` -- the modal
+ * does not talk to the server itself. `AuthenticationSection` stores the
+ * key in its draft state and persists it through the apply pipeline.
  */
 export interface GetGristComProviderInfoModalOptions {
-  /** Called when the user clicks Configure and the secret is accepted. */
-  onConfigure?: () => void;
+  /**
+   * Called when the user clicks Configure with a key that passes
+   * client-side validation. The modal does not talk to the server itself;
+   * the caller is responsible for staging the key in its draft state and
+   * persisting it through the apply pipeline.
+   */
+  onSubmit?: (key: string) => void;
   /** Called when the user dismisses the modal (Cancel / Esc / click-away). */
   onCancel?: () => void;
 }
 
 export class GetGristComProviderInfoModal extends Disposable {
-  private _onConfigure: (() => void) | undefined;
+  private _onSubmit: ((key: string) => void) | undefined;
   private _onCancel: (() => void) | undefined;
   private readonly _configKey: Observable<string> = Observable.create(this, "");
-  private readonly _working: Observable<boolean> = Observable.create(this, false);
   private readonly _error: Observable<boolean> = Observable.create(this, false);
   private readonly _configAPI: ConfigAPI = new ConfigAPI(getHomeUrl());
 
@@ -91,7 +131,7 @@ export class GetGristComProviderInfoModal extends Disposable {
   }
 
   public show(opts: GetGristComProviderInfoModalOptions = {}): void {
-    this._onConfigure = opts.onConfigure;
+    this._onSubmit = opts.onSubmit;
     this._onCancel = opts.onCancel;
     modal((ctl, owner) => {
       this.onDispose(() => ctl.close());
@@ -162,7 +202,7 @@ getgrist.com and paste the configuration key you receive below.", {
           ),
           bigPrimaryButton(
             t("Configure"),
-            dom.prop("disabled", use => use(this._working) || !use(this._configKey)),
+            dom.prop("disabled", use => !use(this._configKey)),
             dom.on("click", () => this._handleConfigure()),
             testId("modal-configure"),
           ),
@@ -182,30 +222,16 @@ getgrist.com and paste the configuration key you receive below.", {
     this.dispose();
   }
 
-  private async _handleConfigure() {
-    if (!this._configKey.get()) {
+  private _handleConfigure() {
+    const key = this._configKey.get().split(/\s+/).join("");
+    const reason = validateGetGristComKey(key);
+    if (reason !== null) {
       this._error.set(true);
+      reportError(new Error(t("Error configuring provider with the provided key: {{reason}}", { reason })));
       return;
     }
-    this._working.set(true);
-    try {
-      await this._configAPI.configureProvider(
-        GETGRIST_COM_PROVIDER_KEY,
-        { GRIST_GETGRISTCOM_SECRET: this._configKey.get() },
-      );
-      this._onConfigure?.();
-      this.dispose();
-    } catch (e) {
-      if (this.isDisposed()) {
-        return;
-      }
-      reportError(e as Error);
-      this._error.set(true);
-    } finally {
-      if (!this.isDisposed()) {
-        this._working.set(false);
-      }
-    }
+    this._onSubmit?.(key);
+    this.dispose();
   }
 }
 

--- a/app/client/ui/PermissionsToggleModel.ts
+++ b/app/client/ui/PermissionsToggleModel.ts
@@ -40,6 +40,8 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
   /** True when any toggle has drifted from its server value. */
   public readonly isDirty: Computed<boolean>;
 
+  public readonly describeChange: Computed<DraftChangeDescription[]>;
+
   /** Which preset, if any, the current toggle state matches. Null if none. */
   public readonly presetDetector: Computed<PresetName | null>;
 
@@ -71,6 +73,15 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
         if (this._isEnvLocked(status, key)) { return false; }
         return use(this.toggles[key]) !== use(this._serverValues[key]);
       });
+    });
+
+    this.describeChange = Computed.create(this, (use) => {
+      const status = use(this.status);
+      const changed = TOGGLE_DEFS
+        .filter(({ key }) => !status || !this._isEnvLocked(status, key))
+        .filter(({ key }) => use(this.toggles[key]) !== use(this._serverValues[key]))
+        .map(({ key, label }) => `${label()}: ${use(this.toggles[key]) ? t("on") : t("off")}`);
+      return [{ label: t("Permissions"), value: changed.join(", ") }];
     });
 
     this.presetDetector = Computed.create(this, (use) => {
@@ -129,14 +140,6 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
     for (const { key } of TOGGLE_DEFS) {
       this._serverValues[key].set(this.toggles[key].get());
     }
-  }
-
-  public describeChange(): DraftChangeDescription[] {
-    const changed = TOGGLE_DEFS
-      .filter(({ key }) => !this.isEnvLocked(key))
-      .filter(({ key }) => this.toggles[key].get() !== this._serverValues[key].get())
-      .map(({ key, label }) => `${label()}: ${this.toggles[key].get() ? t("on") : t("off")}`);
-    return [{ label: t("Permissions"), value: changed.join(", ") }];
   }
 
   private async _load(): Promise<void> {

--- a/app/client/ui/PermissionsToggleModel.ts
+++ b/app/client/ui/PermissionsToggleModel.ts
@@ -131,12 +131,12 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
     }
   }
 
-  public describeChange(): DraftChangeDescription {
+  public describeChange(): DraftChangeDescription[] {
     const changed = TOGGLE_DEFS
       .filter(({ key }) => !this.isEnvLocked(key))
       .filter(({ key }) => this.toggles[key].get() !== this._serverValues[key].get())
       .map(({ key, label }) => `${label()}: ${this.toggles[key].get() ? t("on") : t("off")}`);
-    return { label: t("Permissions"), value: changed.join(", ") };
+    return [{ label: t("Permissions"), value: changed.join(", ") }];
   }
 
   private async _load(): Promise<void> {

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -7,9 +7,10 @@ import { buildAdminAccessDeniedCard } from "app/client/ui/AdminAccessDeniedCard"
 import { cssFadeUp, cssFadeUpGristLogo, cssFadeUpHeading, cssFadeUpSubHeading } from "app/client/ui/AdminPanelCss";
 import { AuthenticationSection } from "app/client/ui/AuthenticationSection";
 import { BackupsSection } from "app/client/ui/BackupsSection";
+import { DraftChangesManager } from "app/client/ui/DraftChanges";
 import { peekSetupReturnFromGetGristCom, SetupReturnStep } from "app/client/ui/GetGristComProvider";
 import { PermissionsSetupSection } from "app/client/ui/PermissionsSetupSection";
-import { quickSetupContinueButton } from "app/client/ui/QuickSetupContinueButton";
+import { quickSetupContinueButton, QuickSetupSection } from "app/client/ui/QuickSetupContinueButton";
 import { QuickSetupServerStep } from "app/client/ui/QuickSetupServerStep";
 import { SandboxSetupSection } from "app/client/ui/SandboxSection";
 import { Stepper } from "app/client/ui2018/Stepper";
@@ -141,9 +142,20 @@ export class QuickSetup extends Disposable {
   private _buildAuthStep(): DomContents {
     return dom.create((owner) => {
       const section = AuthenticationSection.create(owner, { appModel: this._appModel });
+      // Per-step DraftChangesManager so Continue drives apply+restart like
+      // Server/Sandbox steps. In admin panel mode, the section registers
+      // with the panel-level manager instead.
+      const drafts = DraftChangesManager.create(owner);
+      drafts.addSection(section);
+      const step: QuickSetupSection = {
+        canProceed: section.canProceed,
+        isDirty: drafts.hasDraftChanges,
+        isApplying: drafts.isApplying,
+        apply: () => drafts.applyAll(),
+      };
       return dom("div",
         section.buildDom(),
-        quickSetupContinueButton(section, () => this._advanceStep(), testId("auth-continue")),
+        quickSetupContinueButton(step, () => this._advanceStep(), testId("auth-continue")),
       );
     });
   }

--- a/app/client/ui/SandboxSection.ts
+++ b/app/client/ui/SandboxSection.ts
@@ -220,7 +220,9 @@ export class SandboxSetupSection extends SandboxSectionBase {
     isDirty: this._needsRestart,
     needsRestart: true,
     apply: () => this._save(),
-    describeChange: () => [{ label: t("Sandbox"), value: sandboxLabel(this._selected.get() ?? "") }],
+    describeChange: Computed.create(this, use =>
+      [{ label: t("Sandbox"), value: sandboxLabel(use(this._selected) ?? "") }],
+    ),
   };
 
   constructor() {

--- a/app/client/ui/SandboxSection.ts
+++ b/app/client/ui/SandboxSection.ts
@@ -220,7 +220,7 @@ export class SandboxSetupSection extends SandboxSectionBase {
     isDirty: this._needsRestart,
     needsRestart: true,
     apply: () => this._save(),
-    describeChange: () => ({ label: t("Sandbox"), value: sandboxLabel(this._selected.get() ?? "") }),
+    describeChange: () => [{ label: t("Sandbox"), value: sandboxLabel(this._selected.get() ?? "") }],
   };
 
   constructor() {

--- a/storybook/editionSection.stories.ts
+++ b/storybook/editionSection.stories.ts
@@ -1,8 +1,7 @@
 import { Notifier } from "app/client/models/NotifyModel";
-import { AdminPanelControls } from "app/client/ui/AdminPanelCss";
 import { EditionSection } from "app/client/ui/EditionSection";
 
-import { Disposable, DomContents, Observable, styled } from "grainjs";
+import { Disposable, DomContents, styled } from "grainjs";
 
 export default {
   title: "Admin panel/EditionSection",
@@ -12,13 +11,6 @@ export default {
 };
 
 // --- Helpers ----------------------------------------------------------------
-
-function createControls(owner: Disposable): AdminPanelControls {
-  return {
-    needsRestart: Observable.create(owner, false),
-    restartGrist: async () => { /* no-op in storybook */ },
-  };
-}
 
 // ToggleEnterpriseWidget reads `deploymentType` and `activation` straight
 // from window.gristConfig, so stories need to swap it to drive the widget
@@ -43,7 +35,7 @@ function adminStory({ deploymentType, overrides, build }: AdminStoryArgs) {
     render: (_args: any, { owner }: any) => {
       if (deploymentType) { withGristConfig(owner, { deploymentType }); }
       const section = EditionSection.create(owner, {
-        controls: createControls(owner),
+        inAdminPanel: true,
         notifier: Notifier.create(owner),
         overrides,
       });

--- a/test/nbrowser/AdminPanel.ts
+++ b/test/nbrowser/AdminPanel.ts
@@ -59,7 +59,8 @@ describe("AdminPanel", function() {
     assert.equal(await driver.find(".test-usermenu-admin-panel").isDisplayed(), true);
     assert.match(await driver.find(".test-usermenu-admin-panel").getAttribute("href"), /\/admin$/);
     await driver.find(".test-usermenu-admin-panel").click();
-    assert.equal(await gu.waitForAdminPanel().isDisplayed(), true);
+    await gu.waitForAdminPanel();
+    assert.equal(await driver.find(".test-admin-panel").isDisplayed(), true);
   });
 
   it("should include support-grist section", async function() {

--- a/test/nbrowser/AdminPanel.ts
+++ b/test/nbrowser/AdminPanel.ts
@@ -63,6 +63,16 @@ describe("AdminPanel", function() {
     assert.equal(await driver.find(".test-admin-panel").isDisplayed(), true);
   });
 
+  it("opens the change-admin modal when no getgrist provider is configured", async function() {
+    session = await gu.session().personalSite.login();
+    await driver.get(`${server.getHost()}/admin`);
+    await gu.waitForAdminPanel();
+    await toggleItem("authentication");
+    await driver.findWait(".test-admin-auth-change-admin", 2000).click();
+    await driver.findWait(".test-modal-dialog", 2000);
+    await driver.sendKeys(Key.ESCAPE);
+  });
+
   it("should include support-grist section", async function() {
     assert.match(
       await driver.findWait(".test-admin-panel-item-sponsor", 3000).getText(),

--- a/test/nbrowser/AdminPanel.ts
+++ b/test/nbrowser/AdminPanel.ts
@@ -1,6 +1,7 @@
 import { TelemetryLevel } from "app/common/Telemetry";
 import { currentVersion, isEnabled, toggleItem, withExpandedItem } from "test/nbrowser/AdminPanelTools";
 import * as gu from "test/nbrowser/gristUtils";
+import { useFastSandboxProbe } from "test/nbrowser/sandboxProbeFixture";
 import { server, setupTestSuite } from "test/nbrowser/testUtils";
 import { FakeUpdateServer, startFakeUpdateServer } from "test/server/customUtil";
 import * as testUtils from "test/server/testUtils";
@@ -23,6 +24,9 @@ describe("AdminPanel", function() {
     process.env.GRIST_ALLOW_AUTOMATIC_VERSION_CHECKING = "true";
     // Set admin email, but make it non-canonical casing as an extra test.
     process.env.GRIST_DEFAULT_EMAIL = gu.session().email.toUpperCase();
+    // The real sandbox-providers probe takes ~5s on machines without runsc,
+    // and lands inside waitForServer's 5s budget after a page reload.
+    useFastSandboxProbe();
     fakeServer = await startFakeUpdateServer();
     process.env.GRIST_TEST_VERSION_CHECK_URL = `${fakeServer.url()}/version`;
     await server.restart(true);

--- a/test/nbrowser/AuthProviderGetGrist.ts
+++ b/test/nbrowser/AuthProviderGetGrist.ts
@@ -112,6 +112,27 @@ describe("AuthProviderGetGrist", function() {
       // (because nothing else was active and it's the first configured).
       assert.includeMembers(await badges(), ["ACTIVE ON RESTART"]);
     });
+
+    it("clears the staged draft when Dismiss changes is confirmed", async function() {
+      // Continues from the previous test, which staged a getgrist.com draft.
+      // Sanity-check it's still there.
+      assert.includeMembers(await badges(), ["ACTIVE ON RESTART"]);
+
+      const dismissButton = await driver.findWait(".test-admin-panel-dismiss-button", 2000);
+      // Banner uses a grid-template-rows animation; retry until the button
+      // is actually clickable (not still mid-reveal with zero height).
+      await gu.waitToPass(async () => { await dismissButton.click(); }, 2000);
+      const confirmButton = await driver.findWait(".test-modal-confirm", 2000);
+      await confirmButton.click();
+      await gu.waitForServer();
+
+      // Banner hides once nothing is dirty; the dismiss button is gated
+      // on hasDraftChanges and disappears with it.
+      await gu.waitToPass(async () => {
+        assert.isFalse(await driver.find(".test-admin-panel-dismiss-button").isPresent());
+      }, 2000);
+      assert.notInclude(await badges(), "ACTIVE ON RESTART");
+    });
   });
 
   // Server-side behavior tests seed the secret directly via env vars and

--- a/test/nbrowser/AuthProviderGetGrist.ts
+++ b/test/nbrowser/AuthProviderGetGrist.ts
@@ -1,4 +1,3 @@
-import { Activation } from "app/gen-server/entity/Activation";
 import { expandProviderList, itemValue, toggleItem } from "test/nbrowser/AdminPanelTools";
 import * as gu from "test/nbrowser/gristUtils";
 import { startMockOIDCIssuer } from "test/nbrowser/oidcMockServer";
@@ -19,6 +18,17 @@ describe("AuthProviderGetGrist", function() {
   let oldEnv: testUtils.EnvironmentSnapshot;
   let serving: Serving;
   const currentRequest = observable(null as express.Request | null);
+
+  // Build a valid base64 configuration key against the test's fake OIDC server.
+  function buildKey() {
+    return Buffer.from(JSON.stringify({
+      oidcClientId: "some-id",
+      oidcClientSecret: "some-secret",
+      oidcIssuer: serving.url + "?provider=getgrist.com",
+      oidcSkipEndSessionEndpoint: true,
+      owner: { name: "Chimpy", email: "chimpy@getgrist.com" },
+    })).toString("base64");
+  }
 
   before(async function() {
     oldEnv = new testUtils.EnvironmentSnapshot();
@@ -41,182 +51,133 @@ describe("AuthProviderGetGrist", function() {
     await serving?.shutdown();
   });
 
-  it("should show providers with Grist Login", async function() {
-    await server.simulateLogin("user1", process.env.GRIST_DEFAULT_EMAIL!, "docs");
-    await driver.get(`${server.getHost()}/admin`);
-    await gu.waitForAdminPanel();
-    await toggleItem("authentication");
-
-    await gu.waitToPass(async () => {
-      assert.equal(await itemValue("authentication"), "no authentication");
-    }, 500);
-
-    // We should see couple of providers, including "Sign in with Grist".
-    await driver.findWait(".test-admin-auth-provider-row", 2000); // wait for it to appear
-    const providerItems = await driver.findAll(".test-admin-auth-provider-row");
-    assert.isAtLeast(providerItems.length, 2); // We expect to see OIDC provider as well.
-
-    // First one should be "Sign in with Grist".
-    assert.match(await providerItems[0].getText(), /Sign in with getgrist/);
-  });
-
-  it("should allow configuring getgrist.com provider", async function() {
-    const configureButton = await providerRow().find(".test-admin-auth-configure-button");
-    await configureButton.click();
-
-    const textarea = await driver.findWait(".test-admin-auth-config-key-textarea", 2000);
-    const configureModalButton = await driver.find(".test-admin-auth-modal-configure");
-
-    // Button should be grayed out and disabled (should have 'disabled' attribute) when textarea is empty.
-    assert.isFalse(await configureModalButton.isEnabled());
-
-    // Click it while disabled.
-    await configureModalButton.click();
-    // Nothing should happen, modal should stay open.
-    await driver.sleep(100);
-    await gu.checkForErrors();
-
-    // Type some dummy invalid key.
-    await textarea.click();
-    await textarea.sendKeys("invalid-key");
-    await configureModalButton.click();
-    await assertError(/Error configuring provider with the provided key/);
-
-    await textarea.clear();
-    await textarea.sendKeys(Buffer.from(JSON.stringify({ random: "json" })).toString("base64"));
-    await configureModalButton.click();
-    await assertError(/Error configuring provider with the provided key/);
-
-    const validConfig = {
-      oidcClientId: "some-id",
-      oidcClientSecret: "some-secret",
-      oidcIssuer: serving.url + "?provider=getgrist.com",
-      oidcSkipEndSessionEndpoint: true,
-      owner: {
-        name: "Chimpy",
-        email: "chimpy@getgrist.com",
-      },
-    };
-    await textarea.clear();
-    await textarea.sendKeys(Buffer.from(JSON.stringify(validConfig)).toString("base64"));
-    await configureModalButton.click();
-    await gu.waitForServer();
-    await waitForModalToClose();
-
-    // We should see Active on restart badge. GetGrist.com was picked by order.
-    const providerBadges = await badges();
-    assert.includeMembers(providerBadges, ["ACTIVE ON RESTART"]);
-  });
-
-  it("should store config in database", async function() {
-    const db = await server.getDatabase();
-    const activation = await db.connection.manager.findOne(Activation, { where: {} });
-    assert.isDefined(activation);
-    const json = activation!.prefs!.envVars;
-    assert.isDefined(json);
-    assert.isDefined(json!.GRIST_GETGRISTCOM_SECRET);
-  });
-
-  it("should use fake getgristlogin service", async function() {
-    await server.restart();
-    await server.removeLogin();
-    await server.simulateLogin("user1", process.env.GRIST_DEFAULT_EMAIL!, "docs");
-    await driver.get(`${server.getHost()}/admin`);
-    await gu.waitForAdminPanel();
-    await toggleItem("authentication");
-    assert.equal(await itemValue("authentication"), "getgrist.com");
-
-    // Expand the provider list (collapsed when a real provider is active).
-    await expandProviderList();
-
-    // And check that we still see at least 2 providers, including getgrist.com and OIDC
-    const providerItems = await driver.findAll(".test-admin-auth-provider-row");
-    assert.isAtLeast(providerItems.length, 2);
-
-    // First one should be "Sign in with getgrist.com".
-    assert.match(await providerItems[0].getText(), /Sign in with getgrist/);
-
-    // Second one should be OIDC provider.
-    assert.match(await providerItems[1].getText(), /OIDC/);
-
-    // The getgrist.com provider should have Active badge
-    const getGristRow = providerItems[0];
-    const activeBadges = await getGristRow.findAll(".test-admin-auth-badge-active");
-    assert.lengthOf(activeBadges, 1);
-
-    // Second one should have no badges
-    const oidcRow = providerItems[1];
-    const oidcBadges = await oidcRow.findAll(".test-admin-auth-badge");
-    assert.lengthOf(oidcBadges, 0);
-  });
-
-  it("should deactivate getgrist.com and preserve config", async function() {
-    // The previous test left us on the admin panel with getgrist.com active.
-    // Click Deactivate on the hero card.
-    const deactivateButton = await driver.findWait(".test-admin-auth-hero-deactivate", 2000);
-    await deactivateButton.click();
-
-    // Confirm in the modal.
-    const confirmButton = await driver.findWait(".test-modal-confirm", 2000);
-    await confirmButton.click();
-    await gu.waitForServer();
-
-    // After deactivation, getgrist.com should show "Disabled on restart" badge.
-    await expandProviderList();
-    const getGristBadges = await badges();
-    assert.includeMembers(getGristBadges, ["DISABLED ON RESTART"]);
-
-    // The config should still be in the database (preserved, not deleted).
-    const db = await server.getDatabase();
-    const activation = await db.connection.manager.findOne(Activation, { where: {} });
-    assert.isDefined(activation!.prefs!.envVars!.GRIST_GETGRISTCOM_SECRET);
-
-    // After restart, should be back to no authentication.
-    await server.restart();
-    await server.simulateLogin("user1", process.env.GRIST_DEFAULT_EMAIL!, "docs");
-    await driver.get(`${server.getHost()}/admin`);
-    await gu.waitForAdminPanel();
-    await toggleItem("authentication");
-
-    await gu.waitToPass(async () => {
-      assert.equal(await itemValue("authentication"), "no authentication");
-    }, 500);
-
-    // Re-activate getgrist.com — it should still be configured (secret preserved).
-    await expandProviderList();
-    const setActiveButton = await providerRow().find(".test-admin-auth-set-active-button");
-    await setActiveButton.click();
-    const reactivateConfirm = await driver.findWait(".test-modal-confirm", 2000);
-    await reactivateConfirm.click();
-    await gu.waitForServer();
-
-    // Should now show "Active on restart".
-    const reactivatedBadges = await badges();
-    assert.includeMembers(reactivatedBadges, ["ACTIVE ON RESTART"]);
-
-    // Restart and verify it's active again.
-    await server.restart();
-    await server.removeLogin();
-    await server.simulateLogin("user1", process.env.GRIST_DEFAULT_EMAIL!, "docs");
-    await driver.get(`${server.getHost()}/admin`);
-    await gu.waitForAdminPanel();
-    await toggleItem("authentication");
-    assert.equal(await itemValue("authentication"), "getgrist.com");
-  });
-
-  it("should respect GRIST_GETGRISTCOM_SP_HOST env override", async function() {
-    process.env.GRIST_GETGRISTCOM_SP_HOST = "https://invalid-host.example.com";
-    await server.restart();
-    await server.removeLogin();
-    await driver.get(`${server.getHost()}`);
-    await gu.waitForDocMenuToLoad();
-    currentRequest.set(null);
-    const redirectUrl = new Defer<string>();
-    currentRequest.addListener((val) => {
-      redirectUrl.resolve(val?.query.redirect_uri as string);
+  // Exercise the configure modal and the section's draft display.
+  // Persistence and server behavior are covered by the seeded-env-var
+  // tests below.
+  describe("UI flow with no auth configured", function() {
+    before(async function() {
+      delete process.env.GRIST_GETGRISTCOM_SECRET;
+      delete process.env.GRIST_LOGIN_SYSTEM_TYPE;
+      await server.restart();
     });
-    await driver.findWait(".test-user-sign-in", 2000).click();
-    assert.equal(await redirectUrl, "https://invalid-host.example.com/oauth2/callback");
+
+    it("should show providers with Grist Login", async function() {
+      await server.simulateLogin("user1", process.env.GRIST_DEFAULT_EMAIL!, "docs");
+      await driver.get(`${server.getHost()}/admin`);
+      await gu.waitForAdminPanel();
+      await toggleItem("authentication");
+
+      await gu.waitToPass(async () => {
+        assert.equal(await itemValue("authentication"), "no authentication");
+      }, 500);
+
+      await driver.findWait(".test-admin-auth-provider-row", 2000);
+      const providerItems = await driver.findAll(".test-admin-auth-provider-row");
+      assert.isAtLeast(providerItems.length, 2);
+      assert.match(await providerItems[0].getText(), /Sign in with getgrist/);
+    });
+
+    it("should validate the key and stage the configuration as a draft", async function() {
+      const configureButton = await providerRow().find(".test-admin-auth-configure-button");
+      await configureButton.click();
+
+      const textarea = await driver.findWait(".test-admin-auth-config-key-textarea", 2000);
+      const configureModalButton = await driver.find(".test-admin-auth-modal-configure");
+
+      // Empty textarea -> Configure disabled.
+      assert.isFalse(await configureModalButton.isEnabled());
+      await configureModalButton.click();
+      await driver.sleep(100);
+      await gu.checkForErrors();
+
+      // Invalid base64.
+      await textarea.click();
+      await textarea.sendKeys("invalid-key");
+      await configureModalButton.click();
+      await assertError(/Error configuring provider with the provided key/);
+
+      // Valid base64 but missing required fields.
+      await textarea.clear();
+      await textarea.sendKeys(Buffer.from(JSON.stringify({ random: "json" })).toString("base64"));
+      await configureModalButton.click();
+      await assertError(/Error configuring provider with the provided key/);
+
+      // Valid key.
+      await textarea.clear();
+      await textarea.sendKeys(buildKey());
+      await configureModalButton.click();
+      await waitForModalToClose();
+
+      // The badge reflects the draft: getgrist.com will be active on apply
+      // (because nothing else was active and it's the first configured).
+      assert.includeMembers(await badges(), ["ACTIVE ON RESTART"]);
+    });
+  });
+
+  // Server-side behavior tests seed the secret directly via env vars and
+  // restart, bypassing the UI configure modal. They verify how the server
+  // behaves when getgrist.com is the active auth provider, and how the
+  // section presents that state in the admin panel.
+  describe("when getgrist.com is configured via env vars", function() {
+    before(async function() {
+      process.env.GRIST_GETGRISTCOM_SECRET = buildKey();
+      // Don't pin GRIST_LOGIN_SYSTEM_TYPE -- coreLogins picks the first
+      // configured system, which is getgrist.com.
+      delete process.env.GRIST_LOGIN_SYSTEM_TYPE;
+      await server.restart();
+    });
+
+    after(async function() {
+      delete process.env.GRIST_GETGRISTCOM_SECRET;
+      delete process.env.GRIST_GETGRISTCOM_SP_HOST;
+    });
+
+    it("shows getgrist.com as the active provider", async function() {
+      await server.removeLogin();
+      await server.simulateLogin("user1", process.env.GRIST_DEFAULT_EMAIL!, "docs");
+      await driver.get(`${server.getHost()}/admin`);
+      await gu.waitForAdminPanel();
+      await toggleItem("authentication");
+      assert.equal(await itemValue("authentication"), "getgrist.com");
+
+      // Provider list collapses when a real provider is active; expand to inspect.
+      await expandProviderList();
+      const providerItems = await driver.findAll(".test-admin-auth-provider-row");
+      assert.isAtLeast(providerItems.length, 2);
+      assert.match(await providerItems[0].getText(), /Sign in with getgrist/);
+      assert.match(await providerItems[1].getText(), /OIDC/);
+
+      const activeBadges = await providerItems[0].findAll(".test-admin-auth-badge-active");
+      assert.lengthOf(activeBadges, 1);
+      assert.lengthOf(await providerItems[1].findAll(".test-admin-auth-badge"), 0);
+    });
+
+    it("shows DISABLED ON RESTART when the user clicks Deactivate", async function() {
+      // The previous test left us on the admin panel with getgrist.com active.
+      const deactivateButton = await driver.findWait(".test-admin-auth-hero-deactivate", 2000);
+      await deactivateButton.click();
+      const confirmButton = await driver.findWait(".test-modal-confirm", 2000);
+      await confirmButton.click();
+
+      await expandProviderList();
+      const getGristBadges = await badges();
+      assert.includeMembers(getGristBadges, ["DISABLED ON RESTART"]);
+    });
+
+    it("respects GRIST_GETGRISTCOM_SP_HOST when constructing the OAuth redirect", async function() {
+      process.env.GRIST_GETGRISTCOM_SP_HOST = "https://invalid-host.example.com";
+      await server.restart();
+      await server.removeLogin();
+      await driver.get(`${server.getHost()}`);
+      await gu.waitForDocMenuToLoad();
+      currentRequest.set(null);
+      const redirectUrl = new Defer<string>();
+      currentRequest.addListener((val) => {
+        redirectUrl.resolve(val?.query.redirect_uri as string);
+      });
+      await driver.findWait(".test-user-sign-in", 2000).click();
+      assert.equal(await redirectUrl, "https://invalid-host.example.com/oauth2/callback");
+    });
   });
 });
 

--- a/test/nbrowser/BootPage.ts
+++ b/test/nbrowser/BootPage.ts
@@ -93,19 +93,14 @@ describe("BootPage", function() {
     it("reports server is in service in Admin Panel", async function() {
       await driver.get(`${server.getHost()}/admin`);
       await gu.waitForAdminPanel();
-      assert.equal(
-        await driver.find(".test-admin-panel-item-value-service-status").getText(),
-        "in service",
-      );
+      // Probe-driven badge starts at "checking" and settles asynchronously.
+      await driver.findContentWait(".test-admin-panel-item-value-service-status", "in service", 2000);
       await toggleItem("service-status");
       assert.isFalse(await driver.find(".test-service-status-env-variable-notice").isPresent());
     });
 
     it("reports boot key is disabled in Admin Panel", async function() {
-      assert.equal(
-        await driver.find(".test-admin-panel-item-value-boot-key").getText(),
-        "disabled",
-      );
+      await driver.findContentWait(".test-admin-panel-item-value-boot-key", "disabled", 2000);
       await toggleItem("boot-key");
       assert.isFalse(await driver.find(".test-boot-key-status-remove-boot-key").isPresent());
       assert.isFalse(await driver.find(".test-boot-key-status-env-variable-notice").isPresent());
@@ -522,10 +517,7 @@ describe("BootPage", function() {
     it("reports server is out of service in Admin Panel", async function() {
       await driver.get(`${server.getHost()}/admin?boot-key=abc123`);
       await gu.waitForAdminPanel();
-      assert.equal(
-        await driver.find(".test-admin-panel-item-value-service-status").getText(),
-        "out of service",
-      );
+      await driver.findContentWait(".test-admin-panel-item-value-service-status", "out of service", 2000);
       await toggleItem("service-status");
       assert.match(
         await driver.find(".test-service-status-env-variable-notice").getText(),
@@ -540,10 +532,7 @@ describe("BootPage", function() {
 
       await driver.get(`${server.getHost()}/admin?boot-key=abc123`);
       await gu.waitForAdminPanel();
-      assert.equal(
-        await driver.find(".test-admin-panel-item-value-service-status").getText(),
-        "in service",
-      );
+      await driver.findContentWait(".test-admin-panel-item-value-service-status", "in service", 2000);
       await toggleItem("service-status");
       assert.isTrue(await driver.find(".test-service-status-enter-maintenance-mode").isDisplayed());
       assert.isFalse(await driver.find(".test-service-status-env-variable-notice").isPresent());

--- a/test/nbrowser/QuickSetupAuth.ts
+++ b/test/nbrowser/QuickSetupAuth.ts
@@ -31,11 +31,16 @@ async function isModalOpen(): Promise<boolean> {
 }
 
 async function openConfigureModal(): Promise<void> {
-  // Provider rows are only in the DOM when the list is expanded.
-  const header = await driver.findWait(".test-admin-auth-provider-list-header", 4000);
-  if (await header.getAttribute("aria-expanded") === "false") {
-    await header.click();
-  }
+  // Same race as the row click below -- AuthenticationSection's buildDom
+  // re-renders when async fetches land, so even the header's aria-expanded
+  // read can hit a stale element if the rebuild happens between findWait
+  // and getAttribute.
+  await gu.waitToPass(async () => {
+    const header = await driver.findWait(".test-admin-auth-provider-list-header", 4000);
+    if (await header.getAttribute("aria-expanded") === "false") {
+      await header.click();
+    }
+  }, 2000);
   // Retry the row lookup and click together: AuthenticationSection's
   // buildDom domComputes over async `_providers` and `_loginSystemId`,
   // so the row subtree can be replaced between the find and the click.


### PR DESCRIPTION
This makes authentication changes work like other draft changes in the admin panel. There's still more to do here since after an authentication change, we'll be zapping all sessions and user will need to go through a login rather than just have things silently stop working.