### PR TITLE
[tiny] Prevent console error when pressing ctrl+alt+o on homepage

### DIFF
--- a/app/client/components/RegionFocusSwitcher.ts
+++ b/app/client/components/RegionFocusSwitcher.ts
@@ -400,6 +400,9 @@ export class RegionFocusSwitcher extends Disposable {
   }
 
   private _toggleCreatorPanel() {
+    if (!getPanelElement("right")) {
+      return;
+    }
     const current = this._state.get().region;
     const gristDoc = this._getGristDoc();
     if (current?.type === "panel" && current.id === "right") {


### PR DESCRIPTION
## Context

The right panel (the creator panel) doesn't exist on some pages, like the homepage. Before, when we pressed the shortcut to toggle it, it would trigger a JS error that shows up as a notification in the bottom right corner. There was no real impact besides that but that's already not great :eyes: 

## Proposed solution

Now, when we press the shortcut, we silently do nothing if we notice that there is no panel to toggle.

## Related issues

No related issue but @dsagal told me about this. Sorry for not catching it earlier.

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
