### PR TITLE
Reserve "forum" as a subdomain

### DIFF
--- a/app/common/orgNameUtils.ts
+++ b/app/common/orgNameUtils.ts
@@ -14,7 +14,7 @@ const BLACKLISTED_SUBDOMAINS = new Set([
   // some in any case, but specified here also in case that minimum changes.
   "w", "ww", "wwww", "wwwww",
   "docs", "api", "static",
-  "ftp", "imap", "pop", "smtp", "mail", "git", "blog", "wiki", "support", "kb", "help",
+  "ftp", "imap", "pop", "smtp", "mail", "git", "blog", "wiki", "support", "kb", "help", "forum",
   "admin", "store", "dev", "beta",
   "community", "try", "wpx", "telemetry",
 


### PR DESCRIPTION
This adds "forum" alongside the other reserved names like "support" and "help" in the shared blacklist for subdomains.

This list lives in app/common and ships with every Grist install. In principle, it feels like the list would be configurable per deployment, but a sensible default has served us fine so far and is better than no list at all. Revisit as soon as someone needs better.
