### PR TITLE
Store a session for anonymous user when requesting using XHR

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ Grist can be configured in many ways. Here are the main environment variables it
 | GRIST_LOG_AS_JSON | When this variable is set to `true` or a truthy value, output log lines in JSON as opposed to a plain text format. |
 | GRIST_LOG_API_DETAILS | When this variable is set to `true` or a truthy value, log the API calls details. |
 | COOKIE_MAX_AGE | session cookie max age, defaults to 90 days; can be set to "none" to make it a session cookie |
+| COOKIE_MAX_AGE_ANONYMOUS | session cookie max age for anonymous sessions, defaults to 5 minutes; can be set to "none" to make it a session cookie |
 | HOME_PORT | port number to listen on for REST API server; if set to "share", add API endpoints to regular grist port. |
 | PORT | port number to listen on for Grist server |
 | REDIS_URL | optional redis server for browser sessions and db query caching |

--- a/app/server/lib/Authorizer.ts
+++ b/app/server/lib/Authorizer.ts
@@ -16,7 +16,7 @@ import {
 import { expressWrap } from "app/server/lib/expressWrap";
 import { RequestWithOrg } from "app/server/lib/extractOrg";
 import { GristServer } from "app/server/lib/GristServer";
-import { COOKIE_MAX_AGE,
+import { COOKIE_MAX_AGE, COOKIE_MAX_AGE_ANONYMOUS,
   cookieName as sessionCookieName, getAllowedOrgForSessionID, getCookieDomain } from "app/server/lib/gristSessions";
 import { getBootKey } from "app/server/lib/gristSettings";
 import log from "app/server/lib/log";
@@ -141,6 +141,8 @@ function setRequestUser(mreq: RequestWithLogin, dbManager: HomeDBAuth, user: Use
   mreq.userId = user.id;
   mreq.userIsAuthorized = (user.id !== dbManager.getAnonymousUserId());
 
+  expandUserSessionIfNewlyLoggedIn(mreq);
+
   const fullUser = dbManager.makeFullUser(user);
   // This is dumb, but historically, we used 'email' field inconsistently; in this Authorizer
   // flow, it was set to the normalized email, rather than the display email. The difference is
@@ -154,6 +156,19 @@ function setRequestUser(mreq: RequestWithLogin, dbManager: HomeDBAuth, user: Use
   mreq.fullUser = fullUser;
   if (!mreq.users) {
     mreq.users = [fullUser];
+  }
+}
+
+/**
+ * Expand the user session lifetime if they have just logged in, since anonymous sessions have a shorter lifetime.
+ * This makes the session reflect the value set in COOKIE_MAX_AGE.
+ */
+function expandUserSessionIfNewlyLoggedIn(mreq: RequestWithLogin) {
+  const { originalMaxAge, maxAge } = mreq.session.cookie;
+  if (mreq.userIsAuthorized && COOKIE_MAX_AGE !== null && originalMaxAge && originalMaxAge < COOKIE_MAX_AGE) {
+    mreq.session.cookie.originalMaxAge = COOKIE_MAX_AGE;
+    mreq.session.cookie.expires = new Date(Date.now() + COOKIE_MAX_AGE + maxAge - originalMaxAge);
+    forceSessionChange(mreq.session);
   }
 }
 
@@ -484,15 +499,22 @@ export async function addRequestUser(
     },
   });
 
-  // Initialize altSessionId from the session. The original code guarded this with
-  // `!authDone && !skipSession`, which excluded access-token and boot-key paths.
-  // We now use just `!skipSession`, which is slightly broader: access-token and
+  const session = mreq.session;
+
+  const isAnon = identity.user.id === dbManager.getAnonymousUserId();
+  const genShortLivingSessionID: boolean = isAnon && mreq.xhr;
+  if (!skipSession && genShortLivingSessionID) {
+    session.cookie ||= {};
+    session.cookie.maxAge = COOKIE_MAX_AGE_ANONYMOUS;
+  }
+
+  // Initialize altSessionId from the session.
+  // We just use `!skipSession`, which is slightly broader: access-token and
   // boot-key requests will also get an altSessionId. This is harmless because
   // access-token requests are GETs for attachments (no trigger formulas) and
   // boot-key requests are admin-only. The alternative — threading authDone through
   // the IdentityResult — would complicate the interface for no practical benefit.
-  if (!skipSession && !identity.hasApiKey) {
-    const session = mreq.session;
+  if (!skipSession && !identity.hasApiKey && (!isAnon || genShortLivingSessionID)) {
     if (session && !session.altSessionId) {
       generateAltSessionID(session);
     }

--- a/app/server/lib/gristSessions.ts
+++ b/app/server/lib/gristSessions.ts
@@ -6,6 +6,7 @@ import log from "app/server/lib/log";
 import { fromCallback } from "app/server/lib/serverUtils";
 import { Sessions } from "app/server/lib/Sessions";
 
+import assert from "assert";
 import * as crypto from "crypto";
 import * as path from "path";
 
@@ -17,10 +18,25 @@ import { createClient } from "redis";
 
 export const cookieName = process.env.GRIST_SESSION_COOKIE || "grist_sid";
 
-export const COOKIE_MAX_AGE =
-  process.env.COOKIE_MAX_AGE === "none" ? null :
-    isNumber(process.env.COOKIE_MAX_AGE || "") ? Number(process.env.COOKIE_MAX_AGE) :
-      90 * 24 * 60 * 60 * 1000;  // 90 days in milliseconds
+function parseMaxAge(val: string | undefined, defaultValue: number): number | null {
+  return val === "none" ? null :
+    isNumber(val || "") ? Number(val) :
+      defaultValue;
+}
+
+export const COOKIE_MAX_AGE = parseMaxAge(
+  process.env.COOKIE_MAX_AGE,
+  90 * 24 * 60 * 60 * 1000, // 90 days in milliseconds
+);
+
+export const COOKIE_MAX_AGE_ANONYMOUS = parseMaxAge(
+  process.env.COOKIE_MAX_AGE_ANONYMOUS,
+  5 * 60 * 1000,
+);
+
+assert.ok((COOKIE_MAX_AGE_ANONYMOUS ?? Infinity) <= (COOKIE_MAX_AGE ?? Infinity),
+  "COOKIE_MAX_AGE_ANONYMOUS cannot be greater than COOKIE_MAX_AGE as anonymous session " +
+  "cannot live longer than regular sessions");
 
 // RedisStore and SqliteStore are expected to provide a set/get interface for sessions.
 export interface SessionStore {

--- a/test/server/lib/Authorizer.ts
+++ b/test/server/lib/Authorizer.ts
@@ -171,13 +171,33 @@ describe("Authorizer", function() {
 
   // This checks we create an altSessionID for Anonymous users. Useful in particular to give them
   // rights through Access Rules.
-  it("does generate a session when calling the API as anonymous", async function() {
+  it("does generate a session when calling the API as anonymous when using XHR", async function() {
     const nbSessionsBefore = await countSessions(server);
     const resp = await axios.get(`${serverUrl}/api/orgs`, anon);
 
     const nbSessionsAfter = await countSessions(server);
     assert.equal(resp.status, 200);
     assert.equal(nbSessionsAfter, nbSessionsBefore + 1, "A new session should have been created during the API call");
+    assert.exists(resp.headers["set-cookie"], "a cookie should have been returned");
+    assert.include(resp.headers["set-cookie"]![0], "Expires=");
+    assert.isBelow(
+      new Date(resp.headers["set-cookie"]![0].match(/(?<=Expires=)[^;]*/)![0]).getTime(),
+      Date.now() + 5 * 60 * 1000,
+    );
+  });
+
+  it("does not generate a session when calling the API as anonymous when NOT using XHR", async function() {
+    const anonNoXhr = configForUser("Anonymous");
+    // Delete the X-Requested-With Header set to "XMLHttpRequest", so we simulate a call
+    // using tools like curl.
+    delete anonNoXhr.headers!["X-Requested-With"];
+
+    const nbSessionsBefore = await countSessions(server);
+    const resp = await axios.get(`${serverUrl}/api/orgs`, anonNoXhr);
+
+    const nbSessionsAfter = await countSessions(server);
+    assert.equal(resp.status, 200);
+    assert.equal(nbSessionsAfter, nbSessionsBefore, "No session should have been created during the API call");
   });
 
   it("websocket allows openDoc for viewer", async function() {


### PR DESCRIPTION
## Context

Follow-up of #2246.

When making requests, we would like to avoid polluting the session store.

We could, as I thought initially, just skip the session creation for anonymous users, but as explained by Paul, it is possible to define an Access Rule in which we allow users to edit their own rows using the session ID:

<img width="1410" height="264" alt="Access Rules allowing to edit rows using the formula 'user.SessionID == $altSessionID'" src="https://github.com/user-attachments/assets/883c126a-86a4-4b51-bb01-14a8cca56f50" />

And create a *trigger* formula to store the user session ID:
<img width="1583" height="574" alt="A column with a trigger formula set to 'user.SessionID' meant to store for each row the sessionID used to create the row" src="https://github.com/user-attachments/assets/c22fe717-e1e2-4cbc-ac5c-70d328c6156c" />

In such case, anonymous user *need* to have a session ID.

## Proposed solution

Solving the issue while preserving this feature is not a simple task. Here is my proposal:
1. When the request is supposedly made by a browser (so using XHR), *and also* the user is not authenticated, we create a session with a shorter lifetime. By default it is set to 5 minutes (I can increase the default value if requested), and it is configurable using the `COOKIE_MAX_AGE_ANONYMOUS` env variable
2. In the other case, I don't generate an altSessionId as I assume that it has not much value (or does it for the logs maybe? But probably it is not reliable?)

## Related issues

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
