### PR TITLE
Feature : add kubernetes sandbox flavor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,11 @@ COPY sandbox/requirements.txt /grist/sandbox/requirements.txt
 RUN \
   cd /grist/sandbox/pyodide && make setup
 
+# get kubectl
+RUN curl -LO "https://dl.k8s.io/release/v1.35.3/bin/linux/amd64/kubectl"
+RUN install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+RUN rm kubectl
+
 ################################################################################
 ## Python collection stage
 ################################################################################
@@ -122,6 +127,9 @@ RUN \
 
 # Copy runsc.
 COPY --from=sandbox /runsc /usr/bin/runsc
+
+# Copy kubectl
+COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/kubectl
 
 # Add files needed for running server.
 COPY package.json /grist/package.json

--- a/app/server/lib/NSandbox.ts
+++ b/app/server/lib/NSandbox.ts
@@ -23,6 +23,7 @@ import * as shutdown from "app/server/lib/shutdown";
 
 import { ChildProcess, fork, spawn, SpawnOptionsWithoutStdio } from "child_process";
 import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 import { Stream, Writable } from "stream";
 
@@ -524,6 +525,7 @@ const spawners = {
   unsandboxed,        // No sandboxing, straight to host python.
   // This offers no protection to the host.
   docker,             // Run sandboxes in distinct docker containers.
+  kube,               // Run sandboxes in distinct kubernetes pods.
   gvisor,             // Gvisor's runsc sandbox.
   macSandboxExec,     // Use "sandbox-exec" on Mac.
   pyodide,            // Run data engine using pyodide.
@@ -1055,6 +1057,68 @@ function docker(options: ISandboxOptions): SandboxProcess {
   ]);
   log.rawDebug("cannot do process control via docker yet", { ...options.logMeta });
   return { name: "docker", child, control: () => new NoProcessControl(child) };
+}
+
+/**
+ * Helper function to run python in a container with k8s. Each sandbox run in a
+ * distinct pod. GRIST_SANDBOX should be the name of an image where
+ * `python` can be run and all Grist dependencies are installed.  See
+ * `sandbox/docker` for more. Extra kubectl run arguments can be given through
+ * KUBE_EXTRA_ARGS.
+ */
+function kube(options: ISandboxOptions): SandboxProcess {
+  const { command } = options;
+  if (options.minimalPipeMode === false) {
+    throw new Error("kubernetes only supports 3-pipe operation");
+  }
+  const paths = getAbsolutePaths(options);
+  const wrapperArgs = new FlagBag({ env: "--env", mount: "-m" });
+  wrapperArgs.push(...options.testSandboxArgs);
+  if (paths.importDir) {
+    throw new Error("kubernetes does not support importDir usage");
+  }
+  wrapperArgs.addAllEnv(getInsertedEnv(options));
+  wrapperArgs.addEnv("PYTHONPATH", "grist:thirdparty");
+
+  const commandParts = [
+    // DETERMINISTIC_MODE is already set by getInsertedEnv().  We also take
+    // responsibility here for running faketime around python.
+    ...(options.deterministicMode ? ["faketime", "-f", FAKETIME] : []),
+    "python",
+  ];
+
+  const pythonArgs = [
+    ...options.testPythonArgs,
+    ...(options.useGristEntrypoint !== false ? ["grist/main.py"] : []),
+  ];
+
+  const appendArgs = [
+    ...(options.comment ? [options.comment] : []),
+    ...(options.appendArgs ?? []),
+  ];
+
+  if (process.env.KUBE_EXTRA_ARGS) {
+    wrapperArgs.push(...process.env.KUBE_EXTRA_ARGS.split(" "));
+  }
+
+  let podname: string = os.hostname() + "-";
+  for (let i = 0; i < 8; i++) {
+    podname += "abcdefghijklmnopqrstuvwxyz".charAt(Math.floor(Math.random() * 26));
+  }
+  const kubectlPath = which.sync("kubectl");
+  const child = spawn(kubectlPath, [
+    "run", "--rm", "--command=true", "--restart=Never",
+    "-i",
+    ...wrapperArgs.get(),
+    `--image=${command || "grist-docker-sandbox"}`,  // this is the docker image to use
+    podname,
+    "--",
+    ...commandParts,
+    ...pythonArgs,
+    ...appendArgs,
+  ]);
+  log.rawDebug("cannot do process control via kubernetes yet", { ...options.logMeta });
+  return { name: "kubernetes", child, control: () => new NoProcessControl(child) };
 }
 
 /**

--- a/app/server/lib/NSandbox.ts
+++ b/app/server/lib/NSandbox.ts
@@ -13,6 +13,7 @@ import { getAppRoot, getAppRootFor, getUnpackedAppRoot } from "app/server/lib/pl
 import {
   DirectProcessControl,
   ISandboxControl,
+  KubeSandboxControl,
   NoProcessControl,
   ProcessInfo,
   SubprocessControl,
@@ -1064,7 +1065,7 @@ function docker(options: ISandboxOptions): SandboxProcess {
  * distinct pod. GRIST_SANDBOX should be the name of an image where
  * `python` can be run and all Grist dependencies are installed.  See
  * `sandbox/docker` for more. Extra kubectl run arguments can be given through
- * KUBE_EXTRA_ARGS.
+ * KUBE_EXTRA_ARGS. For run specific arguments, use KUBE_EXTRA_RUN_ARGS.
  */
 function kube(options: ISandboxOptions): SandboxProcess {
   const { command } = options;
@@ -1097,8 +1098,8 @@ function kube(options: ISandboxOptions): SandboxProcess {
     ...(options.appendArgs ?? []),
   ];
 
-  if (process.env.KUBE_EXTRA_ARGS) {
-    wrapperArgs.push(...process.env.KUBE_EXTRA_ARGS.split(" "));
+  if (process.env.KUBE_EXTRA_RUN_ARGS) {
+    wrapperArgs.push(...process.env.KUBE_EXTRA_RUN_ARGS.split(" "));
   }
 
   let podname: string = os.hostname() + "-";
@@ -1107,6 +1108,7 @@ function kube(options: ISandboxOptions): SandboxProcess {
   }
   const kubectlPath = which.sync("kubectl");
   const child = spawn(kubectlPath, [
+    ...(process.env.KUBE_EXTRA_ARGS ? process.env.KUBE_EXTRA_ARGS.split(" ") : []),
     "run", "--rm", "--command=true", "--restart=Never",
     "-i",
     ...wrapperArgs.get(),
@@ -1118,7 +1120,7 @@ function kube(options: ISandboxOptions): SandboxProcess {
     ...appendArgs,
   ]);
   log.rawDebug("cannot do process control via kubernetes yet", { ...options.logMeta });
-  return { name: "kubernetes", child, control: () => new NoProcessControl(child) };
+  return { name: "kubernetes", child, control: () => new KubeSandboxControl(child, podname) };
 }
 
 /**

--- a/app/server/lib/NSandbox.ts
+++ b/app/server/lib/NSandbox.ts
@@ -23,6 +23,7 @@ import * as sandboxUtil from "app/server/lib/sandboxUtil";
 import * as shutdown from "app/server/lib/shutdown";
 
 import { ChildProcess, fork, spawn, SpawnOptionsWithoutStdio } from "child_process";
+import { createHash, randomBytes } from "crypto";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -1102,10 +1103,12 @@ function kube(options: ISandboxOptions): SandboxProcess {
     wrapperArgs.push(...process.env.KUBE_EXTRA_RUN_ARGS.split(" "));
   }
 
-  let podname: string = os.hostname() + "-";
-  for (let i = 0; i < 8; i++) {
-    podname += "abcdefghijklmnopqrstuvwxyz".charAt(Math.floor(Math.random() * 26));
+  let podname: string = os.hostname().toLowerCase().replace(/[^0-9a-z-]/g, "-");
+  if (podname.length > 39) {
+    podname = podname.substring(0, 20) + createHash("sha256").update(podname).digest("hex").substring(0, 19);
   }
+  podname = "grist-engine-" + podname + "-" + randomBytes(5).toString("hex");
+
   const kubectlPath = which.sync("kubectl");
   const child = spawn(kubectlPath, [
     ...(process.env.KUBE_EXTRA_ARGS ? process.env.KUBE_EXTRA_ARGS.split(" ") : []),

--- a/app/server/lib/SandboxControl.ts
+++ b/app/server/lib/SandboxControl.ts
@@ -6,6 +6,7 @@ import * as childProcess from "child_process";
 import * as util from "util";
 
 import pidusage from "pidusage";
+import * as which from "which";
 
 const execFile = util.promisify(childProcess.execFile);
 
@@ -73,6 +74,33 @@ export class NoProcessControl implements ISandboxControl {
   }
 
   public async close() {
+  }
+
+  public prepareToClose() {
+  }
+
+  public async kill() {
+    this._process.kill("SIGKILL");
+  }
+
+  public async getUsage() {
+    return { memory: Infinity };
+  }
+}
+
+/**
+ * Dummy control interface that does no monitoring or throttling.
+ */
+export class KubeSandboxControl implements ISandboxControl {
+  constructor(private _process: childProcess.ChildProcess, private _podName: string) {
+  }
+
+  public async close() {
+    const kubectlPath = which.sync("kubectl");
+    childProcess.spawn(kubectlPath, [
+      ...(process.env.KUBE_EXTRA_ARGS ? process.env.KUBE_EXTRA_ARGS.split(" ") : []),
+      "delete", "pod", this._podName, "--now",
+    ]);
   }
 
   public prepareToClose() {

--- a/app/server/lib/SandboxControl.ts
+++ b/app/server/lib/SandboxControl.ts
@@ -100,7 +100,7 @@ export class KubeSandboxControl implements ISandboxControl {
     childProcess.spawn(kubectlPath, [
       ...(process.env.KUBE_EXTRA_ARGS ? process.env.KUBE_EXTRA_ARGS.split(" ") : []),
       "delete", "pod", this._podName, "--now",
-    ]);
+    ], { stdio: ["ignore", "inherit", "inherit"] });
   }
 
   public prepareToClose() {

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.11
 
 COPY requirements.txt /tmp/requirements.txt
+COPY gris[t] /grist
 
 RUN \
   pip3 install -r /tmp/requirements.txt

--- a/sandbox/docker/Makefile
+++ b/sandbox/docker/Makefile
@@ -1,3 +1,9 @@
+image-embeded:
+	cp -r ../grist ../requirements.txt .  # docker build requires files to be present.
+	docker build -t grist-docker-sandbox .
+	rm -rf grist requirements.txt
+
 image:
 	cp ../requirements.txt .  # docker build requires files to be present.
 	docker build -t grist-docker-sandbox .
+	rm requirements.txt


### PR DESCRIPTION
## Context

In the objective of replacing the gvisor sandboxing by µVMs for environment with high security considerations, I ended up to implement this inside a kubernetes cluster, which allows to abstract the container backend.

## Proposed solution

Adds a `kube` flavor with two new environment variable to configure the pod creation and management :
- `KUBE_EXTRA_ARGS` common to pod creation and deletion, typically for setting a namespace
- `KUBE_EXTRA_RUN_ARGS` to configure the pod, for example `--labels=isolated=on`

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
This is a new feature not discussed in an issue before, only with the DINUM team.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [x] 🙋 no, because I need help <!-- Detail how we can help you -->

I've of course tested in local, but the testing needs a kube cluster, I'm not sure about how to do this inside the test suite.