### PR TITLE
Fix mixed-content error loading bundled widgets behind https

### DIFF
--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1962,8 +1962,17 @@ export class FlexServer implements GristServer {
       // allocate by using GRIST_UNTRUSTED_PORT=0. But we do need to
       // remember how to contact it.
       if (process.env.APP_UNTRUSTED_URL === undefined) {
-        const url = new URL(this.getOwnUrl());
+        // Base the plugin URL on the public home URL when available, so the
+        // protocol and hostname match what the browser uses to reach Grist,
+        // and only swap in the untrusted port. Falling back to getOwnUrl()
+        // uses the server's bind address (e.g. 0.0.0.0) and always http,
+        // which breaks behind https (mixed content) or a 0.0.0.0 bind. See
+        // https://github.com/gristlabs/grist-core/issues/2376.
+        const url = new URL(getHomeUrl() || this.getOwnUrl());
         url.port = String(userPort || ports.serverPort);
+        url.pathname = "/";
+        url.search = "";
+        url.hash = "";
         this._pluginUrl = url.href;
       }
     }


### PR DESCRIPTION





## Context

When plugins are served on a separate port without APP_UNTRUSTED_URL set, the plugin URL was built from getOwnUrl(), which always uses http:// and the server bind address (GRIST_HOST, e.g. 0.0.0.0). This produced URLs like http://0.0.0.0:44505, which browsers block as mixed active content on an https site, breaking the built-in Calendar widget and others.

## Proposed solution


Base the plugin URL on the public home URL (APP_HOME_URL) when available, keeping its protocol and hostname and only swapping in the untrusted port.



## Related issues

Fixes #2376


## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [X] 💭 no, because my laptop went out of free ram and OOK kill docker when I was building an image to test, and I lack time today, and I prefer to share this sooner than later.
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts


