### PR TITLE
Use direct fetch for trusted urls to fix duplicate doc with doc worker and proxy for untrusted urls

### DIFF
--- a/app/common/uploads.ts
+++ b/app/common/uploads.ts
@@ -50,4 +50,5 @@ export interface FetchUrlOptions {
   googleAuthorizationCode?: string;   // The authorization code received from Google Auth Service.
   fileName?: string;                  // The filename for external resource.
   headers?: { [key: string]: string };  // Additional headers to use when accessing external resource.
+  isTrusted?: boolean;                // Whether this is a trusted internal request.
 }

--- a/app/common/uploads.ts
+++ b/app/common/uploads.ts
@@ -50,5 +50,4 @@ export interface FetchUrlOptions {
   googleAuthorizationCode?: string;   // The authorization code received from Google Auth Service.
   fileName?: string;                  // The filename for external resource.
   headers?: { [key: string]: string };  // Additional headers to use when accessing external resource.
-  isTrusted?: boolean;                // Whether this is a trusted internal request.
 }

--- a/app/server/lib/uploads.ts
+++ b/app/server/lib/uploads.ts
@@ -11,7 +11,6 @@ import { downloadFromGDrive, isDriveUrl } from "app/server/lib/GoogleImport";
 import { GristServer, RequestWithGrist } from "app/server/lib/GristServer";
 import { guessExt } from "app/server/lib/guessExt";
 import log from "app/server/lib/log";
-import fetch from "node-fetch";
 import { fetchUntrustedWithAgent } from "app/server/lib/ProxyAgent";
 import { optStringParam } from "app/server/lib/requestUtils";
 import { isPathWithin } from "app/server/lib/serverUtils";
@@ -27,6 +26,7 @@ import { Application, Request, RequestHandler, Response } from "express";
 import * as fse from "fs-extra";
 import pick from "lodash/pick";
 import * as multiparty from "multiparty";
+import fetch from "node-fetch";
 import { Response as FetchResponse } from "node-fetch";
 import * as tmp from "tmp";
 

--- a/app/server/lib/uploads.ts
+++ b/app/server/lib/uploads.ts
@@ -11,6 +11,7 @@ import { downloadFromGDrive, isDriveUrl } from "app/server/lib/GoogleImport";
 import { GristServer, RequestWithGrist } from "app/server/lib/GristServer";
 import { guessExt } from "app/server/lib/guessExt";
 import log from "app/server/lib/log";
+import fetch from "node-fetch";
 import { fetchUntrustedWithAgent } from "app/server/lib/ProxyAgent";
 import { optStringParam } from "app/server/lib/requestUtils";
 import { isPathWithin } from "app/server/lib/serverUtils";
@@ -35,7 +36,11 @@ import * as tmp from "tmp";
 const INACTIVITY_CLEANUP_MS = 60 * 60 * 1000;     // an hour, very generously.
 
 // A hook for dependency injection.
-export const Deps = { fetch: fetchUntrustedWithAgent, INACTIVITY_CLEANUP_MS };
+export const Deps = {
+  fetchUntrusted: fetchUntrustedWithAgent,
+  fetchTrusted: fetch,
+  INACTIVITY_CLEANUP_MS,
+};
 
 // An optional UploadResult, with parameters.
 export interface FormResult {
@@ -447,7 +452,8 @@ async function _fetchURL(url: string, accessId: string | null, options?: FetchUr
       response = await downloadFromGDrive(url, code);
       fileName = ""; // Read the file name from headers.
     } else {
-      response = await Deps.fetch(url, {
+      const fetchFunc = options?.isTrusted ? Deps.fetchTrusted : Deps.fetchUntrusted;
+      response = await fetchFunc(url, {
         redirect: "follow",
         follow: 10,
         headers,
@@ -513,7 +519,7 @@ export async function fetchDoc(
 
   // Download the document, in full or as a template.
   const url = new URL(`api/docs/${docId}/download?template=${Number(template)}`, apiBaseUrl);
-  return _fetchURL(url.href, accessId, { headers });
+  return _fetchURL(url.href, accessId, { headers, isTrusted: true });
 }
 
 // Re-issue failures as exceptions.

--- a/app/server/lib/uploads.ts
+++ b/app/server/lib/uploads.ts
@@ -37,7 +37,7 @@ const INACTIVITY_CLEANUP_MS = 60 * 60 * 1000;     // an hour, very generously.
 
 // A hook for dependency injection.
 export const Deps = {
-  fetchUntrusted: fetchUntrustedWithAgent,
+  fetch: fetchUntrustedWithAgent,
   fetchTrusted: fetch,
   INACTIVITY_CLEANUP_MS,
 };
@@ -452,7 +452,7 @@ async function _fetchURL(url: string, accessId: string | null, options?: FetchUr
       response = await downloadFromGDrive(url, code);
       fileName = ""; // Read the file name from headers.
     } else {
-      const fetchFunc = options?.isTrusted ? Deps.fetchTrusted : Deps.fetchUntrusted;
+      const fetchFunc = options?.isTrusted ? Deps.fetchTrusted : Deps.fetch;
       response = await fetchFunc(url, {
         redirect: "follow",
         follow: 10,

--- a/app/server/lib/uploads.ts
+++ b/app/server/lib/uploads.ts
@@ -448,7 +448,7 @@ async function _fetchURL(
   url: string,
   accessId: string | null,
   options?: FetchUrlOptions,
-  isTrusted?: boolean
+  isTrusted?: boolean,
 ): Promise<UploadResult> {
   try {
     const code = options?.googleAuthorizationCode;

--- a/app/server/lib/uploads.ts
+++ b/app/server/lib/uploads.ts
@@ -38,7 +38,7 @@ const INACTIVITY_CLEANUP_MS = 60 * 60 * 1000;     // an hour, very generously.
 // A hook for dependency injection.
 export const Deps = {
   fetch: fetchUntrustedWithAgent,
-  fetchTrusted: fetch,
+  fetchInternal: fetch,
   INACTIVITY_CLEANUP_MS,
 };
 
@@ -442,13 +442,13 @@ export async function fetchURL(url: string, accessId: string | null, options?: F
  * Register a new upload with resource fetched from a url, optionally including credentials in
  * request. Returns corresponding UploadInfo.
  *
- * @param isTrusted Internal parameter: only used by fetchDoc() for internal doc worker URLs.
+ * @param isInternal Internal parameter: only used by fetchDoc() for internal doc worker URLs.
  */
 async function _fetchURL(
   url: string,
   accessId: string | null,
   options?: FetchUrlOptions,
-  isTrusted?: boolean,
+  isInternal?: boolean,
 ): Promise<UploadResult> {
   try {
     const code = options?.googleAuthorizationCode;
@@ -459,7 +459,7 @@ async function _fetchURL(
       response = await downloadFromGDrive(url, code);
       fileName = ""; // Read the file name from headers.
     } else {
-      const fetchFunc = isTrusted ? Deps.fetchTrusted : Deps.fetch;
+      const fetchFunc = isInternal ? Deps.fetchInternal : Deps.fetch;
       response = await fetchFunc(url, {
         redirect: "follow",
         follow: 10,
@@ -527,7 +527,7 @@ export async function fetchDoc(
   // Download the document, in full or as a template.
   const url = new URL(`api/docs/${docId}/download?template=${Number(template)}`, apiBaseUrl);
   // The doc worker URL is trusted and internal. Bypass GRIST_PROXY_FOR_UNTRUSTED_URLS to prevent connection failures.
-  return _fetchURL(url.href, accessId, { headers }, /* isTrusted */ true);
+  return _fetchURL(url.href, accessId, { headers }, /* isInternal */ true);
 }
 
 // Re-issue failures as exceptions.

--- a/app/server/lib/uploads.ts
+++ b/app/server/lib/uploads.ts
@@ -441,8 +441,15 @@ export async function fetchURL(url: string, accessId: string | null, options?: F
 /**
  * Register a new upload with resource fetched from a url, optionally including credentials in
  * request. Returns corresponding UploadInfo.
+ *
+ * @param isTrusted Internal parameter: only used by fetchDoc() for internal doc worker URLs.
  */
-async function _fetchURL(url: string, accessId: string | null, options?: FetchUrlOptions): Promise<UploadResult> {
+async function _fetchURL(
+  url: string,
+  accessId: string | null,
+  options?: FetchUrlOptions,
+  isTrusted?: boolean
+): Promise<UploadResult> {
   try {
     const code = options?.googleAuthorizationCode;
     let fileName = options?.fileName ?? "";
@@ -452,7 +459,7 @@ async function _fetchURL(url: string, accessId: string | null, options?: FetchUr
       response = await downloadFromGDrive(url, code);
       fileName = ""; // Read the file name from headers.
     } else {
-      const fetchFunc = options?.isTrusted ? Deps.fetchTrusted : Deps.fetch;
+      const fetchFunc = isTrusted ? Deps.fetchTrusted : Deps.fetch;
       response = await fetchFunc(url, {
         redirect: "follow",
         follow: 10,
@@ -519,7 +526,7 @@ export async function fetchDoc(
 
   // Download the document, in full or as a template.
   const url = new URL(`api/docs/${docId}/download?template=${Number(template)}`, apiBaseUrl);
-  return _fetchURL(url.href, accessId, { headers, isTrusted: true });
+  return _fetchURL(url.href, accessId, { headers }, /* isTrusted */ true);
 }
 
 // Re-issue failures as exceptions.

--- a/app/server/lib/uploads.ts
+++ b/app/server/lib/uploads.ts
@@ -526,6 +526,7 @@ export async function fetchDoc(
 
   // Download the document, in full or as a template.
   const url = new URL(`api/docs/${docId}/download?template=${Number(template)}`, apiBaseUrl);
+  // The doc worker URL is trusted and internal. Bypass GRIST_PROXY_FOR_UNTRUSTED_URLS to prevent connection failures.
   return _fetchURL(url.href, accessId, { headers }, /* isTrusted */ true);
 }
 

--- a/test/server/lib/uploads.ts
+++ b/test/server/lib/uploads.ts
@@ -249,10 +249,10 @@ describe("uploads", function() {
         response = new Response(streamify("a, b\n0, 1\n"));
         url = "fake/trusted/url";
         response.headers.set("content-type", "text/csv; charset=utf-8");
-        
+
         // Call fetchURL with isTrusted: true
         const result = await fetchURL(url, null, { isTrusted: true });
-        
+
         // Verify fetchTrusted was called and fetch was not
         sinon.assert.calledOnce(fetchTrustedStub);
         sinon.assert.notCalled(Deps.fetch as any);
@@ -264,10 +264,10 @@ describe("uploads", function() {
         response = new Response(streamify("a, b\n0, 1\n"));
         url = "fake/untrusted/url";
         response.headers.set("content-type", "text/csv; charset=utf-8");
-        
+
         // Call fetchURL without isTrusted option
         const result = await fetchURL(url, null);
-        
+
         // Verify fetch was called and fetchTrusted was not
         sinon.assert.calledOnce(Deps.fetch as any);
         sinon.assert.notCalled(Deps.fetchTrusted as any);

--- a/test/server/lib/uploads.ts
+++ b/test/server/lib/uploads.ts
@@ -253,9 +253,9 @@ describe("uploads", function() {
         // Call fetchURL with isTrusted: true
         const result = await fetchURL(url, null, { isTrusted: true });
         
-        // Verify fetchTrusted was called and fetchUntrusted was not
+        // Verify fetchTrusted was called and fetch was not
         sinon.assert.calledOnce(fetchTrustedStub);
-        sinon.assert.notCalled(Deps.fetchUntrusted as any);
+        sinon.assert.notCalled(Deps.fetch as any);
         assert.equal(result.files.length, 1);
       });
 
@@ -268,8 +268,8 @@ describe("uploads", function() {
         // Call fetchURL without isTrusted option
         const result = await fetchURL(url, null);
         
-        // Verify fetchUntrusted was called and fetchTrusted was not
-        sinon.assert.calledOnce(Deps.fetchUntrusted as any);
+        // Verify fetch was called and fetchTrusted was not
+        sinon.assert.calledOnce(Deps.fetch as any);
         sinon.assert.notCalled(Deps.fetchTrusted as any);
         assert.equal(result.files.length, 1);
       });

--- a/test/server/lib/uploads.ts
+++ b/test/server/lib/uploads.ts
@@ -243,6 +243,36 @@ describe("uploads", function() {
         assert.equal(result3.files.length, 1);
         assert.deepEqual(pick(result3.files[0], ["origName", "ext"]), { origName: "file3.csv", ext: ".json" });
       });
+
+      it("should use fetchTrusted when isTrusted option is true", async function() {
+        const fetchTrustedStub = sandbox.stub(Deps, "fetchTrusted").callsFake(async () => response);
+        response = new Response(streamify("a, b\n0, 1\n"));
+        url = "fake/trusted/url";
+        response.headers.set("content-type", "text/csv; charset=utf-8");
+        
+        // Call fetchURL with isTrusted: true
+        const result = await fetchURL(url, null, { isTrusted: true });
+        
+        // Verify fetchTrusted was called and fetchUntrusted was not
+        sinon.assert.calledOnce(fetchTrustedStub);
+        sinon.assert.notCalled(Deps.fetchUntrusted as any);
+        assert.equal(result.files.length, 1);
+      });
+
+      it("should use fetch when isTrusted option is false or not set", async function() {
+        sandbox.stub(Deps, "fetchTrusted").callsFake(async () => response);
+        response = new Response(streamify("a, b\n0, 1\n"));
+        url = "fake/untrusted/url";
+        response.headers.set("content-type", "text/csv; charset=utf-8");
+        
+        // Call fetchURL without isTrusted option
+        const result = await fetchURL(url, null);
+        
+        // Verify fetchUntrusted was called and fetchTrusted was not
+        sinon.assert.calledOnce(Deps.fetchUntrusted as any);
+        sinon.assert.notCalled(Deps.fetchTrusted as any);
+        assert.equal(result.files.length, 1);
+      });
     });
 
     it("should respect access ids for uploads", async function() {

--- a/test/server/lib/uploads.ts
+++ b/test/server/lib/uploads.ts
@@ -265,6 +265,7 @@ describe("uploads", function() {
         const sandbox = sinon.createSandbox();
         try {
           const response = new Response(streamify("doc content"));
+          response.headers.set("content-disposition", "attachment; filename=\"document.grist\"");
           sandbox.stub(Deps, "fetchInternal").resolves(response);
           sandbox.stub(Deps, "fetch").rejects(new Error("should not be called"));
 

--- a/test/server/lib/uploads.ts
+++ b/test/server/lib/uploads.ts
@@ -245,8 +245,7 @@ describe("uploads", function() {
       });
 
       it("should use fetch by default for public fetchURL", async function() {
-        sandbox.stub(Deps, "fetchTrusted").callsFake(async () => response);
-        response = new Response(streamify("a, b\n0, 1\n"));
+        sandbox.stub(Deps, "fetchTrusted").rejects(new Error("should not be called"));
         url = "fake/untrusted/url";
         response.headers.set("content-type", "text/csv; charset=utf-8");
 

--- a/test/server/lib/uploads.ts
+++ b/test/server/lib/uploads.ts
@@ -246,6 +246,7 @@ describe("uploads", function() {
       });
 
       it("should use fetch by default for public fetchURL", async function() {
+        const response = new Response(streamify("a, b\n0, 1\n"));
         sandbox.stub(Deps, "fetchInternal").rejects(new Error("should not be called"));
         url = "fake/untrusted/url";
         response.headers.set("content-type", "text/csv; charset=utf-8");
@@ -260,7 +261,7 @@ describe("uploads", function() {
       });
     });
 
-    describe("fetchDoc", async function() {
+    describe("fetchDoc", function() {
       it("should use fetchInternal for doc worker URLs", async function() {
         const sandbox = sinon.createSandbox();
         try {

--- a/test/server/lib/uploads.ts
+++ b/test/server/lib/uploads.ts
@@ -244,28 +244,13 @@ describe("uploads", function() {
         assert.deepEqual(pick(result3.files[0], ["origName", "ext"]), { origName: "file3.csv", ext: ".json" });
       });
 
-      it("should use fetchTrusted when isTrusted option is true", async function() {
-        const fetchTrustedStub = sandbox.stub(Deps, "fetchTrusted").callsFake(async () => response);
-        response = new Response(streamify("a, b\n0, 1\n"));
-        url = "fake/trusted/url";
-        response.headers.set("content-type", "text/csv; charset=utf-8");
-
-        // Call fetchURL with isTrusted: true
-        const result = await fetchURL(url, null, { isTrusted: true });
-
-        // Verify fetchTrusted was called and fetch was not
-        sinon.assert.calledOnce(fetchTrustedStub);
-        sinon.assert.notCalled(Deps.fetch as any);
-        assert.equal(result.files.length, 1);
-      });
-
-      it("should use fetch when isTrusted option is false or not set", async function() {
+      it("should use fetch by default for public fetchURL", async function() {
         sandbox.stub(Deps, "fetchTrusted").callsFake(async () => response);
         response = new Response(streamify("a, b\n0, 1\n"));
         url = "fake/untrusted/url";
         response.headers.set("content-type", "text/csv; charset=utf-8");
 
-        // Call fetchURL without isTrusted option
+        // Call fetchURL (uses Deps.fetch by default for untrusted requests)
         const result = await fetchURL(url, null);
 
         // Verify fetch was called and fetchTrusted was not

--- a/test/server/lib/uploads.ts
+++ b/test/server/lib/uploads.ts
@@ -1,4 +1,5 @@
-import { createTmpDir, Deps, fetchURL, moveUpload, UploadSet } from "app/server/lib/uploads";
+import * as DocWorkerUtils from "app/server/lib/DocWorkerUtils";
+import { createTmpDir, Deps, fetchDoc, fetchURL, moveUpload, UploadSet } from "app/server/lib/uploads";
 import { globalUploadSet } from "app/server/lib/uploads";
 import { createFile } from "test/server/docTools";
 import { setTmpLogLevel } from "test/server/testUtils";
@@ -256,6 +257,43 @@ describe("uploads", function() {
         sinon.assert.calledOnce(Deps.fetch as any);
         sinon.assert.notCalled(Deps.fetchInternal as any);
         assert.equal(result.files.length, 1);
+      });
+    });
+
+    describe("fetchDoc", async function() {
+      it("should use fetchInternal for doc worker URLs", async function() {
+        const sandbox = sinon.createSandbox();
+        try {
+          const response = new Response(streamify("doc content"));
+          sandbox.stub(Deps, "fetchInternal").resolves(response);
+          sandbox.stub(Deps, "fetch").rejects(new Error("should not be called"));
+
+          const server = {
+            getHomeDBManager: () => ({
+              getRawDocById: sandbox.stub().resolves({ id: "doc123" }),
+            }),
+            getTag: () => "tag1",
+          } as any;
+
+          const req = {
+            get: sandbox.stub().returns(undefined),
+            socket: { remoteAddress: "127.0.0.1" },
+          } as any;
+
+          sandbox.stub(DocWorkerUtils, "getDocWorkerInfoOrSelfPrefix").resolves({
+            docWorker: { id: "worker1", internalUrl: "http://internal:8000", publicUrl: "http://public:8000" },
+          });
+
+          await fetchDoc(server, {} as any, "url123", req, null, false);
+
+          sinon.assert.calledOnce(Deps.fetchInternal as any);
+          sinon.assert.notCalled(Deps.fetch as any);
+          const call = (Deps.fetchInternal as any).getCall(0);
+          assert.include(call.args[0], "api/docs/doc123/download");
+        } finally {
+          sandbox.restore();
+          await globalUploadSet.cleanupAll();
+        }
       });
     });
 

--- a/test/server/lib/uploads.ts
+++ b/test/server/lib/uploads.ts
@@ -245,16 +245,16 @@ describe("uploads", function() {
       });
 
       it("should use fetch by default for public fetchURL", async function() {
-        sandbox.stub(Deps, "fetchTrusted").rejects(new Error("should not be called"));
+        sandbox.stub(Deps, "fetchInternal").rejects(new Error("should not be called"));
         url = "fake/untrusted/url";
         response.headers.set("content-type", "text/csv; charset=utf-8");
 
         // Call fetchURL (uses Deps.fetch by default for untrusted requests)
         const result = await fetchURL(url, null);
 
-        // Verify fetch was called and fetchTrusted was not
+        // Verify fetch was called and fetchInternal was not
         sinon.assert.calledOnce(Deps.fetch as any);
-        sinon.assert.notCalled(Deps.fetchTrusted as any);
+        sinon.assert.notCalled(Deps.fetchInternal as any);
         assert.equal(result.files.length, 1);
       });
     });


### PR DESCRIPTION
## Context

On self-hosted instances, if APP_DOC_INTERNAL_URL is set (in a multi-workers architecture), it is a trusted URL and it should not use the GRIST_PROXY_FOR_UNTRUSTED_URLS.

Without this change, when both GRIST_PROXY_FOR_UNTRUSTED_URLS and APP_DOC_INTERNAL_URL are set, the "Duplicate document..." action fails and displays error "Remote server returned an error (Unknown Host)".
(And there is the same error for "Save Copy..." of a snapshot.)


## Proposed solution

Use direct fetch for trusted urls, to fix duplicate doc with doc worker and proxy for untrusted urls

## Related issues

Fixes https://github.com/gristlabs/grist-core/issues/2253

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

