### PR TITLE
Tweak a few tests to survive a mid-test server restart

### DIFF
--- a/app/server/lib/TestingHooks.ts
+++ b/app/server/lib/TestingHooks.ts
@@ -61,13 +61,18 @@ function connectToSocket(rpc: Rpc, socket: net.Socket): Rpc {
 
 export interface TestingHooksClient extends ITestingHooks {
   close(): void;
+  // True after the socket closes (peer-close too, e.g. RestartShell worker exit). Check before reuse.
+  isClosed(): boolean;
 }
 
 export async function connectTestingHooks(socketPath: string): Promise<TestingHooksClient> {
   const socket = await connect(socketPath);
+  let closed = false;
+  socket.on("close", () => { closed = true; });
   const rpc = connectToSocket(new Rpc({ logger: {} }), socket);
   return Object.assign(rpc.getStub<TestingHooks>("testing", tiCheckers.ITestingHooks), {
     close: () => socket.end(),
+    isClosed: () => closed,
   });
 }
 

--- a/test/nbrowser/CustomWidgets.ts
+++ b/test/nbrowser/CustomWidgets.ts
@@ -100,7 +100,7 @@ describe("CustomWidgets", function() {
 
   // Switches widget manifest url
   async function useManifest(url: string) {
-    await server.testingHooks.setWidgetRepositoryUrl(url ? `${widgetServerUrl}${url}` : "");
+    await (await server.getTestingHooks()).setWidgetRepositoryUrl(url ? `${widgetServerUrl}${url}` : "");
   }
 
   async function reloadWidgets() {
@@ -169,7 +169,7 @@ describe("CustomWidgets", function() {
   });
 
   after(async function() {
-    await server.testingHooks.setWidgetRepositoryUrl("");
+    await (await server.getTestingHooks()).setWidgetRepositoryUrl("");
     oldEnv.restore();
     await server.restart();
   });

--- a/test/nbrowser/CustomWidgetsConfig.ts
+++ b/test/nbrowser/CustomWidgetsConfig.ts
@@ -198,7 +198,7 @@ describe("CustomWidgetsConfig", function() {
     });
     cleanup.addAfterAll(widgetServer.shutdown);
     widgetServerUrl = widgetServer.url;
-    await server.testingHooks.setWidgetRepositoryUrl(`${widgetServerUrl}${manifestEndpoint}`);
+    await (await server.getTestingHooks()).setWidgetRepositoryUrl(`${widgetServerUrl}${manifestEndpoint}`);
 
     mainSession = await gu.session().login();
     const doc = await mainSession.tempDoc(cleanup, "CustomWidget.grist");
@@ -209,7 +209,7 @@ describe("CustomWidgetsConfig", function() {
 
   after(async function() {
     if (gu.noCleanup) { return; }
-    await server.testingHooks.setWidgetRepositoryUrl("");
+    await (await server.getTestingHooks()).setWidgetRepositoryUrl("");
     oldEnv.restore();
     await server.restart();
   });

--- a/test/nbrowser/QuickSetupAuth.ts
+++ b/test/nbrowser/QuickSetupAuth.ts
@@ -242,6 +242,7 @@ describe("QuickSetupAuth", function() {
       oidc = await startMockOIDCIssuer({ authorize: true });
       // testServer.ts puts HOME_PORT in the child env only, so read the port off the server URL.
       const homePort = new URL(server.getHost()).port;
+      if (!homePort) { throw new Error(`No port in server URL: ${server.getHost()}`); }
       await restartWithEnv({
         // GRIST_RESTART_SHELL=true overrides the GRIST_TESTING_SOCKET gate in
         // shouldRunAsRestartShell so /api/admin/restart actually drives a

--- a/test/nbrowser/QuickSetupAuth.ts
+++ b/test/nbrowser/QuickSetupAuth.ts
@@ -240,7 +240,8 @@ describe("QuickSetupAuth", function() {
 
     before(async function() {
       oidc = await startMockOIDCIssuer({ authorize: true });
-      const homePort = process.env.HOME_PORT;
+      // testServer.ts puts HOME_PORT in the child env only, so read the port off the server URL.
+      const homePort = new URL(server.getHost()).port;
       await restartWithEnv({
         // GRIST_RESTART_SHELL=true overrides the GRIST_TESTING_SOCKET gate in
         // shouldRunAsRestartShell so /api/admin/restart actually drives a

--- a/test/nbrowser/testServer.ts
+++ b/test/nbrowser/testServer.ts
@@ -46,6 +46,7 @@ export class TestServerMerged extends EventEmitter implements IMochaServer {
   private _exitPromise: Promise<number | string>;
   private _starts: number = 0;
   private _testingSocketPath: string;
+  private _reconnectingHooks?: Promise<TestingHooksClient>;
   private _dbManager?: HomeDBManager;
   private _driver?: WebDriver;
 
@@ -300,8 +301,14 @@ export class TestServerMerged extends EventEmitter implements IMochaServer {
   public async getTestingHooks() {
     // A RestartShell worker exit (/api/admin/restart) peer-closes our socket; reconnect to
     // the same path -- each respawned worker rebinds the socket file via GRIST_TESTING_SOCKET.
-    if (this.testingHooks?.isClosed()) {
-      this.testingHooks = await connectTestingHooks(this._testingSocketPath);
+    // Cache the in-flight reconnect so concurrent callers share one socket.
+    if (this.testingHooks?.isClosed() && !this._reconnectingHooks) {
+      this._reconnectingHooks = connectTestingHooks(this._testingSocketPath)
+        .then(hooks => this.testingHooks = hooks)
+        .finally(() => { this._reconnectingHooks = undefined; });
+    }
+    if (this._reconnectingHooks) {
+      await this._reconnectingHooks;
     }
     return this.testingHooks;
   }

--- a/test/nbrowser/testServer.ts
+++ b/test/nbrowser/testServer.ts
@@ -299,7 +299,7 @@ export class TestServerMerged extends EventEmitter implements IMochaServer {
 
   public async getTestingHooks() {
     // A RestartShell worker exit (/api/admin/restart) peer-closes our socket; reconnect to
-    // the same path -- the RestartShell parent rebinds it.
+    // the same path -- each respawned worker rebinds the socket file via GRIST_TESTING_SOCKET.
     if (this.testingHooks?.isClosed()) {
       this.testingHooks = await connectTestingHooks(this._testingSocketPath);
     }

--- a/test/nbrowser/testServer.ts
+++ b/test/nbrowser/testServer.ts
@@ -45,6 +45,7 @@ export class TestServerMerged extends EventEmitter implements IMochaServer {
   private _server: ChildProcess;
   private _exitPromise: Promise<number | string>;
   private _starts: number = 0;
+  private _testingSocketPath: string;
   private _dbManager?: HomeDBManager;
   private _driver?: WebDriver;
 
@@ -185,6 +186,7 @@ export class TestServerMerged extends EventEmitter implements IMochaServer {
     await this.waitServerReady(60000);
 
     // Prepare testingHooks for certain behind-the-scenes interactions with the server.
+    this._testingSocketPath = testingSocket;
     this.testingHooks = await connectTestingHooks(testingSocket);
     this.emit("start");
   }
@@ -296,6 +298,11 @@ export class TestServerMerged extends EventEmitter implements IMochaServer {
   }
 
   public async getTestingHooks() {
+    // A RestartShell worker exit (/api/admin/restart) peer-closes our socket; reconnect to
+    // the same path -- the RestartShell parent rebinds it.
+    if (this.testingHooks?.isClosed()) {
+      this.testingHooks = await connectTestingHooks(this._testingSocketPath);
+    }
     return this.testingHooks;
   }
 


### PR DESCRIPTION
Some tests got tweaked to run in the Grist Labs SaaS environment, and now need a smaller tweak to work again in core. The size of the tweak is getting smaller each time, so hopefully they are converging :-)
