### PR TITLE
polish the quick-setup arrival paths

### DIFF
--- a/app/client/lib/urlUtils.ts
+++ b/app/client/lib/urlUtils.ts
@@ -89,7 +89,7 @@ export function getLoginOrSignupUrl(options: GetLoginOrSignupUrlOptions = {}): s
 
 // Navigate the browser to the login page, with the current URL as `nextUrl`.
 export function redirectToLogin() {
-  window.location.assign(getLoginUrl({ nextUrl: window.location.href }));
+  window.location.assign(getLoginUrl());
 }
 
 export function getWelcomeHomeUrl() {

--- a/app/client/ui/AdminLeftPanel.ts
+++ b/app/client/ui/AdminLeftPanel.ts
@@ -81,8 +81,7 @@ export function buildAdminLeftPanel(
       css.cssTools.cls("-collapsed", use => !use(panelOpen)),
       css.cssSectionHeader(css.cssSectionHeaderText(pageNames.settings)),
       buildPageEntry("admin", "Home"),
-      // TODO: Uncomment when setup page is ready.
-      // buildPageEntry("setup", "Settings"),
+      buildPageEntry("setup", "Settings"),
       restartBanner ? dom.maybe(restartBanner.isVisible, () =>
         cssApplyChangesEntry(
           css.cssPageButton(

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -164,6 +164,11 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
     return getgristLogin?.metadata?.owner ?? null;
   });
 
+  // Set by apply() to communicate to afterApply() whether the restart it just
+  // triggered will kill the operator's session, in which case afterApply
+  // redirects through sign-in.
+  private _willInvalidateSession = false;
+
   constructor(private _options: AuthenticationSectionOptions) {
     super();
 
@@ -237,13 +242,25 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
    * routes the now-signed-out admin through sign-in.
    */
   public async apply(): Promise<void> {
-    for (const [providerKey, config] of this._draftConfigs.get()) {
+    // Decide once, up front, whether the upcoming restart will kill the
+    // operator's session: any provider draft sets `onRestartClearSessions`
+    // server-side (configureProvider / setActiveAuthProvider), and a queued
+    // admin-email change is staged with the same flag (see _setInstallAdmin).
+    const draftConfigs = this._draftConfigs.get();
+    const activeChoice = this._draftActiveProvider.get();
+    const prefs = this._prefsPendingChanges.get();
+    this._willInvalidateSession =
+      draftConfigs.size > 0 ||
+      activeChoice !== null ||
+      Boolean(prefs?.onRestartSetAdminEmail) ||
+      Boolean(prefs?.onRestartReplaceEmailWithAdmin);
+
+    for (const [providerKey, config] of draftConfigs) {
       await this._configAPI.configureProvider(providerKey, config);
       this._updateDraftConfigs(draft => draft.delete(providerKey));
       this._recentlyConfigured.add(providerKey);
     }
 
-    const activeChoice = this._draftActiveProvider.get();
     if (activeChoice !== null) {
       await this._configAPI.setActiveAuthProvider(activeChoice);
       this._draftActiveProvider.set(null);
@@ -258,13 +275,18 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
   }
 
   /**
-   * Auth changes invalidate the admin's session, so once the manager has
-   * restarted we redirect through sign-in rather than trying to refetch
-   * (the API would 401 anyway). Returning `{ redirected: true }` tells the
-   * manager and its caller to skip any post-apply work.
+   * When the upcoming restart will invalidate the operator's session
+   * (provider config/switch, or a queued admin transfer), redirect
+   * through sign-in once the manager has restarted -- the API would 401
+   * anyway, and in the Quick Setup wizard the operator needs to come
+   * back as the new admin to reach the next step. Returning
+   * `{ redirected: true }` tells the manager and its caller to skip
+   * any post-apply work. When nothing session-clearing applied, we let
+   * the manager continue with its normal post-apply.
    */
   public async afterApply(): Promise<ApplyResult> {
     if (this.isDisposed()) { return; }
+    if (!this._willInvalidateSession) { return; }
     redirectToLogin();
     return { redirected: true };
   }
@@ -500,6 +522,7 @@ effect after you restart Grist."),
     saveModal((_ctl, owner) => {
       const changeAdminModal = ChangeAdminModal.create(owner, {
         currentUserEmail,
+        installAPI: this._installAPI,
         defaultEmail: this._getgristLoginOwner.get()?.email,
         onSave: async ({ email, replace }) => {
           await this._setInstallAdmin(email, replace);
@@ -518,9 +541,15 @@ effect after you restart Grist."),
 
   private async _setInstallAdmin(email: string, replace: boolean) {
     const onRestartReplaceEmailWithAdmin = replace ? this._currentUserEmail : undefined;
+    // The operator is handing off admin, so their current session needs
+    // to die at the upcoming restart. Otherwise they reload as a stripped
+    // -of-admin ghost (or, in the Quick Setup wizard, can't reach the
+    // next step at all). Mirrors what configureProvider /
+    // setActiveAuthProvider already do server-side.
     await this._installAPI.updateInstallPrefs({
       onRestartSetAdminEmail: email,
       onRestartReplaceEmailWithAdmin,
+      onRestartClearSessions: true,
     });
     if (this.isDisposed()) { return; }
 

--- a/app/client/ui/BootPage.ts
+++ b/app/client/ui/BootPage.ts
@@ -24,6 +24,7 @@ import { ApiError } from "app/common/ApiError";
 import { AdminPanelPage } from "app/common/gristUrls";
 import { isEmail } from "app/common/gutil";
 import { tokens } from "app/common/ThemePrefs";
+import { getGristConfig } from "app/common/urlUtils";
 
 import { Computed, Disposable, dom, makeTestId, Observable, styled } from "grainjs";
 
@@ -225,7 +226,11 @@ check your terminal, container logs, or hosting panel: {{exampleBootKeyBanner}}`
             this._loginError.set(null);
 
             const nextParam = new URLSearchParams(window.location.search).get("next");
-            const next = AdminPanelPage.parse(nextParam) || "admin";
+            // Out of service: drop the admin into the setup wizard, not the installation page.
+            // Treat only an explicit `false` as out-of-service so a missing/cached gristConfig
+            // doesn't redirect admins to /admin/setup unexpectedly.
+            const fallback: AdminPanelPage = getGristConfig().inService === false ? "setup" : "admin";
+            const next = AdminPanelPage.parse(nextParam) || fallback;
             window.location.assign(urlState().makeUrl({ adminPanel: next }));
           },
           onError: (e) => {

--- a/app/client/ui/BootPage.ts
+++ b/app/client/ui/BootPage.ts
@@ -24,7 +24,7 @@ import { ApiError } from "app/common/ApiError";
 import { AdminPanelPage } from "app/common/gristUrls";
 import { isEmail } from "app/common/gutil";
 import { tokens } from "app/common/ThemePrefs";
-import { getGristConfig } from "app/common/urlUtils";
+import { getAdminConfig } from "app/common/urlUtils";
 
 import { Computed, Disposable, dom, makeTestId, Observable, styled } from "grainjs";
 
@@ -226,10 +226,9 @@ check your terminal, container logs, or hosting panel: {{exampleBootKeyBanner}}`
             this._loginError.set(null);
 
             const nextParam = new URLSearchParams(window.location.search).get("next");
-            // Out of service: drop the admin into the setup wizard, not the installation page.
-            // Treat only an explicit `false` as out-of-service so a missing/cached gristConfig
+            // Treat only an explicit `false` as out-of-service so a missing/cached config
             // doesn't redirect admins to /admin/setup unexpectedly.
-            const fallback: AdminPanelPage = getGristConfig().inService === false ? "setup" : "admin";
+            const fallback: AdminPanelPage = getAdminConfig().inService === false ? "setup" : "admin";
             const next = AdminPanelPage.parse(nextParam) || fallback;
             window.location.assign(urlState().makeUrl({ adminPanel: next }));
           },

--- a/app/client/ui/ChangeAdminModal.ts
+++ b/app/client/ui/ChangeAdminModal.ts
@@ -37,8 +37,12 @@ export class ChangeAdminModal extends Disposable {
   public async save() {
     const email = this._email.get();
     const replace = this._replace.get();
-    if (replace && await this._options.installAPI.userExists(email)) {
-      throw new Error(t("An account with {{email}} already exists.", { email }));
+    if (replace) {
+      const exists = await this._options.installAPI.userExists(email);
+      if (this.isDisposed()) { return; }
+      if (exists) {
+        throw new Error(t("An account with {{email}} already exists.", { email }));
+      }
     }
     await this._options.onSave({ email, replace });
   }

--- a/app/client/ui/ChangeAdminModal.ts
+++ b/app/client/ui/ChangeAdminModal.ts
@@ -3,6 +3,7 @@ import { cssInput } from "app/client/ui/cssInput";
 import { cssField, cssLabel } from "app/client/ui/MakeCopyMenu";
 import { cssRadioCheckboxOptions, radioCheckboxOption } from "app/client/ui2018/checkbox";
 import { isEmail } from "app/common/gutil";
+import { InstallAPI } from "app/common/InstallAPI";
 
 import { Computed, Disposable, dom, input, Observable } from "grainjs";
 
@@ -10,6 +11,7 @@ const t = makeT("ChangeAdminModal");
 
 export interface ChangeAdminModalOptions {
   currentUserEmail: string;
+  installAPI: InstallAPI;
   defaultEmail?: string;
   onSave: (fields: { email: string, replace: boolean }) => Promise<void>;
 }
@@ -26,8 +28,19 @@ export class ChangeAdminModal extends Disposable {
 
   public get saveDisabled() { return this._saveDisabled; }
 
+  /**
+   * Replace cannot succeed when an account already exists at the new admin
+   * email -- the rename would violate logins.email's uniqueness, and the
+   * resulting restart-time failure rolls back the whole change. Check up
+   * front and throw a useful error so saveModal keeps the modal open.
+   */
   public async save() {
-    await this._options.onSave({ email: this._email.get(), replace: this._replace.get() });
+    const email = this._email.get();
+    const replace = this._replace.get();
+    if (replace && await this._options.installAPI.userExists(email)) {
+      throw new Error(t("An account with {{email}} already exists.", { email }));
+    }
+    await this._options.onSave({ email, replace });
   }
 
   public buildDom() {

--- a/app/common/InstallAPI.ts
+++ b/app/common/InstallAPI.ts
@@ -89,7 +89,7 @@ export class InstallAPIImpl extends BaseAPI implements InstallAPI {
   public async userExists(email: string): Promise<boolean> {
     const url = new URL(`${this._url}/api/install/users/exists`);
     url.searchParams.set("email", email);
-    const resp = await this.requestJson(url.toString(), { method: "GET" });
+    const resp = await this.requestJson(url.href, { method: "GET" });
     return Boolean((resp as { exists?: boolean }).exists);
   }
 

--- a/app/common/InstallAPI.ts
+++ b/app/common/InstallAPI.ts
@@ -50,6 +50,8 @@ export interface InstallAPI {
   getChecks(): Promise<{ probes: BootProbeInfo[] }>;
   runCheck(id: string): Promise<BootProbeResult>;
   getPermissionsStatus(): Promise<PermissionsStatus>;
+  /** True if a user with this login email exists in the home DB. */
+  userExists(email: string): Promise<boolean>;
 }
 
 export class InstallAPIImpl extends BaseAPI implements InstallAPI {
@@ -82,6 +84,13 @@ export class InstallAPIImpl extends BaseAPI implements InstallAPI {
 
   public async getPermissionsStatus(): Promise<PermissionsStatus> {
     return this.requestJson(`${this._url}/api/install/permissions`, { method: "GET" });
+  }
+
+  public async userExists(email: string): Promise<boolean> {
+    const url = new URL(`${this._url}/api/install/users/exists`);
+    url.searchParams.set("email", email);
+    const resp = await this.requestJson(url.toString(), { method: "GET" });
+    return Boolean((resp as { exists?: boolean }).exists);
   }
 
   private get _url(): string {

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -1045,6 +1045,10 @@ export interface GristLoadConfig {
   userPresenceMaxUsers?: number;
 
   warnBeforeSharingPublicly?: boolean;
+
+  // Whether the installation is "in service". Set to false on fresh installs guarded by the
+  // boot key, until an operator brings the server live.
+  inService?: boolean;
 }
 
 /**

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -1045,14 +1045,10 @@ export interface GristLoadConfig {
   userPresenceMaxUsers?: number;
 
   warnBeforeSharingPublicly?: boolean;
-
-  // Whether the installation is "in service". Set to false on fresh installs guarded by the
-  // boot key, until an operator brings the server live.
-  inService?: boolean;
 }
 
 /**
- * Settings sent with all Grist admin pages (/admin).
+ * Settings sent with admin-group Grist pages.
  */
 export interface AdminPageConfig extends GristLoadConfig {
   /** Whether there is a parent process that can restart Grist. */
@@ -1060,6 +1056,12 @@ export interface AdminPageConfig extends GristLoadConfig {
 
   /** Whether AdminControls are available and should be enabled in UI. */
   adminControls?: boolean;
+
+  /**
+   * Whether the installation is "in service". Set to false on fresh installs
+   * guarded by the boot key, until an operator brings the server live.
+   */
+  inService?: boolean;
 }
 
 export const Features = StringUnion(

--- a/app/server/lib/Boot.ts
+++ b/app/server/lib/Boot.ts
@@ -2,6 +2,7 @@ import { ApiError } from "app/common/ApiError";
 import { normalizeEmail } from "app/common/emails";
 import { isEmail } from "app/common/gutil";
 import { UserProfile } from "app/common/UserAPI";
+import { makeAdminPageConfig } from "app/server/lib/adminPageConfig";
 import { appSettings } from "app/server/lib/AppSettings";
 import { RequestWithLogin } from "app/server/lib/Authorizer";
 import { expressWrap, secureJsonErrorHandler } from "app/server/lib/expressWrap";
@@ -73,7 +74,7 @@ export class BootKeyLoginMiddleware implements GristLoginMiddleware {
       await this._server.sendAppPage(req, res, {
         path: "app.html",
         status: 200,
-        config: {},
+        config: makeAdminPageConfig(this._server),
       });
     }));
 

--- a/app/server/lib/adminPageConfig.ts
+++ b/app/server/lib/adminPageConfig.ts
@@ -1,0 +1,22 @@
+import { AdminPageConfig } from "app/common/gristUrls";
+import { isAffirmative } from "app/common/gutil";
+import { GristServer } from "app/server/lib/GristServer";
+import { getInService } from "app/server/lib/gristSettings";
+
+export function canRestart() {
+  return isAffirmative(process.env.GRIST_RUNNING_UNDER_SUPERVISOR) ||
+    isAffirmative(process.env.GRIST_UNDER_RESTART_SHELL);
+}
+
+/**
+ * Per-request config sent by admin-group endpoints (e.g. /admin, /boot).
+ * `runningUnderSupervisor` doubles as the discriminator used by
+ * `getAdminConfig()` on the client.
+ */
+export function makeAdminPageConfig(gristServer: GristServer): Partial<AdminPageConfig> {
+  return {
+    runningUnderSupervisor: canRestart(),
+    adminControls: gristServer.create.areAdminControlsAvailable(),
+    inService: getInService().value,
+  };
+}

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -164,6 +164,19 @@ export function attachEarlyEndpoints(options: AttachOptions) {
     }),
   );
 
+  // Used by the "Change admin user" modal to flag the case where a Replace
+  // would later fail at restart because a user with the new admin email
+  // already exists (the rename can't satisfy the unique constraint on
+  // logins.email).
+  app.get(
+    "/api/install/users/exists",
+    expressWrap(async (req, res) => {
+      const email = stringParam(req.query.email, "email");
+      const user = await gristServer.getHomeDBManager().getExistingUserByLogin(email);
+      return sendOkReply(req, res, { exists: Boolean(user) });
+    }),
+  );
+
   app.patch(
     "/api/install/prefs",
     json({ limit: "1mb" }),

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -5,8 +5,6 @@ import {
   ConfigValue,
   ConfigValueCheckers,
 } from "app/common/Config";
-import { AdminPageConfig } from "app/common/gristUrls";
-import { isAffirmative } from "app/common/gutil";
 import { InstallPrefs } from "app/common/Install";
 import { PermissionsStatus, PrefSource } from "app/common/InstallAPI";
 import { getOrgKey } from "app/gen-server/ApiServer";
@@ -15,6 +13,7 @@ import {
   PreviousAndCurrent,
   QueryResult,
 } from "app/gen-server/lib/homedb/Interfaces";
+import { canRestart, makeAdminPageConfig } from "app/server/lib/adminPageConfig";
 import { appSettings } from "app/server/lib/AppSettings";
 import { RequestWithLogin } from "app/server/lib/Authorizer";
 import { BootProbes } from "app/server/lib/BootProbes";
@@ -47,11 +46,6 @@ import {
 import isEmpty from "lodash/isEmpty";
 import pick from "lodash/pick";
 
-function canRestart() {
-  return isAffirmative(process.env.GRIST_RUNNING_UNDER_SUPERVISOR) ||
-    isAffirmative(process.env.GRIST_UNDER_RESTART_SHELL);
-}
-
 export interface AttachOptions {
   app: Application;
   gristServer: GristServer;
@@ -82,14 +76,10 @@ export function attachEarlyEndpoints(options: AttachOptions) {
     "/admin/:subpath(*)?",
     userIdMiddleware,
     expressWrap(async (req, res) => {
-      const config: Partial<AdminPageConfig> = {
-        runningUnderSupervisor: canRestart(),
-        adminControls: gristServer.create.areAdminControlsAvailable(),
-      };
       return gristServer.sendAppPage(req, res, {
         path: "app.html",
         status: 200,
-        config,
+        config: makeAdminPageConfig(gristServer),
       });
     }),
   );

--- a/app/server/lib/sendAppPage.ts
+++ b/app/server/lib/sendAppPage.ts
@@ -24,7 +24,6 @@ import { RequestWithOrg } from "app/server/lib/extractOrg";
 import { GristServer } from "app/server/lib/GristServer";
 import {
   getAnonPlaygroundEnabled, getCanAnyoneCreateOrgs,
-  getInService,
   getOnboardingTutorialDocId, getPersonalOrgsEnabled,
   getTemplateOrg,
   getUserPresenceMaxUsers,
@@ -145,7 +144,6 @@ export function makeGristConfig(options: MakeGristConfigOptions): GristLoadConfi
     adminDefinedUrls: process.env.GRIST_CUSTOM_COMMON_URLS,
     userPresenceMaxUsers: getUserPresenceMaxUsers(),
     warnBeforeSharingPublicly: isAffirmative(process.env.GRIST_WARN_BEFORE_SHARING_PUBLICLY),
-    inService: getInService().value,
   };
   return {
     ...config,

--- a/app/server/lib/sendAppPage.ts
+++ b/app/server/lib/sendAppPage.ts
@@ -24,6 +24,7 @@ import { RequestWithOrg } from "app/server/lib/extractOrg";
 import { GristServer } from "app/server/lib/GristServer";
 import {
   getAnonPlaygroundEnabled, getCanAnyoneCreateOrgs,
+  getInService,
   getOnboardingTutorialDocId, getPersonalOrgsEnabled,
   getTemplateOrg,
   getUserPresenceMaxUsers,
@@ -144,6 +145,7 @@ export function makeGristConfig(options: MakeGristConfigOptions): GristLoadConfi
     adminDefinedUrls: process.env.GRIST_CUSTOM_COMMON_URLS,
     userPresenceMaxUsers: getUserPresenceMaxUsers(),
     warnBeforeSharingPublicly: isAffirmative(process.env.GRIST_WARN_BEFORE_SHARING_PUBLICLY),
+    inService: getInService().value,
   };
   return {
     ...config,

--- a/test/nbrowser/BootPage.ts
+++ b/test/nbrowser/BootPage.ts
@@ -1,6 +1,7 @@
 import { Activation } from "app/gen-server/entity/Activation";
 import { toggleItem } from "test/nbrowser/AdminPanelTools";
 import * as gu from "test/nbrowser/gristUtils";
+import { useFastSandboxProbe } from "test/nbrowser/sandboxProbeFixture";
 import { server, setupTestSuite } from "test/nbrowser/testUtils";
 import * as testUtils from "test/server/testUtils";
 
@@ -11,7 +12,15 @@ describe("BootPage", function() {
 
   setupTestSuite();
 
+  // Skip the slow gvisor probe; the admin panel hits it on every load.
+  // Snapshot/restore at the top level so the env var doesn't leak into
+  // subsequent nbrowser suites in the same worker process.
   let oldEnv: testUtils.EnvironmentSnapshot;
+  before(() => {
+    oldEnv = new testUtils.EnvironmentSnapshot();
+    useFastSandboxProbe();
+  });
+  after(() => oldEnv.restore());
 
   const waitForBootPage = () => driver.findWait(".test-boot-page-content", 2000);
 
@@ -25,6 +34,8 @@ describe("BootPage", function() {
   };
 
   describe("setup gate on new installation", function() {
+    let oldEnv: testUtils.EnvironmentSnapshot;
+
     before(async function() {
       oldEnv = new testUtils.EnvironmentSnapshot();
 
@@ -58,6 +69,8 @@ describe("BootPage", function() {
   });
 
   describe("setup gate on existing installation", function() {
+    let oldEnv: testUtils.EnvironmentSnapshot;
+
     before(async function() {
       oldEnv = new testUtils.EnvironmentSnapshot();
 
@@ -162,6 +175,7 @@ describe("BootPage", function() {
 
   describe("login without GRIST_BOOT_KEY set", function() {
     let bootKey = "";
+    let oldEnv: testUtils.EnvironmentSnapshot;
 
     before(async function() {
       await server.removeLogin();
@@ -212,7 +226,8 @@ describe("BootPage", function() {
       );
     });
 
-    it("redirects to /admin after submitting admin email", async function() {
+    it("redirects to /admin/setup after submitting admin email", async function() {
+      // Out of service => land in the setup wizard, not the installation page.
       assert.equal(
         await driver.find(".test-boot-page-email-input").getAttribute("value"),
         "",
@@ -221,6 +236,7 @@ describe("BootPage", function() {
       await driver.find(".test-boot-page-continue").click();
       await gu.waitForServer();
       await gu.waitForAdminPanel();
+      await driver.findWait(".test-quick-setup-server-continue", 2000);
       const { name, email } = await gu.getUser();
       assert.deepEqual({ name, email }, { name: "john", email: "john@example.com" });
     });
@@ -251,10 +267,15 @@ describe("BootPage", function() {
     });
 
     it("reports server is out of service in Admin Panel", async function() {
-      assert.equal(
-        await driver.find(".test-admin-panel-item-value-service-status").getText(),
-        "out of service",
-      );
+      // Confirm the previous test's post-login redirect landed in the setup
+      // wizard (out-of-service fallback), then jump to the installation page
+      // to inspect service status.
+      assert.match(await driver.getCurrentUrl(), /\/admin\/setup(\?|#|$)/);
+      await driver.findWait(".test-quick-setup-server-continue", 2000);
+
+      await driver.get(`${server.getHost()}/admin`);
+      await gu.waitForAdminPanel();
+      await driver.findContentWait(".test-admin-panel-item-value-service-status", "out of service", 2000);
       await toggleItem("service-status");
       assert.isFalse(await driver.find(".test-service-status-env-variable-notice").isPresent());
     });
@@ -344,6 +365,8 @@ describe("BootPage", function() {
   });
 
   describe("login with GRIST_BOOT_KEY set", function() {
+    let oldEnv: testUtils.EnvironmentSnapshot;
+
     before(async function() {
       await server.removeLogin();
 
@@ -422,6 +445,8 @@ describe("BootPage", function() {
   });
 
   describe("with GRIST_IN_SERVICE set to true", function() {
+    let oldEnv: testUtils.EnvironmentSnapshot;
+
     before(async function() {
       await server.removeLogin();
 
@@ -482,6 +507,8 @@ describe("BootPage", function() {
   });
 
   describe("with GRIST_IN_SERVICE set to false", function() {
+    let oldEnv: testUtils.EnvironmentSnapshot;
+
     before(async function() {
       await server.removeLogin();
 


### PR DESCRIPTION
Two small fixes for admins coming into Grist through the Quick Setup wizard, plus the link to get there from the admin panel.

After an auth change, the admin panel now sends you through /login with a clean relative path. Previously it passed the full window.location.href as the next-url, which the server then prefixed with /o/<org>, producing a doubled-up URL like /o/docs/https://host/admin/setup. Reusing the same default the rest of the login helpers use (a path, not a full URL) keeps the round trip tidy.

After signing in with the boot key, an admin lands on /admin/setup if the server is still out of service, and on /admin once it's live. The in-service flag now travels alongside the rest of GristLoadConfig, so the boot page can decide where to send the admin without a separate API call.

The "Quick setup" entry in the admin sidebar is now visible -- the page it points at is ready, so the placeholder TODO can come out.

The BootPage tests get the same useFastSandboxProbe helper the other admin-panel tests already use, and a new assertion checks that the post boot-key redirect lands on /admin/setup when the server is out of service.
