### PR TITLE
block strangers from the Quick Setup page

### DIFF
--- a/app/client/ui/AdminAccessDeniedCard.ts
+++ b/app/client/ui/AdminAccessDeniedCard.ts
@@ -1,0 +1,36 @@
+import { makeT } from "app/client/lib/localization";
+import { urlState } from "app/client/models/gristUrlState";
+import { SectionCard } from "app/client/ui/SettingsLayout";
+import { bigPrimaryButtonLink } from "app/client/ui2018/buttons";
+import { testId } from "app/client/ui2018/cssVars";
+
+import { dom } from "grainjs";
+
+const t = makeT("AdminAccessDeniedCard");
+
+/**
+ * Fallback card shown to visitors who land on an admin page without the
+ * privileges to use it -- either no signed-in user, or a user who fails
+ * the install-admin check. Points them at the boot-key recovery path.
+ */
+export function buildAdminAccessDeniedCard() {
+  // `next` is validated against AdminPanelPage on arrival, so it can't redirect
+  // off-site even if a user hand-edits the URL.
+  const bootUrl = new URL(urlState().makeUrl({ boot: "boot" }), window.location.origin);
+  const adminPanel = urlState().state.get().adminPanel;
+  if (adminPanel && adminPanel !== "admin") {
+    bootUrl.searchParams.set("next", adminPanel);
+  }
+  return SectionCard(t("Administrator Panel Unavailable"), [
+    dom("p", t(`You do not have access to the administrator panel.
+Please log in as an administrator.`)),
+    dom("p", t(`If you are the server operator, you can sign in using the boot key from your server logs.`)),
+    dom("p",
+      bigPrimaryButtonLink(
+        dom.attr("href", bootUrl.href),
+        t("Sign in with boot key"),
+      ),
+    ),
+    testId("admin-panel-error"),
+  ]);
+}

--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -8,6 +8,7 @@ import { AuditLogsModel, AuditLogsModelImpl } from "app/client/models/AuditLogsM
 import { urlState } from "app/client/models/gristUrlState";
 import { AccountWidget } from "app/client/ui/AccountWidget";
 import { cssEmail, cssUserInfo, cssUserName } from "app/client/ui/AccountWidgetCss";
+import { buildAdminAccessDeniedCard } from "app/client/ui/AdminAccessDeniedCard";
 import { buildAdminData } from "app/client/ui/AdminControls";
 import { buildAdminLeftPanel, getPageNames } from "app/client/ui/AdminLeftPanel";
 import {
@@ -50,7 +51,7 @@ import { buildInstallationIdDisplay } from "app/client/ui/ToggleEnterpriseWidget
 import { createTopBarHome } from "app/client/ui/TopBar";
 import { createUserImage } from "app/client/ui/UserImage";
 import { fullBreadcrumbs } from "app/client/ui2018/breadcrumbs";
-import { basicButton, bigPrimaryButton, bigPrimaryButtonLink } from "app/client/ui2018/buttons";
+import { basicButton, bigPrimaryButton } from "app/client/ui2018/buttons";
 import { testId, theme } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
 import { cssLink, makeLinks } from "app/client/ui2018/links";
@@ -86,6 +87,10 @@ const t = makeT("AdminPanel");
 // consider a version check to be stale. It's a big number, but we're
 // still far away from the max at Number.MAX_SAFE_INTEGER
 const STALE_VERSION_CHECK_TIME_IN_MS = 14 * 24 * 60 * 60 * 1000;
+
+function isInstallationPage(page: AdminPanelPage): boolean {
+  return page === "admin" || page === "setup";
+}
 
 /**
  * Shared restart-banner state so the left-panel "Apply changes" entry can
@@ -167,7 +172,7 @@ export class AdminPanel extends Disposable {
       // Setting tabIndex allows selecting and copying text. This is helpful on admin pages, e.g.
       // to copy GRIST_BOOT_KEY or version number. But we don't set it for buidAdminData() pages
       // because it messes with focus in GridViews, and its unclear how to undo its effect.
-      dom.attr("tabindex", use => ["admin", "setup"].includes(use(this._page)) ? "-1" : null),
+      dom.attr("tabindex", use => isInstallationPage(use(this._page)) ? "-1" : null),
 
       dom.domComputed(this._page, (page) => {
         if (page === "admin") {
@@ -179,7 +184,7 @@ export class AdminPanel extends Disposable {
         }
       }),
 
-      cssPageContainer.cls("-admin-pages", use => use(this._page) !== "admin"),
+      cssPageContainer.cls("-admin-pages", use => !isInstallationPage(use(this._page))),
 
       testId("admin-panel"),
     );
@@ -308,21 +313,7 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
    * which could include a legit administrator if auth is misconfigured.
    */
   private _buildMainContentForOthers() {
-    return SectionCard(t("Administrator Panel Unavailable"), [
-      dom("p", t(`You do not have access to the administrator panel.
-Please log in as an administrator.`)),
-      dom(
-        "p",
-        t(`If you are the server operator, you can sign in using the boot key from your server logs.`),
-      ),
-      dom("p",
-        bigPrimaryButtonLink(
-          urlState().setLinkUrl({ boot: "boot" }),
-          t("Sign in with boot key"),
-        ),
-      ),
-      testId("admin-panel-error"),
-    ]);
+    return buildAdminAccessDeniedCard();
   }
 
   private _buildMainContentForAdmin() {

--- a/app/client/ui/BootPage.ts
+++ b/app/client/ui/BootPage.ts
@@ -21,6 +21,7 @@ import { theme } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
 import { unstyledButton } from "app/client/ui2018/unstyled";
 import { ApiError } from "app/common/ApiError";
+import { AdminPanelPage } from "app/common/gristUrls";
 import { isEmail } from "app/common/gutil";
 import { tokens } from "app/common/ThemePrefs";
 
@@ -223,7 +224,9 @@ check your terminal, container logs, or hosting panel: {{exampleBootKeyBanner}}`
 
             this._loginError.set(null);
 
-            window.location.assign(urlState().makeUrl({ adminPanel: "admin" }));
+            const nextParam = new URLSearchParams(window.location.search).get("next");
+            const next = AdminPanelPage.parse(nextParam) || "admin";
+            window.location.assign(urlState().makeUrl({ adminPanel: next }));
           },
           onError: (e) => {
             if (this.isDisposed()) { return; }

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -3,6 +3,7 @@ import { AdminChecks } from "app/client/models/AdminChecks";
 import { AppModel } from "app/client/models/AppModel";
 import { reportError } from "app/client/models/errors";
 import { getHomeUrl } from "app/client/models/homeUrl";
+import { buildAdminAccessDeniedCard } from "app/client/ui/AdminAccessDeniedCard";
 import { cssFadeUp, cssFadeUpGristLogo, cssFadeUpHeading, cssFadeUpSubHeading } from "app/client/ui/AdminPanelCss";
 import { AuthenticationSection } from "app/client/ui/AuthenticationSection";
 import { BackupsSection } from "app/client/ui/BackupsSection";
@@ -27,6 +28,9 @@ interface Step {
 export class QuickSetup extends Disposable {
   private _activeStep = Observable.create<number>(this, 0);
   private _checks = new AdminChecks(this, new InstallAPIImpl(getHomeUrl()));
+  // True once `_checks.fetchAvailableChecks()` has settled. Prevents a flash
+  // of the access-denied card while probes are still `[]` from initialization.
+  private _checksLoaded = Observable.create<boolean>(this, false);
   private _steps: Step[] = [
     {
       label: t("Server"),
@@ -57,10 +61,25 @@ export class QuickSetup extends Disposable {
 
   constructor(private _appModel: AppModel) {
     super();
-    this._checks.fetchAvailableChecks().catch(reportError);
   }
 
   public buildDom() {
+    if (!this._appModel.currentValidUser) {
+      return buildAdminAccessDeniedCard();
+    }
+    this._checks.fetchAvailableChecks()
+      .catch(reportError)
+      .finally(() => {
+        if (!this.isDisposed()) { this._checksLoaded.set(true); }
+      });
+    return dom.maybe(this._checksLoaded, () =>
+      this._checks.probes.get().length > 0 ?
+        this._buildSetupContent() :
+        buildAdminAccessDeniedCard(),
+    );
+  }
+
+  private _buildSetupContent() {
     return cssMainContent(
       cssFadeUpGristLogo(),
       cssFadeUpHeading(t("Quick setup")),

--- a/test/nbrowser/QuickSetupAuth.ts
+++ b/test/nbrowser/QuickSetupAuth.ts
@@ -123,4 +123,20 @@ describe("QuickSetupAuth", function() {
     assert.notMatch(pageText, /Restart required/,
       "Restart warning should not appear in setup wizard");
   });
+
+  it("should show access denied card to a non-admin visitor", async function() {
+    // Sign out and load /admin/setup directly. The page must not render the
+    // configure controls -- it should fall back to the boot-key card so a
+    // misconfigured-or-curious visitor sees the same "go away" UI as on
+    // /admin.
+    await server.removeLogin();
+    await driver.get(`${server.getHost()}/admin/setup`);
+    await driver.findContentWait(
+      ".test-admin-panel-error", "Administrator Panel Unavailable", 2000,
+    );
+    assert.isTrue(await driver.findContent("a", "Sign in with boot key").isDisplayed());
+    // Setup steps must not be rendered.
+    assert.lengthOf(await driver.findAll(".test-quick-setup-auth-continue"), 0);
+    assert.lengthOf(await driver.findAll(".test-quick-setup-server-continue"), 0);
+  });
 });


### PR DESCRIPTION
Until now, anyone who knew the URL could open /admin/setup and see the same configure controls a real admin sees. The buttons didn't actually work -- the API still rejected the calls -- but the page itself never said no.

The page now checks who is signed in. If you are not the admin, you get the same "Administrator Panel Unavailable" card as /admin, with a link to sign in using the boot key.

The card is shared between AdminPanel and QuickSetup so they stay in sync. A new browser test signs out, loads /admin/setup, and confirms the setup wizard never appears.
