### PR TITLE
enh: form widget takes conditions

### DIFF
--- a/app/client/components/Forms/Field.ts
+++ b/app/client/components/Forms/Field.ts
@@ -3,10 +3,10 @@ import { buildEditor } from "app/client/components/Forms/Editor";
 import { FormView } from "app/client/components/Forms/FormView";
 import { BoxModel, ignoreClick } from "app/client/components/Forms/Model";
 import * as css from "app/client/components/Forms/styles";
-import { ReferenceUtils } from "app/client/lib/ReferenceUtils";
 import { stopEvent } from "app/client/lib/domUtils";
 import { makeT } from "app/client/lib/localization";
-import { DocModel, refRecord } from "app/client/models/DocModel";
+import { ReferenceUtils } from "app/client/lib/ReferenceUtils";
+import { DocModel, refRecord, type ViewFieldRec } from "app/client/models/DocModel";
 import TableModel from "app/client/models/TableModel";
 import {
   FormFieldOptions,
@@ -22,9 +22,10 @@ import { autoGrow } from "app/client/ui/forms";
 import { cssCheckboxSquare, cssLabel, squareCheckbox } from "app/client/ui2018/checkbox";
 import { cssRadioInput } from "app/client/ui2018/radio";
 import { toggleSwitch } from "app/client/ui2018/toggleSwitch";
-import { ChoiceItem, buildDropdownConditionFilter } from "app/client/widgets/ChoiceListEditor";
+import { buildDropdownConditionFilter, ChoiceItem } from "app/client/widgets/ChoiceListEditor";
 import { isBlankValue } from "app/common/gristTypes";
 import { Constructor, not } from "app/common/gutil";
+import { UIRowId } from "app/plugin/GristAPI";
 
 import {
   BindableValue,
@@ -45,9 +46,6 @@ import {
   UseCB,
 } from "grainjs";
 import * as ko from "knockout";
-
-import type { ViewFieldRec } from "app/client/models/DocModel";
-import { UIRowId } from "app/plugin/GristAPI";
 
 const testId = makeTestId("test-forms-");
 

--- a/app/client/components/Forms/Field.ts
+++ b/app/client/components/Forms/Field.ts
@@ -3,6 +3,7 @@ import { buildEditor } from "app/client/components/Forms/Editor";
 import { FormView } from "app/client/components/Forms/FormView";
 import { BoxModel, ignoreClick } from "app/client/components/Forms/Model";
 import * as css from "app/client/components/Forms/styles";
+import { ReferenceUtils } from "app/client/lib/ReferenceUtils";
 import { stopEvent } from "app/client/lib/domUtils";
 import { makeT } from "app/client/lib/localization";
 import { DocModel, refRecord } from "app/client/models/DocModel";
@@ -21,6 +22,7 @@ import { autoGrow } from "app/client/ui/forms";
 import { cssCheckboxSquare, cssLabel, squareCheckbox } from "app/client/ui2018/checkbox";
 import { cssRadioInput } from "app/client/ui2018/radio";
 import { toggleSwitch } from "app/client/ui2018/toggleSwitch";
+import { ChoiceItem, buildDropdownConditionFilter } from "app/client/widgets/ChoiceListEditor";
 import { isBlankValue } from "app/common/gristTypes";
 import { Constructor, not } from "app/common/gutil";
 
@@ -31,6 +33,7 @@ import {
   dom,
   DomContents,
   DomElementArg,
+  fromKo,
   Holder,
   IDisposableOwner,
   IDomArgs,
@@ -44,8 +47,14 @@ import {
 import * as ko from "knockout";
 
 import type { ViewFieldRec } from "app/client/models/DocModel";
+import { UIRowId } from "app/plugin/GristAPI";
 
 const testId = makeTestId("test-forms-");
+
+/** Source-table row for evaluating column dropdown conditions in the form widget (matches grid editors). */
+function normalizeContextRowIdForDropdown(rid: UIRowId | null | undefined): number {
+  return typeof rid === "number" && !Number.isNaN(rid) ? rid : -1;
+}
 
 const t = makeT("Field");
 
@@ -378,18 +387,31 @@ class ChoiceModel extends Question {
 
   constructor(model: FieldModel) {
     super(model);
+    const contextRowId = fromKo(this, model.view.cursor.rowId);
     this.choices = Computed.create(this, (use) => {
-      // Read choices from field.
       const field = use(this.field);
       const choices = use(field.widgetOptionsJson.prop("choices"))?.slice() ?? [];
 
-      // Make sure it is an array of strings.
       if (!Array.isArray(choices) || choices.some(choice => typeof choice !== "string")) {
         return [];
-      } else {
-        sortChoicesInPlace(choices, item => String(item), use(this._sortOrder));
-        return choices;
       }
+      sortChoicesInPlace(choices, item => String(item), use(this._sortOrder));
+
+      const dropdownCond = use(field.dropdownCondition);
+      if (dropdownCond?.text) {
+        const compiled = use(field.dropdownConditionCompiled);
+        if (compiled?.kind !== "success") {
+          return [];
+        }
+        const filter = buildDropdownConditionFilter({
+          dropdownConditionCompiled: compiled.result,
+          gristDoc: model.view.gristDoc,
+          tableId: use(field.tableId),
+          rowId: normalizeContextRowIdForDropdown(use(contextRowId)),
+        });
+        return choices.filter(c => filter(new ChoiceItem(c, false, false)));
+      }
+      return choices;
     });
   }
 
@@ -532,6 +554,9 @@ class RefListModel extends Question {
     return use(field.widgetOptionsJson.prop("formOptionsAlignment")) ?? "vertical";
   });
 
+  private readonly _refUtils: ReferenceUtils;
+  private readonly _formContextRowId: Observable<UIRowId | null>;
+
   private _sortOrder = Computed.create<FormOptionsSortOrder | undefined>(this, (use) => {
     const field = use(this.field);
     return use(field.widgetOptionsJson.prop("formOptionsSortOrder"));
@@ -539,6 +564,8 @@ class RefListModel extends Question {
 
   constructor(model: FieldModel) {
     super(model);
+    this._refUtils = this.autoDispose(new ReferenceUtils(model.field.peek(), model.view.gristDoc));
+    this._formContextRowId = fromKo(this, model.view.cursor.rowId);
     this.options = this._getOptions();
   }
 
@@ -573,8 +600,15 @@ class RefListModel extends Question {
     const observer = this._columnObserver(this, this.model.view.gristDoc.docModel, tableId, colId);
 
     return Computed.create(this, (use) => {
-      const values = use(observer)
-        .filter(([_id, value]) => !isBlankValue(value))
+      const tuples = use(observer)
+        .filter(([_id, value]) => !isBlankValue(value));
+
+      const rowIds = tuples.map(([id]) => Number(id));
+      const allowed = this._refUtils.filterByDropdownCondition(rowIds, use(this._formContextRowId));
+      const allowedSet = new Set(allowed);
+
+      const values = tuples
+        .filter(([id]) => allowedSet.has(Number(id)))
         .map(([id, value]) => ({ label: String(value), value: String(id) }));
 
       sortChoicesInPlace(values, item => item.label, use(this._sortOrder));

--- a/app/client/lib/ReferenceUtils.ts
+++ b/app/client/lib/ReferenceUtils.ts
@@ -9,7 +9,6 @@ import { TableData } from "app/client/models/TableData";
 import { getReferencedTableId, isRefListType } from "app/common/gristTypes";
 import { EmptyRecordView } from "app/common/RecordView";
 import { BaseFormatter } from "app/common/ValueFormatter";
-
 import { UIRowId } from "app/plugin/GristAPI";
 
 import { Disposable, dom, Observable } from "grainjs";

--- a/app/client/lib/ReferenceUtils.ts
+++ b/app/client/lib/ReferenceUtils.ts
@@ -1,5 +1,5 @@
 import { GristDoc } from "app/client/components/GristDoc";
-import { ACIndex, ACResults } from "app/client/lib/ACIndex";
+import { ACIndex, ACResults, normalizeText } from "app/client/lib/ACIndex";
 import { makeT } from "app/client/lib/localization";
 import { ICellItem } from "app/client/models/ColumnACIndexes";
 import { ColumnCache } from "app/client/models/ColumnCache";
@@ -9,6 +9,8 @@ import { TableData } from "app/client/models/TableData";
 import { getReferencedTableId, isRefListType } from "app/common/gristTypes";
 import { EmptyRecordView } from "app/common/RecordView";
 import { BaseFormatter } from "app/common/ValueFormatter";
+
+import { UIRowId } from "app/plugin/GristAPI";
 
 import { Disposable, dom, Observable } from "grainjs";
 
@@ -85,6 +87,33 @@ export class ReferenceUtils extends Disposable {
       );
     }
     return acIndex.search(text);
+  }
+
+  /**
+   * Keeps only referenced-record row ids that satisfy the column's dropdown condition for the
+   * given row of the source table (the table containing this reference column).
+   */
+  public filterByDropdownCondition(
+    rowIds: number[],
+    contextRowId: UIRowId | null | undefined,
+  ): number[] {
+    if (!this.hasDropdownCondition) { return rowIds; }
+    const ctx =
+      typeof contextRowId === "number" && !Number.isNaN(contextRowId) ? contextRowId : -1;
+    try {
+      const filter = this._buildDropdownConditionACFilter(ctx);
+      return rowIds.filter((id) => {
+        const text = this.idToText(id);
+        const item: ICellItem = {
+          rowId: id,
+          text,
+          cleanText: normalizeText(text),
+        };
+        return filter(item);
+      });
+    } catch {
+      return [];
+    }
   }
 
   public buildNoItemsMessage() {


### PR DESCRIPTION
## Context

In Grist, “Filter displayed dropdown values with a condition” (the column dropdown condition) is applied via
Choice: buildDropdownConditionFilter in ChoiceListEditor / ChoiceEditor
Reference: ReferenceUtils + _buildDropdownConditionACFilter in ReferenceEditor

The Form widget built its own option lists in Field.ts (ChoiceModel and RefListModel) from raw choices / all rows in the referenced table and never applied that condition.

## Proposed solution

Added filterByDropdownCondition which keeps only referenced-row ids that pass the same predicate as the reference autocomplete (using normalizeText for ICellItem).

After sorting choices, if dropdownCondition has text, choices are filtered with buildDropdownConditionFilter, using the form view as context aligned with ChoiceEditor.

Creates a ReferenceUtils for the field and filters candidate rows with filterByDropdownCondition
Context row handling uses normalizeContextRowIdForDropdown: a numeric cursor row id is passed through; null / "new" maps to -1 so getRecord misses and the formula sees an EmptyRecordView, consistent with other editors on a new row.

## Related issues

 #1093

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ x ] 🙋 no, because I need help // 
- 
- couldn't run the build
- 

