### PR TITLE
Issue 2160 prevent anon fork

### DIFF
--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -138,6 +138,7 @@ import { createAttachmentsIndex, DocStorage, REMOVE_UNUSED_ATTACHMENTS_DELAY } f
 import { expandQuery, getFormulaErrorForExpandQuery } from "app/server/lib/ExpandedQuery";
 import { GranularAccess, GranularAccessForBundle } from "app/server/lib/GranularAccess";
 import { GristServer } from "app/server/lib/GristServer";
+import { getAnonPlaygroundEnabled } from "app/server/lib/gristSettings";
 import {
   AssistanceFormulaEvaluationResult,
   AssistanceSchemaPromptV1Context,
@@ -193,7 +194,6 @@ import throttle from "lodash/throttle";
 import without from "lodash/without";
 import * as moment from "moment-timezone";
 import fetch from "node-fetch";
-import { getAnonPlaygroundEnabled } from "app/server/lib/gristSettings";
 
 const MAX_RECENT_ACTIONS = 100;
 

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -193,6 +193,7 @@ import throttle from "lodash/throttle";
 import without from "lodash/without";
 import * as moment from "moment-timezone";
 import fetch from "node-fetch";
+import { getAnonPlaygroundEnabled } from "app/server/lib/gristSettings";
 
 const MAX_RECENT_ACTIONS = 100;
 
@@ -1842,6 +1843,9 @@ export class ActiveDoc extends EventEmitter {
   public async fork(docSession: OptDocSession): Promise<ForkResult> {
     const dbManager = this._getHomeDbManagerOrFail();
     const user = docSession.fullUser;
+    if (user?.anonymous && !getAnonPlaygroundEnabled()) {
+      throw new ApiError("Anonymous document creation is disabled", 401);
+    }
     // For now, fork only if user can read everything (or is owner).
     // TODO: allow forks with partial content.
     if (!user || !await this.canDownload(docSession)) {

--- a/app/server/lib/ITestingHooks-ti.ts
+++ b/app/server/lib/ITestingHooks-ti.ts
@@ -29,6 +29,10 @@ export const ITestingHooks = t.iface([], {
   "setWidgetRepositoryUrl": t.func("void", t.param("url", "string")),
   "getMemoryUsage": t.func("object"),
   "tickleUnhandledErrors": t.func("void", t.param("errType", "string")),
+  "addEnv": t.func("void", t.param("env", t.iface([], {
+    [t.indexKey]: "string",
+  }))),
+  "resetEnv": t.func("void"),
 });
 
 const exportedTypeSuite: t.ITypeSuite = {

--- a/app/server/lib/ITestingHooks.ts
+++ b/app/server/lib/ITestingHooks.ts
@@ -25,6 +25,6 @@ export interface ITestingHooks {
   setWidgetRepositoryUrl(url: string): Promise<void>;
   getMemoryUsage(): Promise<object>;  // actually NodeJS.MemoryUsage
   tickleUnhandledErrors(errType: string): Promise<void>;
-  addEnv(env: {[key: string]: string}): Promise<void>;
+  addEnv(env: { [key: string]: string }): Promise<void>;
   resetEnv(): Promise<void>;
 }

--- a/app/server/lib/ITestingHooks.ts
+++ b/app/server/lib/ITestingHooks.ts
@@ -25,4 +25,6 @@ export interface ITestingHooks {
   setWidgetRepositoryUrl(url: string): Promise<void>;
   getMemoryUsage(): Promise<object>;  // actually NodeJS.MemoryUsage
   tickleUnhandledErrors(errType: string): Promise<void>;
+  addEnv(env: {[key: string]: string}): Promise<void>;
+  resetEnv(): Promise<void>;
 }

--- a/app/server/lib/TestingHooks.ts
+++ b/app/server/lib/TestingHooks.ts
@@ -5,6 +5,7 @@ import * as Client from "app/server/lib/Client";
 import { Comm } from "app/server/lib/Comm";
 import { Deps as DiscourseConnectDeps } from "app/server/lib/DiscourseConnect";
 import { FlexServer } from "app/server/lib/FlexServer";
+import { invalidateAllReloadableSettings, invalidateReloadableSettings } from "app/server/lib/gristSettings";
 import { ClientJsonMemoryLimits, ITestingHooks } from "app/server/lib/ITestingHooks";
 import ITestingHooksTI from "app/server/lib/ITestingHooks-ti";
 import log from "app/server/lib/log";
@@ -16,6 +17,7 @@ import * as net from "net";
 
 import { Request } from "express";
 import { IMessage, Rpc } from "grain-rpc";
+import clone from "lodash/clone";
 import * as t from "ts-interface-checker";
 
 const tiCheckers = t.createCheckers(ITestingHooksTI, { UserProfile: t.name("object") });
@@ -62,6 +64,8 @@ export async function connectTestingHooks(socketPath: string): Promise<TestingHo
 }
 
 export class TestingHooks implements ITestingHooks {
+  private _oldEnv: NodeJS.ProcessEnv | null = null;
+
   constructor(
     private _port: number,
     private _comm: Comm,
@@ -273,5 +277,32 @@ export class TestingHooks implements ITestingHooks {
     } else {
       throw new Error(`Unrecognized errType ${errType}`);
     }
+  }
+
+  public async addEnv(env: NodeJS.ProcessEnv) {
+    // If `_oldEnv` is not set, this means that we are in the initial state with the env variables
+    // Let's snapshot the environment variables so we can later call `resetEnv`
+    if (!this._oldEnv) {
+      this._oldEnv = clone(process.env);
+    }
+
+    Object.assign(process.env, env);
+    const envKeys = Object.keys(env);
+    invalidateReloadableSettings(...envKeys);
+  }
+
+  public async resetEnv() {
+    if (this._oldEnv === null) {
+      return;
+    }
+
+    Object.assign(process.env, this._oldEnv);
+    for (const key of Object.keys(process.env)) {
+      if (this._oldEnv[key] === undefined) {
+        delete process.env[key];
+      }
+    }
+    this._oldEnv = null;
+    invalidateAllReloadableSettings();
   }
 }

--- a/app/server/lib/gristSettings.ts
+++ b/app/server/lib/gristSettings.ts
@@ -45,7 +45,6 @@ export interface ValueWithSource<T> {
  */
 export const RestartRequiredSettingEnvVar = StringUnion(
   "APP_HOME_URL",
-  "GRIST_ANON_PLAYGROUND",
   "GRIST_FORCE_LOGIN",
   "GRIST_GETGRISTCOM_SECRET",
   "GRIST_LOGIN_SYSTEM_TYPE",
@@ -63,6 +62,7 @@ export type RestartRequiredSettingEnvVar = typeof RestartRequiredSettingEnvVar.v
  */
 export const ReloadableSettingEnvVar = StringUnion(
   "GRIST_ADMIN_EMAIL",
+  "GRIST_ANON_PLAYGROUND",
   "GRIST_BOOT_KEY",
   "GRIST_IN_SERVICE",
 );
@@ -330,6 +330,12 @@ export function invalidateReloadableSettings(...envVars: string[]) {
   for (const envVar of envVars) {
     if (!ReloadableSettingEnvVar.guard(envVar)) { continue; }
 
+    settingsByEnvVar[envVar].cache.clear();
+  }
+}
+
+export function invalidateAllReloadableSettings() {
+  for (const envVar of ReloadableSettingEnvVar.values) {
     settingsByEnvVar[envVar].cache.clear();
   }
 }

--- a/test/server/lib/docapi/DocApiDocuments.ts
+++ b/test/server/lib/docapi/DocApiDocuments.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for document operations:
  * - POST /docs/{did}/force-reload
+ * - POST /docs/{did}/fork
  * - POST /docs/{did}/assign
  * - GET/POST /docs/{did}/replace
  * - GET /docs/{did}/snapshots
@@ -17,12 +18,13 @@
 
 import { ActionSummary } from "app/common/ActionSummary";
 import { DocState } from "app/common/DocState";
+import { isAffirmative } from "app/common/gutil";
 import { UserAPI, UserAPIImpl } from "app/common/UserAPI";
 import { configForUser } from "test/gen-server/testUtils";
 import { addAllScenarios, ORG_NAME, TestContext } from "test/server/lib/docapi/helpers";
 import * as testUtils from "test/server/testUtils";
 
-import axios from "axios";
+import axios, { AxiosRequestConfig } from "axios";
 import { assert } from "chai";
 import FormData from "form-data";
 import range from "lodash/range";
@@ -527,6 +529,41 @@ function addDocumentsTests(getCtx: () => TestContext) {
 
       resp = await axios.get(`${homeUrl}/dw/zing/api/docs/${docIds.Timesheets}/tables/Table1/data`, chimpy);
       assert.equal(resp.status, 404);
+    }
+  });
+
+  it("POST /docs/{did}/fork rejects when anonymous playground is disabled", async function() {
+    const { docs, nobody, chimpy, serverUrl, userApi } = getCtx();
+    const forkDocAs = (docId: string, user: AxiosRequestConfig) => axios.post(`${serverUrl}/api/docs/${docId}/fork`, null, user);
+    let docId: string | null = null;
+
+    try {
+      // Create a document and share it publicly
+      const ws1 = (await userApi.getOrgWorkspaces("current"))[0].id;
+      docId = await userApi.newDoc({ name: "some-doc" }, ws1);
+      await userApi.updateDocPermissions(docId, { users: { "anon@getgrist.com": "viewers" } });
+
+      // Try to fork the document as anonymous user when GRIST_ANON_PLAYGROUNT=false
+      await docs.testingHooks.addEnv({ GRIST_ANON_PLAYGROUND: "false" });
+      let resp = await forkDocAs(docId, nobody);
+      assert.equal(resp.status, 401);
+      assert.equal(resp.data.error, "Anonymous document creation is disabled");
+
+      // Still it should work as chimpy
+      resp = await forkDocAs(docId, chimpy);
+      assert.equal(resp.status, 200);
+      console.log(resp.data);
+
+      // Reset to the default environment and try again to fork, it should work
+      await docs.testingHooks.resetEnv();
+      resp = await forkDocAs(docId, nobody);
+      assert.equal(resp.status, 200);
+    } finally {
+      // Cleanup the trunk document (the endpoint also delete the forks)
+      if (!isAffirmative(process.env.NO_CLEANUP) && docId) {
+        await userApi.deleteDoc(docId);
+      }
+      await docs.testingHooks.resetEnv();
     }
   });
 }


### PR DESCRIPTION
## Context

The `GRIST_ANON_PLAYGROUND` env variable, when set to false, is meant to prevent anonymous users from creating new documents.
But anonymous users can still open a template and fork a document, and then edit it. 

## Proposed solution

Prevent anonymous user from forking too when this env variable is set to false.

## Related issues

Fixes #2160 

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<img width="422" height="216" alt="An error popup saying 'Anonymous document creation is disabled'" src="https://github.com/user-attachments/assets/02ec4988-226b-4888-ac88-947139e79d90" />

