### PR TITLE
Make the server crash if the login middleware fails to init #2373

### DIFF
--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -1384,6 +1384,15 @@ export class FlexServer implements GristServer {
       const loginSystem = await this.resolveLoginSystem();
       this._loginMiddleware = await loginSystem.getMiddleware(this);
     } catch (err) {
+      // If Grist is in service, let's not fall back to the boot key login middleware.
+      // github.com/gristlabs/grist-core/issues/2373
+      // Let's make the server unhealthy, so it can be restarted and try to join the IdP again.
+      // The one downside is that admin page is unusable for diagnosing the problem.
+      // It can be removed once this issue is addressed: https://github.com/gristlabs/grist-core/issues/2373
+      if (getInService().value) {
+        throw err;
+      }
+
       // We need to start even if login middleware fails to initialize, and report it so that admins
       // can fix the problem using the admin UI.
       log.error("Error initializing login middleware:", err);

--- a/stubs/app/server/server.ts
+++ b/stubs/app/server/server.ts
@@ -267,5 +267,6 @@ export async function main() {
 if (require.main === module) {
   main().catch((err) => {
     log.error(err);
+    process.exit(1);
   });
 }

--- a/test/fixtures/projects/forms.ts
+++ b/test/fixtures/projects/forms.ts
@@ -25,7 +25,7 @@ function setupTest(owner: IDisposableOwner) {
     // Show the form contents.
     forms.checkboxItem([{ disabled: true }, dom.prop("checked", isFilled)], "Is Form Filled?"),
     dom("textarea", { rows: "8", cols: "80" }, dom.prop("value", formValue)),
-    dom.on("change", (e, form) => {
+    dom.on("change", (e, form: HTMLFormElement) => {
       isFilled.set(forms.isFormFilled(form, ["sky-*", "meaning"]));
       formValue.set(JSON.stringify(formDataToObj(form), null, 2));
     }),

--- a/test/nbrowser/AuthProvider.ts
+++ b/test/nbrowser/AuthProvider.ts
@@ -21,6 +21,7 @@ describe("AuthProvider", function() {
     oldEnv = new testUtils.EnvironmentSnapshot();
     process.env.GRIST_DEFAULT_EMAIL = user.email;
     process.env.GRIST_TEST_SERVER_DEPLOYMENT_TYPE = "core";
+    process.env.GRIST_IN_SERVICE = "false";
     useFastSandboxProbe();
     await server.restart();
 

--- a/test/nbrowser/QuickSetupAuth.ts
+++ b/test/nbrowser/QuickSetupAuth.ts
@@ -71,6 +71,7 @@ describe("QuickSetupAuth", function() {
     GRIST_DEFAULT_EMAIL: user.email,
     GRIST_TEST_SERVER_DEPLOYMENT_TYPE: "core",
     GRIST_LOG_HTTP: "1",
+    GRIST_IN_SERVICE: "false",
   }));
 
   async function navigateToAuthStep() {
@@ -188,6 +189,7 @@ describe("QuickSetupAuth", function() {
       GRIST_OIDC_IDP_CLIENT_SECRET: "test-secret",
       GRIST_OIDC_IDP_SKIP_END_SESSION_ENDPOINT: "true",
       GRIST_OIDC_SP_HOST: "localhost",
+      GRIST_IN_SERVICE: "false",
     }));
 
     it("should enable Continue button when auth is configured but erroring", async function() {
@@ -248,6 +250,8 @@ describe("QuickSetupAuth", function() {
         // shouldRunAsRestartShell so /api/admin/restart actually drives a
         // worker restart in nbrowser (default would 409).
         GRIST_RESTART_SHELL: "true",
+
+        GRIST_IN_SERVICE: "true",
 
         // Use a single-port setup, including for PORT, which is used for the RestartShell.
         HOME_PORT: homePort,


### PR DESCRIPTION
## Context

When Grist is configured to use OIDC to authenticate users, it used to crash when the identity provider (IdP) was not available. This way, if Grist is configured to restart automatically, another attempt could be made (it's not ideal, see #1912).

But since version 1.7.13, a fallback to the login page with the boot key has been implemented:
https://github.com/gristlabs/grist-core/blob/27bd050a0f6853e45e2059a05a1bebb2d9fbe19b/app/server/lib/FlexServer.ts#L1371-L1383

We have faced recently an incident in which users could not login and were offered to login using the boot key (which, of course, they did not have). What happened is the following:
1. We had an internal network issue, making the workers crash and restart
2. At some point, the servers have stopped crashing, but they still could not join the IdP
3. As a result, the users were not redirected to our IdP to login, and they could not authenticate anymore.

## Proposed solution

Until #1912 is implemented, let's just make the server crash when `GRIST_IN_SERVICE=true`.

## Related issues

Fixes #2373

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [x] 🙋 no, because I need help <!-- Detail how we can help you -->

I don't know where I can implement test (if we think it is desirable).