### PR TITLE
Adds /records/list POST endpoint

### DIFF
--- a/app/plugin/DocApiTypes-ti.ts
+++ b/app/plugin/DocApiTypes-ti.ts
@@ -60,6 +60,17 @@ export const RecordsPut = t.iface([], {
   "records": t.tuple("AddOrUpdateRecord", t.rest(t.array("AddOrUpdateRecord"))),
 });
 
+export const RecordsListPost = t.iface([], {
+  "filter": t.opt(t.iface([], {
+    [t.indexKey]: t.array("any"),
+  })),
+  "sort": t.opt(t.array("string")),
+  "limit": t.opt("number"),
+  "hidden": t.opt("boolean"),
+  "immediate": t.opt("boolean"),
+  "cellFormat": t.opt("CellFormatType"),
+});
+
 export const RecordId = t.name("number");
 
 export const MinimalRecord = t.iface([], {
@@ -140,6 +151,7 @@ const exportedTypeSuite: t.ITypeSuite = {
   RecordsPatch,
   RecordsPost,
   RecordsPut,
+  RecordsListPost,
   RecordId,
   MinimalRecord,
   ColumnsPost,

--- a/app/plugin/DocApiTypes.ts
+++ b/app/plugin/DocApiTypes.ts
@@ -1,4 +1,5 @@
 import { CellValue } from "app/plugin/GristData";
+import { CellFormatType } from "app/plugin/GristAPI";
 
 /**
  * JSON schema for api /record endpoint. Used in POST method for adding new records.
@@ -68,24 +69,36 @@ export interface BulkAddOrUpdateRecordResult {
 }
 
 /**
- * JSON schema for the body of api /record PATCH endpoint
+ * JSON schema for the body of api /records PATCH endpoint
  */
 export interface RecordsPatch {
   records: [Record, ...Record[]]; // at least one record is required
 }
 
 /**
- * JSON schema for the body of api /record POST endpoint
+ * JSON schema for the body of api /records POST endpoint
  */
 export interface RecordsPost {
   records: [NewRecord, ...NewRecord[]]; // at least one record is required
 }
 
 /**
- * JSON schema for the body of api /record PUT endpoint
+ * JSON schema for the body of api /records PUT endpoint
  */
 export interface RecordsPut {
   records: [AddOrUpdateRecord, ...AddOrUpdateRecord[]]; // at least one record is required
+}
+
+/**
+ * JSON schema for the body of api /records/list POST endpoint
+ */
+export interface RecordsListPost {
+  filter?: { [colId: string]: any[] };  // Column filters, mapping colId to array of allowed values.
+  sort?: string[];    // See QueryParameters in DocApi.
+  limit?: number;     // Limit on number of rows to return.
+  hidden?: boolean;   // Include hidden columns (manualSort, gristHelper_*).
+  immediate?: boolean; // Skip waiting for document initialization.
+  cellFormat?: CellFormatType;
 }
 
 export type RecordId = number;

--- a/app/plugin/DocApiTypes.ts
+++ b/app/plugin/DocApiTypes.ts
@@ -1,5 +1,5 @@
-import { CellValue } from "app/plugin/GristData";
 import { CellFormatType } from "app/plugin/GristAPI";
+import { CellValue } from "app/plugin/GristData";
 
 /**
  * JSON schema for api /record endpoint. Used in POST method for adding new records.

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -42,6 +42,7 @@ import { QueryResult } from "app/gen-server/lib/homedb/Interfaces";
 import * as Types from "app/plugin/DocApiTypes";
 import DocApiTypesTI from "app/plugin/DocApiTypes-ti";
 import { CellFormatType } from "app/plugin/GristAPI";
+import GristApiTI from "app/plugin/GristAPI-ti";
 import GristDataTI from "app/plugin/GristData-ti";
 import { OpOptions } from "app/plugin/TableOperations";
 import { TableOperationsImpl, TableOperationsPlatform } from "app/plugin/TableOperationsImpl";
@@ -128,13 +129,14 @@ import * as t from "ts-interface-checker";
 // Schema validators for api endpoints that creates or updates records.
 const {
   RecordsPatch, RecordsPost, RecordsPut,
+  RecordsListPost,
   ColumnsPost, ColumnsPatch, ColumnsPut,
   SqlPost,
   TablesPost, TablesPatch,
   SetAttachmentStorePost,
-} = t.createCheckers(DocApiTypesTI, GristDataTI);
+} = t.createCheckers(DocApiTypesTI, GristDataTI, GristApiTI);
 
-for (const checker of [RecordsPatch, RecordsPost, RecordsPut, ColumnsPost, ColumnsPatch,
+for (const checker of [RecordsPatch, RecordsPost, RecordsPut, RecordsListPost, ColumnsPost, ColumnsPatch,
   SqlPost, TablesPost, TablesPatch]) {
   checker.setReportedPath("body");
 }
@@ -281,6 +283,17 @@ export class DocWorkerApi {
         const records = await getTableRecords(activeDoc, req,
           { includeHidden: isAffirmative(req.query.hidden), cellFormat },
         );
+        res.json({ records });
+      }),
+    );
+
+    // Get the specified table in record-oriented format, with parameters in the POST body.
+    this._app.post("/api/docs/:docId/tables/:tableId/records/list", canView, validate(RecordsListPost),
+      withDoc(async (activeDoc, req, res) => {
+        const body = req.body as Types.RecordsListPost;
+        const tableId = await getRealTableId(req.params.tableId, { activeDoc, req });
+        const columnData = await readTable(req, activeDoc, tableId, body.filter ?? {}, body);
+        const records = asRecords(columnData, { includeHidden: body.hidden, cellFormat: body.cellFormat });
         res.json({ records });
       }),
     );
@@ -2266,6 +2279,10 @@ export interface QueryParameters {
   limit?: number;   // Limit on number of rows to return.
   cellFormat?: CellFormatType;
 }
+
+/**
+ * *
+ */
 
 /**
  * Extract a sort parameter from a request, if present.  Follows

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -290,10 +290,10 @@ export class DocWorkerApi {
     // Get the specified table in record-oriented format, with parameters in the POST body.
     this._app.post("/api/docs/:docId/tables/:tableId/records/list", canView, validate(RecordsListPost),
       withDoc(async (activeDoc, req, res) => {
-        const body = req.body as Types.RecordsListPost;
+        const params = req.body as Types.RecordsListPost;
         const tableId = await getRealTableId(req.params.tableId, { activeDoc, req });
-        const columnData = await readTable(req, activeDoc, tableId, body.filter ?? {}, body);
-        const records = asRecords(columnData, { includeHidden: body.hidden, cellFormat: body.cellFormat });
+        const columnData = await readTable(req, activeDoc, tableId, params.filter ?? {}, params);
+        const records = asRecords(columnData, { includeHidden: params.hidden, cellFormat: params.cellFormat });
         res.json({ records });
       }),
     );

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -2281,10 +2281,6 @@ export interface QueryParameters {
 }
 
 /**
- * *
- */
-
-/**
  * Extract a sort parameter from a request, if present.  Follows
  * https://jsonapi.org/format/#fetching-sorting for want of a better
  * standard - comma separated, defaulting to ascending order, keys

--- a/test/server/lib/docapi/DocApiRecords.ts
+++ b/test/server/lib/docapi/DocApiRecords.ts
@@ -181,6 +181,126 @@ function addRecordsTests(getCtx: () => TestContext) {
     );
   });
 
+  describe("POST /docs/{did}/tables/{tid}/records/list", function() {
+    it("retrieves the same data as GET /records", async function() {
+      const { serverUrl, docIds, chimpy } = getCtx();
+      const url = `${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1`;
+
+      const getResp = await axios.get(`${url}/records`, chimpy);
+      const postResp = await axios.post(`${url}/records/list`, {}, chimpy);
+      assert.equal(postResp.status, 200);
+      assert.deepEqual(postResp.data, getResp.data);
+
+      // Also test with table ref (numeric ID).
+      const urlByRef = `${serverUrl}/api/docs/${docIds.Timesheets}/tables/1`;
+      const getByRef = await axios.get(`${urlByRef}/records`, chimpy);
+      const postByRef = await axios.post(`${urlByRef}/records/list`, {}, chimpy);
+      assert.equal(postByRef.status, 200);
+      assert.deepEqual(postByRef.data, getByRef.data);
+    });
+
+    it("supports filters", async function() {
+      const { serverUrl, docIds, chimpy } = getCtx();
+      const url = `${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1`;
+
+      async function checkParity(filter: { [colId: string]: any[] }) {
+        const query = "filter=" + encodeURIComponent(JSON.stringify(filter));
+        const getResp = await axios.get(`${url}/records?${query}`, chimpy);
+        const postResp = await axios.post(`${url}/records/list`, { filter }, chimpy);
+        assert.equal(postResp.status, getResp.status);
+        assert.deepEqual(postResp.data, getResp.data);
+        return postResp;
+      }
+
+      await checkParity({ B: ["world"] });
+      await checkParity({ id: [1] });
+      await checkParity({ B: [""], A: [""] });
+      await checkParity({});
+      await checkParity({ B: ["world"], C: ["Neptune"] });
+
+      // Bad column name.
+      const badCol = await axios.post(`${url}/records/list`, { filter: { BadCol: [""] } }, chimpy);
+      assert.equal(badCol.status, 400);
+      assert.match(badCol.data.error, /BadCol/);
+
+      // Non-array filter value is rejected by schema validation.
+      const badVal = await axios.post(`${url}/records/list`, { filter: { B: "world" } }, chimpy);
+      assert.equal(badVal.status, 400);
+    });
+
+    it("supports sort and limit", async function() {
+      const { serverUrl, docIds, chimpy } = getCtx();
+      const url = `${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1`;
+
+      async function checkParity(body: { sort?: string[]; limit?: number }, params: { sort?: string; limit?: number }) {
+        const getResp = await axios.get(`${url}/records`, { ...chimpy, params });
+        const postResp = await axios.post(`${url}/records/list`, body, chimpy);
+        assert.equal(postResp.status, 200);
+        assert.deepEqual(postResp.data, getResp.data);
+      }
+
+      await checkParity({ sort: ["A"] }, { sort: "A" });
+      await checkParity({ sort: ["-A"] }, { sort: "-A" });
+      await checkParity({ sort: ["B", "-A"] }, { sort: "B,-A" });
+      await checkParity({ limit: 1 }, { limit: 1 });
+      await checkParity({ sort: ["B"], limit: 2 }, { sort: "B", limit: 2 });
+    });
+
+    it("includes hidden columns when requested", async function() {
+      const { serverUrl, docIds, chimpy } = getCtx();
+      const url = `${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1`;
+
+      const getResp = await axios.get(`${url}/records`, { ...chimpy, params: { hidden: true } });
+      const postResp = await axios.post(`${url}/records/list`, { hidden: true }, chimpy);
+      assert.equal(postResp.status, 200);
+      assert.deepEqual(postResp.data, getResp.data);
+      assert.property(postResp.data.records[0].fields, "manualSort");
+    });
+
+    it("handles errors and hidden columns", async function() {
+      const { serverUrl, docIds, chimpy } = getCtx();
+      const url = `${serverUrl}/api/docs/${docIds.ApiDataRecordsTest}/tables/Table1`;
+
+      // Without hidden: should match GET and exclude hidden columns.
+      const getResp = await axios.get(`${url}/records`, chimpy);
+      const postResp = await axios.post(`${url}/records/list`, {}, chimpy);
+      assert.equal(postResp.status, 200);
+      assert.deepEqual(postResp.data, getResp.data);
+      assert.notProperty(postResp.data.records[0].fields, "manualSort");
+      assert.notProperty(postResp.data.records[0].fields, "gristHelper_Display");
+      assert.deepEqual(postResp.data.records[0].errors, { A: "ZeroDivisionError" });
+
+      // With hidden: should include hidden columns.
+      const getHidden = await axios.get(`${url}/records`, { ...chimpy, params: { hidden: true } });
+      const postHidden = await axios.post(`${url}/records/list`, { hidden: true }, chimpy);
+      assert.equal(postHidden.status, 200);
+      assert.deepEqual(postHidden.data, getHidden.data);
+      assert.property(postHidden.data.records[0].fields, "manualSort");
+      assert.property(postHidden.data.records[0].fields, "gristHelper_Display");
+    });
+
+    it("validates request schema", async function() {
+      const { serverUrl, docIds, chimpy } = getCtx();
+      const url = `${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1/records/list`;
+
+      const resp1 = await axios.post(url, { sort: "A" }, chimpy);
+      assert.equal(resp1.status, 400);
+
+      const resp2 = await axios.post(url, { limit: "abc" }, chimpy);
+      assert.equal(resp2.status, 400);
+
+      const resp3 = await axios.post(url, { filter: "bad" }, chimpy);
+      assert.equal(resp3.status, 400);
+    });
+
+    it("respects document permissions", async function() {
+      const { serverUrl, docIds, kiwi } = getCtx();
+      const resp = await axios.post(
+        `${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1/records/list`, {}, kiwi);
+      assert.equal(resp.status, 403);
+    });
+  });
+
   it("GET /docs/{did}/tables/{tid}/records supports cellFormat=typed", async function() {
     // Create a new document with various column types.
     const { serverUrl, userApi, chimpy } = getCtx();


### PR DESCRIPTION
## Context

The main way to fetch records via the API is `GET /api/docs/{docId}/tables/{tableId}/records`. 

This endpoint accepts a `filter` parameter, which can be used to restrict the rows returned by matching on column values. The `filter` parameter is passes in via normal query parameters in the URL.

URLs have character limits which vary between browser and server implementations, typically around 2000 characters. This makes it easy to craft a `filter` parameter that is valid, but won't fit within a URL. For example, matching on a long text entry, or many emails.

This makes many sensible filter values impossible to actually send to Grist. 

## Proposed solution

This adds a `POST /api/docs/{docId}/tables/{tableId}/records/list` endpoint, that accepts all the parameters in a JSON body, avoiding URL length limits.

This is follows the precedent set by other databases such as [Airtable](https://support.airtable.com/docs/enforcement-of-url-length-limit-for-web-api-requests) or [Google Firestore](https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/runQuery).


## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [X] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

