### PR TITLE
ActionSummarizer: make explicit when rows may be dropped

### DIFF
--- a/app/common/ActionSummarizer.ts
+++ b/app/common/ActionSummarizer.ts
@@ -213,6 +213,7 @@ export class ActionSummarizer {
       // if many rows, just take some from start and one from end as examples
       selectedRows = [...rowIds.slice(0, this._maxRows - 1).entries()];
       selectedRows.push([rowIds.length - 1, rowIds[rowIds.length - 1]]);
+      td.mayBeIncomplete = true;
     }
 
     const alwaysPreserveColIds = new Set(this._options?.alwaysPreserveColIds || []);
@@ -480,6 +481,7 @@ function bulkCellFor(rc: RowChange | undefined): CellDelta | undefined {
  * e2 may be modified, and will be copied if so.
  */
 function mergeColumn(present1: RowChanges, present2: RowChanges,
+  incomplete1: boolean | undefined, incomplete2: boolean | undefined,
   e1: ColumnDelta, e2: CopyOnWrite<ColumnDelta>): ColumnDelta {
   for (const key of (Object.keys(present1) as unknown as number[])) {
     let v1 = e1[key];
@@ -489,6 +491,16 @@ function mergeColumn(present1: RowChanges, present2: RowChanges,
       delete e2.write()[key];
       continue;
     }
+    // A row marked "updated" in a side whose cellDelta has no entry for
+    // this column can mean two things: the column was untouched (and we
+    // can recover the value from the other side) or the summarizer
+    // deliberately dropped the cell to stay under `maximumInlineRows` (so
+    // '?' is the accurate answer). If the source summary's
+    // mayBeIncomplete flag is unset, we know it's the first case and can
+    // recover. If it's set, we don't know which case it is, and have to
+    // err on the side of uncertainty.
+    const v1Untouched = v1 === undefined && !incomplete1;
+    const v2Untouched = v2 === undefined && !incomplete2;
     v1 = v1 || bulkCellFor(present1[key]);
     v2 = v2 || bulkCellFor(present2[key]);
     if (!v2)    { e2.write()[key] = e1[key]; continue; }
@@ -503,7 +515,12 @@ function mergeColumn(present1: RowChanges, present2: RowChanges,
       }
       continue;
     }
-    e2.write()[key] = [v1[0], v2[1]];  // Change is from initial value in e1 to final value in e2.
+    // Default composition is [v1[0], v2[1]]. Recover from the other side
+    // when one side's synthesized '?' came from a complete summary that
+    // simply didn't touch this column at this row.
+    const pre = (v1Untouched && v1[0] === "?") ? v2[0] : v1[0];
+    const post = (v2Untouched && v2[1] === "?") ? v1[1] : v2[1];
+    e2.write()[key] = [pre, post];
   }
   return e2.read();
 }
@@ -536,12 +553,15 @@ function getRowChanges(e: TableDelta): RowChanges {
  */
 function mergeTable(e1: TableDelta,  e2: CopyOnWrite<TableDelta>): TableDelta {
   // First, sort out any changes to names of columns.
-  const names = planNameMerge(e1.columnRenames, e2.read().columnRenames);
-  const columnDeltasCow = copyOnWrite(e2.read().columnDeltas);
+  const e2td = e2.read();
+  const names = planNameMerge(e1.columnRenames, e2td.columnRenames);
+  const columnDeltasCow = copyOnWrite(e2td.columnDeltas);
   mergeNames(names, e1.columnDeltas, columnDeltasCow,
     mergeColumn.bind(null,
       getRowChanges(e1),
-      getRowChanges(e2.read())));
+      getRowChanges(e2td),
+      e1.mayBeIncomplete,
+      e2td.mayBeIncomplete));
   if (columnDeltasCow.hasWrite()) {
     e2.write();
     e2.read().columnDeltas = columnDeltasCow.read();
@@ -575,6 +595,9 @@ function mergeTable(e1: TableDelta,  e2: CopyOnWrite<TableDelta>): TableDelta {
     removeRows,
     updateRows,
   });
+  if (e1.mayBeIncomplete || e2td.mayBeIncomplete) {
+    e2.write().mayBeIncomplete = true;
+  }
   return e2.read();
 }
 

--- a/app/common/ActionSummarizer.ts
+++ b/app/common/ActionSummarizer.ts
@@ -481,7 +481,7 @@ function bulkCellFor(rc: RowChange | undefined): CellDelta | undefined {
  * e2 may be modified, and will be copied if so.
  */
 function mergeColumn(present1: RowChanges, present2: RowChanges,
-  incomplete1: boolean | undefined, incomplete2: boolean | undefined,
+  incomplete1: true | undefined, incomplete2: true | undefined,
   e1: ColumnDelta, e2: CopyOnWrite<ColumnDelta>): ColumnDelta {
   for (const key of (Object.keys(present1) as unknown as number[])) {
     let v1 = e1[key];

--- a/app/common/ActionSummary.ts
+++ b/app/common/ActionSummary.ts
@@ -102,7 +102,7 @@ export interface TableDelta {
    * composition) should treat the cell as unknown rather than recover a
    * value from elsewhere.
    */
-  mayBeIncomplete?: boolean;
+  mayBeIncomplete?: true;
 }
 
 /**

--- a/app/common/ActionSummary.ts
+++ b/app/common/ActionSummary.ts
@@ -92,6 +92,17 @@ export interface TableDelta {
   /** Partial record of cell-level changes - large bulk changes not included. */
   columnDeltas: { [colId: string]: ColumnDelta };
   columnRenames: LabelDelta[];  /** a list of column renames/additions/removals */
+  /**
+   * Set if any bulk action on this table dropped per-cell values to stay
+   * under `maximumInlineRows`. When unset (the default), a row in
+   * `updateRows` with no matching `columnDeltas` entry can be relied on
+   * to mean "column untouched for this row." When set, that interpretation
+   * is no longer safe: the missing entry might be an untouched column or
+   * might be a deliberately dropped value, and consumers (including
+   * composition) should treat the cell as unknown rather than recover a
+   * value from elsewhere.
+   */
+  mayBeIncomplete?: boolean;
 }
 
 /**

--- a/test/server/lib/ActionSummary.ts
+++ b/test/server/lib/ActionSummary.ts
@@ -555,6 +555,12 @@ describe("ActionSummary", function() {
   });
 
   it("summarizes partially uncached changes consistently", async function() {
+    // The summaries here simulate a summarizer that dropped some cell
+    // values to stay under the inline-rows limit: rows 12-14 / 15-16 are
+    // in updateRows but their cellDelta entries were not recorded.
+    // mayBeIncomplete = true marks that state, so composition keeps the
+    // '?' wildcard rather than recovering an intermediate value from the
+    // other summary (which wouldn't be the bundle-overall pre / post).
     const summary1: ActionSummary = {
       tableRenames: [["Fish", "Sharks"]],
       tableDeltas: {
@@ -562,6 +568,7 @@ describe("ActionSummary", function() {
           updateRows: [1, 13, 14, 15, 16],
           removeRows: [10],
           addRows: [11, 12],
+          mayBeIncomplete: true,
           columnDeltas: {
             "years": {
               1: [["11"], ["111"]],
@@ -591,6 +598,7 @@ describe("ActionSummary", function() {
           updateRows: [2, 11, 12, 14, 15],
           removeRows: [9, 16],
           addRows: [],
+          mayBeIncomplete: true,
           columnDeltas: {
             minutes: {
               2: [["22"], ["222"]],
@@ -613,6 +621,7 @@ describe("ActionSummary", function() {
           updateRows: [1, 2, 13, 14, 15],
           removeRows: [9, 10, 16],
           addRows: [11, 12],
+          mayBeIncomplete: true,
           columnDeltas: {
             "minutes": {
               1: [["11"], ["111"]],
@@ -639,6 +648,111 @@ describe("ActionSummary", function() {
     };
     const result = concatenateSummariesCleanly([summary1, summary2]);
     assert.deepEqual(result, summary3);
+  });
+
+  it("composes a row touched in one summary with a value carried only by the other", async function() {
+    // Focused regression test for `mergeColumn` precision: row 1 is marked
+    // "updated" in summary1 because summary1 changed its `other` column,
+    // but summary1 doesn't carry an entry for the `target` column. summary2
+    // carries the real pre/post for `target` on row 1. The composed result
+    // should report `target[1]` at its real values, not synthesize a `'?'`
+    // wildcard for the side summary1 didn't carry.
+    const summary1: ActionSummary = {
+      tableRenames: [],
+      tableDeltas: {
+        T: {
+          updateRows: [1],
+          removeRows: [],
+          addRows: [],
+          columnDeltas: { other: { 1: [["x"], ["y"]] } },
+          columnRenames: [],
+        },
+      },
+    };
+    const summary2: ActionSummary = {
+      tableRenames: [],
+      tableDeltas: {
+        T: {
+          updateRows: [1],
+          removeRows: [],
+          addRows: [],
+          columnDeltas: { target: { 1: [["a"], ["b"]] } },
+          columnRenames: [],
+        },
+      },
+    };
+    const merged = concatenateSummariesCleanly([summary1, summary2]);
+    assert.deepEqual(merged.tableDeltas.T!.columnDeltas.target[1], [["a"], ["b"]]);
+    // The composed summary inherits no `mayBeIncomplete` (neither input
+    // had it).
+    assert.notProperty(merged.tableDeltas.T!, "mayBeIncomplete");
+  });
+
+  it("sets mayBeIncomplete on a bulk action that exceeds the inline-rows cap", async function() {
+    const session = docTools.createFakeSession();
+    const doc: ActiveDoc = await docTools.createDoc("incomplete-cap.grist");
+    await doc.applyUserActions(session, [
+      ["AddTable", "Frogs", [{ id: "species" }]],
+    ]);
+    // Add many rows in one bulk action - well over the default 10-row cap.
+    const ids = Array.from({ length: 30 }, (_, i) => i + 1);
+    await doc.applyUserActions(session, [
+      ["BulkAddRecord", "Frogs", ids, { species: ids.map(x => "frog " + x) }],
+    ]);
+    const sum = await summarizeLastAction(doc);
+    assert.equal(sum.tableDeltas.Frogs.mayBeIncomplete, true);
+  });
+
+  it("does not set mayBeIncomplete on a small update", async function() {
+    const session = docTools.createFakeSession();
+    const doc: ActiveDoc = await docTools.createDoc("incomplete-small.grist");
+    await doc.applyUserActions(session, [
+      ["AddTable", "Frogs", [{ id: "species" }]],
+      ["AddRecord", "Frogs", null, { species: "frog 1" }],
+    ]);
+    await doc.applyUserActions(session, [
+      ["UpdateRecord", "Frogs", 1, { species: "renamed" }],
+    ]);
+    const sum = await summarizeLastAction(doc);
+    assert.notProperty(sum.tableDeltas.Frogs, "mayBeIncomplete");
+  });
+
+  it("keeps the '?' wildcard when composing summaries flagged as mayBeIncomplete", async function() {
+    // Same shape as the test above, but summary1 declares itself
+    // `mayBeIncomplete: true` (some cells were dropped to stay under the
+    // inline-rows limit). The composition should respect that and keep
+    // the '?' wildcard on the pre side rather than recovering from
+    // summary2's pre, because for a dropped cell summary2's pre is an
+    // intermediate value, not the bundle-overall pre.
+    const summary1: ActionSummary = {
+      tableRenames: [],
+      tableDeltas: {
+        T: {
+          updateRows: [1],
+          removeRows: [],
+          addRows: [],
+          mayBeIncomplete: true,
+          columnDeltas: { target: { 2: [["a2"], ["b2"]] } },
+          columnRenames: [],
+        },
+      },
+    };
+    const summary2: ActionSummary = {
+      tableRenames: [],
+      tableDeltas: {
+        T: {
+          updateRows: [1],
+          removeRows: [],
+          addRows: [],
+          columnDeltas: { target: { 1: [["a"], ["b"]] } },
+          columnRenames: [],
+        },
+      },
+    };
+    const merged = concatenateSummariesCleanly([summary1, summary2]);
+    assert.deepEqual(merged.tableDeltas.T!.columnDeltas.target[1], ["?", ["b"]]);
+    // mayBeIncomplete propagates through composition.
+    assert.equal(merged.tableDeltas.T!.mayBeIncomplete, true);
   });
 
   it("recognizes bulk removal", async function() {
@@ -746,6 +860,9 @@ describe("ActionSummary", function() {
       5: [null, ["place 5"]],
       8: [null, ["place 8"]],
     };
+    // Truncation drove `mayBeIncomplete` on; the no-limit summary above
+    // didn't have it. Mark the expected to match.
+    sum.tableDeltas.Frogs.mayBeIncomplete = true;
     assert.deepEqual(sum2, sum);
   });
 

--- a/test/server/lib/ActionSummary.ts
+++ b/test/server/lib/ActionSummary.ts
@@ -682,10 +682,10 @@ describe("ActionSummary", function() {
       },
     };
     const merged = concatenateSummariesCleanly([summary1, summary2]);
-    assert.deepEqual(merged.tableDeltas.T!.columnDeltas.target[1], [["a"], ["b"]]);
+    assert.deepEqual(merged.tableDeltas.T.columnDeltas.target[1], [["a"], ["b"]]);
     // The composed summary inherits no `mayBeIncomplete` (neither input
     // had it).
-    assert.notProperty(merged.tableDeltas.T!, "mayBeIncomplete");
+    assert.notProperty(merged.tableDeltas.T, "mayBeIncomplete");
   });
 
   it("sets mayBeIncomplete on a bulk action that exceeds the inline-rows cap", async function() {
@@ -750,9 +750,9 @@ describe("ActionSummary", function() {
       },
     };
     const merged = concatenateSummariesCleanly([summary1, summary2]);
-    assert.deepEqual(merged.tableDeltas.T!.columnDeltas.target[1], ["?", ["b"]]);
+    assert.deepEqual(merged.tableDeltas.T.columnDeltas.target[1], ["?", ["b"]]);
     // mayBeIncomplete propagates through composition.
-    assert.equal(merged.tableDeltas.T!.mayBeIncomplete, true);
+    assert.equal(merged.tableDeltas.T.mayBeIncomplete, true);
   });
 
   it("recognizes bulk removal", async function() {

--- a/test/server/lib/docapi/DocApiDocuments.ts
+++ b/test/server/lib/docapi/DocApiDocuments.ts
@@ -392,6 +392,7 @@ function addDocumentsTests(getCtx: () => TestContext) {
             ),
           },
           columnRenames: [],
+          mayBeIncomplete: true,
         },
       },
     };


### PR DESCRIPTION
When `concatenateSummaries` merges two summaries and one has a cellDelta entry for a row that the other doesn't, the merge fills the missing side with a '?' wildcard. That covers one case but overshoots another:

- Limit hit: the summarizer dropped the cell to stay under `maximumInlineRows`. Value really is unknown; '?' is right.
- Cross-column: the row is in updateRows because some action touched a different column. This column wasn't touched, so the other summary's pre/post is the truth and '?' loses information.

To `mergeColumn`, both cases look the same. Add a `mayBeIncomplete?: boolean` flag on `TableDelta`. The summarizer sets it when `_addRows` drops cells; composition propagates it; `mergeColumn` recovers the real value when the source's flag is unset, keeps '?' when set.
