### PR TITLE
send admins through sign-in after they change auth settings

### DIFF
--- a/app/client/lib/urlUtils.ts
+++ b/app/client/lib/urlUtils.ts
@@ -87,6 +87,11 @@ export function getLoginOrSignupUrl(options: GetLoginOrSignupUrlOptions = {}): s
   return getLoginPageUrl("signin", options);
 }
 
+// Navigate the browser to the login page, with the current URL as `nextUrl`.
+export function redirectToLogin() {
+  window.location.assign(getLoginUrl({ nextUrl: window.location.href }));
+}
+
 export function getWelcomeHomeUrl() {
   const url = buildURL("/welcome/home", {
     hash: null,

--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -2,6 +2,7 @@ import { buildHomeBanners } from "app/client/components/Banners";
 import { makeT } from "app/client/lib/localization";
 import { markdown } from "app/client/lib/markdown";
 import { getTimeFromNow } from "app/client/lib/timeUtils";
+import { redirectToLogin } from "app/client/lib/urlUtils";
 import { AdminCheckRequest, AdminChecks, probeDetails, ProbeDetails } from "app/client/models/AdminChecks";
 import { AppModel, getHomeUrl, reportError } from "app/client/models/AppModel";
 import { AuditLogsModel, AuditLogsModelImpl } from "app/client/models/AuditLogsModel";
@@ -202,6 +203,9 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
   // separately via `_drafts.needsRestart`; both are combined into
   // `_showRestartBanner`.
   public needsRestart = Observable.create(this, false);
+  // Set when a pending change will sign the admin out on apply. Read
+  // after restart to route through /login.
+  public needsLogin = Observable.create(this, false);
   // Sticky flag: true after the user has applied changes without a restart
   // in an environment that doesn't support auto-restart. Keeps the manual
   // restart reminder on screen until the user reloads the page. Cleared only
@@ -298,10 +302,21 @@ class AdminInstallationPanel extends Disposable implements AdminPanelControls {
     // their own. They only mark themselves `needsRestart` and route through
     // here, so a single user click always produces exactly one restart even
     // when several sections are dirty at once.
+    // Snapshot before applying: the restart clears it.
+    const willInvalidateSession = this.needsLogin.get();
+
     if (this._drafts.needsRestart.get()) {
       await this._drafts.applyAll();
     } else {
       await this._configAPI.restartServer();
+      if (!await this._configAPI.waitUntilReady()) {
+        await reloadSafe();
+        return;
+      }
+    }
+    if (willInvalidateSession) {
+      redirectToLogin();
+      return;
     }
     await reloadSafe();
   }

--- a/app/client/ui/AdminPanelCss.ts
+++ b/app/client/ui/AdminPanelCss.ts
@@ -10,7 +10,12 @@ import { components, tokens } from "app/common/ThemePrefs";
 import { dom, IDisposableOwner, keyframes, Observable, styled } from "grainjs";
 
 export interface AdminPanelControls {
+  // Pending changes need a restart to take effect; drives the banner.
   needsRestart: Observable<boolean>;
+  // Pending changes will sign the admin out on apply, so route through
+  // /login afterwards instead of reloading. Today this matches needsRestart,
+  // but they're conceptually distinct.
+  needsLogin: Observable<boolean>;
   restartGrist: () => Promise<void>;
 }
 

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -1,6 +1,7 @@
 import { makeT } from "app/client/lib/localization";
 import { localStorageBoolObs } from "app/client/lib/localStorageObs";
 import { cssMarkdownSpan } from "app/client/lib/markdown";
+import { redirectToLogin } from "app/client/lib/urlUtils";
 import { AdminChecks } from "app/client/models/AdminChecks";
 import { AppModel, getHomeUrl, reportError } from "app/client/models/AppModel";
 import {
@@ -12,6 +13,7 @@ import {
 } from "app/client/ui/AdminPanelCss";
 import { ChangeAdminModal } from "app/client/ui/ChangeAdminModal";
 import { GetGristComProviderInfoModal, getGristComProviderMeta } from "app/client/ui/GetGristComProvider";
+import { ApplyResult } from "app/client/ui/QuickSetupContinueButton";
 import { quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
 import { cssCardSurface } from "app/client/ui/SettingsLayout";
 import { cssHeroCard } from "app/client/ui/SetupCard";
@@ -88,6 +90,7 @@ export class AuthenticationSection extends Disposable {
   private _inAdminPanel = Boolean(this._options.controls);
   private _controls = this._options.controls ?? {
     needsRestart: Observable.create(this, false),
+    needsLogin: Observable.create(this, false),
     restartGrist: async () => { await new ConfigAPI(getHomeUrl()).restartServer(); },
   };
 
@@ -141,12 +144,14 @@ export class AuthenticationSection extends Disposable {
    * Apply pending auth changes by restarting the server and waiting until
    * it's ready again. The relevant config writes have already happened
    * inline (via the configuration modals); this is purely the restart so
-   * the new config takes effect. After restart, re-fetches providers and
-   * prefs so the section reflects the post-restart state.
+   * the new config takes effect.
    *
-   * No-op when there are no pending changes. Throws on restart timeout.
+   * On success, fires a top-level navigation through sign-in (the admin's
+   * session is gone after the restart) and returns `{ redirected: true }`
+   * so the caller knows not to run any post-apply step. No-op when there
+   * are no pending changes. Throws on restart timeout.
    */
-  public async apply(): Promise<void> {
+  public async apply(): Promise<ApplyResult> {
     if (!this.isDirty.get()) { return; }
     if (this.isApplying.get()) { return; }
     this.isApplying.set(true);
@@ -155,11 +160,12 @@ export class AuthenticationSection extends Disposable {
       if (!await this._configAPI.waitUntilReady()) {
         throw new Error("Timed out waiting for Grist server to restart");
       }
-      if (this.isDisposed()) { return; }
-      await Promise.all([this._fetchProviders(), this._fetchPrefsPendingChanges()]);
     } finally {
       if (!this.isDisposed()) { this.isApplying.set(false); }
     }
+    if (this.isDisposed()) { return; }
+    redirectToLogin();
+    return { redirected: true };
   }
 
   public buildDom() {
@@ -397,6 +403,7 @@ authentication system.",
     const needsRestart = hasActiveOnRestartProvider || hasUnappliedRestartPrefs;
     if (needsRestart) {
       this._controls.needsRestart.set(true);
+      this._controls.needsLogin.set(true);
     }
   }
 }

--- a/app/client/ui/QuickSetupContinueButton.ts
+++ b/app/client/ui/QuickSetupContinueButton.ts
@@ -21,6 +21,14 @@ import { Computed, dom, DomElementArg, Observable, styled, UseCBOwner } from "gr
 
 const t = makeT("QuickSetupContinueButton");
 
+/**
+ * What `apply()` reports back. `void` (the default) means the apply
+ * completed and the wizard should run its post-apply action; the
+ * `{ redirected: true }` variant means a top-level navigation has been
+ * fired, and the caller should not run any further post-apply work.
+ */
+export type ApplyResult = void | { redirected: true };
+
 export interface QuickSetupSection {
   /** True when the step's content is in a state the user can move past. */
   canProceed: Computed<boolean>;
@@ -31,8 +39,11 @@ export interface QuickSetupSection {
   /**
    * Persist any pending changes and (if needed) restart the server.
    * No-op if nothing is pending. Owns its own `isApplying` flag.
+   * Returns `{ redirected: true }` when the apply fired a top-level
+   * navigation (e.g. session-clearing auth change → sign-in); the caller
+   * should not run any post-apply action in that case.
    */
-  apply(): Promise<void>;
+  apply(): Promise<ApplyResult>;
   /** Optional per-step label override. Return null/undefined to use the default labels. */
   customLabel?(use: UseCBOwner): string | null | undefined;
 }
@@ -57,12 +68,14 @@ export function quickSetupContinueButton(
       dom.boolAttr("disabled", use => !use(section.canProceed) || use(section.isApplying)),
       dom.on("click", async () => {
         if (section.isApplying.get()) { return; }
+        let result: ApplyResult;
         try {
-          await section.apply();
+          result = await section.apply();
         } catch (err) {
           reportError(err as Error);
           return;
         }
+        if (result?.redirected) { return; }
         onAfter();
       }),
       ...args,

--- a/app/server/lib/TestingHooks.ts
+++ b/app/server/lib/TestingHooks.ts
@@ -12,6 +12,7 @@ import { connect, fromCallback } from "app/server/lib/serverUtils";
 import { WidgetRepositoryImpl } from "app/server/lib/WidgetRepository";
 
 import { EventEmitter } from "events";
+import * as fs from "fs";
 import * as net from "net";
 
 import { Request } from "express";
@@ -23,6 +24,13 @@ const tiCheckers = t.createCheckers(ITestingHooksTI, { UserProfile: t.name("obje
 export function startTestingHooks(socketPath: string, port: number,
   comm: Comm, flexServer: FlexServer,
   workerServers: FlexServer[]): Promise<net.Server> {
+  // Unix domain socket files stick around after the previous owner exits,
+  // so reusing the same path on an in-process restart (RestartShell forking
+  // a fresh worker) would fail to bind. Remove it first; the path is
+  // test-private so this is safe.
+  try { fs.unlinkSync(socketPath); } catch (err: any) {
+    if (err?.code !== "ENOENT") { throw err; }
+  }
   // Create socket server listening on the given path for testing connections.
   return new Promise((resolve, reject) => {
     const server = net.createServer();

--- a/test/nbrowser/AuthProvider.ts
+++ b/test/nbrowser/AuthProvider.ts
@@ -1,10 +1,11 @@
 import { expandProviderList, itemValue, toggleItem } from "test/nbrowser/AdminPanelTools";
 import * as gu from "test/nbrowser/gristUtils";
+import { startMockOIDCIssuer } from "test/nbrowser/oidcMockServer";
+import { useFastSandboxProbe } from "test/nbrowser/sandboxProbeFixture";
 import { server, setupTestSuite } from "test/nbrowser/testUtils";
-import { serveSomething, Serving } from "test/server/customUtil";
+import { Serving } from "test/server/customUtil";
 import * as testUtils from "test/server/testUtils";
 
-import * as express from "express";
 import { assert, driver, WebElementPromise } from "mocha-webdriver";
 
 describe("AuthProvider", function() {
@@ -20,19 +21,10 @@ describe("AuthProvider", function() {
     oldEnv = new testUtils.EnvironmentSnapshot();
     process.env.GRIST_DEFAULT_EMAIL = user.email;
     process.env.GRIST_TEST_SERVER_DEPLOYMENT_TYPE = "core";
+    useFastSandboxProbe();
     await server.restart();
 
-    serving = await serveSomething((app) => {
-      app.use(express.json());
-      app.get("/.well-known/openid-configuration", (req, res) => {
-        res.json({
-          issuer: serving.url + "?provider=getgrist.com",
-        });
-      });
-      app.use((req) => {
-        assert.fail(`Unexpected request to test OIDC server: ${req.method} ${req.url}`);
-      });
-    });
+    serving = await startMockOIDCIssuer({ failUnexpectedRequests: true });
   });
 
   after(async function() {

--- a/test/nbrowser/AuthProviderGetGrist.ts
+++ b/test/nbrowser/AuthProviderGetGrist.ts
@@ -1,8 +1,10 @@
 import { Activation } from "app/gen-server/entity/Activation";
 import { expandProviderList, itemValue, toggleItem } from "test/nbrowser/AdminPanelTools";
 import * as gu from "test/nbrowser/gristUtils";
+import { startMockOIDCIssuer } from "test/nbrowser/oidcMockServer";
+import { useFastSandboxProbe } from "test/nbrowser/sandboxProbeFixture";
 import { server, setupTestSuite } from "test/nbrowser/testUtils";
-import { Defer, serveSomething, Serving } from "test/server/customUtil";
+import { Defer, Serving } from "test/server/customUtil";
 import * as testUtils from "test/server/testUtils";
 
 import * as express from "express";
@@ -24,26 +26,12 @@ describe("AuthProviderGetGrist", function() {
     process.env.GRIST_TEST_SERVER_DEPLOYMENT_TYPE = "core";
     // Make sure no APP_HOME_URL is set, to use calculated one.
     delete process.env.APP_HOME_URL;
+    useFastSandboxProbe();
     await server.restart();
 
-    serving = await serveSomething((app) => {
-      app.use((req, res, next) => {
-        currentRequest.set(req);
-        next();
-      });
-      app.use(express.json());
-      app.get("/.well-known/openid-configuration", (req, res) => {
-        res.json({
-          issuer: `${serving.url}?provider=getgrist.com`,
-          authorization_endpoint: `${serving.url}/authorize`,
-        });
-      });
-      app.get("/authorize", (req, res) => {
-        res.sendStatus(200);
-      });
-      app.use((req) => {
-        console.warn(`Unexpected request to test OIDC server: ${req.method} ${req.url}`);
-      });
+    serving = await startMockOIDCIssuer({
+      authorize: true,
+      onRequest: req => currentRequest.set(req),
     });
   });
 

--- a/test/nbrowser/QuickSetupAuth.ts
+++ b/test/nbrowser/QuickSetupAuth.ts
@@ -1,4 +1,6 @@
+import { FORWARD_AUTH_PROVIDER_KEY } from "app/common/loginProviders";
 import * as gu from "test/nbrowser/gristUtils";
+import { startMockOIDCIssuer } from "test/nbrowser/oidcMockServer";
 import { server, setupTestSuite } from "test/nbrowser/testUtils";
 import * as testUtils from "test/server/testUtils";
 
@@ -124,6 +126,106 @@ describe("QuickSetupAuth", function() {
       "Restart warning should not appear in setup wizard");
   });
 
+  it("should advance to the next step on Continue when nothing is dirty", async function() {
+    // OIDC is configured (and erroring) from the earlier test. The continue
+    // button is enabled (a real provider is active) but isDirty is false
+    // because nothing is pending. Click should advance to the Backups step
+    // rather than triggering a restart or sign-in redirect.
+    await navigateToAuthStep();
+    const continueBtn = await driver.findWait(".test-quick-setup-auth-continue", 2000);
+    await gu.waitToPass(async () => {
+      assert.equal(await continueBtn.getAttribute("disabled"), null);
+    }, 2000);
+
+    await continueBtn.click();
+    await driver.findWait(".test-quick-setup-backups-continue", 2000);
+  });
+
+  // The redirect test exercises a real /api/admin/restart cycle, which
+  // requires the test server to run under RestartShell mode. Setup is
+  // heavy (three serial restarts to put forward-auth in prefs while
+  // keeping OIDC configured), so it lives in `before()` rather than the
+  // `it`. The sub-suite's `after()` restarts out of shell mode so later
+  // tests in the parent suite are unaffected.
+  describe("session-clearing apply (RestartShell mode)", function() {
+    let envSnapshot: testUtils.EnvironmentSnapshot;
+    let oidc: Awaited<ReturnType<typeof startMockOIDCIssuer>>;
+
+    before(async function() {
+      envSnapshot = new testUtils.EnvironmentSnapshot();
+      try {
+        oidc = await startMockOIDCIssuer({ authorize: true });
+
+        // GRIST_RESTART_SHELL=true overrides the GRIST_TESTING_SOCKET gate in
+        // shouldRunAsRestartShell so /api/admin/restart actually drives a
+        // worker restart in nbrowser (default would 409).
+        process.env.GRIST_RESTART_SHELL = "true";
+        process.env.GRIST_OIDC_IDP_ISSUER = oidc.url;
+        process.env.GRIST_OIDC_IDP_CLIENT_ID = "test-client-id";
+        process.env.GRIST_OIDC_IDP_CLIENT_SECRET = "test-client-secret";
+        process.env.GRIST_OIDC_IDP_SKIP_END_SESSION_ENDPOINT = "true";
+        process.env.GRIST_FORWARD_AUTH_HEADER = "x-forwarded-user";
+        process.env.GRIST_FORWARD_AUTH_LOGOUT_PATH = "/logout";
+        await server.restart();
+        // GRIST_OIDC_SP_HOST is a full URL used as a base for the callback URL.
+        process.env.GRIST_OIDC_SP_HOST = server.getHost();
+        await server.restart();
+
+        // Persist active=forward-auth in prefs (not env) so isNewFixedByEnv
+        // doesn't block the UI's "Set as active" buttons.
+        await server.simulateLogin(user.name, user.email, "docs");
+        await driver.get(`${server.getHost()}/admin`);
+        const setActiveOk = await driver.executeAsyncScript(`
+          const done = arguments[arguments.length - 1];
+          fetch('/api/config/auth-providers/set-active', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ providerKey: ${JSON.stringify(FORWARD_AUTH_PROVIDER_KEY)} }),
+            credentials: 'include',
+          }).then(r => done(r.ok)).catch(e => done('error: ' + e.message));
+        `);
+        assert.strictEqual(setActiveOk, true);
+        await server.restart();
+      } catch (err) {
+        // after() doesn't run if before() throws, so undo what we touched.
+        envSnapshot.restore();
+        await oidc?.shutdown();
+        throw err;
+      }
+    });
+
+    after(async function() {
+      envSnapshot.restore();
+      // Restart out of shell mode so subsequent suites' testingHooks RPC
+      // connection re-initialises against a fresh worker.
+      await server.restart();
+      await oidc?.shutdown();
+    });
+
+    it("should redirect through sign-in after applying a session-clearing auth change",
+      async function() {
+        await navigateToAuthStep();
+        const header = await driver.findWait(".test-admin-auth-provider-list-header", 4000);
+        if (await header.getAttribute("aria-expanded") === "false") {
+          await header.click();
+        }
+        const oidcRow = await driver.findContentWait(
+          ".test-admin-auth-provider-row", /OIDC/, 4000);
+        await oidcRow.find(".test-admin-auth-set-active-button").click();
+        await driver.findWait(".test-modal-confirm", 2000).click();
+        await gu.waitForServer();
+
+        const continueBtn = await driver.findWait(".test-quick-setup-auth-continue", 2000);
+        await gu.waitToPass(async () => {
+          assert.match(await continueBtn.getText(), /Apply and Continue/i);
+        }, 2000);
+
+        await continueBtn.click();
+        await driver.wait(async () => (await driver.getCurrentUrl()).startsWith(oidc.url), 30000);
+        assert.match(await driver.getPageSource(), /oidc-mock-authorize/);
+      });
+  });
+
   it("should show access denied card to a non-admin visitor", async function() {
     // Sign out and load /admin/setup directly. The page must not render the
     // configure controls -- it should fall back to the boot-key card so a
@@ -138,5 +240,24 @@ describe("QuickSetupAuth", function() {
     // Setup steps must not be rendered.
     assert.lengthOf(await driver.findAll(".test-quick-setup-auth-continue"), 0);
     assert.lengthOf(await driver.findAll(".test-quick-setup-server-continue"), 0);
+  });
+
+  it("should show access denied card to a signed-in non-admin user", async function() {
+    // Same fallback should apply when the visitor is signed in but is not
+    // the install admin -- they shouldn't see the configure controls just
+    // because they have a session.
+    const nonAdmin = gu.translateUser("user2");
+    await server.removeLogin();
+    try {
+      await server.simulateLogin(nonAdmin.name, nonAdmin.email, "docs");
+      await driver.get(`${server.getHost()}/admin/setup`);
+      await driver.findContentWait(
+        ".test-admin-panel-error", "Administrator Panel Unavailable", 2000,
+      );
+      assert.lengthOf(await driver.findAll(".test-quick-setup-auth-continue"), 0);
+      assert.lengthOf(await driver.findAll(".test-quick-setup-server-continue"), 0);
+    } finally {
+      await server.removeLogin();
+    }
   });
 });

--- a/test/nbrowser/oidcMockServer.ts
+++ b/test/nbrowser/oidcMockServer.ts
@@ -1,0 +1,62 @@
+import { serveSomething, Serving } from "test/server/customUtil";
+
+import * as express from "express";
+import { assert } from "mocha-webdriver";
+
+export interface MockOIDCIssuerOptions {
+  // Fail any request not handled by an explicit route. Use when the test
+  // only expects discovery to be hit.
+  failUnexpectedRequests?: boolean;
+  // Advertise an /authorize endpoint and respond 200 there. Use when the
+  // test follows a redirect from /login through to the issuer.
+  authorize?: boolean;
+  // Capture every request before route handlers run.
+  onRequest?: (req: express.Request) => void;
+}
+
+/**
+ * Fake OIDC issuer for nbrowser tests. Pass `serving.url` as
+ * GRIST_OIDC_IDP_ISSUER. Caller owns the lifecycle: call `shutdown()`
+ * in your `after()` hook.
+ */
+export async function startMockOIDCIssuer(
+  options: MockOIDCIssuerOptions = {},
+): Promise<Serving> {
+  const serving: Serving = await serveSomething((app) => {
+    if (options.onRequest) {
+      const onRequest = options.onRequest;
+      app.use((req, _res, next) => { onRequest(req); next(); });
+    }
+    app.use(express.json());
+    app.get("/.well-known/openid-configuration", (_req, res) => {
+      const config: Record<string, unknown> = {
+        issuer: serving.url + "?provider=getgrist.com",
+      };
+      if (options.authorize) {
+        config.authorization_endpoint = serving.url + "/authorize";
+        // Extra endpoints openid-client requires when it walks discovery
+        // for real (e.g. QuickSetupAuth's RestartShell case). Routes don't
+        // need to actually exist; nothing in our tests reaches them.
+        config.token_endpoint = serving.url + "/token";
+        config.jwks_uri = serving.url + "/jwks";
+        config.response_types_supported = ["code"];
+        config.subject_types_supported = ["public"];
+        config.id_token_signing_alg_values_supported = ["RS256"];
+      }
+      res.json(config);
+    });
+    if (options.authorize) {
+      app.get("/authorize", (_req, res) => {
+        res.status(200).type("html").send(
+          "<!doctype html><html><body>oidc-mock-authorize</body></html>",
+        );
+      });
+    }
+    if (options.failUnexpectedRequests) {
+      app.use((req) => {
+        assert.fail(`Unexpected request to test OIDC server: ${req.method} ${req.url}`);
+      });
+    }
+  });
+  return serving;
+}

--- a/test/nbrowser/sandboxProbeFixture.ts
+++ b/test/nbrowser/sandboxProbeFixture.ts
@@ -1,0 +1,26 @@
+import { BootProbeResult } from "app/common/BootProbe";
+
+// Canned probe result for tests that load the AdminPanel but don't care
+// about the sandbox section. Stops the real /probes/sandbox-providers
+// handler from spawning a gvisor probe, which takes ~5s to fail on
+// machines without runsc and can time out waitForServer.
+export const FAST_NO_SANDBOX_PROBE: BootProbeResult = {
+  status: "success",
+  details: {
+    options: [{
+      flavor: "unsandboxed",
+      available: true,
+      effective: true,
+      functional: true,
+      configured: false,
+      lastSuccessfulStep: "none",
+    }],
+    current: "unsandboxed",
+  },
+};
+
+// Set the probe-result env var. Caller should snapshot/restore env around
+// this so the value doesn't leak between suites.
+export function useFastSandboxProbe(fixture: BootProbeResult = FAST_NO_SANDBOX_PROBE) {
+  process.env.GRIST_TEST_SANDBOX_PROVIDERS_PROBE_RESULT = JSON.stringify(fixture);
+}


### PR DESCRIPTION
After an admin configures auth in the Quick Setup wizard or admin panel, Grist now sends them through /login instead of leaving the page wedged on a 401. The session is cleared by the restart the change requires; the redirect picks up the current URL, so signing back in returns the admin to where they were.

The wizard's apply path is in AuthenticationSection.apply, and the admin panel's is in AdminPanel._performRestart. Both use a small redirectToLogin helper in urlUtils.ts.

A new browser test covers the wizard end-to-end. Several small pieces of test infrastructure came along with it:

- TestingHooks unlinks its unix socket file before binding, so an in-process server restart can rebind without an EADDRINUSE.

- A getTestingOverride helper (gated on GRIST_TESTING_SOCKET so production can't trip it) lets the test harness skip the slow sandbox boot-probe.

- The OIDC mock issuer used by AuthProvider and AuthProviderGetGrist moved into a shared helper at test/nbrowser/oidcMockServer.ts.

- The new test opts the wizard into RestartShell mode so /api/admin/restart actually drives a worker restart in nbrowser.
