### PR TITLE
Use eager page load strategy for nbrowser tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,7 +196,7 @@ jobs:
         run: |
           mkdir -p $MOCHA_WEBDRIVER_LOGDIR
           export GREP_TESTS=$(echo $TESTS | sed "s/.*:nbrowser-\([^:]*\).*/\1/")
-          MOCHA_WEBDRIVER_SKIP_CLEANUP=1 MOCHA_WEBDRIVER_HEADLESS=1 yarn run test:nbrowser --parallel --jobs 3
+          MOCHA_WEBDRIVER_SKIP_CLEANUP=1 MOCHA_WEBDRIVER_HEADLESS=1 yarn run test:nbrowser --parallel --jobs 4
         env:
           TESTS: ${{ matrix.tests }}
           MOCHA_WEBDRIVER_LOGDIR: ${{ runner.temp }}/test-logs/webdriver


### PR DESCRIPTION
By default, Selenium's driver.get() waits for the full window.onload event before returning, which means waiting for every sub-resource (images, fonts, deferred scripts) to finish loading. Switching the page load strategy to "eager" makes it return as soon as the DOM is ready instead.

This is safe for our tests because every navigation is already followed by an explicit wait for a specific element (such as waitForDocToLoad or findWait), so the extra time spent waiting for sub-resources after the DOM is ready isn't doing any work for us.

Local timing on a small batch of suites suggested a few percent improvement in wall-clock time, but the measurement was noisy and the real impact across the full nbrowser run will only show up in CI. The change is a single config line.
