### PR TITLE
Translations: clean up dud keys and unblock auto-pruning

### DIFF
--- a/app/client/ui/AuditLogStreamingConfig.ts
+++ b/app/client/ui/AuditLogStreamingConfig.ts
@@ -256,7 +256,7 @@ function showDestinationForm(options: DestinationFormOptions) {
             testId("streaming-destination-form-cancel"),
           ),
           bigPrimaryButton(
-            t(submitButtonLabel),
+            submitButtonLabel,
             { type: "submit" },
             dom.boolAttr("disabled", use => use(pending) || use(disabled)),
             testId("streaming-destination-form-apply"),

--- a/app/client/ui/GridViewMenus.ts
+++ b/app/client/ui/GridViewMenus.ts
@@ -34,6 +34,28 @@ import * as weasel from "popweasel";
 
 const t = makeT("GridViewMenus");
 
+// Translate the label of a column type. Labels come from `UserType.typeDefs[X].label`
+// (see app/client/widgets/UserType.ts), so the set is fixed. The explicit switch lets
+// i18next-scanner see every key as a literal `t(...)` call; without it, dynamic
+// `t(label)` would make these keys look orphaned to the scanner.
+export function translateColumnTypeLabel(label: string): string {
+  switch (label) {
+    case "Any": return t("Any");
+    case "Text": return t("Text");
+    case "Numeric": return t("Numeric");
+    case "Integer": return t("Integer");
+    case "Toggle": return t("Toggle");
+    case "Date": return t("Date");
+    case "DateTime": return t("DateTime");
+    case "Choice": return t("Choice");
+    case "Choice List": return t("Choice List");
+    case "Reference": return t("Reference");
+    case "Reference List": return t("Reference List");
+    case "Attachment": return t("Attachment");
+    default: return label;
+  }
+}
+
 export function buildAddColumnMenu(gridView: GridView, index?: number) {
   const isSummaryTable = Boolean(gridView.viewSection.table().summarySourceTable());
   return [
@@ -66,7 +88,7 @@ export function getColumnTypes(gristDoc: GristDoc, tableId: string, pure = false
       testIdName: string,
       icon: IconName | undefined,
       openCreatorPanel: boolean } => ({
-      displayName: t(ct.obj.label),
+      displayName: translateColumnTypeLabel(ct.obj.label),
       colType: ct.type,
       testIdName: ct.obj.label.toLowerCase().replace(" ", "-"),
       icon: ct.obj.icon,

--- a/app/client/ui/OnboardingPage.ts
+++ b/app/client/ui/OnboardingPage.ts
@@ -46,6 +46,24 @@ const choices: { icon: IconName, color: string, textKey: string }[] = [
   { icon: "UseOther",   color: "#929299",              textKey: "Other"               },
 ];
 
+// Translate an onboarding choice label. Keys are pinned in the `choices` array above;
+// the explicit switch lets i18next-scanner see them as literal `t(...)` calls.
+function translateOnboardingChoice(textKey: string): string {
+  switch (textKey) {
+    case "Product Development": return t("Product Development");
+    case "Finance & Accounting": return t("Finance & Accounting");
+    case "Media Production": return t("Media Production");
+    case "IT & Technology": return t("IT & Technology");
+    case "Marketing": return t("Marketing");
+    case "Research": return t("Research");
+    case "Sales": return t("Sales");
+    case "Education": return t("Education");
+    case "HR & Management": return t("HR & Management");
+    case "Other": return t("Other");
+    default: return textKey;
+  }
+}
+
 export function shouldShowOnboardingPage(userPrefsObs: Observable<UserPrefs>): boolean {
   return Boolean(getGristConfig().survey && userPrefsObs.get()?.showNewUserQuestions);
 }
@@ -202,9 +220,9 @@ function buildQuestions(owner: IDisposableOwner, incrementStep: IncrementStep, s
           cssUseCase.cls("-selected", useCases[i]),
           dom.on("click", () => useCases[i].set(!useCases[i].get())),
           (item.icon !== "UseOther" ?
-            t(item.textKey) :
+            translateOnboardingChoice(item.textKey) :
             [
-              cssOtherLabel(t(item.textKey)),
+              cssOtherLabel(translateOnboardingChoice(item.textKey)),
               cssOtherInput(useOther, {}, { type: "text", placeholder: t("Type here") },
                 // The following subscribes to changes to selection observable, and focuses the input when
                 // this item is selected.

--- a/app/client/ui/ThemeConfig.ts
+++ b/app/client/ui/ThemeConfig.ts
@@ -11,6 +11,17 @@ import { Computed, Disposable, dom, makeTestId, styled } from "grainjs";
 const testId = makeTestId("test-theme-config-");
 const t = makeT("ThemeConfig");
 
+// Translate a theme-picker option label. Explicit switch so i18next-scanner sees
+// every key as a literal `t(...)` call.
+function translateThemeLabel(label: string): string {
+  switch (label) {
+    case "Light": return t("Light");
+    case "Dark": return t("Dark");
+    case "Light (High Contrast)": return t("Light (High Contrast)");
+    default: return label;
+  }
+}
+
 export class ThemeConfig extends Disposable {
   private _themePrefs = this._appModel.themePrefs;
 
@@ -47,13 +58,12 @@ export class ThemeConfig extends Disposable {
           select(
             this._themeName,
             [
-              { value: "GristLight", label: "Light" },
-              { value: "GristDark", label: "Dark" },
-              { value: "HighContrastLight", label: "Light (High Contrast)" },
+              { value: "GristLight", label: translateThemeLabel("Light") },
+              { value: "GristDark", label: translateThemeLabel("Dark") },
+              { value: "HighContrastLight", label: translateThemeLabel("Light (High Contrast)") },
             ],
             {
               disabled: this._syncWithOS,
-              translateOptionLabels: true,
             },
           ),
           testId("appearance"),

--- a/app/client/ui2018/menus.ts
+++ b/app/client/ui2018/menus.ts
@@ -227,9 +227,6 @@ const defaults = {
 export interface SelectOptions<T> extends weasel.ISelectUserOptions {
   /** Additional DOM element args to pass to each select option. */
   renderOptionArgs?: (option: IOptionFull<T | null>) => DomElementArg;
-
-  /** Whether to translate the labels of the provided options. */
-  translateOptionLabels?: boolean;
 }
 
 /**
@@ -280,7 +277,7 @@ export function select<T>(obs: Observable<T>, optionArray: MaybeObsArray<IOption
   return weasel.select(obs, optionArray, selectOptions, op =>
     cssOptionRow(
       op.icon ? cssOptionRowIcon(op.icon) : null,
-      cssOptionLabel(options.translateOptionLabels ? t(op.label) : op.label),
+      cssOptionLabel(op.label),
       renderOptionArgs ? renderOptionArgs(op) : null,
       testId("select-row"),
     ),

--- a/app/client/widgets/FieldBuilder.ts
+++ b/app/client/widgets/FieldBuilder.ts
@@ -18,6 +18,7 @@ import { ColumnRec, DocModel, ViewFieldRec } from "app/client/models/DocModel";
 import { SaveableObjObservable, setSaveValue } from "app/client/models/modelUtil";
 import { CombinedStyle, Style } from "app/client/models/Styles";
 import { FieldSettingsMenu } from "app/client/ui/FieldMenus";
+import { translateColumnTypeLabel } from "app/client/ui/GridViewMenus";
 import { cssBlockedCursor, cssLabel, cssRow } from "app/client/ui/RightPanelStyles";
 import { textButton } from "app/client/ui2018/buttons";
 import { buttonSelect, cssButtonSelect } from "app/client/ui2018/buttonSelect";
@@ -151,7 +152,7 @@ export class FieldBuilder extends Disposable {
       _.each(UserType.typeDefs, (def: any, key: string | number) => {
         const o: IOptionFull<string> = {
           value: key as string,
-          label: def.label,
+          label: translateColumnTypeLabel(def.label),
           icon: def.icon,
         };
         if (key === "Any") {
@@ -274,7 +275,6 @@ export class FieldBuilder extends Disposable {
               {
                 disabled,
                 defaultLabel: t("Mixed format"),
-                translateOptionLabels: true,
               },
             ),
           testId("widget-select"),
@@ -319,14 +319,13 @@ export class FieldBuilder extends Disposable {
             use(this.isCallPending),
           menuCssClass: cssTypeSelectMenu.className,
           defaultLabel: t("Mixed types"),
-          translateOptionLabels: true,
           renderOptionArgs: (op) => {
             if (["Ref", "RefList"].includes(selectType.get())) {
               // Don't show tip if a reference column type is already selected.
               return;
             }
 
-            if (op.label === "Reference") {
+            if (op.value === "Ref") {
               return this.gristDoc.behavioralPromptsManager.attachPopup("referenceColumns", {
                 popupOptions: {
                   attach: `.${cssTypeSelectMenu.className}`,

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,5 +1,0 @@
-files:
-  - source: /static/locales/en.*.json
-    translation: /static/locales/%two_letters_code%.%original_file_name%
-    translation_replace:
-      "en.": ''

--- a/static/locales/bg.client.json
+++ b/static/locales/bg.client.json
@@ -1075,21 +1075,6 @@
     "Hidden {{label}}": "Скрит {{label}}",
     "Show {{label}}": "Покажи {{label}}"
   },
-  "WelcomeQuestions": {
-    "Education": "Образование",
-    "Finance & Accounting": "Финанси и счетоводство",
-    "HR & Management": "ТРЗ и управление",
-    "IT & Technology": "ИТ и технологии",
-    "Marketing": "Маркетинг",
-    "Media Production": "Медийно производство",
-    "Other": "Други",
-    "Product Development": "Разработване на продукти",
-    "Research": "Изследвания",
-    "Sales": "Продажби",
-    "Type here": "Въведете тук",
-    "Welcome to Grist!": "Добре дошли в Grist!",
-    "What brings you to Grist? Please help us serve you better.": "Какво ви доведе в Grist? Моля, помогнете ни да ви обслужаваме по-добре."
-  },
   "WidgetTitle": {
     "Cancel": "Отказ",
     "Override widget title": "Замяна на заглавието на джаджа",
@@ -1582,5 +1567,18 @@
     "Form": "Формуляр",
     "Chart": "Графика",
     "Table": "Таблица"
+  },
+  "OnboardingPage": {
+    "Product Development": "Разработване на продукти",
+    "Finance & Accounting": "Финанси и счетоводство",
+    "Media Production": "Медийно производство",
+    "IT & Technology": "ИТ и технологии",
+    "Marketing": "Маркетинг",
+    "Research": "Изследвания",
+    "Sales": "Продажби",
+    "Education": "Образование",
+    "HR & Management": "ТРЗ и управление",
+    "Other": "Други",
+    "Type here": "Въведете тук"
   }
 }

--- a/static/locales/cs.client.json
+++ b/static/locales/cs.client.json
@@ -963,7 +963,17 @@
     "Type here": "Zadejte zde",
     "What organization are you with?": "V jaké organizaci pracujete?",
     "Your organization": "Vaše organizace",
-    "Your role": "Vaše role"
+    "Your role": "Vaše role",
+    "Product Development": "Vývoj produktu",
+    "Finance & Accounting": "Finance a účetnictví",
+    "Media Production": "Mediální produkce",
+    "IT & Technology": "IT a technologie",
+    "Marketing": "Marketing",
+    "Research": "Výzkum",
+    "Sales": "Prodej",
+    "Education": "Vzdělávání",
+    "HR & Management": "Lidské zdroje a řízení",
+    "Other": "Ostatní"
   },
   "SiteSwitcher": {
     "Create new team site": "Vytvořit nové stránky týmu",
@@ -971,7 +981,8 @@
   },
   "ThemeConfig": {
     "Appearance ": "Vzhled ",
-    "Switch appearance automatically to match system": "Přepnout vzhled automaticky podle systému"
+    "Switch appearance automatically to match system": "Přepnout vzhled automaticky podle systému",
+    "Light": "Světlé"
   },
   "AppModel": {
     "This team site is suspended. Documents can be read, but not modified.": "Tato týmová stránka je pozastavena. Dokumenty lze číst, ale nelze je upravovat."
@@ -1008,21 +1019,6 @@
   },
   "SelectionSummary": {
     "Copied to clipboard": "Zkopírováno do schránky"
-  },
-  "WelcomeQuestions": {
-    "Welcome to Grist!": "Vítejte na Grist!",
-    "Other": "Ostatní",
-    "Sales": "Prodej",
-    "Finance & Accounting": "Finance a účetnictví",
-    "Education": "Vzdělávání",
-    "Media Production": "Mediální produkce",
-    "Marketing": "Marketing",
-    "Research": "Výzkum",
-    "What brings you to Grist? Please help us serve you better.": "Co vás přivedlo ke Grist? Pomozte nám, abychom vám mohli lépe sloužit.",
-    "Product Development": "Vývoj produktu",
-    "Type here": "Zadejte zde",
-    "HR & Management": "Lidské zdroje a řízení",
-    "IT & Technology": "IT a technologie"
   },
   "ConditionalStyle": {
     "Row style": "Styl řádku",
@@ -1213,10 +1209,8 @@
     "Date": "Datum",
     "DateTime": "Datum a čas",
     "* Workspaces are available on team plans. ": "* Pracovní prostory jsou k dispozici v týmových plánech. ",
-    "Light": "Světlé",
     "Integer": "Celé číslo",
     "By Name": "Podle názvu",
-    "Custom": "Vlastní",
     "Choice": "Výběr",
     "Text": "Text",
     "By Date Modified": "Podle data úpravy"

--- a/static/locales/de.client.json
+++ b/static/locales/de.client.json
@@ -997,7 +997,8 @@
     },
     "ThemeConfig": {
         "Appearance ": "Aussehen ",
-        "Switch appearance automatically to match system": "Schalten Sie das Aussehen automatisch auf das System"
+        "Switch appearance automatically to match system": "Schalten Sie das Aussehen automatisch auf das System",
+        "Light": "Hell"
     },
     "Tools": {
         "Access Rules": "Zugriffsregeln",
@@ -1114,21 +1115,6 @@
         "Show {{label}}": "{{label}} anzeigen",
         "Visible {{label}}": "Sichtbar {{label}}"
     },
-    "WelcomeQuestions": {
-        "Education": "Bildung",
-        "Finance & Accounting": "Finanzbuchhaltung",
-        "HR & Management": "Personal und Management",
-        "IT & Technology": "IT und Technologie",
-        "Marketing": "Vermarktung",
-        "Media Production": "Medienproduktion",
-        "Other": "Sonstiges",
-        "Product Development": "Produktentwicklung",
-        "Research": "Forschung",
-        "Sales": "Umsatz",
-        "Type here": "Hier tippen",
-        "Welcome to Grist!": "Willkommen bei Grist!",
-        "What brings you to Grist? Please help us serve you better.": "Was bringt Sie zu Grist? Bitte helfen Sie uns, Sie besser zu bedienen."
-    },
     "WidgetTitle": {
         "Cancel": "Abbrechen",
         "DATA TABLE NAME": "NAME DER DATENTABELLE",
@@ -1196,8 +1182,6 @@
         "Date": "Datum",
         "Search columns": "Spalten suchen",
         "By Name": "Nach Name",
-        "Custom": "Benutzerdefiniert",
-        "Light": "Hell",
         "By Date Modified": "Nach Änderungsdatum"
     },
     "modals": {
@@ -2013,7 +1997,17 @@
         "Your role": "Ihre Rolle",
         "Skip step": "Schritt überspringen",
         "Skip tutorial": "Tutorial überspringen",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist mag wie eine Tabellenkalkulation aussehen, aber es verhält sich nicht immer wie eine solche. Entdecken Sie, was Grist anders macht."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist mag wie eine Tabellenkalkulation aussehen, aber es verhält sich nicht immer wie eine solche. Entdecken Sie, was Grist anders macht.",
+        "Product Development": "Produktentwicklung",
+        "Finance & Accounting": "Finanzbuchhaltung",
+        "Media Production": "Medienproduktion",
+        "IT & Technology": "IT und Technologie",
+        "Marketing": "Vermarktung",
+        "Research": "Forschung",
+        "Sales": "Umsatz",
+        "Education": "Bildung",
+        "HR & Management": "Personal und Management",
+        "Other": "Sonstiges"
     },
     "OnboardingCards": {
         "Complete the tutorial": "Fertigen Sie das Tutorial",

--- a/static/locales/el.client.json
+++ b/static/locales/el.client.json
@@ -918,7 +918,8 @@
     },
     "ThemeConfig": {
         "Appearance ": "Εμφάνιση ",
-        "Switch appearance automatically to match system": "Αυτόματη αλλαγή εμφάνισης ώστε να ταιριάζει με το σύστημα"
+        "Switch appearance automatically to match system": "Αυτόματη αλλαγή εμφάνισης ώστε να ταιριάζει με το σύστημα",
+        "Light": "Φωτεινό"
     },
     "Tools": {
         "API console": "Κονσόλα API",
@@ -1027,21 +1028,6 @@
         "Hide {{label}} (batch mode)": "Απόκρυψη {{label}} (λειτουργία παρτίδας)",
         "Show {{label}} (batch mode)": "Εμφάνιση {{label}} (λειτουργία παρτίδας)"
     },
-    "WelcomeQuestions": {
-        "Education": "Εκπαίδευση",
-        "Finance & Accounting": "Χρηματοοικονομικά και Λογιστική",
-        "HR & Management": "Ανθρώπινο Δυναμικό και Διοίκηση",
-        "IT & Technology": "Πληροφορική και Τεχνολογία",
-        "Marketing": "Μάρκετινγκ",
-        "Media Production": "Παραγωγή Μέσων Ενημέρωσης",
-        "Other": "Άλλο",
-        "Research": "Έρευνα",
-        "Type here": "Πληκτρολογήστε εδώ",
-        "Welcome to Grist!": "Καλώς ήρθατε στο Grist!",
-        "Product Development": "Ανάπτυξη Προϊόντων",
-        "What brings you to Grist? Please help us serve you better.": "Τι σας φέρνει στο Grist; Παρακαλούμε βοηθήστε μας να σας εξυπηρετήσουμε καλύτερα.",
-        "Sales": "Πωλήσεις"
-    },
     "WidgetTitle": {
         "Cancel": "Ακύρωση",
         "DATA TABLE NAME": "ΟΝΟΜΑ ΠΙΝΑΚΑ ΔΕΔΟΜΕΝΩΝ",
@@ -1118,8 +1104,6 @@
         "Reference List": "Λίστα Αναφοράς",
         "Attachment": "Συννημένο",
         "Search columns": "Αναζήτηση στηλών",
-        "Light": "Φωτεινό",
-        "Custom": "Προσαρμοσμένο",
         "Choice List": "Λίστα Επιλογών",
         "By Date Modified": "Κατά ημερομηνία Τροποποίησης",
         "Date": "Ημερομηνία",
@@ -1792,7 +1776,17 @@
         "Your organization": "Ο οργανισμός σας",
         "Tell us who you are": "Πες μας ποιος είσαι",
         "What brings you to Grist (you can select multiple)?": "Τι σας φέρνει στο Grist (μπορείτε να επιλέξετε πολλαπλά);",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Το Grist μπορεί να μοιάζει με υπολογιστικό φύλλο, αλλά δεν λειτουργεί πάντα έτσι. Ανακαλύψτε τι κάνει το Grist να διαφέρει."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Το Grist μπορεί να μοιάζει με υπολογιστικό φύλλο, αλλά δεν λειτουργεί πάντα έτσι. Ανακαλύψτε τι κάνει το Grist να διαφέρει.",
+        "Product Development": "Ανάπτυξη Προϊόντων",
+        "Finance & Accounting": "Χρηματοοικονομικά και Λογιστική",
+        "Media Production": "Παραγωγή Μέσων Ενημέρωσης",
+        "IT & Technology": "Πληροφορική και Τεχνολογία",
+        "Marketing": "Μάρκετινγκ",
+        "Research": "Έρευνα",
+        "Sales": "Πωλήσεις",
+        "Education": "Εκπαίδευση",
+        "HR & Management": "Ανθρώπινο Δυναμικό και Διοίκηση",
+        "Other": "Άλλο"
     },
     "ToggleEnterpriseWidget": {
         "Enable Grist Enterprise": "Ενεργοποίηση Grist Enterprise",

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -958,7 +958,10 @@
     },
     "ThemeConfig": {
         "Appearance ": "Appearance ",
-        "Switch appearance automatically to match system": "Switch appearance automatically to match system"
+        "Switch appearance automatically to match system": "Switch appearance automatically to match system",
+        "Dark": "Dark",
+        "Light": "Light",
+        "Light (High Contrast)": "Light (High Contrast)"
     },
     "Tools": {
         "Access Rules": "Access Rules",
@@ -1079,21 +1082,6 @@
         "Hide {{label}} (batch mode)": "Hide {{label}} (batch mode)",
         "Show {{label}} (batch mode)": "Show {{label}} (batch mode)"
     },
-    "WelcomeQuestions": {
-        "Education": "Education",
-        "Finance & Accounting": "Finance and Accounting",
-        "HR & Management": "HR and Management",
-        "IT & Technology": "IT and Technology",
-        "Marketing": "Marketing",
-        "Media Production": "Media Production",
-        "Other": "Other",
-        "Product Development": "Product Development",
-        "Research": "Research",
-        "Sales": "Sales",
-        "Type here": "Type here",
-        "Welcome to Grist!": "Welcome to Grist!",
-        "What brings you to Grist? Please help us serve you better.": "What brings you to Grist? Please help us serve you better."
-    },
     "WidgetTitle": {
         "Cancel": "Cancel",
         "DATA TABLE NAME": "DATA TABLE NAME",
@@ -1167,26 +1155,7 @@
     "menus": {
         "* Workspaces are available on team plans. ": "* Workspaces are available on team plans. ",
         "Select fields": "Select fields",
-        "Upgrade now": "Upgrade now",
-        "Any": "Any",
-        "Numeric": "Numeric",
-        "Text": "Text",
-        "Integer": "Integer",
-        "Toggle": "Toggle",
-        "Date": "Date",
-        "DateTime": "DateTime",
-        "Choice": "Choice",
-        "Choice List": "Choice List",
-        "Reference": "Reference",
-        "Reference List": "Reference List",
-        "Attachment": "Attachment",
-        "Search columns": "Search columns",
-        "By Name": "By Name",
-        "By Date Modified": "By date Modified",
-        "Light": "Light",
-        "Custom": "Custom",
-        "Dark": "Dark",
-        "Light (High Contrast)": "Light (High Contrast)"
+        "Upgrade now": "Upgrade now"
     },
     "modals": {
         "Cancel": "Cancel",
@@ -2080,7 +2049,17 @@
         "What organization are you with?": "What organization are you with?",
         "Your organization": "Your organization",
         "Your role": "Your role",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.",
+        "Education": "Education",
+        "Finance & Accounting": "Finance & Accounting",
+        "HR & Management": "HR & Management",
+        "IT & Technology": "IT & Technology",
+        "Marketing": "Marketing",
+        "Media Production": "Media Production",
+        "Other": "Other",
+        "Product Development": "Product Development",
+        "Research": "Research",
+        "Sales": "Sales"
     },
     "ToggleEnterpriseWidget": {
         "An activation key is used to run Grist Enterprise after a trial period\nof 30 days has expired. Get an activation key by [signing up for Grist\nEnterprise]({{signupLink}}). You do not need an activation key to run\nGrist Core.\n\nLearn more in our [Help Center]({{helpCenter}}).": "An activation key is used to run Grist Enterprise after a trial period\nof 30 days has expired. Get an activation key by [signing up for Grist\nEnterprise]({{signupLink}}). You do not need an activation key to run\nGrist Core.\n\nLearn more in our [Help Center]({{helpCenter}}).",

--- a/static/locales/es.client.json
+++ b/static/locales/es.client.json
@@ -767,7 +767,8 @@
     },
     "ThemeConfig": {
         "Appearance ": "Apariencia ",
-        "Switch appearance automatically to match system": "Cambiar la apariencia automáticamente para que coincida con el sistema"
+        "Switch appearance automatically to match system": "Cambiar la apariencia automáticamente para que coincida con el sistema",
+        "Light": "Claro"
     },
     "Tools": {
         "Access Rules": "Reglas de acceso",
@@ -845,21 +846,6 @@
         "Hidden {{label}}": "{{label}} oculta",
         "Show {{label}}": "Mostrar {{label}}",
         "Visible {{label}}": "{{label}} visible"
-    },
-    "WelcomeQuestions": {
-        "Education": "Educación",
-        "Finance & Accounting": "Finanzas y Contabilidad",
-        "HR & Management": "RRHH y Gestión",
-        "IT & Technology": "TI y Tecnología",
-        "Marketing": "Publicidad",
-        "Media Production": "Producción audiovisual",
-        "Other": "Otros",
-        "Product Development": "Desarrollo de productos",
-        "Research": "Investigación",
-        "Sales": "Ventas",
-        "Type here": "Escriba aquí",
-        "Welcome to Grist!": "¡Bienvenido a Grist!",
-        "What brings you to Grist? Please help us serve you better.": "¿Qué te trae a Grist? Por favor, ayúdenos a servirle mejor."
     },
     "WidgetTitle": {
         "Cancel": "Cancelar",
@@ -1142,9 +1128,7 @@
         "Toggle": "Alternar",
         "Search columns": "Búsqueda por columnas",
         "By Date Modified": "Por fecha de modificación",
-        "By Name": "Por nombre",
-        "Light": "Claro",
-        "Custom": "Personalizado"
+        "By Name": "Por nombre"
     },
     "modals": {
         "Cancel": "Cancelar",
@@ -1947,7 +1931,17 @@
         "Go hands-on with the Grist Basics tutorial": "Práctica con el tutorial básico de Grist",
         "Go to the tutorial!": "¡Ve al tutorial!",
         "What organization are you with?": "¿A qué organización perteneces?",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist puede parecer una hoja de cálculo, pero no siempre actúa como tal. Descubre por qué Grist es diferente."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist puede parecer una hoja de cálculo, pero no siempre actúa como tal. Descubre por qué Grist es diferente.",
+        "Product Development": "Desarrollo de productos",
+        "Finance & Accounting": "Finanzas y Contabilidad",
+        "Media Production": "Producción audiovisual",
+        "IT & Technology": "TI y Tecnología",
+        "Marketing": "Publicidad",
+        "Research": "Investigación",
+        "Sales": "Ventas",
+        "Education": "Educación",
+        "HR & Management": "RRHH y Gestión",
+        "Other": "Otros"
     },
     "ViewLayout": {
         "Delete": "Borrar",

--- a/static/locales/eu.client.json
+++ b/static/locales/eu.client.json
@@ -843,7 +843,10 @@
     },
     "ThemeConfig": {
         "Appearance ": "Itxura ",
-        "Switch appearance automatically to match system": "Aldatu itxura automatikoki sistemarekin bat egiteko"
+        "Switch appearance automatically to match system": "Aldatu itxura automatikoki sistemarekin bat egiteko",
+        "Light": "Argia",
+        "Dark": "Iluna",
+        "Light (High Contrast)": "Argia (kontraste handia)"
     },
     "Tools": {
         "Access Rules": "Sarbide-arauak",
@@ -949,21 +952,6 @@
         "Hide {{label}} (batch mode)": "Ezkutatu {{label}} (batch modua)",
         "Show {{label}} (batch mode)": "Erakutsi {{label}} (batch modua)"
     },
-    "WelcomeQuestions": {
-        "Education": "Hezkuntza",
-        "Other": "Besteak",
-        "Product Development": "Produktuen garapena",
-        "Research": "Ikerketa",
-        "Sales": "Salmenta",
-        "Type here": "Idatzi hemen",
-        "Welcome to Grist!": "Ongi etorri Grist-era!",
-        "What brings you to Grist? Please help us serve you better.": "Zerk zakartza Grist-era? Lagun gaitzazu zu hobeto zerbitzatzen.",
-        "Finance & Accounting": "Finantzak eta Kontabilitatea",
-        "HR & Management": "Giza Baliabideak eta Kudeaketa",
-        "IT & Technology": "Informatika eta Teknologia",
-        "Marketing": "Marketina",
-        "Media Production": "Produkzio mediatikoa"
-    },
     "WidgetTitle": {
         "Cancel": "Utzi",
         "Save": "Gorde",
@@ -1040,12 +1028,8 @@
         "Reference": "Erreferentzia",
         "Reference List": "Erreferentzia-zerrenda",
         "Search columns": "Bilaketa-zutabeak",
-        "Custom": "Norberak ezarritakoa",
         "By Name": "Izenaren arabera",
-        "By Date Modified": "Moldatutako dataren arabera",
-        "Light": "Argia",
-        "Dark": "Iluna",
-        "Light (High Contrast)": "Argia (kontraste handia)"
+        "By Date Modified": "Moldatutako dataren arabera"
     },
     "modals": {
         "Cancel": "Utzi",
@@ -2066,7 +2050,17 @@
         "What organization are you with?": "Zein erakunderekin jarduten duzu?",
         "Your role": "Zure rola",
         "Your organization": "Zure erakundea",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Gristek kalkulu-orri baten itxura izan dezake, baina ez du beti halako batek bezala jokatzen. Ikusi zerk bereizten duen Grist."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Gristek kalkulu-orri baten itxura izan dezake, baina ez du beti halako batek bezala jokatzen. Ikusi zerk bereizten duen Grist.",
+        "Product Development": "Produktuen garapena",
+        "Finance & Accounting": "Finantzak eta Kontabilitatea",
+        "Media Production": "Produkzio mediatikoa",
+        "IT & Technology": "Informatika eta Teknologia",
+        "Marketing": "Marketina",
+        "Research": "Ikerketa",
+        "Sales": "Salmenta",
+        "Education": "Hezkuntza",
+        "HR & Management": "Giza Baliabideak eta Kudeaketa",
+        "Other": "Besteak"
     },
     "ToggleEnterpriseWidget": {
         "Grist Enterprise is **enabled**.": "Grist Enterprise **gaituta** dago.",

--- a/static/locales/fi.client.json
+++ b/static/locales/fi.client.json
@@ -730,21 +730,6 @@
     "Update Sort&Filter settings": "Päivitä järjestys- & suodatusasetukset",
     "FILTER": "SUODATA"
   },
-  "WelcomeQuestions": {
-    "What brings you to Grist? Please help us serve you better.": "Mikä tuo sinut Gristin pariin? Auta meitä palvelemaan sinua entistä paremmin.",
-    "Education": "Koulutus",
-    "Finance & Accounting": "Talous ja kirjanpito",
-    "HR & Management": "Henkilöstöhallinto",
-    "IT & Technology": "IT ja teknologia",
-    "Marketing": "Markkinointi",
-    "Media Production": "Mediatuotanto",
-    "Other": "Muu",
-    "Product Development": "Tuotekehitys",
-    "Research": "Tutkimus",
-    "Sales": "Myynti",
-    "Type here": "Kirjoita tähän",
-    "Welcome to Grist!": "Tervetuloa Gristiin!"
-  },
   "VisibleFieldsConfig": {
     "Clear": "Tyhjennä",
     "Show {{label}}": "Näytä {{label}}",
@@ -992,5 +977,18 @@
   "ColumnEditor": {
     "COLUMN DESCRIPTION": "SARAKKEEN KUVAUS",
     "COLUMN LABEL": "SARAKKEEN NIMIKE"
+  },
+  "OnboardingPage": {
+    "Product Development": "Tuotekehitys",
+    "Finance & Accounting": "Talous ja kirjanpito",
+    "Media Production": "Mediatuotanto",
+    "IT & Technology": "IT ja teknologia",
+    "Marketing": "Markkinointi",
+    "Research": "Tutkimus",
+    "Sales": "Myynti",
+    "Education": "Koulutus",
+    "HR & Management": "Henkilöstöhallinto",
+    "Other": "Muu",
+    "Type here": "Kirjoita tähän"
   }
 }

--- a/static/locales/fr.client.json
+++ b/static/locales/fr.client.json
@@ -955,7 +955,10 @@
     },
     "ThemeConfig": {
         "Appearance ": "Apparence ",
-        "Switch appearance automatically to match system": "Adapter l'apparence au système"
+        "Switch appearance automatically to match system": "Adapter l'apparence au système",
+        "Light": "Clair",
+        "Dark": "Sombre",
+        "Light (High Contrast)": "Clair (contraste élevé)"
     },
     "Tools": {
         "TOOLS": "OUTILS",
@@ -1070,21 +1073,6 @@
         "Hide {{label}} (batch mode)": "Masquer {{label}} (mode groupé)",
         "Show {{label}} (batch mode)": "Montrer {{label}} (mode groupé)"
     },
-    "WelcomeQuestions": {
-        "Welcome to Grist!": "Bienvenue sur Grist !",
-        "Product Development": "Développement de produit",
-        "Finance & Accounting": "Finance et comptabilité",
-        "Media Production": "Production de média",
-        "IT & Technology": "Technologie informatique",
-        "Marketing": "Marketing",
-        "Research": "Recherche",
-        "Sales": "Ventes",
-        "Education": "Éducation",
-        "HR & Management": "RH et Gestion",
-        "Other": "Autres",
-        "What brings you to Grist? Please help us serve you better.": "Pourquoi utilisez-vous Grist ? Aidez-nous à l’améliorer.",
-        "Type here": "Écrire ici"
-    },
     "WidgetTitle": {
         "Override widget title": "Renommer la vue",
         "DATA TABLE NAME": "NOM DE LA TABLE",
@@ -1173,11 +1161,7 @@
         "Any": "Non défini",
         "Search columns": "Chercher des colonnes",
         "By Name": "Par Nom",
-        "By Date Modified": "Par Date de modification",
-        "Light": "Clair",
-        "Custom": "Personnalisé",
-        "Dark": "Sombre",
-        "Light (High Contrast)": "Clair (contraste élevé)"
+        "By Date Modified": "Par Date de modification"
     },
     "modals": {
         "Save": "Enregistrer",
@@ -2084,7 +2068,17 @@
         "Tell us who you are": "Dites-nous qui vous êtes",
         "What brings you to Grist (you can select multiple)?": "Qu'est-ce qui vous amène à Grist (vous pouvez en sélectionner plusieurs) ?",
         "What is your role?": "Quel est votre rôle ?",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist ressemble à un tableur, mais ne fonctionne pas toujours comme tel. Découvrez ce qui le rend unique."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist ressemble à un tableur, mais ne fonctionne pas toujours comme tel. Découvrez ce qui le rend unique.",
+        "Product Development": "Développement de produit",
+        "Finance & Accounting": "Finance et comptabilité",
+        "Media Production": "Production de média",
+        "IT & Technology": "Technologie informatique",
+        "Marketing": "Marketing",
+        "Research": "Recherche",
+        "Sales": "Ventes",
+        "Education": "Éducation",
+        "HR & Management": "RH et Gestion",
+        "Other": "Autres"
     },
     "ToggleEnterpriseWidget": {
         "Disable Grist Enterprise": "Désactiver Grist Entreprise",

--- a/static/locales/hu.client.json
+++ b/static/locales/hu.client.json
@@ -957,7 +957,10 @@
     },
     "ThemeConfig": {
         "Appearance ": "Megjelenés ",
-        "Switch appearance automatically to match system": "A megjelenés a rendszerbeállításokhoz igazodjon"
+        "Switch appearance automatically to match system": "A megjelenés a rendszerbeállításokhoz igazodjon",
+        "Light": "Világos",
+        "Dark": "Sötét",
+        "Light (High Contrast)": "Világos (nagy kontrasztú)"
     },
     "Tools": {
         "Access Rules": "Hozzáférési szabályok",
@@ -1078,21 +1081,6 @@
         "Hide {{label}} (batch mode)": "{{label}} elrejtése (kötegelt mód)",
         "Show {{label}} (batch mode)": "{{label}} mutatása (kötegelt mód)"
     },
-    "WelcomeQuestions": {
-        "Education": "Végzettség",
-        "Finance & Accounting": "Pénzügy és számvitel",
-        "HR & Management": "HR és menedzsment",
-        "IT & Technology": "IT és technológia",
-        "Marketing": "Marketing",
-        "Media Production": "Médiatartalom-gyártás",
-        "Other": "Egyéb",
-        "Product Development": "Termékfejlesztés",
-        "Research": "Kutatás",
-        "Sales": "Értékesítés",
-        "Type here": "Írd ide",
-        "Welcome to Grist!": "Üdvözöl a Grist!",
-        "What brings you to Grist? Please help us serve you better.": "Mi miatt kötöttél ki a Grist-nél? A segítségedet kérjük, hogy jobban ki tudjunk szolgálni."
-    },
     "WidgetTitle": {
         "Cancel": "Mégse",
         "DATA TABLE NAME": "ADATTÁBLA NEVE",
@@ -1181,11 +1169,7 @@
         "Attachment": "Csatolmány",
         "Search columns": "Oszlop keresése",
         "By Name": "Név szerint",
-        "By Date Modified": "Módosítás dátuma szerint",
-        "Light": "Világos",
-        "Custom": "Egyéni",
-        "Dark": "Sötét",
-        "Light (High Contrast)": "Világos (nagy kontrasztú)"
+        "By Date Modified": "Módosítás dátuma szerint"
     },
     "modals": {
         "Cancel": "Mégse",
@@ -2116,7 +2100,17 @@
         "What organization are you with?": "Milyen szervezethez tartozol?",
         "Your organization": "A szervezeted",
         "Your role": "A te szereped",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "A Grist úgy néz ki, mint egy táblázat, de nem mindig úgy működik. Fedezd fel, mitől más a Grist."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "A Grist úgy néz ki, mint egy táblázat, de nem mindig úgy működik. Fedezd fel, mitől más a Grist.",
+        "Product Development": "Termékfejlesztés",
+        "Finance & Accounting": "Pénzügy és számvitel",
+        "Media Production": "Médiatartalom-gyártás",
+        "IT & Technology": "IT és technológia",
+        "Marketing": "Marketing",
+        "Research": "Kutatás",
+        "Sales": "Értékesítés",
+        "Education": "Végzettség",
+        "HR & Management": "HR és menedzsment",
+        "Other": "Egyéb"
     },
     "ToggleEnterpriseWidget": {
         "An activation key is used to run Grist Enterprise after a trial period\nof 30 days has expired. Get an activation key by [signing up for Grist\nEnterprise]({{signupLink}}). You do not need an activation key to run\nGrist Core.\n\nLearn more in our [Help Center]({{helpCenter}}).": "A Grist Enterprise futtatásához aktiválókulcs szükséges a 30 napos próbaidőszak\nlejárata után. Szerezz aktiválási kulcsot [a Grist Enterprise szolgáltatásra regisztrációval]( {{signupLink}} ).\nA Grist Core futtatásához nincs szükség aktiváló kulcsra\n\n\nTovábbi információ a [Súgóban]( {{helpCenter}} ).",

--- a/static/locales/id.client.json
+++ b/static/locales/id.client.json
@@ -957,7 +957,10 @@
     },
     "ThemeConfig": {
         "Appearance ": "Tampilan ",
-        "Switch appearance automatically to match system": "Ganti tampilan secara otomatis agar sesuai dengan sistem"
+        "Switch appearance automatically to match system": "Ganti tampilan secara otomatis agar sesuai dengan sistem",
+        "Light": "Terang",
+        "Dark": "Gelap",
+        "Light (High Contrast)": "Terang (Kontras Tinggi)"
     },
     "Tools": {
         "Access Rules": "Aturan Akses",
@@ -1078,21 +1081,6 @@
         "Hide {{label}} (batch mode)": "Sembunyikan {{label}} (mode batch)",
         "Show {{label}} (batch mode)": "Tampilkan {{label}} (mode batch)"
     },
-    "WelcomeQuestions": {
-        "Education": "Pendidikan",
-        "Finance & Accounting": "Keuangan dan Akuntansi",
-        "HR & Management": "SDM dan Manajemen",
-        "IT & Technology": "TI dan Teknologi",
-        "Marketing": "Pemasaran",
-        "Media Production": "Produksi Media",
-        "Other": "Lainnya",
-        "Product Development": "Pengembangan Produk",
-        "Research": "Riset",
-        "Sales": "Penjualan",
-        "Type here": "Ketik di sini",
-        "Welcome to Grist!": "Selamat datang di Grist!",
-        "What brings you to Grist? Please help us serve you better.": "Apa yang membawa Anda ke Grist? Mohon bantu kami melayani Anda dengan lebih baik."
-    },
     "WidgetTitle": {
         "Cancel": "Batal",
         "DATA TABLE NAME": "NAMA TABEL DATA",
@@ -1181,11 +1169,7 @@
         "Attachment": "Lampiran",
         "Search columns": "Kolom pencarian",
         "By Name": "Berdasarkan Nama",
-        "By Date Modified": "Berdasar tanggal Modifikasi",
-        "Light": "Terang",
-        "Custom": "Kustom",
-        "Dark": "Gelap",
-        "Light (High Contrast)": "Terang (Kontras Tinggi)"
+        "By Date Modified": "Berdasar tanggal Modifikasi"
     },
     "modals": {
         "Cancel": "Batal",
@@ -2283,7 +2267,17 @@
         "What organization are you with?": "Anda tergabung dalam organisasi apa?",
         "Your organization": "Organisasi Anda",
         "Your role": "Peran Anda",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist mungkin terlihat seperti spreadsheet, tetapi fungsinya tidak selalu seperti itu. Temukan apa yang membedakan Grist."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist mungkin terlihat seperti spreadsheet, tetapi fungsinya tidak selalu seperti itu. Temukan apa yang membedakan Grist.",
+        "Product Development": "Pengembangan Produk",
+        "Finance & Accounting": "Keuangan dan Akuntansi",
+        "Media Production": "Produksi Media",
+        "IT & Technology": "TI dan Teknologi",
+        "Marketing": "Pemasaran",
+        "Research": "Riset",
+        "Sales": "Penjualan",
+        "Education": "Pendidikan",
+        "HR & Management": "SDM dan Manajemen",
+        "Other": "Lainnya"
     },
     "ToggleEnterpriseWidget": {
         "An activation key is used to run Grist Enterprise after a trial period\nof 30 days has expired. Get an activation key by [signing up for Grist\nEnterprise]({{signupLink}}). You do not need an activation key to run\nGrist Core.\n\nLearn more in our [Help Center]({{helpCenter}}).": "Kunci aktivasi digunakan untuk menjalankan Grist Enterprise setelah masa uji coba\n30 hari berakhir. Dapatkan kunci aktivasi dengan [mendaftar di Grist\nEnterprise]({{signupLink}}). Anda tidak memerlukan kunci aktivasi untuk menjalankan\nGrist Core.\n\nPelajari lebih lanjut di [Pusat Bantuan]({{helpCenter}}) kami.",

--- a/static/locales/it.client.json
+++ b/static/locales/it.client.json
@@ -237,21 +237,6 @@
         "Section: ": "Sezione: ",
         "Unmark On-Demand": "Non rendere on-demand"
     },
-    "WelcomeQuestions": {
-        "What brings you to Grist? Please help us serve you better.": "Che cosa ti ha portato a Grist? Aiutaci a servirti meglio.",
-        "Sales": "Vendite",
-        "Product Development": "Sviluppo di prodotti",
-        "Education": "Istruzione",
-        "Finance & Accounting": "Finanza e contabilità",
-        "HR & Management": "Risorse umane e amministrazione",
-        "IT & Technology": "IT e tecnologia",
-        "Marketing": "Marketing",
-        "Media Production": "Produzione nei media",
-        "Other": "Altro",
-        "Research": "Ricerca",
-        "Type here": "Scrivi qui",
-        "Welcome to Grist!": "Benvenuto in Grist!"
-    },
     "errorPages": {
         "Something went wrong": "Qualcosa non ha funzionato",
         "The requested page could not be found.{{separator}}Please check the URL and try again.": "Impossibile trovare la pagina richiesta.{{separator}}Controllare la URL e provare ancora.",
@@ -1018,7 +1003,8 @@
     },
     "ThemeConfig": {
         "Appearance ": "Aspetto ",
-        "Switch appearance automatically to match system": "Cambia aspetto automaticamente con il sistema"
+        "Switch appearance automatically to match system": "Cambia aspetto automaticamente con il sistema",
+        "Light": "Chiaro"
     },
     "TopBar": {
         "Manage team": "Gestisci il team"
@@ -1122,9 +1108,7 @@
         "Choice": "Scelta",
         "Search columns": "Cerca colonne",
         "By Name": "Per nome",
-        "Light": "Chiaro",
-        "By Date Modified": "Per data di modifica",
-        "Custom": "Personalizzato"
+        "By Date Modified": "Per data di modifica"
     },
     "modals": {
         "Cancel": "Annulla",
@@ -1765,7 +1749,17 @@
         "Skip tutorial": "Salta il tutorial",
         "What is your role?": "Qual è il tuo ruolo?",
         "Your organization": "La tua organizzazione",
-        "Your role": "Il tuo ruolo"
+        "Your role": "Il tuo ruolo",
+        "Product Development": "Sviluppo di prodotti",
+        "Finance & Accounting": "Finanza e contabilità",
+        "Media Production": "Produzione nei media",
+        "IT & Technology": "IT e tecnologia",
+        "Marketing": "Marketing",
+        "Research": "Ricerca",
+        "Sales": "Vendite",
+        "Education": "Istruzione",
+        "HR & Management": "Risorse umane e amministrazione",
+        "Other": "Altro"
     },
     "ViewLayout": {
         "Delete": "Cancella",

--- a/static/locales/ja.client.json
+++ b/static/locales/ja.client.json
@@ -341,21 +341,6 @@
     "Open Access Rules": "アクセスルールを開く",
     "No default access allows access to be granted to individual documents or workspaces, rather than the full team site.": "デフォルトのアクセスでは、チーム サイト全体ではなく、個々のドキュメントまたはワークスペースにアクセスを許可することはできません。"
   },
-  "WelcomeQuestions": {
-    "Welcome to Grist!": "Gristへようこそ！",
-    "HR & Management": "人事労務管理",
-    "Sales": "営業",
-    "Marketing": "マーケティング",
-    "Type here": "ここに入力",
-    "Other": "その他",
-    "Product Development": "製品開発",
-    "Media Production": "メディア制作",
-    "What brings you to Grist? Please help us serve you better.": "グリストをご利用になる理由は何ですか？より良いサービスを提供するためにご協力ください。",
-    "Education": "教育",
-    "IT & Technology": "ITとテクノロジー",
-    "Finance & Accounting": "財務・会計",
-    "Research": "研究"
-  },
   "PagePanels": {
     "Open creator panel": "クリエイターパネルを開く",
     "Close Creator Panel": "クリエイターパネルを閉じる"
@@ -1129,5 +1114,18 @@
   },
   "Menu": {
     "Paragraph": "段落"
+  },
+  "OnboardingPage": {
+    "Product Development": "製品開発",
+    "Finance & Accounting": "財務・会計",
+    "Media Production": "メディア制作",
+    "IT & Technology": "ITとテクノロジー",
+    "Marketing": "マーケティング",
+    "Research": "研究",
+    "Sales": "営業",
+    "Education": "教育",
+    "HR & Management": "人事労務管理",
+    "Other": "その他",
+    "Type here": "ここに入力"
   }
 }

--- a/static/locales/ko.client.json
+++ b/static/locales/ko.client.json
@@ -373,21 +373,6 @@
         "Hidden {{label}}": "{{label}} 숨겨짐",
         "Show {{label}}": "{{label}} 표시"
     },
-    "WelcomeQuestions": {
-        "Welcome to Grist!": "Grist에 오신 것을 환영합니다!",
-        "What brings you to Grist? Please help us serve you better.": "Grist를 사용하게 된 계기는 무엇인가요? 더 나은 서비스를 제공할 수 있도록 도와주세요.",
-        "Other": "기타",
-        "Product Development": "제품 개발",
-        "Education": "교육",
-        "Finance & Accounting": "재무 및 회계",
-        "HR & Management": "인사 및 관리",
-        "IT & Technology": "IT 및 기술",
-        "Marketing": "마케팅",
-        "Media Production": "미디어 제작",
-        "Research": "연구",
-        "Sales": "영업",
-        "Type here": "여기에 입력하세요"
-    },
     "WidgetTitle": {
         "Cancel": "취소",
         "DATA TABLE NAME": "데이터 표 이름",
@@ -430,8 +415,6 @@
         "Search columns": "열 검색",
         "By Name": "이름순",
         "By Date Modified": "수정 날짜순",
-        "Light": "라이트",
-        "Custom": "사용자 정의",
         "* Workspaces are available on team plans. ": "* 워크스페이스는 팀 요금제에서 사용할 수 있습니다. ",
         "Select fields": "필드 선택",
         "Upgrade now": "지금 업그레이드",
@@ -821,7 +804,17 @@
         "What brings you to Grist (you can select multiple)?": "Grist를 사용하게 된 계기는 무엇인가요 (여러 개 선택 가능)?",
         "What is your role?": "당신의 역할은 무엇인가요?",
         "What organization are you with?": "어떤 조직에 속해 있나요?",
-        "Your role": "역할"
+        "Your role": "역할",
+        "Product Development": "제품 개발",
+        "Finance & Accounting": "재무 및 회계",
+        "Media Production": "미디어 제작",
+        "IT & Technology": "IT 및 기술",
+        "Marketing": "마케팅",
+        "Research": "연구",
+        "Sales": "영업",
+        "Education": "교육",
+        "HR & Management": "인사 및 관리",
+        "Other": "기타"
     },
     "ViewLayout": {
         "Delete": "삭제",
@@ -1539,7 +1532,8 @@
     },
     "ThemeConfig": {
         "Appearance ": "모양 ",
-        "Switch appearance automatically to match system": "시스템 설정에 맞춰 자동으로 모양 전환"
+        "Switch appearance automatically to match system": "시스템 설정에 맞춰 자동으로 모양 전환",
+        "Light": "라이트"
     },
     "Tools": {
         "Access Rules": "접근 규칙",

--- a/static/locales/nb_NO.client.json
+++ b/static/locales/nb_NO.client.json
@@ -840,21 +840,6 @@
     "Double-click or hit {{enter}} on a cell to edit it. ": "Dobbeltklikk eller trykk {{enter}} på en celle for å redigere den. ",
     "Browse our {{templateLibrary}} to discover what's possible and get inspired.": "Utforsk vårt {{templateLibrary}} for å oppdage hva som er mulig og for å få inspirasjon."
   },
-  "WelcomeQuestions": {
-    "Finance & Accounting": "Finans og bokføring",
-    "What brings you to Grist? Please help us serve you better.": "Hva bringer deg til Grist? Hjelp oss å tjene dine behov.",
-    "Other": "Annet",
-    "Type here": "Skriv her",
-    "IT & Technology": "IT og teknologi",
-    "HR & Management": "Stabsforvaltning og håndtering",
-    "Product Development": "Produktutvikling",
-    "Research": "Forskning",
-    "Sales": "Salg",
-    "Education": "Utdanning",
-    "Media Production": "Mediaproduksjon",
-    "Marketing": "Markedsføring",
-    "Welcome to Grist!": "Velkommen til Grist."
-  },
   "WidgetTitle": {
     "Cancel": "Avbryt",
     "DATA TABLE NAME": "Datatabellnavn",
@@ -1212,5 +1197,18 @@
   "SearchModel": {
     "Search all tables": "Søk i alle tabeller",
     "Search all pages": "Søk på alle sider"
+  },
+  "OnboardingPage": {
+    "Product Development": "Produktutvikling",
+    "Finance & Accounting": "Finans og bokføring",
+    "Media Production": "Mediaproduksjon",
+    "IT & Technology": "IT og teknologi",
+    "Marketing": "Markedsføring",
+    "Research": "Forskning",
+    "Sales": "Salg",
+    "Education": "Utdanning",
+    "HR & Management": "Stabsforvaltning og håndtering",
+    "Other": "Annet",
+    "Type here": "Skriv her"
   }
 }

--- a/static/locales/pl.client.json
+++ b/static/locales/pl.client.json
@@ -1023,21 +1023,6 @@
         "Hide {{label}} (batch mode)": "Ukryj {{label}} (tryb seryjny)",
         "Show {{label}} (batch mode)": "Pokaż {{label}} (tryb seryjny)"
     },
-    "WelcomeQuestions": {
-        "Education": "Edukacja",
-        "Research": "Badania",
-        "Type here": "Wpisz tutaj",
-        "Welcome to Grist!": "Witamy w Grist!",
-        "What brings you to Grist? Please help us serve you better.": "Co sprowadza cię do Grist? Pomóż nam lepiej Ci służyć.",
-        "Product Development": "Rozwój produktu",
-        "IT & Technology": "IT i technologia",
-        "Marketing": "Marketing",
-        "Media Production": "Produkcja medialna",
-        "Other": "Inne",
-        "Sales": "Sprzedaż",
-        "Finance & Accounting": "Finanse i Księgowość",
-        "HR & Management": "HR i zarządzanie"
-    },
     "WidgetTitle": {
         "DATA TABLE NAME": "NAZWA TABELI DANYCH",
         "Override widget title": "Zastąp tytuł widżetu",
@@ -1121,9 +1106,7 @@
         "Attachment": "Załącznik",
         "Search columns": "Wyszukaj kolumny",
         "By Name": "Według nazwy",
-        "By Date Modified": "Według daty modyfikacji",
-        "Light": "Jasny",
-        "Custom": "Niestandardowy"
+        "By Date Modified": "Według daty modyfikacji"
     },
     "modals": {
         "Cancel": "Anuluj",
@@ -1234,7 +1217,8 @@
     },
     "ThemeConfig": {
         "Appearance ": "Wygląd ",
-        "Switch appearance automatically to match system": "Automatyczne przełączanie wyglądu w celu dopasowania do systemu"
+        "Switch appearance automatically to match system": "Automatyczne przełączanie wyglądu w celu dopasowania do systemu",
+        "Light": "Jasny"
     },
     "TopBar": {
         "Manage team": "Zarządzaj zespołem"
@@ -2005,7 +1989,17 @@
         "What organization are you with?": "Z jaką organizacją jesteś związany?",
         "Your organization": "Twoja organizacja",
         "Your role": "Twoja rola",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist może wyglądać jak arkusz kalkulacyjny, ale nie zawsze tak działa. Odkryj, co wyróżnia Grista."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist może wyglądać jak arkusz kalkulacyjny, ale nie zawsze tak działa. Odkryj, co wyróżnia Grista.",
+        "Product Development": "Rozwój produktu",
+        "Finance & Accounting": "Finanse i Księgowość",
+        "Media Production": "Produkcja medialna",
+        "IT & Technology": "IT i technologia",
+        "Marketing": "Marketing",
+        "Research": "Badania",
+        "Sales": "Sprzedaż",
+        "Education": "Edukacja",
+        "HR & Management": "HR i zarządzanie",
+        "Other": "Inne"
     },
     "ToggleEnterpriseWidget": {
         "An activation key is used to run Grist Enterprise after a trial period\nof 30 days has expired. Get an activation key by [signing up for Grist\nEnterprise]({{signupLink}}). You do not need an activation key to run\nGrist Core.\n\nLearn more in our [Help Center]({{helpCenter}}).": "Klucz aktywacyjny służy do uruchomienia Grist Enterprise po wygaśnięciu 30-dniowego okresu próbnego. Uzyskaj klucz aktywacyjny, [rejestrując się w Grist Enterprise]({{signupLink}}). Do uruchomienia Grist Core nie potrzebujesz klucza aktywacyjnego.\n\nDowiedz się więcej w naszym [Centrum pomocy]({{helpCenter}}).",

--- a/static/locales/pt.client.json
+++ b/static/locales/pt.client.json
@@ -581,7 +581,10 @@
     },
     "ThemeConfig": {
         "Appearance ": "Aparência ",
-        "Switch appearance automatically to match system": "Alternar a aparência automaticamente para corresponder ao sistema"
+        "Switch appearance automatically to match system": "Alternar a aparência automaticamente para corresponder ao sistema",
+        "Light": "Claro",
+        "Dark": "Escuro",
+        "Light (High Contrast)": "Claro (Alto Contraste)"
     },
     "Tools": {
         "Access Rules": "Regras de Acesso",
@@ -884,21 +887,6 @@
         "When checked, this field’s default value can be prefilled from the URL using query parameters.": "Quando selecionado, o valor padrão deste campo pode ser preenchido previamente a partir da URL usando parâmetros de consulta.",
         "With suggestions, users make changes in a personal copy without modifying the original document, then submit these suggestions to be reviewed by the document owner prior to integration.": "Com a função de sugestões, os utilizadores fazem alterações numa cópia pessoal sem modificar o documento original e, em seguida, enviam estas sugestões para serem revisadas pelo proprietário do documento antes da integração.",
         "Unpin to hide the button while keeping the filter.": "Desafixar para ocultar o botão, a manter o filtro."
-    },
-    "WelcomeQuestions": {
-        "IT & Technology": "TI e Tecnologia",
-        "Marketing": "Publicidade",
-        "Media Production": "Produção de Mídia",
-        "Other": "Outros",
-        "Product Development": "Desenvolvimento de Produto",
-        "Research": "Investigação",
-        "Sales": "Vendas",
-        "Type here": "Digite aqui",
-        "Welcome to Grist!": "Bem-vindo ao Grist!",
-        "What brings you to Grist? Please help us serve you better.": "O que te traz ao Grist? Por favor, ajude-nos a atendê-lo melhor.",
-        "Education": "Educação",
-        "Finance & Accounting": "Finanças e Contabilidade",
-        "HR & Management": "RH e Gestão"
     },
     "WidgetTitle": {
         "Cancel": "Cancelar",
@@ -1426,12 +1414,8 @@
         "Reference List": "Lista de Referências",
         "Attachment": "Anexo",
         "Search columns": "Procurar colunas",
-        "Custom": "Personalizado",
         "By Date Modified": "Por Data de Modificação",
-        "By Name": "Por Nome",
-        "Light": "Claro",
-        "Dark": "Escuro",
-        "Light (High Contrast)": "Claro (Alto Contraste)"
+        "By Name": "Por Nome"
     },
     "modals": {
         "Cancel": "Cancelar",
@@ -2028,7 +2012,17 @@
         "Discover Grist in 3 minutes": "Descubra Grist em 3 minutos",
         "Go hands-on with the Grist Basics tutorial": "Pratique com o tutorial Conceitos Básicos do Grist",
         "Go to the tutorial!": "Vá para o tutorial!",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "O Grist pode parecer uma planilha, mas nem sempre age como uma. Descubra o que torna o Grist diferente."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "O Grist pode parecer uma planilha, mas nem sempre age como uma. Descubra o que torna o Grist diferente.",
+        "Product Development": "Desenvolvimento de Produto",
+        "Finance & Accounting": "Finanças e Contabilidade",
+        "Media Production": "Produção de Mídia",
+        "IT & Technology": "TI e Tecnologia",
+        "Marketing": "Publicidade",
+        "Research": "Investigação",
+        "Sales": "Vendas",
+        "Education": "Educação",
+        "HR & Management": "RH e Gestão",
+        "Other": "Outros"
     },
     "ToggleEnterpriseWidget": {
         "An activation key is used to run Grist Enterprise after a trial period\nof 30 days has expired. Get an activation key by [signing up for Grist\nEnterprise]({{signupLink}}). You do not need an activation key to run\nGrist Core.\n\nLearn more in our [Help Center]({{helpCenter}}).": "Uma chave de ativação é usada para executar o Grist Enterprise após um período de avaliação\nde 30 dias tenha expirado. Obtenha uma chave de ativação [inscrevendo-se no Grist\nEmpresarial]({{signupLink}}). Não precisa de uma chave de ativação para executar o\nGrist Core.\n\nSaiba mais na nossa [Central de Ajuda]({{helpCenter}}).",

--- a/static/locales/pt_BR.client.json
+++ b/static/locales/pt_BR.client.json
@@ -1004,7 +1004,10 @@
     },
     "ThemeConfig": {
         "Appearance ": "Aparência ",
-        "Switch appearance automatically to match system": "Alternar a aparência automaticamente para corresponder ao sistema"
+        "Switch appearance automatically to match system": "Alternar a aparência automaticamente para corresponder ao sistema",
+        "Light": "Claro",
+        "Dark": "Escuro",
+        "Light (High Contrast)": "Claro (Alto Contraste)"
     },
     "Tools": {
         "Access Rules": "Regras de Acesso",
@@ -1129,21 +1132,6 @@
         "Hide {{label}} (batch mode)": "Ocultar {{label}} (modo em lote)",
         "Show {{label}} (batch mode)": "Mostrar {{label}} (modo em lote)"
     },
-    "WelcomeQuestions": {
-        "Education": "Educação",
-        "Finance & Accounting": "Finanças e Contabilidade",
-        "HR & Management": "RH e Gestão",
-        "IT & Technology": "TI e Tecnologia",
-        "Marketing": "Publicidade",
-        "Media Production": "Produção de Mídia",
-        "Other": "Outros",
-        "Product Development": "Desenvolvimento de Produto",
-        "Research": "Investigação",
-        "Sales": "Vendas",
-        "Type here": "Digite aqui",
-        "Welcome to Grist!": "Bem-vindo ao Grist!",
-        "What brings you to Grist? Please help us serve you better.": "O que te traz ao Grist? Por favor, ajude-nos a atendê-lo melhor."
-    },
     "WidgetTitle": {
         "Cancel": "Cancelar",
         "DATA TABLE NAME": "NOME DA TABELA DE DADOS",
@@ -1231,12 +1219,8 @@
         "Choice": "Opção",
         "Reference": "Referência",
         "Search columns": "Procurar colunas",
-        "Light": "Claro",
-        "Custom": "Personalizado",
         "By Name": "Por Nome",
-        "By Date Modified": "Por Data de Modificação",
-        "Dark": "Escuro",
-        "Light (High Contrast)": "Claro (Alto Contraste)"
+        "By Date Modified": "Por Data de Modificação"
     },
     "modals": {
         "Cancel": "Cancelar",
@@ -2136,7 +2120,17 @@
         "Skip step": "Pular passo",
         "Back": "Voltar",
         "Welcome": "Bem-vindo",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "O Grist pode parecer uma planilha, mas nem sempre age como uma. Descubra o que torna o Grist diferente."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "O Grist pode parecer uma planilha, mas nem sempre age como uma. Descubra o que torna o Grist diferente.",
+        "Product Development": "Desenvolvimento de Produto",
+        "Finance & Accounting": "Finanças e Contabilidade",
+        "Media Production": "Produção de Mídia",
+        "IT & Technology": "TI e Tecnologia",
+        "Marketing": "Publicidade",
+        "Research": "Investigação",
+        "Sales": "Vendas",
+        "Education": "Educação",
+        "HR & Management": "RH e Gestão",
+        "Other": "Outros"
     },
     "ToggleEnterpriseWidget": {
         "Disable Grist Enterprise": "Desativar o Grist Empresarial",

--- a/static/locales/ro.client.json
+++ b/static/locales/ro.client.json
@@ -692,21 +692,6 @@
     "Access overview": "Prezentare generală a accesului",
     "Inherit access: ": "Moşteneşte acess: "
   },
-  "WelcomeQuestions": {
-    "Welcome to Grist!": "Bun venit la Grist!",
-    "HR & Management": "Resurse Umane și Management",
-    "Sales": "Vânzări",
-    "Marketing": "Marketing",
-    "Type here": "Scrie aici",
-    "Other": "Altele",
-    "Product Development": "Dezvoltare de produs",
-    "Media Production": "Producție media",
-    "What brings you to Grist? Please help us serve you better.": "Ce vă aduce la Grist? Vă rugăm să ne ajutați să vă servim mai bine.",
-    "Education": "Educaţie",
-    "IT & Technology": "IT și Tehnologie",
-    "Finance & Accounting": "Finanțe și Contabilitate",
-    "Research": "Cercetare"
-  },
   "PagePanels": {
     "Open creator panel": "Deschide Panoul creatorului",
     "Close Creator Panel": "Închide Panoul creatorului"
@@ -1350,5 +1335,18 @@
     "Home": "Acasă",
     "Sponsor": "Sponsor",
     "Support Grist": "Sponsor Grist"
+  },
+  "OnboardingPage": {
+    "Product Development": "Dezvoltare de produs",
+    "Finance & Accounting": "Finanțe și Contabilitate",
+    "Media Production": "Producție media",
+    "IT & Technology": "IT și Tehnologie",
+    "Marketing": "Marketing",
+    "Research": "Cercetare",
+    "Sales": "Vânzări",
+    "Education": "Educaţie",
+    "HR & Management": "Resurse Umane și Management",
+    "Other": "Altele",
+    "Type here": "Scrie aici"
   }
 }

--- a/static/locales/ru.client.json
+++ b/static/locales/ru.client.json
@@ -973,7 +973,8 @@
     },
     "ThemeConfig": {
         "Appearance ": "Оформление ",
-        "Switch appearance automatically to match system": "Автоматическое переключение оформления в соответствии с системной настройкой"
+        "Switch appearance automatically to match system": "Автоматическое переключение оформления в соответствии с системной настройкой",
+        "Light": "Светлая"
     },
     "UserManagerModel": {
         "In full": "Полный",
@@ -1182,21 +1183,6 @@
         "Hide {{label}} (batch mode)": "Скрыть {{label}} (пакетный режим)",
         "Show {{label}} (batch mode)": "Показать {{label}} (пакетный режим)"
     },
-    "WelcomeQuestions": {
-        "Marketing": "Маркетинг",
-        "Research": "Исследование",
-        "Sales": "Продажи",
-        "Welcome to Grist!": "Добро пожаловать в Grist!",
-        "What brings you to Grist? Please help us serve you better.": "Как вы пришли к Grist? Пожалуйста, помогите сделать наш сервис лучше.",
-        "Education": "Образование",
-        "HR & Management": "Управление персоналом и Менеджмент",
-        "Finance & Accounting": "Финансы и Бухгалтерия",
-        "Media Production": "Медиапроизводство",
-        "Type here": "Введите здесь",
-        "Product Development": "Разработка продукта",
-        "Other": "Прочее",
-        "IT & Technology": "IT и Технология"
-    },
     "breadcrumbs": {
         "fiddle": "ветка",
         "override": "переопределение",
@@ -1226,9 +1212,7 @@
         "Reference": "Ссылка",
         "Search columns": "Поиск столбцов",
         "By Name": "По Имени",
-        "By Date Modified": "По дате Изменения",
-        "Light": "Светлая",
-        "Custom": "Своя"
+        "By Date Modified": "По дате Изменения"
     },
     "modals": {
         "Cancel": "Отмена",
@@ -1689,9 +1673,9 @@
     },
     "WelcomeCoachingCall": {
         "free coaching call": "бесплатный коуч-звонок",
-    "Maybe later": "Возможно позже",
+        "Maybe later": "Возможно позже",
         "On the call, we'll take the time to understand your needs and tailor the call to you. We can show you the Grist basics, or start working with your data right away to build the dashboards you need.": "Во время звонка мы уделяем время тому, чтобы понять ваши потребности и адаптировать звонок под ваши нужды. Мы можем показать вам основы Grist или сразу начать работать с вашими данными, чтобы создать нужные вам информационные панели.",
-    "Schedule call": "Запланировать звонок",
+        "Schedule call": "Запланировать звонок",
         "Schedule your {{freeCoachingCall}} with a member of our team.": "Запланируйте свой {{freeCoachingCall}} с членом нашей команды.",
         "You may also check out {{ourWeeklyWebinars}} to learn more about Grist.": "Вы также можете проверить {{ourWeeklyWebinars}} чтобы узнать больше о Grist.",
         "our weekly webinars": "наши еженедельные вебинары"
@@ -1954,7 +1938,17 @@
         "Next step": "Следующий шаг",
         "Skip step": "Пропустить шаг",
         "Skip tutorial": "Пропустить обучение",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist может выглядеть как электронная таблица, но это не всегда так. Узнайте, чем отличается Grist от других приложений."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist может выглядеть как электронная таблица, но это не всегда так. Узнайте, чем отличается Grist от других приложений.",
+        "Product Development": "Разработка продукта",
+        "Finance & Accounting": "Финансы и Бухгалтерия",
+        "Media Production": "Медиапроизводство",
+        "IT & Technology": "IT и Технология",
+        "Marketing": "Маркетинг",
+        "Research": "Исследование",
+        "Sales": "Продажи",
+        "Education": "Образование",
+        "HR & Management": "Управление персоналом и Менеджмент",
+        "Other": "Прочее"
     },
     "ToggleEnterpriseWidget": {
         "An activation key is used to run Grist Enterprise after a trial period\nof 30 days has expired. Get an activation key by [signing up for Grist\nEnterprise]({{signupLink}}). You do not need an activation key to run\nGrist Core.\n\nLearn more in our [Help Center]({{helpCenter}}).": "Ключ активации используется для запуска Grist Enterprise после окончания\n30 дневного пробного периода. Получите ключ активации по [подписавшись на Grist\nEnterprise]({{signupLink}}). Для запуска Grist Core вам не нужен ключ активации.\n\nУзнайте больше в нашем [Центр помощи]({{helpCenter}}).",

--- a/static/locales/sk.client.json
+++ b/static/locales/sk.client.json
@@ -1000,21 +1000,6 @@
         "Update Sort&Filter settings": "Aktualizovať nastavenie triedenia a filtrovania",
         "Sort and filter": "Triedenie a filter"
     },
-    "WelcomeQuestions": {
-        "Education": "Vzdelávanie",
-        "Finance & Accounting": "Financie a Účtovníctvo",
-        "HR & Management": "HR a Manažment",
-        "Marketing": "Marketing",
-        "Media Production": "Mediálna Produkcia",
-        "Other": "Ostatné",
-        "Product Development": "Vývoj Produktov",
-        "Research": "Výskum",
-        "Sales": "Predaj",
-        "Type here": "Písať sem",
-        "Welcome to Grist!": "Vitajte v Grist!",
-        "IT & Technology": "IT a Technológie",
-        "What brings you to Grist? Please help us serve you better.": "Čo vás privádza do Gristu? Pomôžte nám, aby sme Vám lepšie poslúžili."
-    },
     "WidgetTitle": {
         "Save": "Uložiť",
         "Cancel": "Zrušiť",
@@ -1087,9 +1072,7 @@
         "Reference List": "Zoznam Referencií",
         "Search columns": "Hľadať stĺpce",
         "By Name": "Podľa Názvu",
-        "By Date Modified": "Podľa dátumu úpravy",
-        "Light": "Svetlé",
-        "Custom": "Vlastné"
+        "By Date Modified": "Podľa dátumu úpravy"
     },
     "modals": {
         "Save": "Uložiť",
@@ -1814,7 +1797,8 @@
     },
     "ThemeConfig": {
         "Appearance ": "Vzhľad ",
-        "Switch appearance automatically to match system": "Automaticky prepnúť vzhľad tak, aby zodpovedal systému"
+        "Switch appearance automatically to match system": "Automaticky prepnúť vzhľad tak, aby zodpovedal systému",
+        "Light": "Svetlé"
     },
     "ValidationPanel": {
         "Rule {{length}}": "Pravidlo {{length}}",
@@ -2005,7 +1989,17 @@
         "Type here": "Zadať sem",
         "Your organization": "Vaša organizácia",
         "Your role": "Vaša úloha",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist môže vyzerať ako tabuľka, ale nie vždy sa tak správa. Objavte v čom je Grist iný."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist môže vyzerať ako tabuľka, ale nie vždy sa tak správa. Objavte v čom je Grist iný.",
+        "Product Development": "Vývoj Produktov",
+        "Finance & Accounting": "Financie a Účtovníctvo",
+        "Media Production": "Mediálna Produkcia",
+        "IT & Technology": "IT a Technológie",
+        "Marketing": "Marketing",
+        "Research": "Výskum",
+        "Sales": "Predaj",
+        "Education": "Vzdelávanie",
+        "HR & Management": "HR a Manažment",
+        "Other": "Ostatné"
     },
     "ToggleEnterpriseWidget": {
         "Disable Grist Enterprise": "Zakázať Grist Enterprise",

--- a/static/locales/sl.client.json
+++ b/static/locales/sl.client.json
@@ -1213,21 +1213,6 @@
     "You may make edits, but they will create a new copy and will\nnot affect the original document.": "Lahko jih uredite, vendar bodo ustvarili novo kopijo in ne bodo\nvplivali na izvirni dokument.",
     "fiddle": "poskus"
   },
-  "WelcomeQuestions": {
-    "Welcome to Grist!": "Dobrodošli v Gristu!",
-    "HR & Management": "HR in management",
-    "Sales": "Prodaja",
-    "Marketing": "Prodaja",
-    "Type here": "Piši tukaj",
-    "Other": "Ostalo",
-    "Product Development": "Razvoj izdelkov",
-    "Media Production": "Medijska produkcija",
-    "What brings you to Grist? Please help us serve you better.": "Kaj te je pripeljalo v Grist? Prosimo, pomagajte nam, da vam bolje služimo.",
-    "Education": "izobraževanje",
-    "IT & Technology": "IT in tehnologija",
-    "Finance & Accounting": "Finance in računovodstvo",
-    "Research": "Raziskovanje"
-  },
   "PagePanels": {
     "Open creator panel": "Odprite panel za ustvarjalce",
     "Close Creator Panel": "Zaprite panel za ustvarjalce"
@@ -1687,7 +1672,17 @@
     "Your role": "Tvoja vloga",
     "Go hands-on with the Grist Basics tutorial": "Preizkusi vadnico Osnove Grista",
     "Discover Grist in 3 minutes": "Odkrij Grist v 3 minutah",
-    "Go to the tutorial!": "Pojdi na vadnico!"
+    "Go to the tutorial!": "Pojdi na vadnico!",
+    "Product Development": "Razvoj izdelkov",
+    "Finance & Accounting": "Finance in računovodstvo",
+    "Media Production": "Medijska produkcija",
+    "IT & Technology": "IT in tehnologija",
+    "Marketing": "Prodaja",
+    "Research": "Raziskovanje",
+    "Sales": "Prodaja",
+    "Education": "izobraževanje",
+    "HR & Management": "HR in management",
+    "Other": "Ostalo"
   },
   "ToggleEnterpriseWidget": {
     "Disable Grist Enterprise": "Onemogoči Grist Enterprise",

--- a/static/locales/sv.client.json
+++ b/static/locales/sv.client.json
@@ -1109,7 +1109,10 @@
     },
     "ThemeConfig": {
         "Appearance ": "Utseende ",
-        "Switch appearance automatically to match system": "Växla utseende automatiskt för att matcha systemet"
+        "Switch appearance automatically to match system": "Växla utseende automatiskt för att matcha systemet",
+        "Light": "Ljust",
+        "Dark": "Mörkt",
+        "Light (High Contrast)": "Ljust (Hög kontrast)"
     },
     "Tools": {
         "Access Rules": "Behörighetsregler",
@@ -1218,21 +1221,6 @@
         "Hide {{label}} (batch mode)": "Dölj {{label}} (gruppvis)",
         "Show {{label}} (batch mode)": "Visa {{label}} (gruppvis)"
     },
-    "WelcomeQuestions": {
-        "Education": "Utbildning",
-        "Finance & Accounting": "Finans och redovisning",
-        "HR & Management": "HR och ledning",
-        "IT & Technology": "IT och teknologi",
-        "Marketing": "Marknadsföring",
-        "Media Production": "Medieproduktion",
-        "Other": "Annat",
-        "Product Development": "Produkt-utveckling",
-        "Research": "Forskning",
-        "Sales": "Försäljning",
-        "Type here": "Skriv här",
-        "Welcome to Grist!": "Välkommen till Grist!",
-        "What brings you to Grist? Please help us serve you better.": "Hur kom du in på Grist? Hjälp oss att stötta dig på bästa sätt."
-    },
     "breadcrumbs": {
         "You may make edits, but they will create a new copy and will\nnot affect the original document.": "Du kan redigera, men det kommer att skapa en ny kopia och\nkommer inte påverka originaldokumentet.",
         "fiddle": "experimentera",
@@ -1312,11 +1300,7 @@
         "Attachment": "Bilaga",
         "Search columns": "Sök kolumner",
         "By Name": "Efter namn",
-        "By Date Modified": "Efter ändringsdatum",
-        "Light": "Ljust",
-        "Custom": "Anpassad",
-        "Dark": "Mörkt",
-        "Light (High Contrast)": "Ljust (Hög kontrast)"
+        "By Date Modified": "Efter ändringsdatum"
     },
     "pages": {
         "Duplicate page": "Duplicera sida",
@@ -2111,7 +2095,17 @@
         "What organization are you with?": "Vilken organisation är du från?",
         "Your organization": "Din organisation",
         "Your role": "Din roll",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist kan se ut som ett kalkylblad, men det fungerar inte alltid som ett. Upptäck vad som gör Grist annorlunda."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist kan se ut som ett kalkylblad, men det fungerar inte alltid som ett. Upptäck vad som gör Grist annorlunda.",
+        "Product Development": "Produkt-utveckling",
+        "Finance & Accounting": "Finans och redovisning",
+        "Media Production": "Medieproduktion",
+        "IT & Technology": "IT och teknologi",
+        "Marketing": "Marknadsföring",
+        "Research": "Forskning",
+        "Sales": "Försäljning",
+        "Education": "Utbildning",
+        "HR & Management": "HR och ledning",
+        "Other": "Annat"
     },
     "ToggleEnterpriseWidget": {
         "An activation key is used to run Grist Enterprise after a trial period\nof 30 days has expired. Get an activation key by [signing up for Grist\nEnterprise]({{signupLink}}). You do not need an activation key to run\nGrist Core.\n\nLearn more in our [Help Center]({{helpCenter}}).": "En aktiveringsnyckel används för att köra Grist Företagsversion efter att försöksperioden\npå 30 dagar är slut. Skaffa en aktiveringsnyckel genom att [registrera för Grist\nFöretagsversion]({{signupLink}}). Du behöver ingen aktiveringsnyckel för att köra \nGrist Core.\n\nLär dig mer i vårt [Hjälpcenter]({{helpCenter}}).",

--- a/static/locales/ta.client.json
+++ b/static/locales/ta.client.json
@@ -803,9 +803,7 @@
         "Attachment": "இணைப்பு",
         "Search columns": "நெடுவரிசைகளைத் தேடுங்கள்",
         "By Name": "பெயரால்",
-        "By Date Modified": "தேதியில் மாற்றியமைக்கப்பட்டது",
-        "Light": "ஒளி",
-        "Custom": "தனிப்பயன்"
+        "By Date Modified": "தேதியில் மாற்றியமைக்கப்பட்டது"
     },
     "modals": {
         "Cancel": "ரத்துசெய்",
@@ -1381,7 +1379,17 @@
         "Your role": "உங்கள் பங்கு",
         "Back": "பின்",
         "Discover Grist in 3 minutes": "3 நிமிடங்களில் கிரிச்ட்டைக் கண்டறியவும்",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "கிரிச்ட் ஒரு விரிதாள் போல தோன்றலாம், ஆனால் அது எப்போதும் ஒன்றைப் போல செயல்படாது. கிரிச்ட்டை வேறுபடுத்துவதைக் கண்டறியவும்."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "கிரிச்ட் ஒரு விரிதாள் போல தோன்றலாம், ஆனால் அது எப்போதும் ஒன்றைப் போல செயல்படாது. கிரிச்ட்டை வேறுபடுத்துவதைக் கண்டறியவும்.",
+        "Product Development": "தயாரிப்பு மேம்பாடு",
+        "Finance & Accounting": "பொருள் மற்றும் கணக்கியல்",
+        "Media Production": "ஊடக தயாரிப்பு",
+        "IT & Technology": "செய்தி தொழில்நுட்பம் மற்றும் தொழில்நுட்பம்",
+        "Marketing": "சந்தைப்படுத்தல்",
+        "Research": "ஆராய்ச்சி",
+        "Sales": "விற்பனை",
+        "Education": "கல்வி",
+        "HR & Management": "மனிதவள மற்றும் மேலாண்மை",
+        "Other": "மற்றொன்று"
     },
     "ToggleEnterpriseWidget": {
         "An activation key is used to run Grist Enterprise after a trial period\nof 30 days has expired. Get an activation key by [signing up for Grist\nEnterprise]({{signupLink}}). You do not need an activation key to run\nGrist Core.\n\nLearn more in our [Help Center]({{helpCenter}}).": "சோதனைக் காலத்திற்குப் பிறகு கிரிச்ட் நிறுவனத்தை இயக்க ஒரு செயல்படுத்தும் விசை பயன்படுத்தப்படுகிறது\n 30 நாட்கள் காலாவதியானது. [கிரிச்டுக்கு பதிவுபெறுவதன் மூலம் செயல்படுத்தும் விசையைப் பெறுங்கள்\n நிறுவன] ({{signupLink}}). இயக்க உங்களுக்கு செயல்படுத்தும் விசை தேவையில்லை\n கிரிச்ட் கோர்.\n\n எங்கள் [உதவி மையத்தில்] மேலும் அறிக ({{helpCenter}}).",
@@ -1762,7 +1770,8 @@
     },
     "ThemeConfig": {
         "Appearance ": "தோற்றம் ",
-        "Switch appearance automatically to match system": "கணினியுடன் பொருந்தக்கூடிய வகையில் தானாகவே தோற்றத்தை மாற்றவும்"
+        "Switch appearance automatically to match system": "கணினியுடன் பொருந்தக்கூடிய வகையில் தானாகவே தோற்றத்தை மாற்றவும்",
+        "Light": "ஒளி"
     },
     "TopBar": {
         "Manage team": "அணியை நிர்வகிக்கவும்",
@@ -1829,21 +1838,6 @@
         "Show {{label}}": "{{label}} ஐக் காட்டு",
         "Hide {{label}} (batch mode)": "மறை {{label}} (தொகுப்பு முறை)",
         "Show {{label}} (batch mode)": "{{label}} (தொகுப்பு முறை)"
-    },
-    "WelcomeQuestions": {
-        "Education": "கல்வி",
-        "Finance & Accounting": "பொருள் மற்றும் கணக்கியல்",
-        "HR & Management": "மனிதவள மற்றும் மேலாண்மை",
-        "IT & Technology": "செய்தி தொழில்நுட்பம் மற்றும் தொழில்நுட்பம்",
-        "Marketing": "சந்தைப்படுத்தல்",
-        "Media Production": "ஊடக தயாரிப்பு",
-        "Other": "மற்றொன்று",
-        "Product Development": "தயாரிப்பு மேம்பாடு",
-        "Research": "ஆராய்ச்சி",
-        "Sales": "விற்பனை",
-        "Type here": "இங்கே தட்டச்சு செய்க",
-        "Welcome to Grist!": "கிரிச்டுக்கு வருக!",
-        "What brings you to Grist? Please help us serve you better.": "உங்களைத் தூண்டுவது எது? தயவுசெய்து உங்களுக்கு சிறப்பாக பணி செய்ய எங்களுக்கு உதவுங்கள்."
     },
     "breadcrumbs": {
         "You may make edits, but they will create a new copy and will\nnot affect the original document.": "நீங்கள் திருத்தங்களைச் செய்யலாம், ஆனால் அவை புதிய நகலை உருவாக்கும்\n அசல் ஆவணத்தை பாதிக்காது.",

--- a/static/locales/uk.client.json
+++ b/static/locales/uk.client.json
@@ -226,7 +226,8 @@
     },
     "ThemeConfig": {
         "Switch appearance automatically to match system": "Автоматично змінювати оформлення відповідно до системи",
-        "Appearance ": "Оформлення "
+        "Appearance ": "Оформлення ",
+        "Light": "Світло"
     },
     "HomeIntro": {
         "Create empty document": "Створити пустий документ",
@@ -1058,21 +1059,6 @@
     "AppModel": {
         "This team site is suspended. Documents can be read, but not modified.": "Цей сайт команди обмежений. Документи можна читати, але редагування не доступне."
     },
-    "WelcomeQuestions": {
-        "Education": "Освіта",
-        "Finance & Accounting": "Фінанси та облік",
-        "Marketing": "Маркетинг",
-        "Media Production": "Медіавиробництво",
-        "Other": "Інше",
-        "Product Development": "Розробка продукту",
-        "Research": "Дослідження",
-        "Sales": "Продажі",
-        "Type here": "Введіть тут",
-        "What brings you to Grist? Please help us serve you better.": "Що привело вас до Grist? Будь ласка, допоможіть зробити наш сервіс кращим.",
-        "HR & Management": "Управління персоналом та Менеджмент",
-        "IT & Technology": "IT та Технології",
-        "Welcome to Grist!": "Ласкаво просимо до Grist!"
-    },
     "WidgetTitle": {
         "Cancel": "Відмінити",
         "DATA TABLE NAME": "ІМ'Я ТАБЛИЦІ ДАНИХ",
@@ -1156,9 +1142,7 @@
         "Attachment": "Вкладення",
         "Search columns": "Шукати стовпці",
         "By Name": "За іменем",
-        "By Date Modified": "За датою змін",
-        "Light": "Світло",
-        "Custom": "Користувацька"
+        "By Date Modified": "За датою змін"
     },
     "modals": {
         "Cancel": "Відмінити",
@@ -2006,7 +1990,17 @@
         "What organization are you with?": "З якою організацією ви працюєте?",
         "Your organization": "Ваша організація",
         "Your role": "Ваша роль",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist може виглядати як електронна таблиця, але він не завжди так поводиться. Дізнайтеся, що відрізняє Grist від інших."
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist може виглядати як електронна таблиця, але він не завжди так поводиться. Дізнайтеся, що відрізняє Grist від інших.",
+        "Product Development": "Розробка продукту",
+        "Finance & Accounting": "Фінанси та облік",
+        "Media Production": "Медіавиробництво",
+        "IT & Technology": "IT та Технології",
+        "Marketing": "Маркетинг",
+        "Research": "Дослідження",
+        "Sales": "Продажі",
+        "Education": "Освіта",
+        "HR & Management": "Управління персоналом та Менеджмент",
+        "Other": "Інше"
     },
     "ToggleEnterpriseWidget": {
         "An activation key is used to run Grist Enterprise after a trial period\nof 30 days has expired. Get an activation key by [signing up for Grist\nEnterprise]({{signupLink}}). You do not need an activation key to run\nGrist Core.\n\nLearn more in our [Help Center]({{helpCenter}}).": "Ключ активації використовується для запуску Grist Enterprise після закінчення 30-денного пробного періоду.\nОтримайте ключ активації, [зареєструвавшись у Grist\nEnterprise]({{signupLink}}). Вам не потрібен ключ активації для запуску\nGrist Core.\n\nДізнайтеся більше в нашому [Центрі довідки]({{helpCenter}}).",

--- a/static/locales/vi.client.json
+++ b/static/locales/vi.client.json
@@ -819,21 +819,6 @@
     "Hidden Fields cannot be reordered": "Các trường ẩn không thể được sắp xếp lại",
     "Select all": "Chọn tất cả"
   },
-  "WelcomeQuestions": {
-    "Education": "Giáo dục",
-    "Finance & Accounting": "Tài chính và kế toán",
-    "HR & Management": "Quản lý nhân sự",
-    "IT & Technology": "Công nghệ thông tin",
-    "Marketing": "Tiếp thị",
-    "Media Production": "Sản xuất phương tiện truyền thông",
-    "Other": "Khác",
-    "Product Development": "Phát triển sản phẩm",
-    "Research": "Nghiên cứu",
-    "Sales": "Kinh doanh",
-    "Type here": "Nhập vào đây",
-    "Welcome to Grist!": "Chào mừng bạn đến với Grist!",
-    "What brings you to Grist? Please help us serve you better.": "Điều gì đưa bạn đến Grist? Hãy giúp chúng tôi phục vụ bạn tốt hơn."
-  },
   "WidgetTitle": {
     "Cancel": "Hủy",
     "DATA TABLE NAME": "TÊN CỦA BẢNG DỮ LIỆU",
@@ -1416,5 +1401,18 @@
   "Section": {
     "Insert section above": "Chèn phần ở phía trên",
     "Insert section below": "Chèn phần ở bên dưới"
+  },
+  "OnboardingPage": {
+    "Product Development": "Phát triển sản phẩm",
+    "Finance & Accounting": "Tài chính và kế toán",
+    "Media Production": "Sản xuất phương tiện truyền thông",
+    "IT & Technology": "Công nghệ thông tin",
+    "Marketing": "Tiếp thị",
+    "Research": "Nghiên cứu",
+    "Sales": "Kinh doanh",
+    "Education": "Giáo dục",
+    "HR & Management": "Quản lý nhân sự",
+    "Other": "Khác",
+    "Type here": "Nhập vào đây"
   }
 }

--- a/static/locales/zh_Hans.client.json
+++ b/static/locales/zh_Hans.client.json
@@ -661,21 +661,6 @@
         "Hide {{label}} (batch mode)": "隐藏 {{label}}（批量模式）",
         "Show {{label}} (batch mode)": "显示 {{label}}（批量模式）"
     },
-    "WelcomeQuestions": {
-        "IT & Technology": "IT和技术",
-        "Sales": "销售量",
-        "What brings you to Grist? Please help us serve you better.": "是什么让你来到格里斯特？ 请帮助我们更好地为您服务。",
-        "Education": "教育",
-        "Finance & Accounting": "财务与会计",
-        "HR & Management": "人力资源和管理",
-        "Marketing": "营销",
-        "Media Production": "媒体制作",
-        "Other": "其他",
-        "Product Development": "产品开发",
-        "Research": "研究",
-        "Type here": "在此输入",
-        "Welcome to Grist!": "欢迎来到Grist！"
-    },
     "breadcrumbs": {
         "recovery mode": "恢复模式",
         "snapshot": "快照",
@@ -1134,7 +1119,8 @@
     },
     "ThemeConfig": {
         "Appearance ": "外观 ",
-        "Switch appearance automatically to match system": "自动切换外观以匹配系统"
+        "Switch appearance automatically to match system": "自动切换外观以匹配系统",
+        "Light": "浅色"
     },
     "Tools": {
         "Access Rules": "访问规则",
@@ -1214,9 +1200,7 @@
         "Integer": "整数",
         "Search columns": "搜索列",
         "By Name": "按名称",
-        "By Date Modified": "按修改日期",
-        "Custom": "自定义",
-        "Light": "浅色"
+        "By Date Modified": "按修改日期"
     },
     "errorPages": {
         "Add account": "新增帐户",
@@ -2027,7 +2011,17 @@
         "What organization are you with?": "您所在的组织是？",
         "What brings you to Grist (you can select multiple)?": "是什么吸引您使用Grist（您可以多选）？",
         "Your organization": "您的组织",
-        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist 看起来像电子表格，但并不完全像电子表格。了解 Grist 的与众不同之处。"
+        "Grist may look like a spreadsheet, but it doesn't always act like one. Discover what makes Grist different.": "Grist 看起来像电子表格，但并不完全像电子表格。了解 Grist 的与众不同之处。",
+        "Product Development": "产品开发",
+        "Finance & Accounting": "财务与会计",
+        "Media Production": "媒体制作",
+        "IT & Technology": "IT和技术",
+        "Marketing": "营销",
+        "Research": "研究",
+        "Sales": "销售量",
+        "Education": "教育",
+        "HR & Management": "人力资源和管理",
+        "Other": "其他"
     },
     "ToggleEnterpriseWidget": {
         "Grist Enterprise is **enabled**.": "Grist 企业版**已启用**。",

--- a/static/locales/zh_Hant.client.json
+++ b/static/locales/zh_Hant.client.json
@@ -565,21 +565,6 @@
     "Inherit access: ": "繼承存取權限： ",
     "Access overview": "存取權限總覽"
   },
-  "WelcomeQuestions": {
-    "Welcome to Grist!": "歡迎來到 Grist！",
-    "HR & Management": "人力資源與管理",
-    "Sales": "銷售",
-    "Marketing": "行銷",
-    "Type here": "在此輸入",
-    "Other": "其他",
-    "Product Development": "產品開發",
-    "Media Production": "媒體製作",
-    "What brings you to Grist? Please help us serve you better.": "您是怎麼認識 Grist 的？請告訴我們如何能更好地為您服務。",
-    "Education": "教育",
-    "IT & Technology": "資訊科技與科技",
-    "Finance & Accounting": "財務與會計",
-    "Research": "研究"
-  },
   "PagePanels": {
     "Open creator panel": "開啟建立者面板",
     "Close Creator Panel": "關閉建立者面板"
@@ -807,9 +792,7 @@
     "DateTime": "日期時間",
     "Date": "日期",
     "By Name": "依名稱",
-    "By Date Modified": "依修改日期",
-    "Light": "日間",
-    "Custom": "自訂"
+    "By Date Modified": "依修改日期"
   },
   "DocPageModel": {
     "Sorry, access to this document has been denied. [{{error}}]": "抱歉，您被拒絕存取此文件。[{{error}}]",
@@ -1418,7 +1401,8 @@
   },
   "ThemeConfig": {
     "Switch appearance automatically to match system": "自動切換外觀以符合系統",
-    "Appearance ": "外觀 "
+    "Appearance ": "外觀 ",
+    "Light": "日間"
   },
   "GridView": {
     "Click to insert": "點選以插入"
@@ -1687,5 +1671,18 @@
     "Help us make Grist better": "幫助我們改進 Grist",
     "Home": "首頁",
     "Sponsor": "贊助"
+  },
+  "OnboardingPage": {
+    "Product Development": "產品開發",
+    "Finance & Accounting": "財務與會計",
+    "Media Production": "媒體製作",
+    "IT & Technology": "資訊科技與科技",
+    "Marketing": "行銷",
+    "Research": "研究",
+    "Sales": "銷售",
+    "Education": "教育",
+    "HR & Management": "人力資源與管理",
+    "Other": "其他",
+    "Type here": "在此輸入"
   }
 }


### PR DESCRIPTION
Five sites in app/client/** passed a variable to t() rather than a literal, making i18next-scanner blind to the keys those sites actually used. The scanner then reported them as "Unknown" alongside genuinely-dead keys, blocking any auto-prune pass.

Each dynamic call is now wrapped in a small helper containing an explicit switch over the known label set, so every key shows up as a literal t(...) call to the scanner:

- translateColumnTypeLabel in GridViewMenus.ts (used there and in FieldBuilder.ts via import)
- translateThemeLabel in ThemeConfig.ts
- translateOnboardingChoice in OnboardingPage.ts

Drop the SelectOptions.translateOptionLabels mechanism from menus.ts; callers (ThemeConfig, FieldBuilder) now pre-translate option labels via the helpers. In FieldBuilder, the `op.label === "Reference"` comparison becomes `op.value === "Ref"` so it keeps working with translated labels.

Also drop the redundant t(submitButtonLabel) in AuditLogStreamingConfig: submitButtonLabel is already the output of t("Save") / t("Add destination") at its call sites.

Onboarding choice keys lived in the orphaned WelcomeQuestions JSON section but were looked up via the OnboardingPage scope, so they never resolved. Every language was showing English. Migrate those translations to OnboardingPage in every language file, and do the same for theme labels (menus.Light/Dark/Light (High Contrast) to ThemeConfig.*). Drop the orphaned WelcomeQuestions section and the dead menus.* column-type and theme entries from en.client.json.

Also drop the unused crowdin.yml; the project moved to Weblate long ago.

After this change every key the runtime might pass to t() also appears as a literal t(...) call somewhere the scanner can see, so the next prune pass can safely delete anything it reports as Unknown.

Some dead string cleanup:

- WelcomeQuestions.Welcome to Grist! Every language that had it translated also has WelcomeTour.Welcome to Grist! or HomeIntro.Welcome to Grist! already translated (the live consumers). No loss.
- WelcomeQuestions.What brings you to Grist? Please help us serve you better. The live UI uses a different phrasing under OnboardingPage ("What brings you to Grist (you can select multiple)?"), so this English source string is no longer used. The translations of the dead phrasing aren't recoverable, but they correspond to source text that no longer appears in the product. Not a regression.
- menus.{Any, Numeric, Text, Integer, Toggle, Date, DateTime, Choice, Choice List, Reference, Reference List, Attachment, Light, Dark, Custom, Light (High Contrast), Search columns, By Name, By Date Modified} in en.client.json: only removed from en, not from other languages. Live versions live under GridViewMenus, DocMenu, and ThemeConfig. Other languages keep their menus.* translations as orphans until a future prune pass.
