### PR TITLE
Make modals and popups easier to use with keyboard and assistive tools

### DIFF
--- a/app/client/components/RegionFocusSwitcher.ts
+++ b/app/client/components/RegionFocusSwitcher.ts
@@ -3,7 +3,7 @@ import * as commands from "app/client/components/commands";
 import { GristDoc } from "app/client/components/GristDoc";
 import { kbFocusHighlighterClass } from "app/client/components/KeyboardFocusHighlighter";
 import { FocusLayer } from "app/client/lib/FocusLayer";
-import { clearCurrentFocusLock, enableFocusLock, isFocusable } from "app/client/lib/focusUtils";
+import { clearFocusLock, enableFocusLock, isFocusable } from "app/client/lib/focusUtils";
 import { makeT } from "app/client/lib/localization";
 import { App } from "app/client/ui/App";
 import { SpecialDocPage } from "app/common/gristUrls";
@@ -349,7 +349,7 @@ export class RegionFocusSwitcher extends Disposable {
       current.initiator.event :
       undefined;
 
-    clearCurrentFocusLock();
+    clearFocusLock("regionFocusSwitcher");
     removeFocusRings();
     removeTabIndexes();
     if (!mouseEvent) {
@@ -523,7 +523,7 @@ const focusPanel = (panel: PanelRegion, child: HTMLElement | null, gristDoc: Gri
   if (!panelElement) {
     return;
   }
-  enableFocusLock(panelElement);
+  enableFocusLock(panelElement, "regionFocusSwitcher");
 
   // Child element found: focus it if we actually can
   if (child && child !== panelElement && child.isConnected && isFocusable(child)) {

--- a/app/client/components/RegionFocusSwitcher.ts
+++ b/app/client/components/RegionFocusSwitcher.ts
@@ -3,7 +3,7 @@ import * as commands from "app/client/components/commands";
 import { GristDoc } from "app/client/components/GristDoc";
 import { kbFocusHighlighterClass } from "app/client/components/KeyboardFocusHighlighter";
 import { FocusLayer } from "app/client/lib/FocusLayer";
-import { clearFocusLock, enableFocusLock, isFocusable } from "app/client/lib/focusUtils";
+import { clearTabTrap, enableTabTrap, isFocusable } from "app/client/lib/focusUtils";
 import { makeT } from "app/client/lib/localization";
 import { App } from "app/client/ui/App";
 import { SpecialDocPage } from "app/common/gristUrls";
@@ -349,7 +349,7 @@ export class RegionFocusSwitcher extends Disposable {
       current.initiator.event :
       undefined;
 
-    clearFocusLock("regionFocusSwitcher");
+    clearTabTrap("regionFocusSwitcher");
     removeFocusRings();
     removeTabIndexes();
     if (!mouseEvent) {
@@ -364,7 +364,7 @@ export class RegionFocusSwitcher extends Disposable {
 
     // If kb-focusing a panel:
     //   - actually focus the panel dom element, or its previously focused child,
-    //   - trap the Tab key inside it (see `enableFocusLock`).
+    //   - trap the Tab key inside it (see `enableTabTrap`).
     //   - make the Tab key available for normal browser navigation in the panel (see `escapeViewLayout`)
     if (!mouseEvent && isPanel && panelElement && current.region) {
       focusPanel(
@@ -516,14 +516,14 @@ const ATTRS = {
 /**
  * Focus the given panel dom element (or the given element inside it, if any), and let the grist doc view know about it.
  *
- * When focusing a panel, the tab key is trapped inside it (see `enableFocusLock`).
+ * When focusing a panel, the tab key is trapped inside it (see `enableTabTrap`).
  */
 const focusPanel = (panel: PanelRegion, child: HTMLElement | null, gristDoc: GristDoc | null) => {
   const panelElement = getPanelElement(panel.id);
   if (!panelElement) {
     return;
   }
-  enableFocusLock(panelElement, "regionFocusSwitcher");
+  enableTabTrap(panelElement, "regionFocusSwitcher");
 
   // Child element found: focus it if we actually can
   if (child && child !== panelElement && child.isConnected && isFocusable(child)) {

--- a/app/client/components/RegionFocusSwitcher.ts
+++ b/app/client/components/RegionFocusSwitcher.ts
@@ -3,14 +3,14 @@ import * as commands from "app/client/components/commands";
 import { GristDoc } from "app/client/components/GristDoc";
 import { kbFocusHighlighterClass } from "app/client/components/KeyboardFocusHighlighter";
 import { FocusLayer } from "app/client/lib/FocusLayer";
-import { isFocusable, trapTabKey } from "app/client/lib/focusUtils";
+import { clearCurrentFocusLock, enableFocusLock, isFocusable } from "app/client/lib/focusUtils";
 import { makeT } from "app/client/lib/localization";
 import { App } from "app/client/ui/App";
 import { SpecialDocPage } from "app/common/gristUrls";
 import { mod } from "app/common/gutil";
 import { components } from "app/common/ThemePrefs";
 
-import { Disposable, dom, Holder, Observable, styled, UseCBOwner } from "grainjs";
+import { Disposable, dom, Observable, styled, UseCBOwner } from "grainjs";
 import isEqual from "lodash/isEqual";
 
 const t = makeT("RegionFocusSwitcher");
@@ -660,24 +660,6 @@ const blurPanelChild = (panel: PanelRegion) => {
   if (containsActiveElement(panelElement)) {
     (document.activeElement as HTMLElement).blur();
   }
-};
-
-const _focusLockHolder = Holder.create(null);
-
-const clearCurrentFocusLock = () => _focusLockHolder.clear();
-
-/**
- * Trap the tab key inside the given panel element.
- *
- * That makes pressing tab and shift+tab loop exclusively through focusable elements that are *in* the panel.
- */
-const enableFocusLock = (panelElement: HTMLElement) => {
-  clearCurrentFocusLock();
-  _focusLockHolder.autoDispose(dom.onElem(panelElement, "keydown", (event, elem) => {
-    if (event.key === "Tab") {
-      trapTabKey(elem, event);
-    }
-  }));
 };
 
 const getPanelElement = (id: Panel): HTMLElement | null => {

--- a/app/client/components/RegionFocusSwitcher.ts
+++ b/app/client/components/RegionFocusSwitcher.ts
@@ -10,7 +10,7 @@ import { SpecialDocPage } from "app/common/gristUrls";
 import { mod } from "app/common/gutil";
 import { components } from "app/common/ThemePrefs";
 
-import { Disposable, dom, IDisposable, Observable, styled, UseCBOwner } from "grainjs";
+import { Disposable, dom, Holder, Observable, styled, UseCBOwner } from "grainjs";
 import isEqual from "lodash/isEqual";
 
 const t = makeT("RegionFocusSwitcher");
@@ -43,7 +43,7 @@ export class RegionFocusSwitcher extends Disposable {
     initiator: undefined,
   });
 
-  private _tabTrap?: IDisposable;
+  private _tabTrap = Holder.create(this);
 
   private get _gristDocObs() { return this._app?.pageModel?.gristDoc; }
   // Previously focused elements for each panel (not used for view section ids)
@@ -351,8 +351,7 @@ export class RegionFocusSwitcher extends Disposable {
       current.initiator.event :
       undefined;
 
-    this._tabTrap?.dispose();
-    this._tabTrap = undefined;
+    this._tabTrap.clear();
     removeFocusRings();
     removeTabIndexes();
     if (!mouseEvent) {
@@ -370,7 +369,7 @@ export class RegionFocusSwitcher extends Disposable {
     //   - actually focus the panel dom element, or its previously focused child,
     //   - make the Tab key available for normal browser navigation in the panel (see `escapeViewLayout`)
     if (!mouseEvent && isPanel && panelElement && current.region) {
-      this._tabTrap = enableTabTrap(panelElement);
+      this._tabTrap.autoDispose(enableTabTrap(panelElement));
       focusPanel(
         current.region as PanelRegion,
         this._prevFocusedElements[current.region.id as Panel] as HTMLElement | null,

--- a/app/client/components/RegionFocusSwitcher.ts
+++ b/app/client/components/RegionFocusSwitcher.ts
@@ -3,14 +3,14 @@ import * as commands from "app/client/components/commands";
 import { GristDoc } from "app/client/components/GristDoc";
 import { kbFocusHighlighterClass } from "app/client/components/KeyboardFocusHighlighter";
 import { FocusLayer } from "app/client/lib/FocusLayer";
-import { clearTabTrap, enableTabTrap, isFocusable } from "app/client/lib/focusUtils";
+import { enableTabTrap, isFocusable } from "app/client/lib/focusUtils";
 import { makeT } from "app/client/lib/localization";
 import { App } from "app/client/ui/App";
 import { SpecialDocPage } from "app/common/gristUrls";
 import { mod } from "app/common/gutil";
 import { components } from "app/common/ThemePrefs";
 
-import { Disposable, dom, Observable, styled, UseCBOwner } from "grainjs";
+import { Disposable, dom, IDisposable, Observable, styled, UseCBOwner } from "grainjs";
 import isEqual from "lodash/isEqual";
 
 const t = makeT("RegionFocusSwitcher");
@@ -42,6 +42,8 @@ export class RegionFocusSwitcher extends Disposable {
     region: undefined,
     initiator: undefined,
   });
+
+  private _tabTrap?: IDisposable;
 
   private get _gristDocObs() { return this._app?.pageModel?.gristDoc; }
   // Previously focused elements for each panel (not used for view section ids)
@@ -349,7 +351,8 @@ export class RegionFocusSwitcher extends Disposable {
       current.initiator.event :
       undefined;
 
-    clearTabTrap("regionFocusSwitcher");
+    this._tabTrap?.dispose();
+    this._tabTrap = undefined;
     removeFocusRings();
     removeTabIndexes();
     if (!mouseEvent) {
@@ -363,10 +366,11 @@ export class RegionFocusSwitcher extends Disposable {
     const panelElement = isPanel && current.region?.id && getPanelElement((current.region as PanelRegion).id);
 
     // If kb-focusing a panel:
-    //   - actually focus the panel dom element, or its previously focused child,
     //   - trap the Tab key inside it (see `enableTabTrap`).
+    //   - actually focus the panel dom element, or its previously focused child,
     //   - make the Tab key available for normal browser navigation in the panel (see `escapeViewLayout`)
     if (!mouseEvent && isPanel && panelElement && current.region) {
+      this._tabTrap = enableTabTrap(panelElement);
       focusPanel(
         current.region as PanelRegion,
         this._prevFocusedElements[current.region.id as Panel] as HTMLElement | null,
@@ -515,15 +519,12 @@ const ATTRS = {
 
 /**
  * Focus the given panel dom element (or the given element inside it, if any), and let the grist doc view know about it.
- *
- * When focusing a panel, the tab key is trapped inside it (see `enableTabTrap`).
  */
 const focusPanel = (panel: PanelRegion, child: HTMLElement | null, gristDoc: GristDoc | null) => {
   const panelElement = getPanelElement(panel.id);
   if (!panelElement) {
     return;
   }
-  enableTabTrap(panelElement, "regionFocusSwitcher");
 
   // Child element found: focus it if we actually can
   if (child && child !== panelElement && child.isConnected && isFocusable(child)) {

--- a/app/client/components/modals.ts
+++ b/app/client/components/modals.ts
@@ -1,6 +1,5 @@
 import * as commands from "app/client/components/commands";
 import { GristDoc } from "app/client/components/GristDoc";
-import { FocusLayer } from "app/client/lib/FocusLayer";
 import { makeT } from "app/client/lib/localization";
 import { reportSuccess } from "app/client/models/errors";
 import { basicButton, bigPrimaryButton, primaryButton } from "app/client/ui2018/buttons";
@@ -34,7 +33,6 @@ export function buildConfirmDelete(
       dom.autoDispose(remember),
       testId("confirm-deleteRows"),
       testId("confirm-popup"),
-      (elem) => { FocusLayer.create(ctl, { defaultFocusElem: elem, pauseMousetrap: true }); },
       dom.onKeyDown({
         Escape: () => ctl.close(),
         Enter: () => { onSave(remember.get()); ctl.close(); },
@@ -76,7 +74,6 @@ export function showDeprecatedWarning(
   const tooltip = modalTooltip(refElement, ctl =>
     cssWideContainer(
       testId("popup-warning-deprecated"),
-      (elem) => { FocusLayer.create(ctl, { defaultFocusElem: elem, pauseMousetrap: true }); },
       dom.onKeyDown({
         Escape: () => { ctl.close(); onClose(remember.get()); },
         Enter: () => { ctl.close(); onClose(remember.get()); },
@@ -165,7 +162,6 @@ export function showTipPopup(
       cssBehavioralPromptContainer(
         dom.autoDispose(dontShowTips),
         testId("behavioral-prompt"),
-        (elem) => { FocusLayer.create(ctl, { defaultFocusElem: elem, pauseMousetrap: true }); },
         dom.onKeyDown({
           Escape: () => ctl.close(),
           Enter: () => { onClose(dontShowTips.get()); ctl.close(); },
@@ -223,7 +219,6 @@ export function showNewsPopup(
       cssNewsPopupModal.cls(""),
       cssNewsPopupContainer(
         testId("behavioral-prompt"),
-        (elem) => { FocusLayer.create(ctl, { defaultFocusElem: elem, pauseMousetrap: true }); },
         dom.onKeyDown({
           Escape: () => { ctl.close(); },
           Enter: () => { ctl.close(); },

--- a/app/client/lib/Mousetrap.js
+++ b/app/client/lib/Mousetrap.js
@@ -64,13 +64,26 @@ if (typeof window === "undefined") {
 
 
   var mousetrapBindingsPaused = false;
+  var mousetrapPausesCount = 0;
 
   /**
    * Globally pause or unpause mousetrap bindings. This is useful e.g. while a context menu is being
    * shown, which has its own keyboard handling.
+   *
+   * Note that you are not guaranteed that Mousetrap.setPause(false) actually reactivates the keybindings:
+   * we internally count the number of Mousetrap.setPause(true) calls, and only release the pause when every matching
+   * Mousetrap.setPause(false) call has been made.
+   *
+   * This is to handle the places where we pause/unpause multiple times in a row because we first open a menu (one pause),
+   * then a modal (one pause, but also one release because the menu closes).
    */
   Mousetrap.setPaused = function(yesNo) {
-    mousetrapBindingsPaused = yesNo;
+    if (yesNo) {
+      mousetrapPausesCount++;
+    } else if (mousetrapPausesCount > 0) {
+      mousetrapPausesCount--;
+    }
+    mousetrapBindingsPaused = mousetrapPausesCount > 0;
   };
 
   /**

--- a/app/client/lib/focusUtils.ts
+++ b/app/client/lib/focusUtils.ts
@@ -23,7 +23,10 @@
  * IN THE SOFTWARE.
  */
 
-import { dom, Holder } from "grainjs";
+import { kbFocusHighlighterClass } from "app/client/components/KeyboardFocusHighlighter";
+import { FocusLayer } from "app/client/lib/FocusLayer";
+
+import { Disposable, dom, DomMethod, Holder } from "grainjs";
 
 const _focusLockHolder = Holder.create(null);
 
@@ -44,6 +47,34 @@ export const enableFocusLock = (element: HTMLElement) => {
 export const clearCurrentFocusLock = () => {
   _focusLockHolder.clear();
 };
+
+/**
+ * Lock keyboard focus inside a given element until it is removed from the DOM.
+ *
+ * This is a useful default to use for popups, modal tooltips and things like that.
+ */
+export function lockFocusUntilRemoved(
+  owner: Disposable,
+  options: {
+    pauseMousetrap?: boolean;
+  } = {},
+): DomMethod<HTMLElement> {
+  const { pauseMousetrap = true } = options;
+
+  return (elem: HTMLElement) => {
+    elem.classList.add(kbFocusHighlighterClass);
+    if (!elem.hasAttribute("tabindex")) {
+      elem.setAttribute("tabindex", "-1");
+    }
+    enableFocusLock(elem);
+    owner.onDispose(() => clearCurrentFocusLock());
+    FocusLayer.create(owner, {
+      defaultFocusElem: elem,
+      pauseMousetrap,
+      allowFocus: target => elem.contains(target),
+    });
+  };
+}
 
 /**
  * Trap the tab key within the given element.

--- a/app/client/lib/focusUtils.ts
+++ b/app/client/lib/focusUtils.ts
@@ -28,7 +28,7 @@ import { FocusLayer } from "app/client/lib/FocusLayer";
 
 import { Disposable, dom, DomMethod, IDisposable } from "grainjs";
 
-const _focusLocks = new Map<string, IDisposable>();
+const _tabTraps = new Map<string, IDisposable>();
 
 /**
  * Trap the tab key inside the given element.
@@ -42,9 +42,9 @@ const _focusLocks = new Map<string, IDisposable>();
  * This means you don't need to think about locks that could collapse between different containers, like two modals
  * on top of each other.
  *
- * You can optionally pass an id in order to be able to remove the lock later with `clearFocusLock`.
+ * You can optionally pass an id in order to be able to remove the lock later with `clearTabTrap`.
  */
-export const enableFocusLock = (element: HTMLElement, id?: string) => {
+export const enableTabTrap = (element: HTMLElement, id?: string) => {
   const listener = dom.onElem(element, "keydown", (event, elem) => {
     if (event.key === "Tab") {
       trapTabKey(elem, event);
@@ -53,13 +53,13 @@ export const enableFocusLock = (element: HTMLElement, id?: string) => {
   if (!id) {
     return;
   }
-  _focusLocks.get(id)?.dispose();
-  _focusLocks.set(id, listener);
+  _tabTraps.get(id)?.dispose();
+  _tabTraps.set(id, listener);
 };
 
-export const clearFocusLock = (id: string) => {
-  _focusLocks.get(id)?.dispose();
-  _focusLocks.delete(id);
+export const clearTabTrap = (id: string) => {
+  _tabTraps.get(id)?.dispose();
+  _tabTraps.delete(id);
 };
 
 /**
@@ -80,7 +80,7 @@ export function lockFocusUntilRemoved(
     if (!elem.hasAttribute("tabindex")) {
       elem.setAttribute("tabindex", "-1");
     }
-    enableFocusLock(elem);
+    enableTabTrap(elem);
     FocusLayer.create(owner, {
       defaultFocusElem: elem,
       pauseMousetrap,

--- a/app/client/lib/focusUtils.ts
+++ b/app/client/lib/focusUtils.ts
@@ -84,7 +84,6 @@ export function lockFocusUntilRemoved(
     FocusLayer.create(owner, {
       defaultFocusElem: elem,
       pauseMousetrap,
-      allowFocus: target => elem.contains(target),
     });
   };
 }

--- a/app/client/lib/focusUtils.ts
+++ b/app/client/lib/focusUtils.ts
@@ -26,26 +26,40 @@
 import { kbFocusHighlighterClass } from "app/client/components/KeyboardFocusHighlighter";
 import { FocusLayer } from "app/client/lib/FocusLayer";
 
-import { Disposable, dom, DomMethod, Holder } from "grainjs";
+import { Disposable, dom, DomMethod, IDisposable } from "grainjs";
 
-const _focusLockHolder = Holder.create(null);
+const _focusLocks = new Map<string, IDisposable>();
 
 /**
  * Trap the tab key inside the given element.
  *
  * That makes pressing tab and shift+tab loop exclusively through focusable elements that are *in* the element.
+ *
+ * The lock is pretty permissive, only acting when using the Tab key inside the element.
+ * If focus is moved outside the element (e.g. programmatically, or by clicking outside of it), the lock doesn't do
+ * anything until focus is moved back inside the element.
+ *
+ * This means you don't need to think about locks that could collapse between different containers, like two modals
+ * on top of each other.
+ *
+ * You can optionally pass an id in order to be able to remove the lock later with `clearFocusLock`.
  */
-export const enableFocusLock = (element: HTMLElement) => {
-  clearCurrentFocusLock();
-  _focusLockHolder.autoDispose(dom.onElem(element, "keydown", (event, elem) => {
+export const enableFocusLock = (element: HTMLElement, id?: string) => {
+  const listener = dom.onElem(element, "keydown", (event, elem) => {
     if (event.key === "Tab") {
       trapTabKey(elem, event);
     }
-  }));
+  });
+  if (!id) {
+    return;
+  }
+  _focusLocks.get(id)?.dispose();
+  _focusLocks.set(id, listener);
 };
 
-export const clearCurrentFocusLock = () => {
-  _focusLockHolder.clear();
+export const clearFocusLock = (id: string) => {
+  _focusLocks.get(id)?.dispose();
+  _focusLocks.delete(id);
 };
 
 /**
@@ -67,7 +81,6 @@ export function lockFocusUntilRemoved(
       elem.setAttribute("tabindex", "-1");
     }
     enableFocusLock(elem);
-    owner.onDispose(() => clearCurrentFocusLock());
     FocusLayer.create(owner, {
       defaultFocusElem: elem,
       pauseMousetrap,

--- a/app/client/lib/focusUtils.ts
+++ b/app/client/lib/focusUtils.ts
@@ -23,6 +23,28 @@
  * IN THE SOFTWARE.
  */
 
+import { dom, Holder } from "grainjs";
+
+const _focusLockHolder = Holder.create(null);
+
+/**
+ * Trap the tab key inside the given element.
+ *
+ * That makes pressing tab and shift+tab loop exclusively through focusable elements that are *in* the element.
+ */
+export const enableFocusLock = (element: HTMLElement) => {
+  clearCurrentFocusLock();
+  _focusLockHolder.autoDispose(dom.onElem(element, "keydown", (event, elem) => {
+    if (event.key === "Tab") {
+      trapTabKey(elem, event);
+    }
+  }));
+};
+
+export const clearCurrentFocusLock = () => {
+  _focusLockHolder.clear();
+};
+
 /**
  * Trap the tab key within the given element.
  *

--- a/app/client/lib/focusUtils.ts
+++ b/app/client/lib/focusUtils.ts
@@ -1,10 +1,5 @@
 /**
- * Most of the code is authored by Kitty Giraudel for a11y-dialog https://github.com/KittyGiraudel/a11y-dialog, thanks to her!
- *
- * As keyboard-handling is very specific in Grist, we'd rather copy/paste some base code that can be easily modified,
- * rather than relying on a library.
- *
- * The MIT License (MIT)
+ * This file started as a copy of code authored by Kitty Giraudel for a11y-dialog https://github.com/KittyGiraudel/a11y-dialog, thanks to her!
  *
  * Copyright (c) 2025 Kitty Giraudel
  *

--- a/app/client/lib/focusUtils.ts
+++ b/app/client/lib/focusUtils.ts
@@ -21,9 +21,7 @@
 import { kbFocusHighlighterClass } from "app/client/components/KeyboardFocusHighlighter";
 import { FocusLayer } from "app/client/lib/FocusLayer";
 
-import { Disposable, dom, DomMethod, IDisposable } from "grainjs";
-
-const _tabTraps = new Map<string, IDisposable>();
+import { Disposable, dom, DomMethod } from "grainjs";
 
 /**
  * Trap the tab key inside the given element.
@@ -36,26 +34,13 @@ const _tabTraps = new Map<string, IDisposable>();
  *
  * This means you don't need to think about locks that could collapse between different containers, like two modals
  * on top of each other.
- *
- * You can optionally pass an id in order to be able to remove the lock later with `clearTabTrap`.
  */
-export const enableTabTrap = (element: HTMLElement, id?: string) => {
-  const listener = dom.onElem(element, "keydown", (event, elem) => {
+export const enableTabTrap = (element: HTMLElement) => {
+  return dom.onElem(element, "keydown", (event, elem) => {
     if (event.key === "Tab") {
       trapTabKey(elem, event);
     }
   });
-  if (!id) {
-    return listener;
-  }
-  _tabTraps.get(id)?.dispose();
-  _tabTraps.set(id, listener);
-  return listener;
-};
-
-export const clearTabTrap = (id: string) => {
-  _tabTraps.get(id)?.dispose();
-  _tabTraps.delete(id);
 };
 
 /**

--- a/app/client/lib/focusUtils.ts
+++ b/app/client/lib/focusUtils.ts
@@ -61,6 +61,9 @@ export const clearTabTrap = (id: string) => {
 /**
  * Lock keyboard focus inside a given element until it is removed from the DOM.
  *
+ * The lock is done through trapping Tab key (see `enableTabTrap`), and pausing Mousetrap
+ * (so that the commands bound on Tab are not triggered when tabbing inside the element).
+ *
  * This is a useful default to use for popups, modal tooltips and things like that.
  */
 export function lockFocusUntilRemoved(

--- a/app/client/lib/focusUtils.ts
+++ b/app/client/lib/focusUtils.ts
@@ -51,10 +51,11 @@ export const enableTabTrap = (element: HTMLElement, id?: string) => {
     }
   });
   if (!id) {
-    return;
+    return listener;
   }
   _tabTraps.get(id)?.dispose();
   _tabTraps.set(id, listener);
+  return listener;
 };
 
 export const clearTabTrap = (id: string) => {

--- a/app/client/ui/CreateTeamModal.ts
+++ b/app/client/ui/CreateTeamModal.ts
@@ -7,7 +7,7 @@ import { urlState } from "app/client/models/gristUrlState";
 import { bigBasicButton, bigPrimaryButton, bigPrimaryButtonLink } from "app/client/ui2018/buttons";
 import { mediaSmall, theme, vars } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
-import { IModalControl, modal } from "app/client/ui2018/modals";
+import { cssModalTitle, IModalControl, modal } from "app/client/ui2018/modals";
 import { PlanSelection } from "app/common/BillingAPI";
 import { TEAM_PLAN } from "app/common/Features";
 import { checkSubdomainValidity } from "app/common/orgNameUtils";
@@ -100,7 +100,7 @@ export function buildConfirm({
   return cssConfirmWrapper(
     cssSparks(),
     hspace("1.5em"),
-    cssHeaderLine(t("Team site created"), testId("confirmation")),
+    cssModalTitle(t("Team site created"), testId("confirmation"), cssCenteredModalTitle.cls("")),
     hspace("2em"),
     bigPrimaryButtonLink(
       urlState().setLinkUrl({ org: domain || undefined }), t("Go to your site"), testId("confirmation-link"),
@@ -139,7 +139,7 @@ function buildTeamPage({
   });
   return cssWide(
     dom.autoDispose(disabled),
-    cssHeaderLine(t("Work as a Team"), testId("creation-title")),
+    cssModalTitle(t("Work as a Team"), testId("creation-title"), cssCenteredModalTitle.cls("")),
     cssSubHeaderLine(t("Choose a name and url for your team site")),
     hspace("1.5em"),
     cssColumns(
@@ -252,11 +252,8 @@ const cssSetup = styled("div", `
   flex-grow: 1;
 `);
 
-const cssHeaderLine = styled("div", `
+const cssCenteredModalTitle = styled("div", `
   text-align: center;
-  font-size: 24px;
-  font-weight: 600;
-  margin-bottom: 16px;
 `);
 
 const cssSubHeaderLine = styled("div", `

--- a/app/client/ui2018/modals.ts
+++ b/app/client/ui2018/modals.ts
@@ -1,5 +1,6 @@
 import { kbFocusHighlighterClass } from "app/client/components/KeyboardFocusHighlighter";
 import { FocusLayer } from "app/client/lib/FocusLayer";
+import { clearCurrentFocusLock, enableFocusLock } from "app/client/lib/focusUtils";
 import { makeT } from "app/client/lib/localization";
 import { reportError } from "app/client/models/errors";
 import { cssInput } from "app/client/ui/cssInput";
@@ -203,6 +204,7 @@ export function modal(
   }
 
   function closeModal() {
+    clearCurrentFocusLock();
     document.body.removeChild(modalDom);
     // Ensure we run the disposers for the DOM contained in the modal.
     dom.domDispose(modalDom);
@@ -270,6 +272,7 @@ export function modal(
   );
 
   document.body.appendChild(modalDom);
+  enableFocusLock(modalDom);
   if (variant === "collapsing") { expandModal(); }
 }
 

--- a/app/client/ui2018/modals.ts
+++ b/app/client/ui2018/modals.ts
@@ -1,6 +1,6 @@
 import { kbFocusHighlighterClass } from "app/client/components/KeyboardFocusHighlighter";
 import { FocusLayer } from "app/client/lib/FocusLayer";
-import { clearCurrentFocusLock, enableFocusLock } from "app/client/lib/focusUtils";
+import { clearCurrentFocusLock, enableFocusLock, lockFocusUntilRemoved } from "app/client/lib/focusUtils";
 import { makeT } from "app/client/lib/localization";
 import { reportError } from "app/client/models/errors";
 import { cssInput } from "app/client/ui/cssInput";
@@ -558,7 +558,9 @@ export function modalTooltip(
 ): PopupControl {
   return popupOpen(reference, (ctl: IOpenController) => {
     const element = cssModalTooltip(
+      lockFocusUntilRemoved(ctl),
       domCreator(ctl),
+      { "role": "dialog", "aria-modal": "true" },
     );
     return element;
   }, options);

--- a/app/client/ui2018/modals.ts
+++ b/app/client/ui2018/modals.ts
@@ -257,6 +257,7 @@ export function modal(
         dom.on("click", ev => ev.stopPropagation()),
         noEscapeKey ? null : dom.onKeyDown({ Escape: close }),
         testId("modal-dialog"),
+        { "role": "dialog", "aria-modal": "true" },
       );
       FocusLayer.create(owner, {
         defaultFocusElem: dialogDom,

--- a/app/client/ui2018/modals.ts
+++ b/app/client/ui2018/modals.ts
@@ -633,26 +633,26 @@ export const cssModalDialog = styled("div", `
   }
 `);
 
-export const cssModalTitle = styled(
-  (...args: IDomArgs<HTMLDivElement>) => dom(
-    "div",
-    { id: uniqueId("modal-title-") },
-    (el) => {
-      // waiting for potential domComputed to work
-      setTimeout(() => {
-        el.closest('[role="dialog"]')?.setAttribute("aria-labelledby", el.id);
-      }, 0);
-    },
-    ...args,
-  ), `
-    font-size: ${vars.xxxlargeFontSize};
-    font-weight: ${vars.headerControlTextWeight};
-    color: ${theme.text};
-    margin: 0 0 16px 0;
-    line-height: 32px;
-    overflow-wrap: break-word;
-  `,
+const autoLabelledModalTitle = (...args: IDomArgs<HTMLDivElement>) => dom(
+  "div",
+  { id: uniqueId("modal-title-") },
+  (el) => {
+    // waiting for potential domComputed to work
+    setTimeout(() => {
+      el.closest('[role="dialog"]')?.setAttribute("aria-labelledby", el.id);
+    }, 0);
+  },
+  ...args,
 );
+
+export const cssModalTitle = styled(autoLabelledModalTitle, `
+  font-size: ${vars.xxxlargeFontSize};
+  font-weight: ${vars.headerControlTextWeight};
+  color: ${theme.text};
+  margin: 0 0 16px 0;
+  line-height: 32px;
+  overflow-wrap: break-word;
+`);
 
 export const cssModalSubheading = styled("div", `
   font-size: ${vars.xlargeFontSize};

--- a/app/client/ui2018/modals.ts
+++ b/app/client/ui2018/modals.ts
@@ -1,6 +1,6 @@
 import { kbFocusHighlighterClass } from "app/client/components/KeyboardFocusHighlighter";
 import { FocusLayer } from "app/client/lib/FocusLayer";
-import { clearCurrentFocusLock, enableFocusLock, lockFocusUntilRemoved } from "app/client/lib/focusUtils";
+import { enableFocusLock, lockFocusUntilRemoved } from "app/client/lib/focusUtils";
 import { makeT } from "app/client/lib/localization";
 import { reportError } from "app/client/models/errors";
 import { cssInput } from "app/client/ui/cssInput";
@@ -205,7 +205,6 @@ export function modal(
   }
 
   function closeModal() {
-    clearCurrentFocusLock();
     document.body.removeChild(modalDom);
     // Ensure we run the disposers for the DOM contained in the modal.
     dom.domDispose(modalDom);

--- a/app/client/ui2018/modals.ts
+++ b/app/client/ui2018/modals.ts
@@ -13,9 +13,10 @@ import { cssMenuElem } from "app/client/ui2018/menus";
 import { waitGrainObs } from "app/common/gutil";
 import { MaybePromise } from "app/plugin/gutil";
 
-import { Computed, Disposable, dom, DomContents, DomElementArg, input, keyframes,
+import { Computed, Disposable, dom, DomContents, DomElementArg, IDomArgs, input, keyframes,
   MultiHolder, Observable, styled } from "grainjs";
 import { IOpenController, IPopupOptions, PopupControl, popupOpen } from "popweasel";
+import { uniqueId } from "underscore";
 
 const t = makeT("modals");
 
@@ -630,14 +631,26 @@ export const cssModalDialog = styled("div", `
   }
 `);
 
-export const cssModalTitle = styled("div", `
-  font-size: ${vars.xxxlargeFontSize};
-  font-weight: ${vars.headerControlTextWeight};
-  color: ${theme.text};
-  margin: 0 0 16px 0;
-  line-height: 32px;
-  overflow-wrap: break-word;
-`);
+export const cssModalTitle = styled(
+  (...args: IDomArgs<HTMLDivElement>) => dom(
+    "div",
+    { id: uniqueId("modal-title-") },
+    (el) => {
+      // waiting for potential domComputed to work
+      setTimeout(() => {
+        el.closest('[role="dialog"]')?.setAttribute("aria-labelledby", el.id);
+      }, 0);
+    },
+    ...args,
+  ), `
+    font-size: ${vars.xxxlargeFontSize};
+    font-weight: ${vars.headerControlTextWeight};
+    color: ${theme.text};
+    margin: 0 0 16px 0;
+    line-height: 32px;
+    overflow-wrap: break-word;
+  `,
+);
 
 export const cssModalSubheading = styled("div", `
   font-size: ${vars.xlargeFontSize};

--- a/app/client/ui2018/modals.ts
+++ b/app/client/ui2018/modals.ts
@@ -1,6 +1,6 @@
 import { kbFocusHighlighterClass } from "app/client/components/KeyboardFocusHighlighter";
 import { FocusLayer } from "app/client/lib/FocusLayer";
-import { enableFocusLock, lockFocusUntilRemoved } from "app/client/lib/focusUtils";
+import { enableTabTrap, lockFocusUntilRemoved } from "app/client/lib/focusUtils";
 import { makeT } from "app/client/lib/localization";
 import { reportError } from "app/client/models/errors";
 import { cssInput } from "app/client/ui/cssInput";
@@ -273,7 +273,7 @@ export function modal(
   );
 
   document.body.appendChild(modalDom);
-  enableFocusLock(modalDom);
+  enableTabTrap(modalDom);
   if (variant === "collapsing") { expandModal(); }
 }
 

--- a/app/client/ui2018/modals.ts
+++ b/app/client/ui2018/modals.ts
@@ -636,7 +636,8 @@ const autoLabelledModalTitle = (...args: IDomArgs<HTMLDivElement>) => dom(
   "div",
   { id: uniqueId("modal-title-") },
   (el) => {
-    // waiting for potential domComputed to work
+    // Elements are build bottom-up, so our ancestors (incl. the role=dialog container) aren't attached yet at
+    // construction time. Wait for the next tick when the parent should exist.
     setTimeout(() => {
       el.closest('[role="dialog"]')?.setAttribute("aria-labelledby", el.id);
     }, 0);

--- a/app/client/widgets/DiscussionEditor.ts
+++ b/app/client/widgets/DiscussionEditor.ts
@@ -2,6 +2,7 @@ import { allCommands } from "app/client/components/commands";
 import { showUndoDiscardNotification } from "app/client/components/Drafts";
 import { GristDoc } from "app/client/components/GristDoc";
 import { domDispatch, domOnCustom, makeTestId } from "app/client/lib/domUtils";
+import { lockFocusUntilRemoved } from "app/client/lib/focusUtils";
 import { createObsArray } from "app/client/lib/koArrayWrap";
 import { makeT } from "app/client/lib/localization";
 import { localStorageBoolObs } from "app/client/lib/localStorageObs";
@@ -240,6 +241,7 @@ export class CommentPopup extends Disposable {
         }
       });
       return cssCommentPopup(
+        lockFocusUntilRemoved(ctl),
         testId("popup"),
         dom.domComputed(this._props.cell.isEmpty, (empty) => {
           if (!empty) {
@@ -923,6 +925,7 @@ class CommentEntry extends Disposable {
       this._editableDiv = buildMentionTextBox(
         this.props.text,
         this.props.access,
+        { tabindex: "0" },
         cssCommentEntryText.cls(""),
         cssContentEditable.cls(`-${this.props.mode}`),
         dom.onKeyDown({

--- a/test/fixtures/projects/modals.ts
+++ b/test/fixtures/projects/modals.ts
@@ -128,6 +128,36 @@ function setupTest() {
         ),
       )),
     ),
+
+    dom("div",
+      basicButton(
+        "Nested modals",
+        testId("nested-modals-opener"),
+        dom.on("click", () =>
+          modal(ctl =>
+            dom("div",
+              dom("p", "This is the first modal"),
+              primaryButton(
+                "Open nested modal",
+                testId("nested-modals-open-submodal"),
+                dom.on("click", () => modal(nestedCtrl =>
+                  dom("div",
+                    testId("nested-modals-submodal"),
+                    dom("p", "This is a second modal, appearing on top of the first one"),
+                    primaryButton(
+                      "Close nested modal",
+                      testId("nested-modals-close-submodal"),
+                      dom.on("click", () => nestedCtrl.close()),
+                    ),
+                  ),
+                )),
+              ),
+              basicButton("Close modal", testId("nested-modals-close"), dom.on("click", () => ctl.close())),
+            ),
+          ),
+        ),
+      ),
+    ),
   );
 }
 

--- a/test/fixtures/projects/modals.ts
+++ b/test/fixtures/projects/modals.ts
@@ -1,3 +1,4 @@
+import { kbFocusHighlighterClass, KeyboardFocusHighlighter } from "app/client/components/KeyboardFocusHighlighter";
 import { basicButton } from "app/client/ui2018/buttons";
 import { primaryButton } from "app/client/ui2018/buttons";
 import { confirmModal, modal, saveModal, spinnerModal } from "app/client/ui2018/modals";
@@ -8,12 +9,14 @@ import { dom, input, makeTestId, styled } from "grainjs";
 import { Computed, Observable, observable } from "grainjs";
 
 function setupTest() {
+  KeyboardFocusHighlighter.create(null);
   const confirmed = observable(false);
   const isOpen = observable(false);
   const isSaveModalOpen = observable(false);
   const testId = makeTestId("testui-");
   const asyncTask = observable<{ resolve: () => void } | null>(null);
   return cssTestBox(
+    dom.cls(kbFocusHighlighterClass),
     dom("h1", "Modals"),
     dom("div",
       primaryButton("Confirmation modal",

--- a/test/projects/modals.ts
+++ b/test/projects/modals.ts
@@ -133,6 +133,34 @@ describe("modals", function() {
     await checkClosed();
   });
 
+  it("should handle focus lock with nested modals", async function() {
+    await driver.find(".testui-nested-modals-opener").click();
+    await checkOpen();
+
+    await driver.find(".testui-nested-modals-open-submodal").click();
+    assert.equal(await driver.findWait(".testui-nested-modals-submodal", 100).isPresent(), true);
+    await driver.sendKeys(Key.TAB);
+    await driver.sendKeys(Key.TAB);
+    assert.equal(
+      await driver.switchTo().activeElement().getId(),
+      await driver.find(".testui-nested-modals-close-submodal").getId(),
+      "Tab key should be trapped inside the nested modal",
+    );
+
+    await driver.find(".testui-nested-modals-close-submodal").click();
+    assert.equal(await driver.find(".testui-nested-modals-submodal").isPresent(), false);
+    await driver.sendKeys(Key.TAB);
+    await driver.sendKeys(Key.chord(Key.SHIFT, Key.TAB));
+    assert.equal(
+      await driver.switchTo().activeElement().getId(),
+      await driver.find(".testui-nested-modals-close").getId(),
+      "Tab key should be trapped inside the first modal after closing the nested modal",
+    );
+
+    await driver.sendKeys(Key.ESCAPE);
+    await checkClosed();
+  });
+
   describe("saveModal", function() {
     it("should support arbitrary dom arguments", async () => {
       // Title and saveLabel both include dynamic DOM; check that it works.

--- a/test/projects/modals.ts
+++ b/test/projects/modals.ts
@@ -87,6 +87,49 @@ describe("modals", function() {
     assert.match(await driver.find(".testui-custom-modal-text").getText(), /Closed/);
   });
 
+  it("should use ARIA attributes", async function() {
+    await driver.find(".testui-confirm-modal-opener").click();
+    await checkOpen();
+
+    const modalContainer = await driver.find(".test-modal-dialog");
+    assert.equal(await modalContainer.getAttribute("role"), "dialog");
+    assert.equal(await modalContainer.getAttribute("tabindex"), "-1");
+    assert.equal(await modalContainer.getAttribute("aria-modal"), "true");
+    const modalTitle = await driver.find(".test-modal-title");
+    assert.equal(await modalContainer.getAttribute("aria-labelledby"), await modalTitle.getAttribute("id"));
+    assert.equal(await modalContainer.getAttribute("aria-hidden"), null);
+
+    await driver.sendKeys(Key.ESCAPE);
+    await checkClosed();
+  });
+
+  it("should lock keyboard focus inside the modal", async function() {
+    await driver.find(".testui-confirm-modal-opener").click();
+    await checkOpen();
+
+    // Focus is set on the modal itself on open
+    assert.equal(await driver.switchTo().activeElement().getId(), await driver.find(".test-modal-dialog").getId());
+
+    // pressing Tab loops through the focusable elements inside the modal
+    await driver.sendKeys(Key.TAB);
+    assert.equal(await driver.switchTo().activeElement().getId(), await driver.find(".test-modal-confirm").getId());
+    await driver.sendKeys(Key.TAB);
+    assert.equal(await driver.switchTo().activeElement().getId(), await driver.find(".test-modal-cancel").getId());
+    await driver.sendKeys(Key.TAB);
+    assert.equal(await driver.switchTo().activeElement().getId(), await driver.find(".test-modal-confirm").getId());
+
+    // pressing Shift+Tab loops through the focusable elements inside the modal
+    await driver.sendKeys(Key.chord(Key.SHIFT, Key.TAB));
+    assert.equal(await driver.switchTo().activeElement().getId(), await driver.find(".test-modal-cancel").getId());
+    await driver.sendKeys(Key.chord(Key.SHIFT, Key.TAB));
+    assert.equal(await driver.switchTo().activeElement().getId(), await driver.find(".test-modal-confirm").getId());
+    await driver.sendKeys(Key.chord(Key.SHIFT, Key.TAB));
+    assert.equal(await driver.switchTo().activeElement().getId(), await driver.find(".test-modal-cancel").getId());
+
+    await driver.sendKeys(Key.ESCAPE);
+    await checkClosed();
+  });
+
   describe("saveModal", function() {
     it("should support arbitrary dom arguments", async () => {
       // Title and saveLabel both include dynamic DOM; check that it works.

--- a/test/projects/modals.ts
+++ b/test/projects/modals.ts
@@ -107,8 +107,11 @@ describe("modals", function() {
     await driver.find(".testui-confirm-modal-opener").click();
     await checkOpen();
 
-    // Focus is set on the modal itself on open
-    assert.equal(await driver.switchTo().activeElement().getId(), await driver.find(".test-modal-dialog").getId());
+    assert.equal(
+      await driver.switchTo().activeElement().getId(),
+      await driver.find(".test-modal-dialog").getId(),
+      "focus should be on the modal container after opening the modal",
+    );
 
     // pressing Tab loops through the focusable elements inside the modal
     await driver.sendKeys(Key.TAB);


### PR DESCRIPTION
## Context

Modals can be improved in order to be used properly by everyone.

For now:

- screen reader users don't necessarily understand there are in a modal, because we don't use any modal dialog-related HTML attributes
- keyboard users can get lost by focusing things behind the modal, because of one detected bug in our mousetrap pausing system, and because we don't do anything about trapping the tab key in modals.

## Proposed solution

… Fix everything, noticeably by following the ARIA modal dialog pattern.

## Related issues

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
