### PR TITLE
do not claim to be alive prematurely

### DIFF
--- a/app/common/ConfigAPI.ts
+++ b/app/common/ConfigAPI.ts
@@ -55,17 +55,14 @@ export class ConfigAPI extends BaseAPI {
    * Returns true on success, false on timeout; callers decide how to surface
    * the timeout (throw, silent, page reload, etc).
    *
-   * All callers invoke this after `restartServer()`. The server returns from
-   * `restartServer` before tearing down its listener, so the very first poll
-   * can otherwise hit the still-up old process and return true immediately.
-   * A brief initial delay lets the server begin its restart first.
+   * The restart endpoint marks the server not-ready before its 200 response
+   * returns, so a poll racing the dying old process gets NOT_READY and we
+   * keep polling -- no initial delay needed.
    */
   public async waitUntilReady({
     attempts = 30,
     intervalMs = 1000,
-    initialDelayMs = 500,
-  }: { attempts?: number; intervalMs?: number; initialDelayMs?: number } = {}): Promise<boolean> {
-    await delay(initialDelayMs);
+  }: { attempts?: number; intervalMs?: number } = {}): Promise<boolean> {
     for (let i = 0; i < attempts; i++) {
       try {
         await this.healthcheck();

--- a/app/server/lib/RestartShell.ts
+++ b/app/server/lib/RestartShell.ts
@@ -58,8 +58,10 @@ interface ExitInfo { code: number | null; signal: NodeJS.Signals | null; }
 interface FallbackResponse { status: number; contentType: string; body: string; }
 const plain = (status: number, body: string): FallbackResponse =>
   ({ status, contentType: "text/plain", body });
-const RESTARTING: FallbackResponse =
-  { status: 503, contentType: "application/json", body: JSON.stringify({ error: "restarting" }) };
+const asJson = (status: number, value: unknown): FallbackResponse =>
+  ({ status, contentType: "application/json", body: JSON.stringify(value) });
+const RESTARTING: FallbackResponse = asJson(503, { error: "restarting" });
+const STARTING: FallbackResponse = asJson(503, { error: "starting" });
 const UNHEALTHY = plain(500, "Grist server is unhealthy.");
 const NOT_READY = plain(500, "Grist server is unhealthy (ready not ok).");
 const ALIVE = plain(200, "Grist server is alive.");
@@ -69,8 +71,7 @@ const ALIVE = plain(200, "Grist server is alive.");
  * to a forked child worker. Construct, then `await start()`; hold onto
  * the instance to `restart()` or `shutdown()`.
  */
-export type { RestartShell };
-class RestartShell {
+export class RestartShell {
   private _status: ShellStatus = { kind: "stopped" };
   private _healthy = true;
 
@@ -93,6 +94,16 @@ class RestartShell {
 
   /** Bind the listening socket and spawn the first child. */
   public async start(): Promise<void> {
+    await this.listen();
+    await this.run();
+  }
+
+  /**
+   * Bind the listening socket and arm signal handlers. After this
+   * returns, `port` is set and /status is reachable (answered by the
+   * fallback as "starting" until run() completes).
+   */
+  public async listen(): Promise<void> {
     log.info("RestartShell: starting");
     this._status = { kind: "starting" };
     this._actualPort = await bindPublicSocket(this._server, this._options.publicPort);
@@ -104,7 +115,10 @@ class RestartShell {
     // pid 1 in a container (see grist-core#830, #892).
     shutdownLib.addCleanupHandler(this, () => this.shutdown(), 15000, "RestartShell");
     shutdownLib.cleanupOnSignals("SIGINT", "SIGTERM");
+  }
 
+  /** Spawn the first child and transition to "running" once it's ready. */
+  public async run(): Promise<void> {
     const result = await this._spawnOrFail();
     if (!result.ok) {
       // Shut down so the event loop drains and the process exits
@@ -226,6 +240,7 @@ class RestartShell {
   private _fallbackResponse(req: http.IncomingMessage): FallbackResponse {
     const [pathname, query = ""] = (req.url || "/").split("?");
     if (pathname !== "/status") { return RESTARTING; }
+    if (this._status.kind === "starting") { return STARTING; }
     if (!this._healthy) { return UNHEALTHY; }
     if (isParameterOn(new URLSearchParams(query).get("ready"))) { return NOT_READY; }
     return ALIVE;

--- a/test/server/lib/RestartShell.ts
+++ b/test/server/lib/RestartShell.ts
@@ -5,7 +5,7 @@
 
 import { GristClientSocket } from "app/client/components/GristClientSocket";
 import { delay } from "app/common/delay";
-import { Deps, runRestartShell } from "app/server/lib/RestartShell";
+import { Deps, RestartShell, runRestartShell } from "app/server/lib/RestartShell";
 import { createInitialDb, removeConnection, setUpDB } from "test/gen-server/seed";
 import { configForUser } from "test/gen-server/testUtils";
 import * as testUtils from "test/server/testUtils";
@@ -85,6 +85,38 @@ describe("RestartShell", function() {
     const readyResp = await axios.get(`${serverUrl}/status?ready=1`);
     assert.equal(readyResp.status, 200);
     assert.include(readyResp.data, "alive");
+  });
+
+  it("should not report alive on /status during initial startup", async function() {
+    // Drive listen() and run() ourselves so we can poll /status in
+    // the gap between bind and first-child-ready. Slow the ready
+    // signal to widen the window.
+    await handle.shutdown();
+
+    process.env.GRIST_TEST_RESTART_SHELL_READY_DELAY = "1500";
+    const shell = new RestartShell({
+      publicPort: 0,
+      childEntryPoint: require.resolve("stubs/app/server/server"),
+    });
+    handle = shell;
+
+    await shell.listen();
+    const runPromise = shell.run();
+
+    try {
+      const url = `http://localhost:${shell.port}/status`;
+      let sawStarting = false;
+      const deadline = Date.now() + 5000;
+      while (Date.now() < deadline && !sawStarting) {
+        const r = await axios.get(url, { validateStatus: () => true });
+        assert.notEqual(r.status, 200, `/status returned 200 during initial startup: ${JSON.stringify(r.data)}`);
+        sawStarting = r.status === 503 && r.data?.error === "starting";
+        if (!sawStarting) { await delay(50); }
+      }
+      assert.isTrue(sawStarting, "/status should report 503 starting before first child is ready");
+    } finally {
+      await runPromise;
+    }
   });
 
   it("should reject and set exitCode when initial spawn fails", async function() {


### PR DESCRIPTION
With this change, /status no longer claims the server is "alive" during the very first startup. Before, RestartShell would answer 200 OK on /status before the first child had ever signalled ready; now it returns 503 with {"error":"starting"} until the child is up. Restart windows are unchanged.
