### PR TITLE
Fix (record) card widget bugs

### DIFF
--- a/app/client/components/DataTables.ts
+++ b/app/client/components/DataTables.ts
@@ -192,28 +192,26 @@ export class DataTables extends Disposable {
       ),
       dom.maybe(use => use(table.summarySourceTable) === 0, () => [
         menuDivider(),
+        menuItem(
+          () => this._editRecordCard(table),
+          cssMenuItemIcon("TypeCard"),
+          t("Edit record card"),
+          dom.cls("disabled", use => use(isReadonly)),
+          testId("menu-edit-record-card"),
+        ),
         dom.domComputed(use => use(use(table.recordCardViewSection).disabled), (isDisabled) => {
-          return [
-            menuItem(
-              () => this._editRecordCard(table),
-              cssMenuItemIcon("TypeCard"),
-              t("Edit record card"),
-              dom.cls("disabled", use => use(isReadonly) || isDisabled),
-              testId("menu-edit-record-card"),
-            ),
-            menuItemAsync(
-              async () => {
-                if (isDisabled) {
-                  await this._enableRecordCard(table);
-                } else {
-                  await this._disableRecordCard(table);
-                }
-              },
-              t("{{action}} Record Card", { action: isDisabled ? "Enable" : "Disable" }),
-              dom.cls("disabled", use => use(isReadonly)),
-              testId(`menu-${isDisabled ? "enable" : "disable"}-record-card`),
-            ),
-          ];
+          return menuItemAsync(
+            async () => {
+              if (isDisabled) {
+                await this._enableRecordCard(table);
+              } else {
+                await this._disableRecordCard(table);
+              }
+            },
+            t("{{action}} Record Card", { action: isDisabled ? "Enable" : "Disable" }),
+            dom.cls("disabled", use => use(isReadonly)),
+            testId(`menu-${isDisabled ? "enable" : "disable"}-record-card`),
+          );
         }),
       ]),
       dom.maybe(isReadonly, () => menuText(t("You do not have edit access to this document"))),

--- a/app/client/components/DataTables.ts
+++ b/app/client/components/DataTables.ts
@@ -192,26 +192,28 @@ export class DataTables extends Disposable {
       ),
       dom.maybe(use => use(table.summarySourceTable) === 0, () => [
         menuDivider(),
-        menuItem(
-          () => this._editRecordCard(table),
-          cssMenuItemIcon("TypeCard"),
-          t("Edit record card"),
-          dom.cls("disabled", use => use(isReadonly)),
-          testId("menu-edit-record-card"),
-        ),
         dom.domComputed(use => use(use(table.recordCardViewSection).disabled), (isDisabled) => {
-          return menuItemAsync(
-            async () => {
-              if (isDisabled) {
-                await this._enableRecordCard(table);
-              } else {
-                await this._disableRecordCard(table);
-              }
-            },
-            t("{{action}} Record Card", { action: isDisabled ? "Enable" : "Disable" }),
-            dom.cls("disabled", use => use(isReadonly)),
-            testId(`menu-${isDisabled ? "enable" : "disable"}-record-card`),
-          );
+          return [
+            menuItem(
+              () => this._editRecordCard(table),
+              cssMenuItemIcon("TypeCard"),
+              t("Edit record card"),
+              dom.cls("disabled", use => use(isReadonly) || isDisabled),
+              testId("menu-edit-record-card"),
+            ),
+            menuItemAsync(
+              async () => {
+                if (isDisabled) {
+                  await this._enableRecordCard(table);
+                } else {
+                  await this._disableRecordCard(table);
+                }
+              },
+              t("{{action}} Record Card", { action: isDisabled ? "Enable" : "Disable" }),
+              dom.cls("disabled", use => use(isReadonly)),
+              testId(`menu-${isDisabled ? "enable" : "disable"}-record-card`),
+            ),
+          ];
         }),
       ]),
       dom.maybe(isReadonly, () => menuText(t("You do not have edit access to this document"))),

--- a/app/client/components/RecordLayout.js
+++ b/app/client/components/RecordLayout.js
@@ -160,13 +160,21 @@ RecordLayout.updateLayoutSpecWithFields = function(spec, viewFields) {
   // two-column layout, so add a new row, or a second box to the last row if it's a leaf.
   _.difference(viewFieldIds, specFieldIds).forEach(function(leafId) {
     var newBox = tmpLayout.buildLayoutBox({ leaf: leafId });
-    var rows = tmpLayout.rootBox().childBoxes.peek();
+    var rootBox = tmpLayout.rootBox();
+    if (!rootBox || rootBox.isDisposed()) {
+      // Removing all stale fields from tmpLayout collapses the layout and disposes the root box.
+      // In that case, build a fresh layout.
+      rootBox = tmpLayout.buildLayoutBox({});
+      tmpLayout.setRoot(rootBox);
+    }
+
+    var rows = rootBox.childBoxes.peek();
     if (rows.length >= 1 && _.last(rows).isLeaf()) {
       // Add a new child to the last row.
       _.last(rows).addChild(newBox, true);
     } else {
       // Add a new row.
-      tmpLayout.rootBox().addChild(newBox, true);
+      rootBox.addChild(newBox, true);
     }
   });
 

--- a/sandbox/grist/test_useractions.py
+++ b/sandbox/grist/test_useractions.py
@@ -1830,3 +1830,43 @@ class TestUserActions(test_engine.EngineTestCase):
       [22, 5, 10.5, 29],
       [23, 5, 12.5, 30],
     ])
+
+  def test_record_card_disabled(self):
+    self.load_sample(self.sample)
+    self.apply_user_action(['AddEmptyTable', None])
+    table = self.engine.docmodel.tables.lookupOne(tableId='Table1')
+    record_card = table.recordCardViewSectionRef
+
+    # Check the record card defaults to one field per visible column (A, B, C).
+    default_col_refs = [f.colRef.id for f in record_card.fields]
+    self.assertEqual(len(default_col_refs), 3)
+
+    # Customize the record card so its layout differs from the default: drop its last field, set a
+    # distinctive theme/layout, and disable it.
+    self.apply_user_action(['RemoveRecord', '_grist_Views_section_field', record_card.fields[-1].id])
+    self.apply_user_action(['UpdateRecord', '_grist_Views_section', record_card.id, {
+      'theme': 'compact',
+      'layoutSpec': '{"children":[{"leaf":1}]}',
+      'options': '{"disabled":true}',
+    }])
+    record_card_col_refs = [f.colRef.id for f in record_card.fields]
+    self.assertEqual(len(record_card_col_refs), 2)
+
+    # Add a new card section while the record card is disabled.
+    result = self.apply_user_action(['CreateViewSection', table.id, 0, 'detail', None, None])
+    new_section = self.engine.docmodel.view_sections.table.get_record(result.retValues[0]['sectionRef'])
+
+    # Check it uses the full default field set, not the disabled record card's reduced set, and does not
+    # inherit the record card's theme/layout.
+    self.assertEqual([f.colRef.id for f in new_section.fields], default_col_refs)
+    self.assertNotEqual(new_section.theme, 'compact')
+    self.assertNotIn('disabled', new_section.options or '')
+
+    # Re-enable the record card. A newly added card section now inherits its layout again.
+    self.apply_user_action(['UpdateRecord', '_grist_Views_section', record_card.id, {
+      'options': '{"disabled":false}',
+    }])
+    result = self.apply_user_action(['CreateViewSection', table.id, 0, 'detail', None, None])
+    enabled_section = self.engine.docmodel.view_sections.table.get_record(result.retValues[0]['sectionRef'])
+    self.assertEqual([f.colRef.id for f in enabled_section.fields], record_card_col_refs)
+    self.assertEqual(enabled_section.theme, 'compact')

--- a/sandbox/grist/useractions.py
+++ b/sandbox/grist/useractions.py
@@ -2583,6 +2583,7 @@ class UserActions(object):
     try:
       record_card_disabled = json.loads(record_card_section.options or '{}').get('disabled', False)
     except ValueError:
+      # Normally unreachable, but exercise caution when calling json.loads.
       record_card_disabled = False
     if is_card and not is_record_card and not record_card_disabled:
       # Copy settings from the table's record card section to the new section.

--- a/sandbox/grist/useractions.py
+++ b/sandbox/grist/useractions.py
@@ -2579,9 +2579,13 @@ class UserActions(object):
     section_type = section_rec.parentKey
     is_card = section_type in ('single', 'detail')
     is_record_card = section_rec == table_rec.recordCardViewSectionRef
-    if is_card and not is_record_card:
+    record_card_section = table_rec.recordCardViewSectionRef
+    try:
+      record_card_disabled = json.loads(record_card_section.options or '{}').get('disabled', False)
+    except ValueError:
+      record_card_disabled = False
+    if is_card and not is_record_card and not record_card_disabled:
       # Copy settings from the table's record card section to the new section.
-      record_card_section = table_rec.recordCardViewSectionRef
       self._docmodel.add(section_rec.fields, colRef=[f.colRef for f in record_card_section.fields])
       self._copy_record_card_settings(record_card_section, section_rec)
     else :

--- a/test/nbrowser/RecordLayout.ts
+++ b/test/nbrowser/RecordLayout.ts
@@ -28,6 +28,42 @@ describe("RecordLayout", function() {
     assert.isNotNull(await row.find(".test-vfc-hide").getAttribute("disabled"));
   });
 
+  it("should rebuild layout when saved spec shares no fields with view", async () => {
+    // When a saved layoutSpec shared no fields with the current view,
+    // building the card layout used to throw: all the stale fields would
+    // auto-collapse the layout and dispose its root box, which
+    // updateLayoutSpecWithFields was not checking for.
+    const session = await gu.session().login();
+    await session.tempNewDoc(cleanup);
+    await gu.toggleSidePanel("right", "open");
+    await driver.findContent("button", "Change widget").click();
+    await gu.selectWidget("Card");
+    assert.deepEqual(await getFields(), ["A", "B", "C"]);
+
+    // Overwrite the saved layout with one referencing only non-existent fields, so it has no
+    // overlap at all with the actual viewFields (the scenario that used to throw).
+    const sectionId = await gu.getSectionId();
+    await gu.sendActions([
+      ["UpdateRecord", "_grist_Views_section", sectionId, {
+        layoutSpec: JSON.stringify({ children: [{ leaf: 90001 }, { leaf: 90002 }, { leaf: 90003 }] }),
+      }],
+    ]);
+
+    // Reload so the layout is rebuilt.
+    await gu.reloadDoc();
+
+    // No errors, all fields are present again...
+    await gu.checkForErrors();
+    assert.deepEqual(await getFields(), ["A", "B", "C"]);
+
+    // ...and the layout is preserved.
+    const topA = (await gu.getDetailCell("A", 1).rect()).top;
+    const topB = (await gu.getDetailCell("B", 1).rect()).top;
+    const topC = (await gu.getDetailCell("C", 1).rect()).top;
+    assert.equal(topA, topB);
+    assert.isAbove(topC, topA);
+  });
+
   it("should allow deleting cells", async function() {
     await server.simulateLogin("Chimpy", "chimpy@getgrist.com", "nasa");
     await gu.importFixturesDoc("chimpy", "nasa", "Horizon", "World.grist", "newui");


### PR DESCRIPTION
## Context

Card widgets and record cards have a few bugs:

- New card widgets still use the record card's layout while they are disabled 
- When a card's saved layout spec only has stale field references, building the card layout in the client always throws, leaving the widget in a broken state

## Proposed solution

 - Use the default new card layout while record cards are disabled
 - Add a check for the "no overlap" scenario when building card layouts, and start a new default card layout

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->