### PR TITLE
Let admins change the sandbox flavor from the admin panel

### DIFF
--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -2,7 +2,7 @@ import { buildHomeBanners } from "app/client/components/Banners";
 import { makeT } from "app/client/lib/localization";
 import { markdown } from "app/client/lib/markdown";
 import { getTimeFromNow } from "app/client/lib/timeUtils";
-import { AdminCheckRequest, AdminChecks, probeDetails, ProbeDetails } from "app/client/models/AdminChecks";
+import { AdminCheckRequest, AdminChecks, ProbeDetails } from "app/client/models/AdminChecks";
 import { AppModel, getHomeUrl, reportError } from "app/client/models/AppModel";
 import { AuditLogsModel, AuditLogsModelImpl } from "app/client/models/AuditLogsModel";
 import { urlState } from "app/client/models/gristUrlState";
@@ -41,6 +41,7 @@ import {
 } from "app/client/ui/PermissionsSetupSection";
 import { PermissionsToggleModel } from "app/client/ui/PermissionsToggleModel";
 import { QuickSetup } from "app/client/ui/QuickSetup";
+import { SandboxSetupSection } from "app/client/ui/SandboxSection";
 import { ServiceStatus } from "app/client/ui/ServiceStatus";
 import {
   cssPageTitle,
@@ -63,7 +64,7 @@ import { icon } from "app/client/ui2018/icons";
 import { cssLink, makeLinks } from "app/client/ui2018/links";
 import { confirmModal, spinnerModal } from "app/client/ui2018/modals";
 import { toggleSwitch } from "app/client/ui2018/toggleSwitch";
-import { BootProbeInfo, BootProbeResult, SandboxingBootProbeDetails } from "app/common/BootProbe";
+import { BootProbeInfo, BootProbeResult } from "app/common/BootProbe";
 import { ConfigAPI } from "app/common/ConfigAPI";
 import { delay } from "app/common/delay";
 import { AdminPanelPage, commonUrls, getPageTitleSuffix, LatestVersionAvailable } from "app/common/gristUrls";
@@ -231,6 +232,9 @@ class AdminInstallationPanel extends Disposable {
   // construction time and the "no valid user" admin path renders
   // alternative content that doesn't need the section anyway.
   private _authSection: AuthenticationSection | undefined;
+  // Created in the constructor body since it needs `_checks`. Heavy
+  // provider-enumeration probe is deferred until the row is expanded.
+  private _sandboxSection!: SandboxSetupSection;
 
   // Banner visibility: shown when a tracked section has restart-required
   // pending changes, or the user has applied changes without a restart and
@@ -258,9 +262,15 @@ class AdminInstallationPanel extends Disposable {
       });
     }
 
+    this._sandboxSection = SandboxSetupSection.create(this, {
+      checks: this._checks,
+      inAdminPanel: true,
+    });
+
     this._drafts.addSection(this._baseUrlSection);
     this._drafts.addSection(this._editionSection);
     this._drafts.addSection(this._permissionsModel);
+    this._drafts.addSection(this._sandboxSection);
     if (this._authSection) {
       this._drafts.addSection(this._authSection);
     }
@@ -519,8 +529,8 @@ class AdminInstallationPanel extends Disposable {
           id: "sandboxing",
           name: t("Sandboxing"),
           description: t("Sandbox settings for data engine"),
-          value: this._buildSandboxingDisplay(),
-          expandedContent: this._buildSandboxingNotice(),
+          value: this._sandboxSection.buildStatusDisplay(),
+          expandedContent: this._sandboxSection.buildDom(),
         }),
         SectionItem({
           id: "authentication",
@@ -637,43 +647,6 @@ class AdminInstallationPanel extends Disposable {
   private _buildInstallationIdRow() {
     const installationId = this._editionSection.getInstallationIdObservable();
     return installationId && dom("p", buildInstallationIdDisplay(installationId));
-  }
-
-  private _buildSandboxingDisplay() {
-    return dom.domComputed(
-      (use) => {
-        const req = this._checks.requestCheckById(use, "sandboxing");
-        const result = req ? use(req.result) : undefined;
-        const success = result?.status === "success";
-        const details = result?.details as SandboxingBootProbeDetails | undefined;
-        if (!details) {
-          // Sandbox details get filled out relatively slowly if
-          // this is first time on admin panel. So show "checking"
-          // if we don't have a reported status yet.
-          return cssValueLabel(result?.status ? t("unknown") : t("checking"));
-        }
-        const flavor = details.flavor;
-        const configured = details.configured;
-        return cssValueLabel(
-          configured ?
-            (success ? cssHappyText(t("OK") + `: ${flavor}`) :
-              cssErrorText(t("Error") + `: ${flavor}`)) :
-            cssErrorText(t("unconfigured")));
-      },
-    );
-  }
-
-  private _buildSandboxingNotice() {
-    return [
-      // Use AdminChecks text for sandboxing, in order not to
-      // duplicate.
-      probeDetails.sandboxing.info,
-      dom(
-        "div",
-        { style: "margin-top: 8px" },
-        cssLink({ href: commonUrls.helpSandboxing, target: "_blank" }, t("Learn more.")),
-      ),
-    ];
   }
 
   private _buildAdminUsersComputed(

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -140,10 +140,22 @@ export class QuickSetup extends Disposable {
       // on the Server step) it will have cached a fault. Drop it so the
       // section's load runs fresh now that the server is back.
       this._checks.discardIfFault(SANDBOX_PROBE_ID);
-      const section = SandboxSetupSection.create(owner, this._checks);
+      const section = SandboxSetupSection.create(owner, { checks: this._checks });
+      // Per-step DraftChangesManager so Continue drives apply+restart like
+      // the other steps. In admin panel mode, the section registers with
+      // the panel-level manager instead.
+      const drafts = DraftChangesManager.create(owner);
+      drafts.addSection(section);
+      const step: QuickSetupSection = {
+        canProceed: section.canProceed,
+        isDirty: drafts.hasDraftChanges,
+        isApplying: drafts.isApplying,
+        apply: () => drafts.applyAll(),
+        customLabel: use => section.customLabel(use),
+      };
       return dom("div",
         section.buildDom(),
-        quickSetupContinueButton(section, () => this._advanceStep(), testId("sandbox-continue")),
+        quickSetupContinueButton(step, () => this._advanceStep(), testId("sandbox-continue")),
       );
     });
   }

--- a/app/client/ui/SandboxSection.ts
+++ b/app/client/ui/SandboxSection.ts
@@ -1,12 +1,16 @@
 import { makeT } from "app/client/lib/localization";
-import { AdminChecks } from "app/client/models/AdminChecks";
+import { AdminChecks, probeDetails } from "app/client/models/AdminChecks";
 import { getHomeUrl } from "app/client/models/AppModel";
-import { ConfigSection, DraftChangesManager } from "app/client/ui/DraftChanges";
+import { cssErrorText, cssHappyText } from "app/client/ui/AdminPanelCss";
+import { ConfigSection, DraftChangeDescription } from "app/client/ui/DraftChanges";
 import { quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
+import { cssValueLabel } from "app/client/ui/SettingsLayout";
 import { BadgeConfig, buildCardList, buildHeroCard, buildItemCard } from "app/client/ui/SetupCard";
 import { theme, vars } from "app/client/ui2018/cssVars";
+import { cssLink } from "app/client/ui2018/links";
 import { loadingSpinner } from "app/client/ui2018/loaders";
-import { BootProbeIds } from "app/common/BootProbe";
+import { BootProbeIds, SandboxingBootProbeDetails } from "app/common/BootProbe";
+import { commonUrls } from "app/common/gristUrls";
 import { waitGrainObs } from "app/common/gutil";
 import { InstallAPIImpl } from "app/common/InstallAPI";
 import { SandboxInfo, SandboxingStatus } from "app/common/SandboxInfo";
@@ -18,59 +22,64 @@ const testId = makeTestId("test-sandbox-section-");
 
 export const SANDBOX_PROBE_ID: BootProbeIds = "sandbox-providers";
 
+interface SandboxSetupSectionOptions {
+  checks: AdminChecks;
+  /**
+   * True when rendered inside the admin panel; false / absent in the wizard.
+   * Suppresses the wizard step header so the section fits inside a
+   * SectionItem's expanded-content slot.
+   */
+  inAdminPanel?: boolean;
+}
+
 /**
- * Sandbox configuration section for QuickSetup. Fetches available sandbox
- * options through the shared {@link AdminChecks} (so the probe result is
- * memoized and can be pre-warmed by the wizard), shows them as cards, and
- * lets the user pick one. Conforms to {@link QuickSetupSection} by
- * delegating dirty/apply/restart through a {@link DraftChangesManager}
- * with a single registered {@link ConfigSection} adapter for the sandbox
- * flavor pref. This keeps the apply pipeline (persist + restart + wait,
- * with shared failure handling) the same as the Server step.
+ * Sandbox configuration section. Used in both the QuickSetup wizard and the
+ * Admin Panel. Implements {@link ConfigSection} so the caller registers it
+ * with their own {@link DraftChangesManager}, which keeps the apply pipeline
+ * (persist + restart + wait, with shared failure handling) the same as the
+ * other configurable sections (Auth, Base URL, Edition).
+ *
+ * The full provider list is loaded lazily via the heavy `sandbox-providers`
+ * probe -- spawned only when `buildDom()` runs, so the admin panel's
+ * sandboxing row paints fast and only pays for the probe if the admin
+ * actually expands it. `buildStatusDisplay()` uses the cheap `sandboxing`
+ * probe for the badge.
  */
-export class SandboxSetupSection extends Disposable {
+export class SandboxSetupSection extends Disposable implements ConfigSection {
   public readonly canProceed: Computed<boolean>;
   public readonly isDirty: Computed<boolean>;
-  public readonly isApplying: Observable<boolean>;
+  public readonly needsRestart = true;
+  public readonly describeChange: Computed<DraftChangeDescription[]>;
 
+  private _checks = this._options.checks;
+  private _inAdminPanel = Boolean(this._options.inAdminPanel);
   private _installAPI = new InstallAPIImpl(getHomeUrl());
-  // Data read from the server.
+  // Data read from the server. Loaded lazily on first buildDom().
   private _model = Observable.create<SandboxingStatus | null>(this, null);
   // If there was error loading or saving.
   private _error = Observable.create<string>(this, "");
   // Observable for user selection.
   private _selected = Observable.create<string | null>(this, null);
+  // Tracks whether the provider list has been requested yet. The admin
+  // panel constructs the section eagerly (it needs isDirty to register
+  // with the drafts manager) but we don't want to fire the heavy probe
+  // until the user expands the row.
+  private _loadStarted = false;
 
-  /** True when a different flavor is selected than what's currently active and not env-locked. */
-  private readonly _needsRestart: Computed<boolean> =
-    Computed.create(this, this._model, this._selected, (_, model, selected) => {
+  constructor(private _options: SandboxSetupSectionOptions) {
+    super();
+    this.isDirty = Computed.create(this, this._model, this._selected, (_, model, selected) => {
       if (model?.flavorInEnv) { return false; }
       return !!selected && selected !== model?.current;
     });
-
-  private readonly _drafts = DraftChangesManager.create(this);
-  private readonly _draftSection: ConfigSection = {
-    isDirty: this._needsRestart,
-    needsRestart: true,
-    apply: () => this._save(),
-    describeChange: Computed.create(this, use =>
-      [{ label: t("Sandbox"), value: sandboxLabel(use(this._selected) ?? "") }],
-    ),
-  };
-
-  constructor(private _checks: AdminChecks) {
-    super();
-    this._drafts.addSection(this._draftSection);
     this.canProceed = Computed.create(this, this._selected, (_, s) => !!s);
-    this.isDirty = this._drafts.hasDraftChanges;
-    this.isApplying = this._drafts.isApplying;
-    this._loadStatus().catch((e) => {
-      if (this.isDisposed()) { return; }
-      this._error.set(String(e));
-    });
+    this.describeChange = Computed.create(this, use =>
+      [{ label: t("Sandbox"), value: sandboxLabel(use(this._selected) ?? "") }],
+    );
   }
 
   public buildDom(): DomContents {
+    this._ensureLoadStarted();
     return dom("div",
       testId("sandboxing"),
       dom.maybe(this._error, err => cssError(err)),
@@ -78,11 +87,58 @@ export class SandboxSetupSection extends Disposable {
         if (!s) { return cssLoading(loadingSpinner(), t("Detecting sandbox options...")); }
         return dom("div", this._buildContent(s));
       }),
+      this._inAdminPanel ? this._buildAdminPanelFooter() : null,
     );
   }
 
+  /**
+   * Compact status display for the admin panel's `SectionItem` value cell.
+   * Reads the cheap `sandboxing` probe (current-flavor status only) so it
+   * paints fast without triggering the heavy provider enumeration.
+   */
+  public buildStatusDisplay(): DomContents {
+    return dom.domComputed((use) => {
+      const req = this._checks.requestCheckById(use, "sandboxing");
+      const result = req ? use(req.result) : undefined;
+      // AdminChecks initializes the result observable with status "none" and
+      // keeps it there until the probe lands -- treat that as "checking",
+      // not "unknown" (which would imply the probe answered but with no info).
+      const isPending = !result || result.status === "none";
+      if (isPending) { return cssValueLabel(t("checking")); }
+      const details = result.details as SandboxingBootProbeDetails | undefined;
+      if (!details) { return cssValueLabel(t("unknown")); }
+      if (!details.configured) {
+        return cssValueLabel(cssErrorText(t("unconfigured")));
+      }
+      const { flavor } = details;
+      return cssValueLabel(result.status === "success" ?
+        cssHappyText(t("OK") + `: ${flavor}`) :
+        cssErrorText(t("Error") + `: ${flavor}`));
+    });
+  }
+
   public async apply(): Promise<void> {
-    await this._drafts.applyAll();
+    if (!this.isDirty.get()) { return; }
+    const flavor = this._selected.get();
+    if (!flavor) { return; }
+    try {
+      await this._installAPI.updateInstallPrefs({ envVars: { GRIST_SANDBOX_FLAVOR: flavor } });
+      // Drop `isDirty` -- the chosen flavor is now persisted. The running
+      // server still uses the old flavor until restart, but the restart
+      // banner is driven by the parent (its `_awaitingManualRestart` flag
+      // or `_drafts.needsRestart`), not by us re-reporting dirty.
+      const model = this._model.get();
+      if (model) { this._model.set({ ...model, current: flavor }); }
+    } catch (e) {
+      this._error.set(String(e));
+      throw e;
+    }
+  }
+
+  /** Clear the user's pending selection so the row no longer reads as dirty. */
+  public async dismiss(): Promise<void> {
+    if (!this.isDirty.get()) { return; }
+    this._selected.set(this._model.get()?.current ?? null);
   }
 
   /** Returns "Skip and Continue" when env-locked; otherwise null to use shared defaults. */
@@ -90,21 +146,17 @@ export class SandboxSetupSection extends Disposable {
     return use(this._model)?.flavorInEnv ? t("Skip and Continue") : null;
   }
 
-  private _isLockedByEnv() {
-    return !!this._model.get()?.flavorInEnv;
+  private _ensureLoadStarted() {
+    if (this._loadStarted) { return; }
+    this._loadStarted = true;
+    this._loadStatus().catch((e) => {
+      if (this.isDisposed()) { return; }
+      this._error.set(String(e));
+    });
   }
 
-  private async _save() {
-    const flavor = this._selected.get();
-    const isSelectedByEnv = this._isLockedByEnv();
-    if (flavor && !isSelectedByEnv) {
-      try {
-        await this._installAPI.updateInstallPrefs({ envVars: { GRIST_SANDBOX_FLAVOR: flavor } });
-      } catch (e) {
-        this._error.set(String(e));
-        throw e;
-      }
-    }
+  private _isLockedByEnv() {
+    return !!this._model.get()?.flavorInEnv;
   }
 
   private async _fetchSandboxingStatus(): Promise<SandboxingStatus> {
@@ -124,6 +176,13 @@ export class SandboxSetupSection extends Disposable {
     this._model.set(model);
     if (model.flavorInEnv) {
       this._selected.set(model.current ?? "unsandboxed");
+    } else if (this._inAdminPanel) {
+      // Match the current server state so opening the section in the admin
+      // panel doesn't immediately flag a draft change. The user explicitly
+      // picks a flavor by clicking a radio. In the wizard we instead
+      // pre-select the recommended option because the user got there to
+      // configure a sandbox.
+      this._selected.set(model.current ?? null);
     } else {
       const best = model.options[0];
       this._selected.set(best.flavor ?? "unsandboxed");
@@ -154,8 +213,12 @@ export class SandboxSetupSection extends Disposable {
     const options = status.options;
     const recommended = options.find(o => o.functional && o.effective)?.flavor;
 
-    // When locked by env, hero is the current one; otherwise the recommended one.
-    const heroOption = isLockedByEnv ?
+    // Both the env-locked case and the admin panel show the running flavor
+    // as the hero (the user wants to see what's running, not a suggestion
+    // to switch). The wizard shows the recommended one, since the operator
+    // is being onboarded.
+    const showCurrentAsHero = isLockedByEnv || this._inAdminPanel;
+    const heroOption = showCurrentAsHero ?
       options.find(o => o.flavor === current) ?? options[0] :
       options.find(o => o.flavor === recommended) ?? options[0];
     const otherOptions = options.filter(o => o !== heroOption);
@@ -163,19 +226,24 @@ export class SandboxSetupSection extends Disposable {
     const canSelect = (opt: SandboxInfo) => opt.available && opt.functional !== false;
 
     const badgesFor = (opt: SandboxInfo): BadgeConfig[] => {
-      if (opt.flavor === current && opt.functional && opt.effective) {
-        return [{ label: t("Active"), variant: "primary" }];
+      // "Active" wins even when the boot probe couldn't verify functionality
+      // (it has a tight test timeout) -- if the server reports a flavor as
+      // current, it's actually serving documents with it. Layer Error/Not-
+      // recommended on top so the diagnostic still shows.
+      const badges: BadgeConfig[] = [];
+      if (opt.flavor === current) {
+        badges.push({ label: t("Active"), variant: "primary" });
       }
       if (!opt.available) {
-        return [{ label: t("Not available"), variant: "warning" }];
+        badges.push({ label: t("Not available"), variant: "warning" });
+      } else if (opt.functional === false) {
+        badges.push({ label: t("Error"), variant: "error" });
+      } else if (!opt.effective) {
+        badges.push({ label: t("Not recommended"), variant: "warning" });
+      } else if (badges.length === 0) {
+        badges.push({ label: t("Ready"), variant: "primary" });
       }
-      if (opt.functional === false) {
-        return [{ label: t("Error"), variant: "error" }];
-      }
-      if (!opt.effective) {
-        return [{ label: t("Not recommended"), variant: "warning" }];
-      }
-      return [{ label: t("Ready"), variant: "primary" }];
+      return badges;
     };
 
     const makeRadio = (key: string, disabled?: boolean) => ({
@@ -186,7 +254,7 @@ export class SandboxSetupSection extends Disposable {
     });
 
     return dom("div",
-      quickSetupStepHeader({
+      this._inAdminPanel ? null : quickSetupStepHeader({
         icon: "Lock",
         title: t("Sandboxing"),
         description: t("Grist runs user formulas as Python code. Sandboxing isolates this execution " +
@@ -195,7 +263,7 @@ export class SandboxSetupSection extends Disposable {
 
       isLockedByEnv ? cssEnvWarning(
         t("Sandbox type is set via the GRIST_SANDBOX_FLAVOR environment variable " +
-          "and cannot be changed here. Remove the variable and restart to configure via this wizard."),
+          "and cannot be changed here. Remove the variable and restart to configure it here."),
         testId("env-warning"),
       ) : null,
 
@@ -235,6 +303,16 @@ export class SandboxSetupSection extends Disposable {
           ),
         }) :
         null,
+    );
+  }
+
+  // Admin-panel-only footer reusing the AdminChecks sandbox blurb plus a
+  // help link. Lives at the bottom of the expanded content so admins can
+  // still find the docs that the old read-only row surfaced.
+  private _buildAdminPanelFooter(): DomContents {
+    return cssAdminPanelFooter(
+      probeDetails.sandboxing.info,
+      dom("div", cssLink({ href: commonUrls.helpSandboxing, target: "_blank" }, t("Learn more."))),
     );
   }
 }
@@ -291,4 +369,14 @@ const cssEnvWarning = styled("div", `
   padding: 12px 16px;
   margin-bottom: 16px;
   font-size: ${vars.smallFontSize};
+`);
+
+const cssAdminPanelFooter = styled("div", `
+  margin-top: 16px;
+  font-size: ${vars.smallFontSize};
+  color: ${theme.lightText};
+
+  & > div {
+    margin-top: 8px;
+  }
 `);

--- a/app/server/lib/NSandbox.ts
+++ b/app/server/lib/NSandbox.ts
@@ -726,9 +726,15 @@ export async function testSandboxFlavor(flavor?: string): Promise<SandboxInfo> {
     info.lastSuccessfulStep = "create";
 
     // Step 2: Run a simple Python call to check if the sandbox can execute code.
-    // Give up after 5 seconds if it takes too long.
+    // The result is cached for the life of the server process, so the timeout
+    // just needs to be long enough to outlast the slowest legitimate cold start
+    // (pyodide loading wasm, gvisor first-runsc-invocation, etc.) -- a tight
+    // budget here produces false negatives that mislead admins into thinking
+    // their working sandbox is broken.
+    const TIMEOUT_MS = 10_000;
     const timeoutProm = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("Sandbox test timed out after 5s")), 5000).unref(),
+      setTimeout(() => reject(new Error(`Sandbox test timed out after ${TIMEOUT_MS / 1000}s`)),
+        TIMEOUT_MS).unref(),
     );
     const result = await Promise.race([sandbox.pyCall("get_version"), timeoutProm]);
     if (typeof result !== "number") {

--- a/test/nbrowser/AdminPanelSandbox.ts
+++ b/test/nbrowser/AdminPanelSandbox.ts
@@ -1,0 +1,222 @@
+import { BootProbeResult } from "app/common/BootProbe";
+import { InstallAPIImpl } from "app/common/InstallAPI";
+import { SandboxInfo } from "app/common/SandboxInfo";
+import * as gu from "test/nbrowser/gristUtils";
+import { server, setupTestSuite } from "test/nbrowser/testUtils";
+import * as testUtils from "test/server/testUtils";
+
+import { assert, driver } from "mocha-webdriver";
+
+/**
+ * Verifies that the Sandboxing row in the admin panel is a real
+ * configurable section (not the old read-only probe display). Mirrors
+ * QuickSetupSandbox.ts but exercises the panel-level DraftChangesManager
+ * path: pick a flavor -> restart banner shows the draft -> apply persists
+ * via install prefs.
+ *
+ * We can't actually restart into the new flavor in tests, so we verify the
+ * persisted env-var override via getInstallPrefs and re-read after a fresh
+ * server restart -- same approach as AdminPanelPermissions.
+ */
+
+const WORKS_AND_EFFECTIVE: Partial<SandboxInfo> = {
+  available: true,
+  effective: true,
+  functional: true,
+  configured: true,
+  lastSuccessfulStep: "all",
+};
+
+const UNSANDBOXED: Partial<SandboxInfo> = {
+  available: true,
+  effective: false,
+  functional: true,
+  configured: false,
+  lastSuccessfulStep: "none",
+};
+
+// gVisor + pyodide both functional; current is unsandboxed (fresh install).
+const FIXTURE_GVISOR_AND_PYODIDE: BootProbeResult = {
+  status: "success",
+  details: {
+    options: [
+      { flavor: "gvisor", ...WORKS_AND_EFFECTIVE },
+      { flavor: "pyodide", ...WORKS_AND_EFFECTIVE },
+      { flavor: "unsandboxed", ...UNSANDBOXED },
+    ],
+    current: "unsandboxed",
+  },
+};
+
+// GRIST_SANDBOX_FLAVOR is set in the env -- UI should disable radios and
+// surface the env-locked warning.
+const FIXTURE_ENV_LOCKED: BootProbeResult = {
+  status: "success",
+  details: {
+    options: [
+      { flavor: "gvisor", ...WORKS_AND_EFFECTIVE },
+      { flavor: "pyodide", ...WORKS_AND_EFFECTIVE },
+      { flavor: "unsandboxed", ...UNSANDBOXED },
+    ],
+    current: "gvisor",
+    flavorInEnv: "gvisor",
+  },
+};
+
+describe("AdminPanelSandbox", function() {
+  this.timeout(process.env.DEBUG ? "10m" : "60s");
+  setupTestSuite();
+  gu.bigScreen();
+
+  let oldEnv: testUtils.EnvironmentSnapshot;
+  let session: gu.Session;
+  let installApi: InstallAPIImpl;
+
+  afterEach(() => gu.checkForErrors());
+
+  before(async function() {
+    oldEnv = new testUtils.EnvironmentSnapshot();
+    process.env.GRIST_TEST_SERVER_DEPLOYMENT_TYPE = "core";
+    process.env.GRIST_DEFAULT_EMAIL = gu.session().email;
+    process.env.GRIST_TEST_SANDBOX_PROVIDERS_PROBE_RESULT = JSON.stringify(FIXTURE_GVISOR_AND_PYODIDE);
+    await server.restart(true); // clear database
+    session = await gu.session().personalSite.login();
+    installApi = session.createApi(InstallAPIImpl);
+  });
+
+  after(async function() {
+    oldEnv.restore();
+    await server.restart(true);
+  });
+
+  async function expandSandboxItem() {
+    const header = await driver.findWait(".test-admin-panel-item-name-sandboxing", 3000);
+    await gu.scrollIntoView(header);
+    await header.click();
+    // The heavy probe is mocked, but the section still loads it through the
+    // probe pipeline -- wait for a hero card with a header to render.
+    await gu.waitToPass(async () => {
+      const card = await driver.find(
+        ".test-admin-panel-item-sandboxing .test-setup-card-hero .test-setup-card-header",
+      );
+      assert.notEqual(await card.getText(), "");
+    }, 5000);
+  }
+
+  // Click the collapsible "Other options" header once if its contents aren't
+  // already rendered. The hero flavor (flavor-0) is always present; the rest
+  // live inside the collapsible card list.
+  async function revealOtherOptions(flavor: string) {
+    const selector = `.test-admin-panel-item-sandboxing .test-sandbox-section-flavor-${flavor}`;
+    if ((await driver.findAll(selector)).length === 0) {
+      await driver.findContent(".test-admin-panel-item-sandboxing div", /Other options/i).click();
+    }
+    return driver.findWait(selector, 2000);
+  }
+
+  it("status badge resolves without expanding the row", async function() {
+    await driver.get(`${server.getHost()}/admin`);
+    await gu.waitForAdminPanel();
+    // The badge comes from the cheap `sandboxing` probe, which is the real
+    // server-side check. On grist-core with no GRIST_SANDBOX_FLAVOR it reports
+    // "unconfigured"; in some environments it may surface "Error: unknown".
+    // Either way the badge resolves -- it doesn't sit on "checking" forever.
+    await gu.waitToPass(async () => {
+      assert.match(
+        await driver.find(".test-admin-panel-item-value-sandboxing").getText(),
+        /^((Error:.*)|(OK:.*)|(unconfigured))$/,
+      );
+    }, 5000);
+  });
+
+  it("renders hero card plus other options when expanded", async function() {
+    await driver.get(`${server.getHost()}/admin`);
+    await gu.waitForAdminPanel();
+    await expandSandboxItem();
+
+    // In admin panel mode the hero is the currently-running flavor. The
+    // fixture sets current: "unsandboxed" (a fresh install scenario).
+    const heroHeader = await driver.find(
+      ".test-admin-panel-item-sandboxing .test-sandbox-section-flavor-0 .test-setup-card-header",
+    ).getText();
+    assert.include(heroHeader, "No Sandbox");
+
+    // gVisor and Pyodide are reachable as non-hero options.
+    const gvisor = await revealOtherOptions("gvisor");
+    assert.include(await gvisor.find(".test-setup-card-header").getText(), "gVisor");
+    const pyodide = await revealOtherOptions("pyodide");
+    assert.include(await pyodide.find(".test-setup-card-header").getText(), "Pyodide");
+  });
+
+  it("flags a draft change in the restart banner when a flavor is picked", async function() {
+    await driver.get(`${server.getHost()}/admin`);
+    await gu.waitForAdminPanel();
+    await expandSandboxItem();
+
+    // The current flavor ("unsandboxed") is selected by default. No banner yet.
+    assert.isFalse(await driver.find(".test-admin-panel-draft-changes").isPresent());
+
+    const pyodide = await revealOtherOptions("pyodide");
+    await pyodide.find("input[type='radio']").click();
+
+    // Restart banner should now list Sandbox: Pyodide.
+    const banner = await driver.findWait(".test-admin-panel-draft-changes", 3000);
+    await gu.waitToPass(async () => {
+      const text = await banner.getText();
+      assert.match(text, /Sandbox/);
+      assert.match(text, /Pyodide/);
+    }, 3000);
+
+    // Dismissing should clear the draft and the banner.
+    await driver.find(".test-admin-panel-dismiss-button").click();
+    await driver.findContentWait(".test-modal-confirm", /Dismiss/, 2000).click();
+    await gu.waitToPass(async () => {
+      assert.isFalse(await driver.find(".test-admin-panel-draft-changes").isPresent());
+    }, 3000);
+  });
+
+  it("apply-without-restart persists the flavor via install prefs", async function() {
+    await driver.get(`${server.getHost()}/admin`);
+    await gu.waitForAdminPanel();
+    await expandSandboxItem();
+
+    const pyodide = await revealOtherOptions("pyodide");
+    await pyodide.find("input[type='radio']").click();
+    await driver.findWait(".test-admin-panel-draft-changes", 3000);
+
+    // In test mode the server can't auto-restart, so the manual-apply
+    // button is exposed. Click it; the install prefs should pick up the
+    // GRIST_SANDBOX_FLAVOR override.
+    await driver.findWait(".test-admin-panel-apply-no-restart", 3000);
+    await gu.waitToPass(async () => {
+      await driver.find(".test-admin-panel-apply-no-restart").click();
+    }, 3000);
+    await gu.waitToPass(async () => {
+      assert.isFalse(await driver.find(".test-admin-panel-draft-changes").isPresent());
+    }, 5000);
+
+    const prefs = await installApi.getInstallPrefs();
+    assert.equal(prefs.envVars?.GRIST_SANDBOX_FLAVOR, "pyodide");
+  });
+
+  it("env-locked installs disable the radios and show the warning", async function() {
+    process.env.GRIST_TEST_SANDBOX_PROVIDERS_PROBE_RESULT = JSON.stringify(FIXTURE_ENV_LOCKED);
+    await server.restart();
+    session = await gu.session().personalSite.login();
+    installApi = session.createApi(InstallAPIImpl);
+
+    await driver.get(`${server.getHost()}/admin`);
+    await gu.waitForAdminPanel();
+    await expandSandboxItem();
+
+    assert.isTrue(await driver.find(
+      ".test-admin-panel-item-sandboxing .test-sandbox-section-env-warning",
+    ).isDisplayed());
+
+    // Hero is the env-locked flavor (gvisor) and its radio is disabled.
+    const heroRadio = await driver.find(
+      ".test-admin-panel-item-sandboxing .test-sandbox-section-flavor-0 input[type='radio']",
+    );
+    assert.equal(await heroRadio.getAttribute("disabled"), "true");
+  });
+});


### PR DESCRIPTION
The setup wizard shipped first with a friendly sandbox chooser; this commit lands the planned follow-up of wiring the same chooser into the admin panel. The Sandboxing row used to be read-only -- it showed the current sandbox status and a help link, but to switch flavors you had to set GRIST_SANDBOX_FLAVOR by hand and restart.

What's new in this commit:

- SandboxSetupSection now implements ConfigSection, so it plugs into whichever DraftChangesManager the caller owns. The wizard step keeps its per-step manager; the admin panel registers the section with its panel-wide manager alongside Auth, Base URL, Edition, and Permissions.
- The section renders a compact status badge for the admin panel's SectionItem value cell, and the full card list when the row is expanded. The heavy sandbox-providers probe only fires on expansion, so the admin panel paints fast for everyone else.
- In the admin panel, the hero card is now the sandbox that's actually running (matching how the env-locked case already worked), so a user who picks a flavor and restarts sees their choice front and center. The wizard still leads with the recommended option.
- Badges can now stack: a flavor that's running but reporting a probe error shows "Active" plus "Error" together instead of just "Error", so admins get the full picture.
- The pending-state badge says "checking" instead of "unknown" while the probe is still in flight.

The sandbox boot probe's 5-second timeout was also producing false negatives on slow cold starts (pyodide loading wasm, gvisor's first runsc invocation), which made the admin panel look like a flavor switch hadn't taken effect. Bumped to 10s. The result is cached for the server's lifetime, so this only matters on the first probe after boot.

Covered by a new nbrowser suite (AdminPanelSandbox) that exercises the status badge, the expanded card list, the draft-and-dismiss flow, the apply-without-restart path, and the env-locked warning.
