### PR TITLE
export interface EmojiPickerOptions

### DIFF
--- a/app/client/ui/EmojiPicker.ts
+++ b/app/client/ui/EmojiPicker.ts
@@ -2,7 +2,7 @@ import data from "@emoji-mart/data";
 import { Picker } from "emoji-mart";
 import { DomContents } from "grainjs";
 
-interface EmojiPickerOptions {
+export interface EmojiPickerOptions {
   onEmojiSelect: (emoji: any) => void;
   theme?: "auto" | "dark" | "light";
 }


### PR DESCRIPTION
Export a missing interface referenced in an exported function. Doesn't matter within `grist-core`, but the `grist-static` build trips over this for complicated reasons, and it is hard to work around.
