### PR TITLE
Start the sandbox check early in the setup wizard

### DIFF
--- a/app/client/models/AdminChecks.ts
+++ b/app/client/models/AdminChecks.ts
@@ -49,9 +49,10 @@ export class AdminChecks {
 
   /**
    * Request the result of one of the available checks. Returns information
-   * about the check and a way to observe the result when it arrives.
+   * about the check and a way to observe the result when it arrives. Pass
+   * `background: true` for prefetches (see {@link InstallAPI.runCheckBackground}).
    */
-  public requestCheck(probe: BootProbeInfo): AdminCheckRequest {
+  public requestCheck(probe: BootProbeInfo, options: { background?: boolean } = {}): AdminCheckRequest {
     const { id } = probe;
     let result = this._results.get(id);
     if (!result) {
@@ -60,7 +61,7 @@ export class AdminChecks {
     }
     let request = this._requests.get(id);
     if (!request) {
-      request = new AdminCheckRunner(this._installAPI, id, this._results, this._parent);
+      request = new AdminCheckRunner(this._installAPI, id, this._results, this._parent, options.background);
       this._requests.set(id, request);
     }
     request.start();
@@ -120,14 +121,18 @@ export class AdminCheckRunner {
   constructor(private _installAPI: InstallAPI,
     public id: string,
     public results: Map<string, Observable<BootProbeResult>>,
-    public parent: Disposable) {
-    this._installAPI.runCheck(id).then((result) => {
+    public parent: Disposable,
+    background: boolean = false) {
+    this._installAPI.runCheck(id, { background }).then((result) => {
       if (parent.isDisposed()) { return; }
       const ob = results.get(id);
       if (ob) {
         ob.set(result);
       }
-    }).catch(e => console.error(e));
+    }).catch((e) => {
+      if (parent.isDisposed()) { return; }
+      results.get(id)?.set({ status: "fault", details: { error: String(e) } });
+    });
   }
 
   public start() {

--- a/app/client/models/AdminChecks.ts
+++ b/app/client/models/AdminChecks.ts
@@ -103,6 +103,19 @@ export class AdminChecks {
     this._requests.clear();
     await this.fetchAvailableChecks();
   }
+
+  /**
+   * Drop a cached probe result if it is in a fault state, so the next
+   * {@link requestCheck} re-runs it. Useful after a transient failure
+   * (e.g. a background prefetch that hit the server mid-restart).
+   */
+  public discardIfFault(id: BootProbeIds) {
+    const result = this._results.get(id);
+    if (result?.get().status !== "fault") { return; }
+    result.dispose();
+    this._results.delete(id);
+    this._requests.delete(id);
+  }
 }
 
 /**

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -12,7 +12,7 @@ import { peekSetupReturnFromGetGristCom, SetupReturnStep } from "app/client/ui/G
 import { PermissionsSetupSection } from "app/client/ui/PermissionsSetupSection";
 import { quickSetupContinueButton, QuickSetupSection } from "app/client/ui/QuickSetupContinueButton";
 import { QuickSetupServerStep } from "app/client/ui/QuickSetupServerStep";
-import { SandboxSetupSection } from "app/client/ui/SandboxSection";
+import { SANDBOX_PROBE_ID, SandboxSetupSection } from "app/client/ui/SandboxSection";
 import { Stepper } from "app/client/ui2018/Stepper";
 import { InstallAPIImpl } from "app/common/InstallAPI";
 
@@ -82,7 +82,12 @@ export class QuickSetup extends Disposable {
     this._checks.fetchAvailableChecks()
       .catch(reportError)
       .finally(() => {
-        if (!this.isDisposed()) { this._checksLoaded.set(true); }
+        if (this.isDisposed()) { return; }
+        this._checksLoaded.set(true);
+        // Pre-warm sandbox-providers so the slow real-machine probe is already
+        // running while the user is on earlier steps.
+        const sandboxProbe = this._checks.probes.get().find(p => p.id === SANDBOX_PROBE_ID);
+        if (sandboxProbe) { this._checks.requestCheck(sandboxProbe, { background: true }); }
       });
     return dom.maybe(this._checksLoaded, () =>
       this._checks.probes.get().length > 0 ?
@@ -131,7 +136,7 @@ export class QuickSetup extends Disposable {
 
   private _buildSandboxStep(): DomContents {
     return dom.create((owner) => {
-      const section = SandboxSetupSection.create(owner);
+      const section = SandboxSetupSection.create(owner, this._checks);
       return dom("div",
         section.buildDom(),
         quickSetupContinueButton(section, () => this._advanceStep(), testId("sandbox-continue")),

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -136,6 +136,10 @@ export class QuickSetup extends Disposable {
 
   private _buildSandboxStep(): DomContents {
     return dom.create((owner) => {
+      // If the background prefetch hit the server mid-restart (after Apply
+      // on the Server step) it will have cached a fault. Drop it so the
+      // section's load runs fresh now that the server is back.
+      this._checks.discardIfFault(SANDBOX_PROBE_ID);
       const section = SandboxSetupSection.create(owner, this._checks);
       return dom("div",
         section.buildDom(),

--- a/app/client/ui/SandboxSection.ts
+++ b/app/client/ui/SandboxSection.ts
@@ -1,11 +1,13 @@
 import { makeT } from "app/client/lib/localization";
+import { AdminChecks } from "app/client/models/AdminChecks";
 import { getHomeUrl } from "app/client/models/AppModel";
 import { ConfigSection, DraftChangesManager } from "app/client/ui/DraftChanges";
 import { quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
 import { BadgeConfig, buildCardList, buildHeroCard, buildItemCard } from "app/client/ui/SetupCard";
 import { theme, vars } from "app/client/ui2018/cssVars";
 import { loadingSpinner } from "app/client/ui2018/loaders";
-import { ConfigAPI } from "app/common/ConfigAPI";
+import { BootProbeIds } from "app/common/BootProbe";
+import { waitGrainObs } from "app/common/gutil";
 import { InstallAPIImpl } from "app/common/InstallAPI";
 import { SandboxInfo, SandboxingStatus } from "app/common/SandboxInfo";
 
@@ -14,29 +16,54 @@ import { Computed, Disposable, dom, DomContents, makeTestId, Observable, styled,
 const t = makeT("SandboxSection");
 const testId = makeTestId("test-sandbox-section-");
 
+export const SANDBOX_PROBE_ID: BootProbeIds = "sandbox-providers";
+
 /**
- * Base sandbox configuration section. Fetches available sandbox options,
- * shows them as cards, and lets the user pick one.
+ * Sandbox configuration section for QuickSetup. Fetches available sandbox
+ * options through the shared {@link AdminChecks} (so the probe result is
+ * memoized and can be pre-warmed by the wizard), shows them as cards, and
+ * lets the user pick one. Conforms to {@link QuickSetupSection} by
+ * delegating dirty/apply/restart through a {@link DraftChangesManager}
+ * with a single registered {@link ConfigSection} adapter for the sandbox
+ * flavor pref. This keeps the apply pipeline (persist + restart + wait,
+ * with shared failure handling) the same as the Server step.
  */
-abstract class SandboxSectionBase extends Disposable {
-  protected _configAPI = new ConfigAPI(getHomeUrl());
-  protected _installAPI = new InstallAPIImpl(getHomeUrl());
+export class SandboxSetupSection extends Disposable {
+  public readonly canProceed: Computed<boolean>;
+  public readonly isDirty: Computed<boolean>;
+  public readonly isApplying: Observable<boolean>;
+
+  private _installAPI = new InstallAPIImpl(getHomeUrl());
   // Data read from the server.
-  protected _model = Observable.create<SandboxingStatus | null>(this, null);
+  private _model = Observable.create<SandboxingStatus | null>(this, null);
   // If there was error loading or saving.
-  protected _error = Observable.create<string>(this, "");
+  private _error = Observable.create<string>(this, "");
   // Observable for user selection.
-  protected _selected = Observable.create<string | null>(this, null);
+  private _selected = Observable.create<string | null>(this, null);
 
   /** True when a different flavor is selected than what's currently active and not env-locked. */
-  protected readonly _needsRestart: Computed<boolean> =
+  private readonly _needsRestart: Computed<boolean> =
     Computed.create(this, this._model, this._selected, (_, model, selected) => {
       if (model?.flavorInEnv) { return false; }
       return !!selected && selected !== model?.current;
     });
 
-  constructor() {
+  private readonly _drafts = DraftChangesManager.create(this);
+  private readonly _draftSection: ConfigSection = {
+    isDirty: this._needsRestart,
+    needsRestart: true,
+    apply: () => this._save(),
+    describeChange: Computed.create(this, use =>
+      [{ label: t("Sandbox"), value: sandboxLabel(use(this._selected) ?? "") }],
+    ),
+  };
+
+  constructor(private _checks: AdminChecks) {
     super();
+    this._drafts.addSection(this._draftSection);
+    this.canProceed = Computed.create(this, this._selected, (_, s) => !!s);
+    this.isDirty = this._drafts.hasDraftChanges;
+    this.isApplying = this._drafts.isApplying;
     this._loadStatus().catch((e) => {
       if (this.isDisposed()) { return; }
       this._error.set(String(e));
@@ -49,19 +76,25 @@ abstract class SandboxSectionBase extends Disposable {
       dom.maybe(this._error, err => cssError(err)),
       dom.domComputed(this._model, (s) => {
         if (!s) { return cssLoading(loadingSpinner(), t("Detecting sandbox options...")); }
-        return dom("div",
-          this._buildContent(s),
-          this._buildFooter(),
-        );
+        return dom("div", this._buildContent(s));
       }),
     );
   }
 
-  protected _isLockedByEnv() {
+  public async apply(): Promise<void> {
+    await this._drafts.applyAll();
+  }
+
+  /** Returns "Skip and Continue" when env-locked; otherwise null to use shared defaults. */
+  public customLabel(use: UseCBOwner): string | null {
+    return use(this._model)?.flavorInEnv ? t("Skip and Continue") : null;
+  }
+
+  private _isLockedByEnv() {
     return !!this._model.get()?.flavorInEnv;
   }
 
-  protected async _save() {
+  private async _save() {
     const flavor = this._selected.get();
     const isSelectedByEnv = this._isLockedByEnv();
     if (flavor && !isSelectedByEnv) {
@@ -74,13 +107,18 @@ abstract class SandboxSectionBase extends Disposable {
     }
   }
 
-  protected _buildFooter(): DomContents {
-    return null;
+  private async _fetchSandboxingStatus(): Promise<SandboxingStatus> {
+    const probe = this._checks.probes.get().find(p => p.id === SANDBOX_PROBE_ID);
+    if (!probe) { throw new Error(`${SANDBOX_PROBE_ID} probe not available`); }
+    const req = this._checks.requestCheck(probe);
+    const result = await waitGrainObs(req.result, r => r.status !== "none");
+    if (result.status === "fault") { throw new Error(result.details?.error ?? "probe failed"); }
+    return result.details as SandboxingStatus;
   }
 
   private async _loadStatus() {
-    const result = await this._installAPI.runCheck("sandbox-providers");
-    const model = sortedByPreference(result.details as SandboxingStatus);
+    const status = await this._fetchSandboxingStatus();
+    const model = sortedByPreference(status);
     if (this.isDisposed()) { return; }
 
     this._model.set(model);
@@ -198,47 +236,6 @@ abstract class SandboxSectionBase extends Disposable {
         }) :
         null,
     );
-  }
-}
-
-/**
- * Sandbox section for QuickSetup. Conforms to {@link QuickSetupSection}
- * by delegating dirty/apply/restart through a {@link DraftChangesManager}
- * with a single registered {@link ConfigSection} adapter for the sandbox
- * flavor pref. This keeps the apply pipeline (persist + restart + wait,
- * with shared failure handling) the same as the Server step.
- */
-export class SandboxSetupSection extends SandboxSectionBase {
-  /** Always true once the model has loaded — there's always a default selection. */
-  public readonly canProceed: Computed<boolean> = Computed.create(this, this._selected, (_, s) => !!s);
-
-  public readonly isDirty: Computed<boolean>;
-  public readonly isApplying: Observable<boolean>;
-
-  private readonly _drafts = DraftChangesManager.create(this);
-  private readonly _draftSection: ConfigSection = {
-    isDirty: this._needsRestart,
-    needsRestart: true,
-    apply: () => this._save(),
-    describeChange: Computed.create(this, use =>
-      [{ label: t("Sandbox"), value: sandboxLabel(use(this._selected) ?? "") }],
-    ),
-  };
-
-  constructor() {
-    super();
-    this._drafts.addSection(this._draftSection);
-    this.isDirty = this._drafts.hasDraftChanges;
-    this.isApplying = this._drafts.isApplying;
-  }
-
-  public async apply(): Promise<void> {
-    await this._drafts.applyAll();
-  }
-
-  /** Returns "Skip and Continue" when env-locked; otherwise null to use shared defaults. */
-  public customLabel(use: UseCBOwner): string | null {
-    return use(this._model)?.flavorInEnv ? t("Skip and Continue") : null;
   }
 }
 

--- a/app/common/BaseAPI.ts
+++ b/app/common/BaseAPI.ts
@@ -115,6 +115,32 @@ export class BaseAPI {
 
   @BaseAPI.countRequest
   protected async request(input: string, init: RequestInit = {}): Promise<Response> {
+    return this._doRequest(input, init);
+  }
+
+  /**
+   * Like `request`, but bypasses the pending-request counter. Use for background work
+   * the user isn't waiting on (e.g. prefetches), so tests' `waitForServer` doesn't block.
+   */
+  protected async requestUncounted(input: string, init: RequestInit = {}): Promise<Response> {
+    return this._doRequest(input, init);
+  }
+
+  /**
+   * Make a request, and read the response as JSON. This allows counting the request as pending
+   * until it has been read, which is relied on by tests.
+   */
+  @BaseAPI.countRequest
+  protected async requestJson(input: string, init: RequestInit = {}): Promise<any> {
+    return (await this._doRequest(input, init)).json();
+  }
+
+  /** Like `requestJson`, but bypasses the pending-request counter. See `requestUncounted`. */
+  protected async requestJsonUncounted(input: string, init: RequestInit = {}): Promise<any> {
+    return (await this._doRequest(input, init)).json();
+  }
+
+  private async _doRequest(input: string, init: RequestInit): Promise<Response> {
     init = Object.assign({ headers: this._headers, credentials: "include" }, init);
     if (this._extraParameters) {
       const url = new URL(input);
@@ -129,15 +155,6 @@ export class BaseAPI {
       throwApiError(input, resp, body);
     }
     return resp;
-  }
-
-  /**
-   * Make a request, and read the response as JSON. This allows counting the request as pending
-   * until it has been read, which is relied on by tests.
-   */
-  @BaseAPI.countRequest
-  protected async requestJson(input: string, init: RequestInit = {}): Promise<any> {
-    return (await this.request(input, init)).json();
   }
 }
 

--- a/app/common/InstallAPI.ts
+++ b/app/common/InstallAPI.ts
@@ -83,9 +83,9 @@ export class InstallAPIImpl extends BaseAPI implements InstallAPI {
 
   public runCheck(id: string, opts: { background?: boolean } = {}): Promise<BootProbeResult> {
     const url = `${this._url}/api/probes/${id}`;
-    return opts.background
-      ? this.requestJsonUncounted(url, { method: "GET" })
-      : this.requestJson(url, { method: "GET" });
+    return opts.background ?
+      this.requestJsonUncounted(url, { method: "GET" }) :
+      this.requestJson(url, { method: "GET" });
   }
 
   public async getPermissionsStatus(): Promise<PermissionsStatus> {

--- a/app/common/InstallAPI.ts
+++ b/app/common/InstallAPI.ts
@@ -48,7 +48,12 @@ export interface InstallAPI {
    */
   checkUpdates(): Promise<LatestVersionAvailable>;
   getChecks(): Promise<{ probes: BootProbeInfo[] }>;
-  runCheck(id: string): Promise<BootProbeResult>;
+  /**
+   * Run a probe and return its result. Pass `{ background: true }` for prefetches
+   * the user isn't waiting on (the underlying request bypasses the pending-request
+   * counter so tests' `waitForServer` waits aren't held up).
+   */
+  runCheck(id: string, opts?: { background?: boolean }): Promise<BootProbeResult>;
   getPermissionsStatus(): Promise<PermissionsStatus>;
 }
 
@@ -76,8 +81,11 @@ export class InstallAPIImpl extends BaseAPI implements InstallAPI {
     return this.requestJson(`${this._url}/api/probes`, { method: "GET" });
   }
 
-  public runCheck(id: string): Promise<BootProbeResult> {
-    return this.requestJson(`${this._url}/api/probes/${id}`, { method: "GET" });
+  public runCheck(id: string, opts: { background?: boolean } = {}): Promise<BootProbeResult> {
+    const url = `${this._url}/api/probes/${id}`;
+    return opts.background
+      ? this.requestJsonUncounted(url, { method: "GET" })
+      : this.requestJson(url, { method: "GET" });
   }
 
   public async getPermissionsStatus(): Promise<PermissionsStatus> {

--- a/test/client/_helpers/setupI18n.ts
+++ b/test/client/_helpers/setupI18n.ts
@@ -1,0 +1,10 @@
+/**
+ * Minimal i18next bootstrap for client unit tests. Imported for its side
+ * effect by tests that pull in modules which call `t(...)` at import time
+ * (e.g. via `makeT(...)` in app/client/lib/localization). Without this,
+ * the lazy `i18next.cloneInstance(...)` triggered by the first `t()` call
+ * blows up because the global instance was never initialized.
+ */
+import i18next from "i18next";
+
+void i18next.init({ lng: "en", resources: { en: { translation: {} } } });

--- a/test/client/models/AdminChecks.ts
+++ b/test/client/models/AdminChecks.ts
@@ -1,0 +1,108 @@
+// Must come before the AdminChecks import: that module calls `t(...)` at
+// module load, which requires an initialized global i18next instance.
+import "test/client/_helpers/setupI18n";
+
+import { AdminChecks } from "app/client/models/AdminChecks";
+import { BootProbeInfo, BootProbeResult } from "app/common/BootProbe";
+import { InstallAPI } from "app/common/InstallAPI";
+
+import { assert } from "chai";
+import { Disposable } from "grainjs";
+
+class FakeInstallAPI implements Partial<InstallAPI> {
+  public probes: BootProbeInfo[] = [
+    { id: "sandbox-providers", name: "Sandbox providers" },
+    { id: "authentication", name: "Authentication" },
+  ];
+
+  public runCheckCalls: string[] = [];
+  public results = new Map<string, () => Promise<BootProbeResult>>();
+
+  public async getChecks() {
+    return { probes: this.probes };
+  }
+
+  public runCheck(id: string): Promise<BootProbeResult> {
+    this.runCheckCalls.push(id);
+    const factory = this.results.get(id);
+    if (!factory) { return Promise.reject(new Error(`no fake set for ${id}`)); }
+    return factory();
+  }
+}
+
+class TestOwner extends Disposable {}
+
+describe("AdminChecks", function() {
+  let owner: TestOwner;
+
+  beforeEach(() => {
+    owner = TestOwner.create(null);
+  });
+
+  afterEach(() => {
+    owner.dispose();
+  });
+
+  it("populates the result observable on success", async function() {
+    const api = new FakeInstallAPI();
+    api.results.set("sandbox-providers", async () => ({
+      status: "success",
+      details: { ok: true },
+    }));
+
+    const checks = new AdminChecks(owner, api as unknown as InstallAPI);
+    // Populate probes directly to avoid `fetchAvailableChecks`, which reads
+    // window.gristConfig (not present in this Node-only test environment).
+    checks.probes.set(api.probes);
+
+    const probe = checks.probes.get().find(p => p.id === "sandbox-providers")!;
+    const req = checks.requestCheck(probe);
+    assert.equal(req.result.get().status, "none");
+
+    await new Promise(r => setTimeout(r, 0));
+
+    assert.equal(req.result.get().status, "success");
+    assert.deepEqual(req.result.get().details, { ok: true });
+  });
+
+  it("sets fault status when runCheck rejects", async function() {
+    const api = new FakeInstallAPI();
+    api.results.set("sandbox-providers", async () => {
+      throw new Error("network kaboom");
+    });
+
+    const checks = new AdminChecks(owner, api as unknown as InstallAPI);
+    checks.probes.set(api.probes);
+
+    const probe = checks.probes.get().find(p => p.id === "sandbox-providers")!;
+    const req = checks.requestCheck(probe);
+
+    await new Promise(r => setTimeout(r, 0));
+
+    const result = req.result.get();
+    assert.equal(result.status, "fault");
+    assert.match(String(result.details?.error), /network kaboom/);
+  });
+
+  it("dedupes concurrent requests for the same probe", async function() {
+    const api = new FakeInstallAPI();
+    api.results.set("sandbox-providers", async () => ({
+      status: "success",
+      details: {},
+    }));
+
+    const checks = new AdminChecks(owner, api as unknown as InstallAPI);
+    checks.probes.set(api.probes);
+    const probe = checks.probes.get().find(p => p.id === "sandbox-providers")!;
+
+    const r1 = checks.requestCheck(probe);
+    const r2 = checks.requestCheck(probe);
+
+    // Same observable instance — that's the memoization the prefetch relies on.
+    assert.strictEqual(r1.result, r2.result);
+
+    // Only one network call, even though requestCheck was invoked twice.
+    await new Promise(r => setTimeout(r, 0));
+    assert.equal(api.runCheckCalls.length, 1);
+  });
+});


### PR DESCRIPTION
The Sandboxing step's probe spawns subprocesses to test each available sandbox flavor and was only fired when the user reached that step, making them wait on a spinner. Kick it off as soon as the wizard's probe list arrives so the result is typically already memoized by the time the section subscribes.

- AdminCheckRunner now surfaces rejection as a fault status on the result observable, so subscribers see failures rather than waiting forever on the initial "none".
- SandboxSetupSection takes the shared AdminChecks and reads the memoized observable instead of running its own probe; the listener is autoDisposed in case the section is torn down mid-fetch.
- QuickSetup fires the prefetch right after fetchAvailableChecks resolves.
