### PR TITLE
Make action-summary concatenation sound by chunking bundles

### DIFF
--- a/app/client/components/ActionLog.ts
+++ b/app/client/components/ActionLog.ts
@@ -13,9 +13,9 @@ import { basicButton } from "app/client/ui2018/buttons";
 import { labeledSquareCheckbox } from "app/client/ui2018/checkbox";
 import { theme } from "app/client/ui2018/cssVars";
 import { ActionGroup } from "app/common/ActionGroup";
-import { concatenateSummaryPair } from "app/common/ActionSummarizer";
+import { concatenateSummaries } from "app/common/ActionSummarizer";
 import {
-  ActionSummary, asTabularDiffs, createEmptyActionSummary, defunctTableName, getAffectedTables,
+  ActionSummary, asTabularDiffs, defunctTableName, getAffectedTables,
   LabelDelta,
 } from "app/common/ActionSummary";
 import { CellDelta, TabularDiff, TabularDiffs } from "app/common/TabularDiff";
@@ -110,8 +110,13 @@ export class ActionLog extends dispose.Disposable implements IDomComponent {
    */
   public async getChangesSince(actionNum: number): Promise<ActionSummary> {
     await this._loadActionSummaries();
-    return takeWhile(this.displayStack.all(), item => item.actionNum > actionNum)
-      .reduce((summary, item) => concatenateSummaryPair(item.actionSummary, summary), createEmptyActionSummary());
+    // displayStack is newest-first; reverse to oldest-first so we combine the
+    // changes in the order they happened. concatenateSummaries drops the changes
+    // that cancel out, leaving what display should show.
+    const summaries = takeWhile(this.displayStack.all(), item => item.actionNum > actionNum)
+      .map(item => item.actionSummary)
+      .reverse();
+    return concatenateSummaries(summaries);
   }
 
   /**

--- a/app/client/models/DataTableModelWithDiff.ts
+++ b/app/client/models/DataTableModelWithDiff.ts
@@ -250,6 +250,9 @@ export class TableDataWithDiff {
   private _leftRemovals: Set<number>;
   private _rightRemovals: Set<number>;
   private _updates: Set<number>;
+  // Rows added locally: real positive ids in the core table, kept in the "changed rows only"
+  // view alongside updates and removals. (Remote adds use synthetic negative ids; see rowId < 0.)
+  private _localAdds: Set<number>;
   // Stores pre-deletion column values for each removed row, keyed by rowId.
   // Used to distinguish undo (values match) from ID recycling (values differ).
   private _removedRowValues = new Map<number, Record<string, CellDelta[0]>>();
@@ -268,6 +271,7 @@ export class TableDataWithDiff {
       ...leftTableDelta.updateRows.filter(r => !this._rightRemovals.has(r)),
       ...rightTableDelta.updateRows.filter(r => !this._leftRemovals.has(r)),
     ]);
+    this._localAdds = new Set(leftTableDelta.addRows);
   }
 
   public getColIds(): string[] {
@@ -309,6 +313,7 @@ export class TableDataWithDiff {
     if (this._options?.showAllRows) { return undefined; }
     return (rowId: number | "new") => {
       return rowId === "new" || this._updates.has(rowId) || rowId < 0 ||
+        this._localAdds.has(rowId) ||
         this._leftRemovals.has(rowId) || this._rightRemovals.has(rowId);
     };
   }

--- a/app/client/models/VirtualTable.ts
+++ b/app/client/models/VirtualTable.ts
@@ -3,7 +3,7 @@ import { DocModel } from "app/client/models/DocModel";
 import { reportError } from "app/client/models/errors";
 import { TableData } from "app/client/models/TableData";
 import { concatenateSummaries, summarizeStoredAndUndo } from "app/common/ActionSummarizer";
-import { TableDelta } from "app/common/ActionSummary";
+import { createEmptyTableDelta, TableDelta } from "app/common/ActionSummary";
 import { ProcessedAction } from "app/common/AlternateActions";
 import { DisposableWithEvents } from "app/common/DisposableWithEvents";
 import { DocAction, TableDataAction, UserAction } from "app/common/DocActions";
@@ -105,7 +105,8 @@ export class VirtualTableData extends TableData {
     const summary = concatenateSummaries(
       actions
         .map(action => summarizeStoredAndUndo(action.stored, action.undo)));
-    const delta = summary.tableDeltas[this.getName()];
+    // The summary omits a table with nothing to say (and with no actions has no table at all).
+    const delta = summary.tableDeltas[this.getName()] ?? createEmptyTableDelta();
     return {
       actions,
       delta,

--- a/app/common/ActionBundle.ts
+++ b/app/common/ActionBundle.ts
@@ -63,6 +63,12 @@ export interface SandboxActionBundle {
   direct: EnvContent<boolean>[];
   calc: EnvContent<DocAction>[];
   undo: EnvContent<DocAction>[];   // Inverse actions for all 'stored' actions.
+  // Parallel to 'undo': the index into 'stored' of the action that produced each undo action, as
+  // the engine knows it directly, or null for a front calc-flush restore that the summarizer
+  // attributes for itself. Lets the summarizer chunk a bundle without re-inferring the grouping
+  // (see app/common/ActionLayout.ts chunkByOwners). Enveloped like the other parallel arrays,
+  // though the index is global to the bundle; flattened into LocalActionBundle alongside 'undo'.
+  undoOwner?: EnvContent<number | null>[];
   retValues: any[];                     // Contains retValue for each of userActions.
   rowCount: RowCounts;
   // Mapping of keys (hashes of request args) to all unique requests made in a round of calculation
@@ -91,4 +97,11 @@ export interface LocalActionBundle extends ActionBundle {
   // Applying 'undo' is governed by EDIT rather than READ permissions, so we always apply all undo
   // actions. (It is the result of applying 'undo' that may be addressed to different recipients).
   undo: DocAction[];
+
+  // Parallel to 'undo': the stored-action index each undo corresponds to (or null), as reported
+  // by the engine. Absent on bundles produced before this was recorded, and on bundles assembled
+  // without the data engine; the summarizer then falls back to inferring the grouping. Persisted
+  // with the bundle in the action history, and folded into the action hash when present (see
+  // computeActionHash) so it is covered by the checksum.
+  undoOwner?: (number | null)[];
 }

--- a/app/common/ActionLayout.ts
+++ b/app/common/ActionLayout.ts
@@ -1,0 +1,522 @@
+/**
+ * Chunkers for action bundles.
+ *
+ * Splits a (stored, undo) bundle into sub-bundles ("chunks"), each a complete
+ * (stored, undo) slice that can be summarized on its own and then composed back
+ * together (see ActionSummarizer).
+ *
+ * There are two entry points. `chunkByOwners` is used when the bundle still
+ * carries the engine's own record of which undo each stored action produced: it
+ * just groups by that, one chunk per stored action, which is the finest split.
+ * `chunkByLattice` is the fallback that reconstructs the grouping when the bundle
+ * lacks that record: all history from before ownership was added (immutable, not
+ * backfillable), plus bundles assembled without the data engine. The two share
+ * `analyzeStored`, so a front calc-flush restore is attributed to its removal the
+ * same way regardless of path.
+ *
+ * One rule both chunkers follow: placement decides how a name is read. Later
+ * chunks' renames rekey earlier chunks during composition, so an undo entry's
+ * names mean whatever they meant at its chunk's position. A front calc-flush
+ * restore carries PRE-bundle names (it runs last during undo, after every
+ * rename is rolled back -- see LabelRenames.original_name in the sandbox), so
+ * when it cannot be attributed to its removal it must go in a LEADING chunk,
+ * the only position where pre-bundle names read correctly.
+ *
+ * The rest of this header describes the lattice.
+ *
+ * Why split at all? A single bundle can carry several schema changes at once:
+ * two renames, say, or a column removed and another added under the same name. A
+ * single forward/reverse walk over the whole bundle can't tell a name that
+ * appeared and vanished mid-bundle from the one that really sits at the boundary,
+ * so it picks the wrong answer. Splitting into pieces that each summarize
+ * cleanly, then composing, sidesteps that.
+ *
+ * How it splits: chunking is a least-cost path over a (stored x undo) grid. Each
+ * step is one chunk, a rectangle of consecutive stored and undo entries. A chunk
+ * is priced by whether its undo entries are the inverses we expect from its
+ * forward actions. Every forward action has a known inverse shape, read from the
+ * engine's own action handlers (docactions.py), so this is a contract, not a
+ * guess (see `expectedInverses`). The price treats the undo as an unordered bag,
+ * so a reverse-ordered emission (a formula/data conversion, the one case the
+ * engine emits its two undo steps out of order) still costs zero once both steps
+ * land in one chunk. Coarsening is therefore not a separate pass: it is just the
+ * chunk the search settles on when no finer split works.
+ *
+ * The step shapes are not a 2 x 2 box but a short fixed list of the spans the
+ * engine actually emits (see `EDGE_SHAPES`): a one-to-one action and inverse, a
+ * remove that restores both data and schema, an action with no undo, a front
+ * restore, and the one two-by-two case, the formula/data conversion. That
+ * conversion is the only reordering the engine ever forces, so it is the only
+ * wide shape. A fuzz sweep selects exactly these shapes and never a wider one.
+ *
+ * Cost: with N stored actions and M undo actions (M = O(N), a bounded set of
+ * inverses per action), the search fills an (N+1) by (M+1) grid at five shapes
+ * per cell -- O(N*M) time and space, quadratic in the action count. Edge pricing
+ * compares row lists only after a kind/table match, so the largest action's row
+ * count R multiplies in only when many bulk actions share a table (worst case
+ * O(N*M*R)); otherwise the row work stays linear in the rows touched. N is small
+ * in practice, and the chunker runs once per bundle.
+ */
+
+import { DocAction, getColIdsFromDocAction, getRowIdsFromDocAction, isDataAction } from "app/common/DocActions";
+import { getSetMapValue, isSubset } from "app/common/gutil";
+
+export interface LayoutChunk {
+  stored: DocAction[];
+  undo: DocAction[];
+}
+
+function actKey(t: string, c: string): string { return `${t}/${c}`; }
+
+// Rows / columns a data action touches, as lists; anything else (a schema
+// action) touches neither. The `isDataAction` guard is essential: without it
+// a schema action's payload (a colInfo object, or a name string) would be
+// misread as columns, and its non-row positions as rows.
+function rowsOf(a: DocAction): number[] {
+  return isDataAction(a) ? getRowIdsFromDocAction(a) : [];
+}
+function colsOf(a: DocAction): string[] {
+  return isDataAction(a) ? (getColIdsFromDocAction(a) ?? []) : [];
+}
+// Is every element of `sub` present in `sup`? An update's undo restores a subset
+// of the rows the forward touched -- exactly the rows that had a prior value. So
+// a recompute over all rows pairs with a restore over only the pre-existing rows,
+// and a partial no-op bulk pairs with a restore over only the rows that actually
+// changed. Equality is the common special case.
+function subset<T>(sub: T[], sup: T[]): boolean {
+  return isSubset(new Set(sub), new Set(sup));
+}
+// Order-blind set equality: equal length plus one-way containment (for matching
+// an inverse's rows or columns against the forward action's).
+function sameSet<T>(a: T[], b: T[]): boolean {
+  return a.length === b.length && subset(a, b);
+}
+// True if `a` is a record action with the given verb, single or bulk
+// (`recordKind(a, "Remove")` matches RemoveRecord and BulkRemoveRecord).
+function recordKind(a: DocAction, verb: "Add" | "Remove" | "Update"): boolean {
+  return a[0] === `${verb}Record` || a[0] === `Bulk${verb}Record`;
+}
+
+// Lattice chunker (the model is in the file header above). The objective is a
+// lexicographic score (see `betterScore` below). Every edge cost is local: it
+// reads only its own two slices plus a precomputed defunct index, so this stays
+// a plain Viterbi-shaped DP.
+
+/**
+ * A path's score, smallest wins, compared as a lexicographic tuple. Tiers, most
+ * significant first:
+ *   1. shape:   stranded live-slot undos. Discarding one loses information, so
+ *               this is minimized first.
+ *   2. missing: required inverses with no matching undo.
+ *   3. orphan:  earlier-bundle orphans (a restore no forward here touches).
+ *   4. zeros:   optional steps left unpaired. A coarsening that pairs an
+ *               otherwise-stranded undo across a crossing reduces this, while a
+ *               genuine no-op step cannot be paired, so minimizing it below the
+ *               validity tiers coarsens exactly the crossings.
+ *   5. chunks:  stored-owning chunks, where more is better (finest valid split).
+ * Explicit tiers, not weighted sums, so no number of lower-tier penalties can
+ * ever outweigh one penalty of a more significant tier.
+ */
+interface Score { shape: number; missing: number; orphan: number; zeros: number; chunks: number; }
+interface Node { score: Score; fromI: number; fromJ: number; }
+function betterScore(a: Score, b: Score): boolean {
+  if (a.shape !== b.shape) { return a.shape < b.shape; }
+  if (a.missing !== b.missing) { return a.missing < b.missing; }
+  if (a.orphan !== b.orphan) { return a.orphan < b.orphan; }
+  if (a.zeros !== b.zeros) { return a.zeros < b.zeros; }
+  return a.chunks > b.chunks;
+}
+
+/**
+ * An expected inverse slot contributed by one forward action. `test` is the
+ * shape predicate (kind, table, target; rows subset for updates); `tier`
+ * says how to price the slot when no undo entry matches it: a `required`
+ * inverse is always emitted (missing one is suspicious), a `zero` inverse
+ * may legitimately be empty (no-op update, absent-row remove), and a
+ * `routed` inverse is emitted but may land in the front pre-segment rather
+ * than this chunk (a formula column's data restore).
+ */
+type SlotTier = "required" | "zero" | "routed";
+interface Slot { tier: SlotTier; test: (g: DocAction) => boolean; }
+const req = (test: Slot["test"]): Slot => ({ tier: "required", test });
+const zero = (test: Slot["test"]): Slot => ({ tier: "zero", test });
+const routed = (test: Slot["test"]): Slot => ({ tier: "routed", test });
+
+/**
+ * The inverse(s) we expect from a single forward action (the catalogue read
+ * from the engine, per the file header). Predicates ignore cell values, so they
+ * are local. ModifyColumn deliberately tests only kind+table+col (not which
+ * property changed): the conversion's two ModifyColumns on one column are
+ * interchangeable for closure, which is exactly why their reversed undo
+ * costs nothing inside one chunk.
+ */
+function expectedInverses(s: DocAction): Slot[] {
+  const k = s[0];
+  const t = s[1];
+  switch (k) {
+    case "AddRecord": case "BulkAddRecord":
+      return [req(g => recordKind(g, "Remove") && g[1] === t && sameSet(rowsOf(g), rowsOf(s)))];
+    case "RemoveRecord": case "BulkRemoveRecord":
+      return [zero(g => recordKind(g, "Add") && g[1] === t && subset(rowsOf(g), rowsOf(s)))];
+    case "UpdateRecord": case "BulkUpdateRecord":
+      return [zero(g => recordKind(g, "Update") && g[1] === t &&
+        subset(rowsOf(g), rowsOf(s)) && sameSet(colsOf(g), colsOf(s)))];
+    case "AddColumn":
+      return [req(g => g[0] === "RemoveColumn" && g[1] === t && g[2] === s[2])];
+    case "RemoveColumn":
+      return [
+        req(g => g[0] === "AddColumn" && g[1] === t && g[2] === s[2]),
+        routed(g => recordKind(g, "Update") && g[1] === t && colsOf(g).includes(s[2])),
+      ];
+    case "RenameColumn":
+      return [req(g => g[0] === "RenameColumn" && g[1] === t && g[2] === s[3] && g[3] === s[2])];
+    case "ModifyColumn":
+      return [zero(g => g[0] === "ModifyColumn" && g[1] === t && g[2] === s[2])];
+    case "AddTable":
+      return [req(g => g[0] === "RemoveTable" && g[1] === t)];
+    case "RemoveTable":
+      return [
+        req(g => g[0] === "AddTable" && g[1] === t),
+        routed(g => recordKind(g, "Add") && g[1] === t),
+      ];
+    case "RenameTable":
+      return [req(g => g[0] === "RenameTable" && g[1] === s[2] && g[2] === s[1])];
+    case "ReplaceTableData":
+      return [zero(g => g[0] === "ReplaceTableData" && g[1] === t)];
+  }
+  // Any other kind (including action kinds outside the DocAction union, such as
+  // the engine's internal calc/empty actions, which do flow through here at
+  // runtime) has no expected inverse. This open fallthrough is deliberate: an
+  // exhaustiveness guard over DocAction would mis-handle those runtime kinds.
+  return [];
+}
+
+/**
+ * What the stored side of a bundle tells us about its undo entries: who owns a
+ * front calc-flush restore, and whether an undo is an earlier-bundle orphan.
+ * Shared by both chunkers so the owner-driven path attributes front restores
+ * exactly as the lattice does.
+ */
+interface StoredAnalysis {
+  // The defunct-remove stored that owns a front restore entry, or undefined.
+  restoreOwner: (g: DocAction) => number | undefined;
+  // A genuine earlier-bundle orphan: a restore whose slot no forward here touches.
+  isGhost: (g: DocAction) => boolean;
+}
+
+function analyzeStored(stored: DocAction[]): StoredAnalysis {
+  const N = stored.length;
+  // Defunct-slot index plus the set of slots any forward action touches.
+  const removeColIdx = new Map<string, number>();
+  const addColIdx = new Map<string, number>();
+  const removeTblIdx = new Map<string, number>();
+  const addTblIdx = new Map<string, number>();
+  const removeRowIdx = new Map<string, Map<number, number>>();   // table -> rowId -> removal stored idx
+  const addRowIdx = new Map<string, Map<number, number>>();      // table -> rowId -> add stored idx
+  const liveCols = new Set<string>();
+  const touchedTables = new Set<string>();
+  // Names touched by any in-bundle rename. The indexes below use stored-action
+  // names, a front restore uses pre-bundle names, so a lookup on a renamed name
+  // can miss or, worse, match the removal of a different entity that took over
+  // the name; such restores go unattributed, to a leading chunk. Column names
+  // taint globally: over-vetoing is safe, leading is sound for any restore.
+  const renamedTables = new Set<string>();
+  const renamedCols = new Set<string>();
+  // Name-keyed removal indexes keep the FIRST removal: a front restore names
+  // the pre-bundle entity, which only the first removal can have removed. A
+  // later removal of the same name (a remove/re-add recycle) removes a
+  // different, in-bundle entity; matching the restore to it would file the
+  // original's values under an entity whose add+remove annihilate in
+  // composition. (Row removals stay last-write: rowIds are stable identifiers,
+  // and recycled rows keep per-entity cells, so either write order composes
+  // the same.)
+  const setFirst = (m: Map<string, number>, k: string, v: number) => { if (!m.has(k)) { m.set(k, v); } };
+  for (let i = 0; i < N; i++) {
+    const s = stored[i];
+    const t = s[1];
+    touchedTables.add(t);
+    // A column kind names its slot key once, for both its index and liveCols.
+    switch (s[0]) {
+      case "RemoveColumn": setFirst(removeColIdx, actKey(t, s[2]), i); liveCols.add(actKey(t, s[2])); break;
+      case "AddColumn": addColIdx.set(actKey(t, s[2]), i); liveCols.add(actKey(t, s[2])); break;
+      case "ModifyColumn": liveCols.add(actKey(t, s[2])); break;
+      case "RenameColumn":
+        liveCols.add(actKey(t, s[2]));
+        renamedCols.add(s[2]); renamedCols.add(s[3]);
+        break;
+      case "RemoveTable": setFirst(removeTblIdx, t, i); break;
+      case "AddTable": addTblIdx.set(t, i); break;
+      case "RenameTable": renamedTables.add(t); renamedTables.add(s[2]); break;
+      case "RemoveRecord": case "BulkRemoveRecord":
+        for (const r of rowsOf(s)) { getSetMapValue(removeRowIdx, t, () => new Map()).set(r, i); } break;
+      case "AddRecord": case "BulkAddRecord":
+        for (const r of rowsOf(s)) { getSetMapValue(addRowIdx, t, () => new Map()).set(r, i); } break;
+    }
+    for (const c of colsOf(s)) { liveCols.add(actKey(t, c)); }
+  }
+  // Defunct = removed in this bundle, with any add coming before the removal
+  // (a name re-added after it belongs to a new entity). One rule, three lookups.
+  const isDefunct = (remove?: number, add?: number): boolean =>
+    remove !== undefined && (add === undefined || add < remove);
+  const isColDefunct = (t: string, c: string): boolean =>
+    isDefunct(removeColIdx.get(actKey(t, c)), addColIdx.get(actKey(t, c)));
+  const isTblDefunct = (t: string): boolean =>
+    isDefunct(removeTblIdx.get(t), addTblIdx.get(t));
+  // A defunct row's formula columns recompute to nothing on removal, and the
+  // engine restores their prior values through calc-flush front entries, just
+  // like a defunct column's data.
+  const isRowDefunct = (t: string, r: number): boolean =>
+    isDefunct(removeRowIdx.get(t)?.get(r), addRowIdx.get(t)?.get(r));
+
+  // The defunct-remove stored that owns a front restore entry, or undefined.
+  // A front restore can belong to a removed column, a removed table, or a
+  // removed row whose formula columns were flushed (the row case keeps a
+  // removed summary row's aggregates from being stranded after its removal in a
+  // later chunk, where composition could no longer fold them in).
+  const restoreOwner = (g: DocAction): number | undefined => {
+    if (renamedTables.has(g[1]) || colsOf(g).some(c => renamedCols.has(c))) { return undefined; }
+    if (recordKind(g, "Update")) {
+      for (const c of colsOf(g)) {
+        if (isColDefunct(g[1], c)) { return removeColIdx.get(actKey(g[1], c)); }
+      }
+      const rows = rowsOf(g);
+      if (rows.length > 0 && rows.every(r => isRowDefunct(g[1], r))) {
+        // The engine folds the whole bundle's calc-flush into one restore, so
+        // this entry's rows can belong to several distinct removals (two separate
+        // RemoveRecords on one table merge here). We return the first row's owner.
+        // That only chooses which chunk the restore joins, which is safe either
+        // way. The restore is prepended ahead of every removal in the bundle, so a
+        // row whose removal lands in a later chunk sees the restore there as a
+        // retained [v, v] cell, and that removal composes it into the correct
+        // [v, null]. See the "two separate removes share one merged front restore"
+        // fuzz scenario.
+        return removeRowIdx.get(g[1])!.get(rows[0]);
+      }
+    }
+    if (isTblDefunct(g[1])) { return removeTblIdx.get(g[1]); }
+    return undefined;
+  };
+
+  // A genuine earlier-bundle orphan: a restore whose slot no forward in
+  // this bundle touches.
+  const isGhost = (g: DocAction): boolean => {
+    if (recordKind(g, "Update")) {
+      const cols = colsOf(g);
+      if (cols.length > 0 && cols.every(c => !liveCols.has(actKey(g[1], c)))) { return true; }
+    }
+    return !touchedTables.has(g[1]);
+  };
+
+  return { restoreOwner, isGhost };
+}
+
+/**
+ * Chunk a bundle using the engine's own per-undo ownership instead of inferring
+ * it. `owners[k]` is the index into `stored` of the action that produced
+ * `undo[k]`, or null for a front calc-flush restore (which we attribute to its
+ * owning removal exactly as the lattice does). Each stored action becomes its
+ * own chunk carrying the undo entries it owns -- the finest split, which is what
+ * the lattice searches for but here is known outright. Front restores join their
+ * removal's chunk; one that cannot be safely matched goes to a leading
+ * stored=[] chunk (see the file header). Ownership only comes from the current
+ * engine, so an unowned undo here is always a front restore, never a legacy
+ * orphan.
+ *
+ * Preconditions (the caller checks `owners.length === undo.length`): owner
+ * indices are in range. Undo order within each chunk is preserved by walking
+ * `undo` in order.
+ */
+export function chunkByOwners(stored: DocAction[], undo: DocAction[],
+  owners: readonly (number | null)[]): LayoutChunk[] {
+  const { restoreOwner } = analyzeStored(stored);
+  const ownedUndo: number[][] = stored.map(() => []);
+  const orphans: number[] = [];
+  for (let k = 0; k < undo.length; k++) {
+    const declared = owners[k];
+    // A declared owner must index a real stored action. Otherwise (a front calc-flush
+    // restore, or a defensively-ignored out-of-range owner) attribute it the way the lattice does.
+    const owner = (typeof declared === "number" && declared >= 0 && declared < stored.length) ?
+      declared :
+      restoreOwner(undo[k]) ?? null;
+    (owner === null ? orphans : ownedUndo[owner]).push(k);
+  }
+  const chunks: LayoutChunk[] = stored.map((s, i) => ({ stored: [s], undo: ownedUndo[i].map(k => undo[k]) }));
+  // Leading: pre-bundle names are legible only ahead of every stored action.
+  if (orphans.length > 0) { chunks.unshift({ stored: [], undo: orphans.map(k => undo[k]) }); }
+  return chunks;
+}
+
+export function chunkByLattice(stored: DocAction[], undo: DocAction[]): LayoutChunk[] {
+  const N = stored.length;
+  const M = undo.length;
+  if (M === 0) { return stored.map(s => ({ stored: [s], undo: [] })); }
+
+  // The expected inverses of each stored action, computed once: the DP asks for
+  // them on every edge, but they depend only on the action.
+  const slotsByStored = stored.map(expectedInverses);
+
+  const { restoreOwner, isGhost } = analyzeStored(stored);
+
+  // Category of an undo entry that matched no expected slot in its chunk. A
+  // defunct-slot restore is free ("none") only in the leading front segment,
+  // where calc-flush insert(0) prepends it; a defunct entry stranded inside a
+  // main chunk is a misplaced real inverse ("shape"), which forces the chunk to
+  // widen. A ghost is an earlier-bundle orphan; anything else relates to a live
+  // slot and must be placed, so discarding it ("shape") is the worst case.
+  const penalize = (g: DocAction, leading: boolean): "none" | "orphan" | "shape" => {
+    if (leading && restoreOwner(g) !== undefined) { return "none"; }
+    return isGhost(g) ? "orphan" : "shape";
+  };
+
+  // Closure of the chunk stored[i..i+a) x undo[j..j+b): a minimum-penalty bag
+  // alignment between the chunk's undo entries and its expected inverses,
+  // returned as the per-edge tiers (shape, missing, orphan, zeros) the DP sums.
+  // `zeros` counts unmatched optional (may-emit-no-undo) slots: a coarsening
+  // that pairs an otherwise-stranded undo across a crossing reduces it, while a
+  // genuine no-op step cannot be paired, so minimizing `zeros` coarsens exactly
+  // the crossings.
+  const closureCost = (i: number, a: number, j: number, b: number):
+  { shape: number; missing: number; orphan: number; zeros: number } => {
+    const slots = slotsByStored.slice(i, i + a).flat();
+    const used = new Array<boolean>(b).fill(false);
+    // Claim the first unused undo entry this slot matches, if any.
+    const take = (test: Slot["test"]): boolean => {
+      for (let q = 0; q < b; q++) {
+        if (!used[q] && test(undo[j + q])) { used[q] = true; return true; }
+      }
+      return false;
+    };
+    let shape = 0, missing = 0, orphan = 0, zeros = 0;
+    for (const slot of slots) {
+      if (take(slot.test)) { continue; }
+      // Unmatched: required -> missing; zero -> empty optional step; routed -> free.
+      if (slot.tier === "required") {
+        missing += 1;
+      } else if (slot.tier === "zero") {
+        zeros += 1;
+      }
+    }
+    // The leading front segment (no stored opened yet) is where insert(0)
+    // calc-flush restores live; only there is a defunct restore free.
+    const leading = a === 0 && i === 0;
+    for (let q = 0; q < b; q++) {
+      if (used[q]) { continue; }
+      const p = penalize(undo[j + q], leading);
+      if (p === "shape") { shape += 1; } else if (p === "orphan") { orphan += 1; }
+    }
+    return { shape, missing, orphan, zeros };
+  };
+
+  // Lexicographic DP over the grid: (cost, zeros, -chunks). Each step is one
+  // chunk, an edge spanning `a` stored by `b` undo. The edge shapes are exactly
+  // the ones the engine emits, listed below rather than swept from a 2 x 2 box:
+  //   [1, 1]  one action and its inverse (the common case).
+  //   [1, 2]  a non-formula RemoveColumn/RemoveTable: a data restore plus the
+  //           schema restore, both at the action's position.
+  //   [1, 0]  an action that emits no undo (a no-op update, removing a row that
+  //           isn't there).
+  //   [0, 1]  a front calc-flush restore, or an earlier-bundle orphan. They sit
+  //           ahead of the aligned region and chain one per edge.
+  //   [2, 2]  the to-data ModifyColumn 2-swap (sandbox useractions.py
+  //           doModifyColumn: pop the ModifyColumn inverse, append the column's
+  //           one data-restore BulkUpdateRecord, re-append the inverse). This is
+  //           the ONLY case whose two undo steps cross, so it is the only
+  //           width-2 edge.
+  // A fuzz sweep over the corpus selects exactly these five and never a wider
+  // span (see ActionSummaryFuzz). Listing them, rather than allowing every shape
+  // up to 2 x 2, makes 2 x 2 visibly the sole reorder, and an undo arriving in
+  // an unexpected shape stays unplaced (a `shape` penalty) instead of being
+  // quietly absorbed by an over-wide edge.
+  const EDGE_SHAPES: readonly [number, number][] = [[1, 1], [1, 2], [1, 0], [0, 1], [2, 2]];
+  // best[i][j] is the optimal path reaching grid point (i, j), or null if
+  // unreached. Each step the DP takes covers one chunk (an edge of the grid).
+  const best: (Node | null)[][] =
+    Array.from({ length: N + 1 }, () => new Array<Node | null>(M + 1).fill(null));
+  best[0][0] = { score: { shape: 0, missing: 0, orphan: 0, zeros: 0, chunks: 0 }, fromI: -1, fromJ: -1 };
+  for (let i = 0; i <= N; i++) {
+    for (let j = 0; j <= M; j++) {
+      const cur = best[i][j];
+      if (cur === null) { continue; }
+      for (const [a, b] of EDGE_SHAPES) {
+        if (a > N - i || b > M - j) { continue; }
+        const ec = closureCost(i, a, j, b);
+        const score: Score = {
+          shape: cur.score.shape + ec.shape,
+          missing: cur.score.missing + ec.missing,
+          orphan: cur.score.orphan + ec.orphan,
+          zeros: cur.score.zeros + ec.zeros,
+          chunks: cur.score.chunks + (a >= 1 ? 1 : 0),
+        };
+        const ti = i + a, tj = j + b;
+        const existing = best[ti][tj];
+        if (existing === null || betterScore(score, existing.score)) {
+          best[ti][tj] = { score, fromI: i, fromJ: j };
+        }
+      }
+    }
+  }
+
+  // Backtrack the chosen edges (each is one chunk).
+  const edges: { i: number; a: number; j: number; b: number }[] = [];
+  let ci = N, cj = M;
+  while (ci !== 0 || cj !== 0) {
+    const node = best[ci][cj]!;
+    edges.push({ i: node.fromI, a: ci - node.fromI, j: node.fromJ, b: cj - node.fromJ });
+    ci = node.fromI; cj = node.fromJ;
+  }
+  edges.reverse();
+
+  // Front/orphan (a = 0) entries: attribute defunct restores to their owning
+  // stored; the rest split by position. In the leading segment (i === 0) an
+  // unattributed entry reads as a front restore and goes to a leading chunk;
+  // one consumed later is an earlier-bundle orphan and stays trailing. For
+  // pre-ownership history the leading reading is a choice; it differs from the
+  // old whole-bundle walk only when the entry's own table was renamed
+  // in-bundle, which that walk handled no better.
+  //
+  // Note an asymmetry with the cost model. closureCost prices an owned restore
+  // as free only on the leading edge (a === 0 && i === 0), yet this pass
+  // attributes owned restores on ANY a === 0 edge. They agree in practice: the
+  // engine prepends calc-flush restores to the front of the undo list, so an
+  // owned restore only ever sits in the leading segment, and the least-cost path
+  // consumes it there (the fuzzer never produces an exception). The attribution
+  // itself routes by owner, not by position, so it
+  // would stay correct even if a future shape landed a restore off-front. Only
+  // the free pricing would be wrong then. That reliance on the engine's
+  // front-loading is intentional.
+  const ownedFront = new Map<number, number[]>();
+  const leadingOrphans: number[] = [];
+  const orphans: number[] = [];
+  for (const e of edges) {
+    if (e.a !== 0) { continue; }
+    for (let q = e.j; q < e.j + e.b; q++) {
+      const owner = restoreOwner(undo[q]);
+      if (owner !== undefined) {
+        getSetMapValue(ownedFront, owner, () => []).push(q);
+      } else if (e.i === 0) {
+        leadingOrphans.push(q);
+      } else {
+        orphans.push(q);
+      }
+    }
+  }
+
+  const chunks: LayoutChunk[] = [];
+  if (leadingOrphans.length > 0) {
+    leadingOrphans.sort((x, y) => x - y);
+    chunks.push({ stored: [], undo: leadingOrphans.map(idx => undo[idx]) });
+  }
+  for (const e of edges) {
+    if (e.a === 0) { continue; }
+    const indices: number[] = [];
+    for (let s = e.i; s < e.i + e.a; s++) { indices.push(...(ownedFront.get(s) ?? [])); }
+    for (let q = e.j; q < e.j + e.b; q++) { indices.push(q); }
+    indices.sort((x, y) => x - y);
+    chunks.push({ stored: stored.slice(e.i, e.i + e.a), undo: indices.map(idx => undo[idx]) });
+  }
+  if (orphans.length > 0) {
+    orphans.sort((x, y) => x - y);
+    chunks.push({ stored: [], undo: orphans.map(idx => undo[idx]) });
+  }
+  return chunks;
+}

--- a/app/common/ActionLayout.ts
+++ b/app/common/ActionLayout.ts
@@ -14,6 +14,10 @@
  * `analyzeStored`, so a front calc-flush restore is attributed to its removal the
  * same way regardless of path.
  *
+ * Either way, `coalesceRecordChunks` then merges adjacent chunks made only of
+ * record actions: splitting exists to separate schema changes, and a run of
+ * plain adds, removes and updates is what a single walk always handled.
+ *
  * One rule both chunkers follow: placement decides how a name is read. Later
  * chunks' renames rekey earlier chunks during composition, so an undo entry's
  * names mean whatever they meant at its chunk's position. A front calc-flush
@@ -49,58 +53,88 @@
  * conversion is the only reordering the engine ever forces, so it is the only
  * wide shape. A fuzz sweep selects exactly these shapes and never a wider one.
  *
- * Cost: with N stored actions and M undo actions (M = O(N), a bounded set of
- * inverses per action), the search fills an (N+1) by (M+1) grid at five shapes
- * per cell -- O(N*M) time and space, quadratic in the action count. Edge pricing
- * compares row lists only after a kind/table match, so the largest action's row
- * count R multiplies in only when many bulk actions share a table (worst case
- * O(N*M*R)); otherwise the row work stays linear in the rows touched. N is small
- * in practice, and the chunker runs once per bundle.
+ * Cost: the least-cost path is found by best-first search (Dijkstra) over the
+ * grid. Edge costs are non-negative, so the search settles points in score order
+ * and stops at the far corner having visited only points scoring no worse than
+ * the answer. A well-formed bundle pairs up at zero cost along a thin band, so
+ * the work is close to linear in the action count; a bundle needing penalties
+ * explores only as far as its penalties reach. Edge pricing tests kind, table and
+ * columns before rows, on sets computed once per action.
  */
 
 import { DocAction, getColIdsFromDocAction, getRowIdsFromDocAction, isDataAction } from "app/common/DocActions";
-import { getSetMapValue, isSubset } from "app/common/gutil";
+import { getSetMapValue } from "app/common/gutil";
 
 export interface LayoutChunk {
   stored: DocAction[];
   undo: DocAction[];
 }
 
+/**
+ * What chunkByLattice reports about its search, for tests. Only an undo shape
+ * the inverse catalogue does not recognize can make the search wander, so the
+ * tests hold `settled` to a small multiple of N + M as a check that the
+ * catalogue matches what the engine emits.
+ */
+export interface LatticeStats {
+  settled: number;   // grid points settled; about N + M for a well-formed bundle
+}
+
 function actKey(t: string, c: string): string { return `${t}/${c}`; }
 
-// Rows / columns a data action touches, as lists; anything else (a schema
-// action) touches neither. The `isDataAction` guard is essential: without it
-// a schema action's payload (a colInfo object, or a name string) would be
-// misread as columns, and its non-row positions as rows.
-function rowsOf(a: DocAction): number[] {
-  return isDataAction(a) ? getRowIdsFromDocAction(a) : [];
+/** Per-action facts the chunkers need, computed once so pricing an edge never rebuilds a set. */
+interface ActionInfo {
+  kind: string;
+  table: string;
+  rows: number[];        // rows a record action touches; empty for a schema action
+  rowSet: Set<number>;
+  cols: string[];        // columns a record action carries values for; empty otherwise
+  colSet: Set<string>;
+  name?: string;         // a schema action's target: the column id, or RenameTable's new name
+  name2?: string;        // RenameColumn's new column id
 }
-function colsOf(a: DocAction): string[] {
-  return isDataAction(a) ? (getColIdsFromDocAction(a) ?? []) : [];
+
+function infoOf(a: DocAction): ActionInfo {
+  // The `isDataAction` guard is essential: without it a schema action's payload
+  // (a colInfo object, or a name string) would be misread as columns, and its
+  // non-row positions as rows.
+  const data = isDataAction(a);
+  const rows = data ? getRowIdsFromDocAction(a) : [];
+  const cols = data ? (getColIdsFromDocAction(a) ?? []) : [];
+  const name = !data && typeof a[2] === "string" ? a[2] : undefined;
+  const name2 = !data && typeof a[3] === "string" ? a[3] : undefined;
+  return { kind: a[0], table: a[1], rows, rowSet: new Set(rows), cols, colSet: new Set(cols), name, name2 };
 }
-// Is every element of `sub` present in `sup`? An update's undo restores a subset
-// of the rows the forward touched -- exactly the rows that had a prior value. So
-// a recompute over all rows pairs with a restore over only the pre-existing rows,
-// and a partial no-op bulk pairs with a restore over only the rows that actually
-// changed. Equality is the common special case.
-function subset<T>(sub: T[], sup: T[]): boolean {
-  return isSubset(new Set(sub), new Set(sup));
+
+// Is every row of `sub` among the rows of `sup`? An update's undo restores a
+// subset of the rows the forward touched -- exactly the rows that had a prior
+// value. So a recompute over all rows pairs with a restore over only the
+// pre-existing rows, and a partial no-op bulk pairs with a restore over only the
+// rows that actually changed. Equality is the common special case.
+function rowsSubset(sub: ActionInfo, sup: ActionInfo): boolean {
+  if (sub.rowSet.size > sup.rowSet.size) { return false; }
+  for (const r of sub.rows) { if (!sup.rowSet.has(r)) { return false; } }
+  return true;
 }
-// Order-blind set equality: equal length plus one-way containment (for matching
-// an inverse's rows or columns against the forward action's).
-function sameSet<T>(a: T[], b: T[]): boolean {
-  return a.length === b.length && subset(a, b);
+// Order-blind set equality of rows (for matching an inverse against its forward).
+function rowsSame(a: ActionInfo, b: ActionInfo): boolean {
+  return a.rowSet.size === b.rowSet.size && rowsSubset(a, b);
+}
+// Order-blind set equality of columns.
+function colsSame(a: ActionInfo, b: ActionInfo): boolean {
+  if (a.colSet.size !== b.colSet.size) { return false; }
+  for (const c of a.cols) { if (!b.colSet.has(c)) { return false; } }
+  return true;
 }
 // True if `a` is a record action with the given verb, single or bulk
 // (`recordKind(a, "Remove")` matches RemoveRecord and BulkRemoveRecord).
-function recordKind(a: DocAction, verb: "Add" | "Remove" | "Update"): boolean {
-  return a[0] === `${verb}Record` || a[0] === `Bulk${verb}Record`;
+function recordKind(a: ActionInfo, verb: "Add" | "Remove" | "Update"): boolean {
+  return a.kind === `${verb}Record` || a.kind === `Bulk${verb}Record`;
 }
 
 // Lattice chunker (the model is in the file header above). The objective is a
-// lexicographic score (see `betterScore` below). Every edge cost is local: it
-// reads only its own two slices plus a precomputed defunct index, so this stays
-// a plain Viterbi-shaped DP.
+// lexicographic score (see `compareScore` below). Every edge cost is local: it
+// reads only its own two slices plus a precomputed defunct index.
 
 /**
  * A path's score, smallest wins, compared as a lexicographic tuple. Tiers, most
@@ -113,18 +147,19 @@ function recordKind(a: DocAction, verb: "Add" | "Remove" | "Update"): boolean {
  *               otherwise-stranded undo across a crossing reduces this, while a
  *               genuine no-op step cannot be paired, so minimizing it below the
  *               validity tiers coarsens exactly the crossings.
- *   5. chunks:  stored-owning chunks, where more is better (finest valid split).
+ *   5. merged:  stored actions merged into a wider chunk (one per action beyond
+ *               the first in each chunk), where fewer is better: the finest
+ *               valid split. Every path covers the same N stored actions, so
+ *               minimizing this is the same as maximizing the chunk count.
  * Explicit tiers, not weighted sums, so no number of lower-tier penalties can
- * ever outweigh one penalty of a more significant tier.
+ * ever outweigh one penalty of a more significant tier. Every tier is a
+ * non-negative sum over edges, which is what lets the search be best-first.
  */
-interface Score { shape: number; missing: number; orphan: number; zeros: number; chunks: number; }
-interface Node { score: Score; fromI: number; fromJ: number; }
-function betterScore(a: Score, b: Score): boolean {
-  if (a.shape !== b.shape) { return a.shape < b.shape; }
-  if (a.missing !== b.missing) { return a.missing < b.missing; }
-  if (a.orphan !== b.orphan) { return a.orphan < b.orphan; }
-  if (a.zeros !== b.zeros) { return a.zeros < b.zeros; }
-  return a.chunks > b.chunks;
+interface Score { shape: number; missing: number; orphan: number; zeros: number; merged: number; }
+const ZERO_SCORE: Score = { shape: 0, missing: 0, orphan: 0, zeros: 0, merged: 0 };
+function compareScore(a: Score, b: Score): number {
+  return (a.shape - b.shape) || (a.missing - b.missing) || (a.orphan - b.orphan) ||
+    (a.zeros - b.zeros) || (a.merged - b.merged);
 }
 
 /**
@@ -137,7 +172,7 @@ function betterScore(a: Score, b: Score): boolean {
  * than this chunk (a formula column's data restore).
  */
 type SlotTier = "required" | "zero" | "routed";
-interface Slot { tier: SlotTier; test: (g: DocAction) => boolean; }
+interface Slot { tier: SlotTier; test: (g: ActionInfo) => boolean; }
 const req = (test: Slot["test"]): Slot => ({ tier: "required", test });
 const zero = (test: Slot["test"]): Slot => ({ tier: "zero", test });
 const routed = (test: Slot["test"]): Slot => ({ tier: "routed", test });
@@ -145,44 +180,46 @@ const routed = (test: Slot["test"]): Slot => ({ tier: "routed", test });
 /**
  * The inverse(s) we expect from a single forward action (the catalogue read
  * from the engine, per the file header). Predicates ignore cell values, so they
- * are local. ModifyColumn deliberately tests only kind+table+col (not which
- * property changed): the conversion's two ModifyColumns on one column are
- * interchangeable for closure, which is exactly why their reversed undo
- * costs nothing inside one chunk.
+ * are local, and test the cheap parts (kind, table, columns) before rows.
+ * ModifyColumn deliberately tests only kind+table+col (not which property
+ * changed): the conversion's two ModifyColumns on one column are interchangeable
+ * for closure, which is exactly why their reversed undo costs nothing inside one
+ * chunk.
  */
-function expectedInverses(s: DocAction): Slot[] {
+function expectedInverses(s: DocAction, si: ActionInfo): Slot[] {
   const k = s[0];
   const t = s[1];
   switch (k) {
     case "AddRecord": case "BulkAddRecord":
-      return [req(g => recordKind(g, "Remove") && g[1] === t && sameSet(rowsOf(g), rowsOf(s)))];
+      return [req(g => recordKind(g, "Remove") && g.table === t && rowsSame(g, si))];
     case "RemoveRecord": case "BulkRemoveRecord":
-      return [zero(g => recordKind(g, "Add") && g[1] === t && subset(rowsOf(g), rowsOf(s)))];
+      return [zero(g => recordKind(g, "Add") && g.table === t && rowsSubset(g, si))];
     case "UpdateRecord": case "BulkUpdateRecord":
-      return [zero(g => recordKind(g, "Update") && g[1] === t &&
-        subset(rowsOf(g), rowsOf(s)) && sameSet(colsOf(g), colsOf(s)))];
+      return [zero(g => recordKind(g, "Update") && g.table === t && colsSame(g, si) && rowsSubset(g, si))];
     case "AddColumn":
-      return [req(g => g[0] === "RemoveColumn" && g[1] === t && g[2] === s[2])];
+      return [req(g => g.kind === "RemoveColumn" && g.table === t && g.name === s[2])];
     case "RemoveColumn":
       return [
-        req(g => g[0] === "AddColumn" && g[1] === t && g[2] === s[2]),
-        routed(g => recordKind(g, "Update") && g[1] === t && colsOf(g).includes(s[2])),
+        req(g => g.kind === "AddColumn" && g.table === t && g.name === s[2]),
+        routed(g => recordKind(g, "Update") && g.table === t && g.colSet.has(s[2])),
       ];
     case "RenameColumn":
-      return [req(g => g[0] === "RenameColumn" && g[1] === t && g[2] === s[3] && g[3] === s[2])];
+      return [req(g => g.kind === "RenameColumn" && g.table === t && g.name === s[3] && g.name2 === s[2])];
     case "ModifyColumn":
-      return [zero(g => g[0] === "ModifyColumn" && g[1] === t && g[2] === s[2])];
+      return [zero(g => g.kind === "ModifyColumn" && g.table === t && g.name === s[2])];
     case "AddTable":
-      return [req(g => g[0] === "RemoveTable" && g[1] === t)];
+      return [req(g => g.kind === "RemoveTable" && g.table === t)];
     case "RemoveTable":
       return [
-        req(g => g[0] === "AddTable" && g[1] === t),
-        routed(g => recordKind(g, "Add") && g[1] === t),
+        req(g => g.kind === "AddTable" && g.table === t),
+        routed(g => recordKind(g, "Add") && g.table === t),
       ];
     case "RenameTable":
-      return [req(g => g[0] === "RenameTable" && g[1] === s[2] && g[2] === s[1])];
+      return [req(g => g.kind === "RenameTable" && g.table === s[2] && g.name === s[1])];
     case "ReplaceTableData":
-      return [zero(g => g[0] === "ReplaceTableData" && g[1] === t)];
+      // Always emitted, even when the table was empty (docactions.ReplaceTableData
+      // appends the old data unconditionally).
+      return [req(g => g.kind === "ReplaceTableData" && g.table === t)];
   }
   // Any other kind (including action kinds outside the DocAction union, such as
   // the engine's internal calc/empty actions, which do flow through here at
@@ -199,12 +236,12 @@ function expectedInverses(s: DocAction): Slot[] {
  */
 interface StoredAnalysis {
   // The defunct-remove stored that owns a front restore entry, or undefined.
-  restoreOwner: (g: DocAction) => number | undefined;
+  restoreOwner: (g: ActionInfo) => number | undefined;
   // A genuine earlier-bundle orphan: a restore whose slot no forward here touches.
-  isGhost: (g: DocAction) => boolean;
+  isGhost: (g: ActionInfo) => boolean;
 }
 
-function analyzeStored(stored: DocAction[]): StoredAnalysis {
+function analyzeStored(stored: DocAction[], infos: ActionInfo[]): StoredAnalysis {
   const N = stored.length;
   // Defunct-slot index plus the set of slots any forward action touches.
   const removeColIdx = new Map<string, number>();
@@ -248,11 +285,11 @@ function analyzeStored(stored: DocAction[]): StoredAnalysis {
       case "AddTable": addTblIdx.set(t, i); break;
       case "RenameTable": renamedTables.add(t); renamedTables.add(s[2]); break;
       case "RemoveRecord": case "BulkRemoveRecord":
-        for (const r of rowsOf(s)) { getSetMapValue(removeRowIdx, t, () => new Map()).set(r, i); } break;
+        for (const r of infos[i].rows) { getSetMapValue(removeRowIdx, t, () => new Map()).set(r, i); } break;
       case "AddRecord": case "BulkAddRecord":
-        for (const r of rowsOf(s)) { getSetMapValue(addRowIdx, t, () => new Map()).set(r, i); } break;
+        for (const r of infos[i].rows) { getSetMapValue(addRowIdx, t, () => new Map()).set(r, i); } break;
     }
-    for (const c of colsOf(s)) { liveCols.add(actKey(t, c)); }
+    for (const c of infos[i].cols) { liveCols.add(actKey(t, c)); }
   }
   // Defunct = removed in this bundle, with any add coming before the removal
   // (a name re-added after it belongs to a new entity). One rule, three lookups.
@@ -273,14 +310,13 @@ function analyzeStored(stored: DocAction[]): StoredAnalysis {
   // removed row whose formula columns were flushed (the row case keeps a
   // removed summary row's aggregates from being stranded after its removal in a
   // later chunk, where composition could no longer fold them in).
-  const restoreOwner = (g: DocAction): number | undefined => {
-    if (renamedTables.has(g[1]) || colsOf(g).some(c => renamedCols.has(c))) { return undefined; }
+  const restoreOwner = (g: ActionInfo): number | undefined => {
+    if (renamedTables.has(g.table) || g.cols.some(c => renamedCols.has(c))) { return undefined; }
     if (recordKind(g, "Update")) {
-      for (const c of colsOf(g)) {
-        if (isColDefunct(g[1], c)) { return removeColIdx.get(actKey(g[1], c)); }
+      for (const c of g.cols) {
+        if (isColDefunct(g.table, c)) { return removeColIdx.get(actKey(g.table, c)); }
       }
-      const rows = rowsOf(g);
-      if (rows.length > 0 && rows.every(r => isRowDefunct(g[1], r))) {
+      if (g.rows.length > 0 && g.rows.every(r => isRowDefunct(g.table, r))) {
         // The engine folds the whole bundle's calc-flush into one restore, so
         // this entry's rows can belong to several distinct removals (two separate
         // RemoveRecords on one table merge here). We return the first row's owner.
@@ -290,21 +326,20 @@ function analyzeStored(stored: DocAction[]): StoredAnalysis {
         // retained [v, v] cell, and that removal composes it into the correct
         // [v, null]. See the "two separate removes share one merged front restore"
         // fuzz scenario.
-        return removeRowIdx.get(g[1])!.get(rows[0]);
+        return removeRowIdx.get(g.table)!.get(g.rows[0]);
       }
     }
-    if (isTblDefunct(g[1])) { return removeTblIdx.get(g[1]); }
+    if (isTblDefunct(g.table)) { return removeTblIdx.get(g.table); }
     return undefined;
   };
 
   // A genuine earlier-bundle orphan: a restore whose slot no forward in
   // this bundle touches.
-  const isGhost = (g: DocAction): boolean => {
+  const isGhost = (g: ActionInfo): boolean => {
     if (recordKind(g, "Update")) {
-      const cols = colsOf(g);
-      if (cols.length > 0 && cols.every(c => !liveCols.has(actKey(g[1], c)))) { return true; }
+      if (g.cols.length > 0 && g.cols.every(c => !liveCols.has(actKey(g.table, c)))) { return true; }
     }
-    return !touchedTables.has(g[1]);
+    return !touchedTables.has(g.table);
   };
 
   return { restoreOwner, isGhost };
@@ -328,7 +363,7 @@ function analyzeStored(stored: DocAction[]): StoredAnalysis {
  */
 export function chunkByOwners(stored: DocAction[], undo: DocAction[],
   owners: readonly (number | null)[]): LayoutChunk[] {
-  const { restoreOwner } = analyzeStored(stored);
+  const { restoreOwner } = analyzeStored(stored, stored.map(infoOf));
   const ownedUndo: number[][] = stored.map(() => []);
   const orphans: number[] = [];
   for (let k = 0; k < undo.length; k++) {
@@ -337,7 +372,7 @@ export function chunkByOwners(stored: DocAction[], undo: DocAction[],
     // restore, or a defensively-ignored out-of-range owner) attribute it the way the lattice does.
     const owner = (typeof declared === "number" && declared >= 0 && declared < stored.length) ?
       declared :
-      restoreOwner(undo[k]) ?? null;
+      restoreOwner(infoOf(undo[k])) ?? null;
     (owner === null ? orphans : ownedUndo[owner]).push(k);
   }
   const chunks: LayoutChunk[] = stored.map((s, i) => ({ stored: [s], undo: ownedUndo[i].map(k => undo[k]) }));
@@ -346,16 +381,68 @@ export function chunkByOwners(stored: DocAction[], undo: DocAction[],
   return chunks;
 }
 
-export function chunkByLattice(stored: DocAction[], undo: DocAction[]): LayoutChunk[] {
+// A grid point reached by the search: best score so far, the edge that reached
+// it, and whether it has been popped with its final score.
+interface Node { score: Score; fromI: number; fromJ: number; settled: boolean; }
+
+// A grid point at the score it was pushed with; stale by pop time if the point
+// was improved since, and then skipped.
+interface HeapEntry { key: number; i: number; j: number; score: Score; }
+
+// Best score first, then lowest (i, j), so the search is deterministic.
+function compareEntries(a: HeapEntry, b: HeapEntry): number {
+  return compareScore(a.score, b.score) || (a.i - b.i) || (a.j - b.j);
+}
+
+class MinHeap {
+  private _items: HeapEntry[] = [];
+  public get size() { return this._items.length; }
+  public push(e: HeapEntry) {
+    const items = this._items;
+    items.push(e);
+    let k = items.length - 1;
+    while (k > 0) {
+      const parent = (k - 1) >> 1;
+      if (compareEntries(items[k], items[parent]) >= 0) { break; }
+      [items[k], items[parent]] = [items[parent], items[k]];
+      k = parent;
+    }
+  }
+
+  public pop(): HeapEntry {
+    const items = this._items;
+    const top = items[0];
+    const last = items.pop()!;
+    if (items.length > 0) {
+      items[0] = last;
+      let k = 0;
+      for (;;) {
+        const l = 2 * k + 1, r = l + 1;
+        let m = k;
+        if (l < items.length && compareEntries(items[l], items[m]) < 0) { m = l; }
+        if (r < items.length && compareEntries(items[r], items[m]) < 0) { m = r; }
+        if (m === k) { break; }
+        [items[k], items[m]] = [items[m], items[k]];
+        k = m;
+      }
+    }
+    return top;
+  }
+}
+
+export function chunkByLattice(stored: DocAction[], undo: DocAction[], testStats?: LatticeStats): LayoutChunk[] {
   const N = stored.length;
   const M = undo.length;
+  if (testStats) { testStats.settled = 0; }
   if (M === 0) { return stored.map(s => ({ stored: [s], undo: [] })); }
 
-  // The expected inverses of each stored action, computed once: the DP asks for
-  // them on every edge, but they depend only on the action.
-  const slotsByStored = stored.map(expectedInverses);
+  const storedInfos = stored.map(infoOf);
+  const undoInfos = undo.map(infoOf);
 
-  const { restoreOwner, isGhost } = analyzeStored(stored);
+  // The expected inverses of each stored action, computed once.
+  const slotsByStored = stored.map((s, i) => expectedInverses(s, storedInfos[i]));
+
+  const { restoreOwner, isGhost } = analyzeStored(stored, storedInfos);
 
   // Category of an undo entry that matched no expected slot in its chunk. A
   // defunct-slot restore is free ("none") only in the leading front segment,
@@ -363,37 +450,38 @@ export function chunkByLattice(stored: DocAction[], undo: DocAction[]): LayoutCh
   // main chunk is a misplaced real inverse ("shape"), which forces the chunk to
   // widen. A ghost is an earlier-bundle orphan; anything else relates to a live
   // slot and must be placed, so discarding it ("shape") is the worst case.
-  const penalize = (g: DocAction, leading: boolean): "none" | "orphan" | "shape" => {
+  const penalize = (g: ActionInfo, leading: boolean): "none" | "orphan" | "shape" => {
     if (leading && restoreOwner(g) !== undefined) { return "none"; }
     return isGhost(g) ? "orphan" : "shape";
   };
 
   // Closure of the chunk stored[i..i+a) x undo[j..j+b): a minimum-penalty bag
   // alignment between the chunk's undo entries and its expected inverses,
-  // returned as the per-edge tiers (shape, missing, orphan, zeros) the DP sums.
-  // `zeros` counts unmatched optional (may-emit-no-undo) slots: a coarsening
-  // that pairs an otherwise-stranded undo across a crossing reduces it, while a
-  // genuine no-op step cannot be paired, so minimizing `zeros` coarsens exactly
-  // the crossings.
+  // returned as the per-edge tiers (shape, missing, orphan, zeros) the search
+  // sums. `zeros` counts unmatched optional (may-emit-no-undo) slots: a
+  // coarsening that pairs an otherwise-stranded undo across a crossing reduces
+  // it, while a genuine no-op step cannot be paired, so minimizing `zeros`
+  // coarsens exactly the crossings.
   const closureCost = (i: number, a: number, j: number, b: number):
   { shape: number; missing: number; orphan: number; zeros: number } => {
-    const slots = slotsByStored.slice(i, i + a).flat();
     const used = new Array<boolean>(b).fill(false);
     // Claim the first unused undo entry this slot matches, if any.
     const take = (test: Slot["test"]): boolean => {
       for (let q = 0; q < b; q++) {
-        if (!used[q] && test(undo[j + q])) { used[q] = true; return true; }
+        if (!used[q] && test(undoInfos[j + q])) { used[q] = true; return true; }
       }
       return false;
     };
     let shape = 0, missing = 0, orphan = 0, zeros = 0;
-    for (const slot of slots) {
-      if (take(slot.test)) { continue; }
-      // Unmatched: required -> missing; zero -> empty optional step; routed -> free.
-      if (slot.tier === "required") {
-        missing += 1;
-      } else if (slot.tier === "zero") {
-        zeros += 1;
+    for (let s = i; s < i + a; s++) {
+      for (const slot of slotsByStored[s]) {
+        if (take(slot.test)) { continue; }
+        // Unmatched: required -> missing; zero -> empty optional step; routed -> free.
+        if (slot.tier === "required") {
+          missing += 1;
+        } else if (slot.tier === "zero") {
+          zeros += 1;
+        }
       }
     }
     // The leading front segment (no stored opened yet) is where insert(0)
@@ -401,13 +489,13 @@ export function chunkByLattice(stored: DocAction[], undo: DocAction[]): LayoutCh
     const leading = a === 0 && i === 0;
     for (let q = 0; q < b; q++) {
       if (used[q]) { continue; }
-      const p = penalize(undo[j + q], leading);
+      const p = penalize(undoInfos[j + q], leading);
       if (p === "shape") { shape += 1; } else if (p === "orphan") { orphan += 1; }
     }
     return { shape, missing, orphan, zeros };
   };
 
-  // Lexicographic DP over the grid: (cost, zeros, -chunks). Each step is one
+  // Best-first search over the grid (see the file header). Each step is one
   // chunk, an edge spanning `a` stored by `b` undo. The edge shapes are exactly
   // the ones the engine emits, listed below rather than swept from a 2 x 2 box:
   //   [1, 1]  one action and its inverse (the common case).
@@ -428,39 +516,48 @@ export function chunkByLattice(stored: DocAction[], undo: DocAction[]): LayoutCh
   // an unexpected shape stays unplaced (a `shape` penalty) instead of being
   // quietly absorbed by an over-wide edge.
   const EDGE_SHAPES: readonly [number, number][] = [[1, 1], [1, 2], [1, 0], [0, 1], [2, 2]];
-  // best[i][j] is the optimal path reaching grid point (i, j), or null if
-  // unreached. Each step the DP takes covers one chunk (an edge of the grid).
-  const best: (Node | null)[][] =
-    Array.from({ length: N + 1 }, () => new Array<Node | null>(M + 1).fill(null));
-  best[0][0] = { score: { shape: 0, missing: 0, orphan: 0, zeros: 0, chunks: 0 }, fromI: -1, fromJ: -1 };
-  for (let i = 0; i <= N; i++) {
-    for (let j = 0; j <= M; j++) {
-      const cur = best[i][j];
-      if (cur === null) { continue; }
-      for (const [a, b] of EDGE_SHAPES) {
-        if (a > N - i || b > M - j) { continue; }
-        const ec = closureCost(i, a, j, b);
-        const score: Score = {
-          shape: cur.score.shape + ec.shape,
-          missing: cur.score.missing + ec.missing,
-          orphan: cur.score.orphan + ec.orphan,
-          zeros: cur.score.zeros + ec.zeros,
-          chunks: cur.score.chunks + (a >= 1 ? 1 : 0),
-        };
-        const ti = i + a, tj = j + b;
-        const existing = best[ti][tj];
-        if (existing === null || betterScore(score, existing.score)) {
-          best[ti][tj] = { score, fromI: i, fromJ: j };
-        }
+  const W = M + 1;
+  const keyOf = (i: number, j: number) => i * W + j;
+  const best = new Map<number, Node>();
+  const heap = new MinHeap();
+  best.set(keyOf(0, 0), { score: ZERO_SCORE, fromI: -1, fromJ: -1, settled: false });
+  heap.push({ key: keyOf(0, 0), i: 0, j: 0, score: ZERO_SCORE });
+  let settledCount = 0;
+  while (heap.size > 0) {
+    const { key, i, j, score } = heap.pop();
+    const node = best.get(key)!;
+    // A stale entry: this point was reached again with a better score since.
+    if (node.settled || compareScore(score, node.score) !== 0) { continue; }
+    node.settled = true;
+    settledCount++;
+    if (i === N && j === M) { break; }
+    for (const [a, b] of EDGE_SHAPES) {
+      if (a > N - i || b > M - j) { continue; }
+      const ec = closureCost(i, a, j, b);
+      const next: Score = {
+        shape: score.shape + ec.shape,
+        missing: score.missing + ec.missing,
+        orphan: score.orphan + ec.orphan,
+        zeros: score.zeros + ec.zeros,
+        merged: score.merged + Math.max(0, a - 1),
+      };
+      const nextKey = keyOf(i + a, j + b);
+      const existing = best.get(nextKey);
+      if (existing === undefined || compareScore(next, existing.score) < 0) {
+        best.set(nextKey, { score: next, fromI: i, fromJ: j, settled: false });
+        heap.push({ key: nextKey, i: i + a, j: j + b, score: next });
       }
     }
   }
+  // The [1, 0] and [0, 1] shapes make the far corner reachable from anywhere, so
+  // the search always settles it before the heap empties.
+  if (testStats) { testStats.settled = settledCount; }
 
   // Backtrack the chosen edges (each is one chunk).
   const edges: { i: number; a: number; j: number; b: number }[] = [];
   let ci = N, cj = M;
   while (ci !== 0 || cj !== 0) {
-    const node = best[ci][cj]!;
+    const node = best.get(keyOf(ci, cj))!;
     edges.push({ i: node.fromI, a: ci - node.fromI, j: node.fromJ, b: cj - node.fromJ });
     ci = node.fromI; cj = node.fromJ;
   }
@@ -490,7 +587,7 @@ export function chunkByLattice(stored: DocAction[], undo: DocAction[]): LayoutCh
   for (const e of edges) {
     if (e.a !== 0) { continue; }
     for (let q = e.j; q < e.j + e.b; q++) {
-      const owner = restoreOwner(undo[q]);
+      const owner = restoreOwner(undoInfos[q]);
       if (owner !== undefined) {
         getSetMapValue(ownedFront, owner, () => []).push(q);
       } else if (e.i === 0) {
@@ -519,4 +616,83 @@ export function chunkByLattice(stored: DocAction[], undo: DocAction[]): LayoutCh
     chunks.push({ stored: [], undo: orphans.map(idx => undo[idx]) });
   }
   return chunks;
+}
+
+const RECORD_KINDS = new Set([
+  "AddRecord", "BulkAddRecord", "RemoveRecord", "BulkRemoveRecord", "UpdateRecord", "BulkUpdateRecord",
+]);
+
+/**
+ * Merge adjacent chunks whose stored actions are all record actions (row adds,
+ * removes and updates). Splitting exists to separate schema changes; a run of
+ * record actions between them is what a single walk always handled, so keeping
+ * it split only multiplies the composition work. A chunk with no stored action
+ * is never merged: its position is what makes its names readable. A merged
+ * chunk's undo keeps bundle order, taken from `undo`, the bundle's full list.
+ *
+ * Two limits keep a merged walk equal to the composition of its parts:
+ *  - Rows. A row added and then removed within one walk reads as recycled, not
+ *    transient, and an add or remove of a row the walk already recorded mixes
+ *    two entities' cells. So a run never adds or removes a row it has already
+ *    touched, nor touches a row it has already added or removed. Updates of the
+ *    same rows, a formula cascade, merge freely.
+ *  - Size. An action over `maxInlineRows` (the summarizer's truncation limit,
+ *    Infinity for none) is left in its own chunk: the walk samples such an
+ *    action, and what the sample covers depends on what shares the walk, so
+ *    merging would change the summary, not only how it is computed. That holds
+ *    for updates too, as the fuzz truncation scenarios check.
+ */
+export function coalesceRecordChunks(chunks: LayoutChunk[], undo: DocAction[],
+  maxInlineRows: number = Infinity): LayoutChunk[] {
+  const position = new Map<DocAction, number>();
+  undo.forEach((u, k) => position.set(u, k));
+  const isUpdate = (a: DocAction) => a[0] === "UpdateRecord" || a[0] === "BulkUpdateRecord";
+  const small = (a: DocAction) => !isDataAction(a) || getRowIdsFromDocAction(a).length <= maxInlineRows;
+  // Per table, rows the current run has touched, and rows it has added or removed.
+  let touched = new Map<string, Set<number>>();
+  let churned = new Map<string, Set<number>>();
+  const conflicts = (chunk: LayoutChunk): boolean => {
+    for (const a of chunk.stored) {
+      if (!isDataAction(a)) { continue; }
+      const churn = !isUpdate(a);
+      for (const r of getRowIdsFromDocAction(a)) {
+        if (churned.get(a[1])?.has(r) || (churn && touched.get(a[1])?.has(r))) { return true; }
+      }
+    }
+    return false;
+  };
+  const note = (chunk: LayoutChunk) => {
+    for (const a of chunk.stored) {
+      if (!isDataAction(a)) { continue; }
+      const rows = getRowIdsFromDocAction(a);
+      const t = getSetMapValue(touched, a[1], () => new Set<number>());
+      for (const r of rows) { t.add(r); }
+      if (!isUpdate(a)) {
+        const c = getSetMapValue(churned, a[1], () => new Set<number>());
+        for (const r of rows) { c.add(r); }
+      }
+    }
+  };
+  const out: LayoutChunk[] = [];
+  const merged = new Set<LayoutChunk>();
+  let run: LayoutChunk | null = null;
+  for (const chunk of chunks) {
+    const mergeable = chunk.stored.length > 0 && chunk.stored.every(s => RECORD_KINDS.has(s[0])) &&
+      chunk.stored.every(small) && chunk.undo.every(small);
+    if (mergeable && run && !conflicts(chunk)) {
+      run.stored.push(...chunk.stored);
+      run.undo.push(...chunk.undo);
+      merged.add(run);
+      note(chunk);
+      continue;
+    }
+    touched = new Map(); churned = new Map();
+    run = mergeable ? { stored: [...chunk.stored], undo: [...chunk.undo] } : null;
+    if (run) { note(chunk); }
+    out.push(run ?? chunk);
+  }
+  for (const chunk of merged) {
+    chunk.undo.sort((x, y) => (position.get(x) ?? 0) - (position.get(y) ?? 0));
+  }
+  return out;
 }

--- a/app/common/ActionSummarizer.ts
+++ b/app/common/ActionSummarizer.ts
@@ -1,4 +1,5 @@
 import { getEnvContent, LocalActionBundle } from "app/common/ActionBundle";
+import { chunkByLattice, chunkByOwners } from "app/common/ActionLayout";
 import { ActionSummary, ColumnDelta, createEmptyActionSummary,
   createEmptyTableDelta, defunctTableName, LabelDelta, TableDelta } from "app/common/ActionSummary";
 import { DocAction } from "app/common/DocActions";
@@ -9,10 +10,47 @@ import { CellDelta } from "app/common/TabularDiff";
 
 import clone from "lodash/clone";
 import fromPairs from "lodash/fromPairs";
+import isEqual from "lodash/isEqual";
 import keyBy from "lodash/keyBy";
-import sortBy from "lodash/sortBy";
 import toPairs from "lodash/toPairs";
 import values from "lodash/values";
+
+/**
+ * Building and composing ActionSummaries.
+ *
+ * An ActionSummary is the NET difference between two document states: which
+ * tables, columns, and rows were added, removed, renamed, or changed, and for
+ * the cells we keep, the value before and after. "Net" is the point: change a
+ * cell and change it straight back, and the summary shows nothing.
+ *
+ * How a summary is represented:
+ *  - Cells: a `[before, after]` pair. Each side is a wrapped value like `["x"]`,
+ *    or `null` (the cell did not exist at that end, e.g. its row or column was
+ *    added or removed within the span), or `"?"` (unknown; see incomplete below).
+ *  - Rows: each row id's story is told by which of `addRows` / `removeRows` /
+ *    `updateRows` it lands in. In both add and remove means recycled: the id held
+ *    one entity, then a different one, so their cells must not be merged.
+ *  - Names: table and column renames are `[before, after]` pairs (a `null` side
+ *    is an add or a remove). A removed column's cells are keyed under a
+ *    `-`-prefixed name, so they don't collide with a new column reusing the name.
+ *
+ * Composing two summaries (concatenateSummaryPair) is value-preserving: it keeps
+ * a cell that looks like no change (`[v, v]`), because a later merge can make
+ * that value matter. If a row is removed later, its old value is what shows up as
+ * "this was here and now it's gone". Such cells are dropped only at the end, by
+ * canonicalizeSummary, when the summary is read for display or comparison.
+ * Recycled rows and `"?"` are the deliberate exceptions: their equal-looking
+ * cells are real, not noise.
+ *
+ * Incomplete summaries: a bulk change over many rows is recorded only up to
+ * `maximumInlineRows`. Past that the summary keeps a sample and sets
+ * `mayBeIncomplete`, and a missing cell then reads as `"?"` (unknown) rather than
+ * "absent". Composition keeps `"?"` instead of resolving it either way.
+ *
+ * A single bundle that carries several schema changes at once is first split by
+ * the chunker (see ActionLayout) into pieces that each summarize cleanly; the
+ * per-piece summaries are then composed here.
+ */
 
 /**
  * The default maximum number of rows in a single bulk change that will be recorded
@@ -35,6 +73,12 @@ export interface ActionSummaryOptions {
    * `maximumInlineRows`.
    */
   alwaysPreserveColIds?: string[];
+  /**
+   * Ignore any per-undo ownership the engine recorded with the bundle and infer
+   * the chunk boundaries instead (the `chunkByLattice` path). Off by default, so
+   * when ownership is present it is used. Mainly for testing both paths agree.
+   */
+  ignoreUndoGrouping?: boolean;
 }
 
 export class ActionSummarizer {
@@ -253,10 +297,49 @@ export class ActionSummarizer {
  * that will be suitable for composition.
  */
 export function summarizeAction(body: LocalActionBundle, options?: ActionSummaryOptions): ActionSummary {
-  return summarizeStoredAndUndo(getEnvContent(body.stored), body.undo, options);
+  return summarizeStoredAndUndo(getEnvContent(body.stored), body.undo, options, body.undoOwner);
 }
 
+/**
+ * Build an ActionSummary from a flat (stored, undo) pair.
+ *
+ * A whole-bundle forward/reverse walk commits too early when a single bundle
+ * carries several schema changes (say, multiple renames, or a remove-then-readd
+ * at one slot). The walk can't tell an intermediate name or value, one that
+ * appeared and vanished inside the bundle, from the real before-and-after. So we
+ * first split the bundle into sub-bundles (see ActionLayout), summarize each one
+ * on its own with the walk, and compose the per-chunk summaries with
+ * `concatenateSummaries`. The chunker is here for correctness on multi-change
+ * bundles, not for speed.
+ *
+ * If the bundle carries the engine's per-undo ownership (`undoOwner`, parallel to
+ * `undo`), we chunk by it (`chunkByOwners`); otherwise by `chunkByLattice`. The
+ * lattice is the common case, not a relic: it covers all history from before
+ * ownership was added (immutable, recomputed lazily on read), plus engine-less
+ * bundles. `ignoreUndoGrouping` forces it for testing. Both feed the same walk
+ * and composition, so they agree (checked over the fuzz corpus).
+ *
+ * Aside: very old bundles (pre-~2017) recorded `stored` as only the user-facing
+ * action, with `undo` carrying the metadata-side inverses too. Neither chunker
+ * can attribute those, so they fall into a leading or trailing orphan chunk
+ * (stored=[], by position; see ActionLayout's header) and merge back as the old
+ * whole-bundle walk did.
+ *
+ * The input arrays and their action contents are not mutated.
+ */
 export function summarizeStoredAndUndo(stored: DocAction[], undo: DocAction[],
+  options?: ActionSummaryOptions, undoOwner?: readonly (number | null)[] | null): ActionSummary {
+  // `Array.isArray`, not just a presence check: a bundle round-tripped through the action history
+  // marshaller turns an absent owner list into null, and an older bundle omits it entirely.
+  const useOwners = Array.isArray(undoOwner) && undoOwner.length === undo.length &&
+    !options?.ignoreUndoGrouping;
+  const chunks = useOwners ? chunkByOwners(stored, undo, undoOwner) : chunkByLattice(stored, undo);
+  const summaries = chunks.map(c => summarizeChunkWalked(c.stored, c.undo, options));
+  return concatenateSummaries(summaries);
+}
+
+/** Walk one (stored, undo) chunk into a chunk-local ActionSummary. */
+function summarizeChunkWalked(stored: DocAction[], undo: DocAction[],
   options?: ActionSummaryOptions): ActionSummary {
   const summarizer = new ActionSummarizer(options);
   const summary = createEmptyActionSummary();
@@ -311,6 +394,37 @@ interface NameMerge {
 }
 
 /**
+ * Canonical presentation order for rename entries: sorted by pre-name
+ * ascending, with null pre-names (additions) after all non-null pre-names.
+ * Entries with equal pre-name (only possible when both
+ * pre-names are null, since non-null pre-names are injective) are tie-broken
+ * by post-name ascending, so the order is total and grouping-independent.
+ */
+function compareLabelDelta(a: LabelDelta, b: LabelDelta): number {
+  const [a0, a1] = a;
+  const [b0, b1] = b;
+  if (a0 !== b0) {
+    if (a0 === null) { return 1; }   // additions sort last
+    if (b0 === null) { return -1; }
+    return a0 < b0 ? -1 : 1;
+  }
+  const x = a1 === null ? "" : a1;
+  const y = b1 === null ? "" : b1;
+  return x < y ? -1 : x > y ? 1 : 0;
+}
+
+/**
+ * Put a rename list into canonical form: drop identity renames ([c, c], which
+ * arise from a name renamed away and back within scope) and sort into the stable
+ * presentation order so equivalent summaries always serialize the same way.
+ */
+function canonicalizeRenames(renames: LabelDelta[]): LabelDelta[] {
+  return [...renames]
+    .filter(([pre, post]) => !(pre !== null && pre === post))
+    .sort(compareLabelDelta);
+}
+
+/**
  * Looks at a pair of name change lists (could be tables or columns) and figures out what
  * changes would need to be made to a data structure keyed on those names in order to key
  * it consistently on final names.
@@ -325,11 +439,16 @@ function planNameMerge(names1: LabelDelta[], names2: LabelDelta[]): NameMerge {
   };
   const names1ByFinalName: { [name: string]: LabelDelta } = keyBy(names1, p => p[1]!);
   const names2ByInitialName: { [name: string]: LabelDelta } = keyBy(names2, p => p[0]!);
+  const names2ByFinalName: { [name: string]: LabelDelta } = keyBy(names2, p => p[1]!);
   for (const [before1, after1] of names1) {
     if (!after1) {
       if (!before1) { throw new Error("invalid name change found"); }
-      // Table/column was deleted in part 1.
-      result.dead1.add(before1);
+      // Table/column was deleted in part 1. Its delta is already keyed under
+      // the defunct name (-before1), so we only need to drop a stale entry
+      // under the live name -- unless `before1` was also re-added in part 1
+      // (a recycle), in which case the live `before1` key holds a distinct
+      // new entity that must be preserved.
+      if (!names1ByFinalName[before1]) { result.dead1.add(before1); }
       result.merge.push([before1, null]);
       continue;
     }
@@ -342,11 +461,21 @@ function planNameMerge(names1: LabelDelta[], names2: LabelDelta[]): NameMerge {
     }
     const after2 = pair2[1];
     if (!after2) {
-      // Table/column was deleted in part 2.
-      result.dead2.add(after1);
+      // Table/column was deleted in part 2. Its delta is keyed under the
+      // defunct name there, so only mark the live name dead unless `after1`
+      // was also re-added in part 2 (a recycle), where the live `after1` key
+      // holds a distinct new entity that must be preserved.
+      if (!names2ByFinalName[after1]) { result.dead2.add(after1); }
       if (before1) {
-        // Table/column existed prior to part 1, so we need to expose its history.
-        result.dead1.add(before1);
+        // Table/column existed prior to part 1 (as `before1`), was renamed to
+        // `after1` during part 1, and removed during part 2. In the combined
+        // scope it is removed, so its delta keys under the defunct name of its
+        // original name. Rekey part 1's delta (keyed by `after1`) and part 2's
+        // defunct delta (keyed by `-after1`) onto that final defunct key, so
+        // the row/cell history merges in rather than being stranded or dropped.
+        const finalKey = defunctTableName(before1);
+        result.rename1.set(after1, finalKey);
+        result.rename2.set(defunctTableName(after1), finalKey);
         result.merge.push([before1, null]);
       } else {
         // Table/column did not exist prior to part 1, so we erase it from history.
@@ -367,10 +496,20 @@ function planNameMerge(names1: LabelDelta[], names2: LabelDelta[]): NameMerge {
     result.merge.push([before2, after2]);
     // If table/column is renamed in part 2, and name was stable in part 1,
     // rekey any information about it in part 1.
-    if (before2 && after2) { result.rename1.set(before2, after2); }
+    if (before2 && after2) {
+      result.rename1.set(before2, after2);
+    } else if (before2 && !after2) {
+      // Removed in part 2, but stable (data-only delta, or untouched) in part 1.
+      // Part 1's delta is keyed by the live name `before2`; rekey it onto the
+      // defunct name so it merges with part 2's defunct delta rather than being
+      // stranded under a name that no longer exists in the combined scope.
+      result.rename1.set(before2, defunctTableName(before2));
+    }
   }
-  // For neatness, sort the merge order. Not essential.
-  result.merge = sortBy(result.merge, ([a, b]) => [a || "", b || ""]);
+  // Canonical rename order. This matters: the same order must
+  // result whether a delta was merged here or copied through untouched, or
+  // composition would not be associative on presentation.
+  result.merge.sort(compareLabelDelta);
   return result;
 }
 
@@ -383,11 +522,15 @@ function planNameMerge(names1: LabelDelta[], names2: LabelDelta[]): NameMerge {
  * @param entries: a dictionary of nested data - TableDeltas for tables, ColumnDeltas for columns.
  * @param dead: a set of keys to remove from the dictionary.
  * @param rename: changes of names to apply to the dictionary.
+ * @param mergeOnCollision: how to combine a renamed entry with a distinct entry
+ *   already occupying the target key (see below); without it, the renamed entry
+ *   overwrites and the occupant's data is lost.
  *
  * entries may be modified, and if so will be shallow-copied.
  */
 function renameAndDelete<T>(entries: CopyOnWrite<{ [name: string]: T }>, dead: Set<string>,
-  rename: Map<string, string>) {
+  rename: Map<string, string>,
+  mergeOnCollision?: (incoming: T, existing: CopyOnWrite<T>) => T) {
   if (!(dead.size || rename.size)) {
     return;
   }
@@ -403,9 +546,22 @@ function renameAndDelete<T>(entries: CopyOnWrite<{ [name: string]: T }>, dead: S
       delete entriesCopy[key];
     }
   }
-  // Move all renamed entries back in with their new names.
+  // Move all renamed entries back in with their new names. If the target name
+  // is still occupied by a distinct (non-renamed) entry, that entry and the
+  // renamed one are two facets of the same final entity -- e.g. a table whose
+  // data was recorded under its post-rename name by a calc-flush restore while
+  // its removal was recorded under the pre-rename name. They have to merge, not
+  // overwrite, or the occupant's rows/cells are dropped (breaking composition
+  // associativity). The renamed entry carried the old name, so it is the
+  // earlier facet (e1); the occupant carried the new name (e2).
   for (const [key, val] of rename.entries()) {
-    if (cache[key]) { entriesCopy[val] = cache[key]; }
+    if (!cache[key]) { continue; }
+    if (entriesCopy[val] !== undefined && mergeOnCollision) {
+      const existing = copyOnWrite(entriesCopy[val]);
+      entriesCopy[val] = mergeOnCollision(cache[key], existing);
+    } else {
+      entriesCopy[val] = cache[key];
+    }
   }
 }
 
@@ -423,17 +579,28 @@ function renameAndDelete<T>(entries: CopyOnWrite<{ [name: string]: T }>, dead: S
 function mergeNames<T>(names: NameMerge,
   entries1: { [name: string]: T },
   entries2: CopyOnWrite<{ [name: string]: T }>,
-  mergeEntry: (e1: T, e2: CopyOnWrite<T>) => T): { [name: string]: T } {
+  mergeEntry: (e1: T, e2: CopyOnWrite<T>) => T,
+  transformOrphan?: (e1: T) => T): { [name: string]: T } {
   const entries1Wrapper = copyOnWrite(entries1);
   // Update the keys of the entries1 and entries2 dictionaries to be consistent.
-  renameAndDelete(entries1Wrapper, names.dead1, names.rename1);
-  renameAndDelete(entries2, names.dead2, names.rename2);
+  // A rename whose target key is already occupied merges rather than overwrites
+  // (see renameAndDelete), using the same composition as the cross-part merge.
+  renameAndDelete(entries1Wrapper, names.dead1, names.rename1, mergeEntry);
+  renameAndDelete(entries2, names.dead2, names.rename2, mergeEntry);
 
   // Prepare the composition of the two dictionaries.
   const entries = entries2;                // Start with the second dictionary.
   for (const key of Object.keys(entries1Wrapper.read())) {  // Add material from the first.
     const e1 = entries1Wrapper.read()[key];
-    if (!entries.read()[key]) { entries.write()[key] = e1;  continue; }  // No overlap - just add and move on.
+    if (!entries.read()[key]) {
+      // entries1 has this key, entries2 does not. entries2's part-2 may
+      // still carry row-level changes (notably row removals) that must
+      // apply -- a removed row has no cells afterward. Those
+      // changes aren't in this missing entry, so transformOrphan lets the
+      // caller apply them; otherwise the entry is added unchanged.
+      entries.write()[key] = transformOrphan ? transformOrphan(e1) : e1;
+      continue;
+    }
     const e2cow = copyOnWrite(entries.read()[key]);
     const result = mergeEntry(e1, e2cow);
     if (e2cow.hasWrite()) {
@@ -487,30 +654,36 @@ function mergeColumn(present1: RowChanges, present2: RowChanges,
     let v1 = e1[key];
     let v2 = e2.read()[key];
     if (!v1 && !v2) { continue; }
-    if (present1[key].added && present2[key]?.removed) {
+    // Drop the cell only if the row is added in e1 and removed in e2, and not
+    // the reverse in either: then it is empty at both ends and never really
+    // existed. Judge by the two parts together. A row both added and removed in
+    // e1 was already there at the start, so keep its old value. And if either
+    // part may be incomplete, a missing cell could be hiding a reused row id, so
+    // don't drop it then.
+    const t1 = present1[key], t2 = present2[key];
+    if (t1.added && !t1.removed && t2?.removed && !t2?.added && !incomplete1 && !incomplete2) {
       delete e2.write()[key];
       continue;
     }
-    // A row marked "updated" in a side whose cellDelta has no entry for
-    // this column can mean two things: the column was untouched (and we
-    // can recover the value from the other side) or the summarizer
-    // deliberately dropped the cell to stay under `maximumInlineRows` (so
-    // '?' is the accurate answer). If the source summary's
-    // mayBeIncomplete flag is unset, we know it's the first case and can
-    // recover. If it's set, we don't know which case it is, and have to
-    // err on the side of uncertainty.
+    // A row marked "updated" on a side that has no cell here means one of two
+    // things: the column simply wasn't touched (so the value lives on the other
+    // side and we can copy it over), or the summarizer dropped the cell to keep a
+    // large bulk change small (so "?" for unknown is the right answer). If that
+    // side is not flagged incomplete, it's the first case and we recover the
+    // value. If it is, we can't tell, so we keep it unknown.
     const v1Untouched = v1 === undefined && !incomplete1;
     const v2Untouched = v2 === undefined && !incomplete2;
-    v1 = v1 || bulkCellFor(present1[key]);
-    v2 = v2 || bulkCellFor(present2[key]);
+    v1 = v1 || bulkCellFor(t1);
+    v2 = v2 || bulkCellFor(t2);
     if (!v2)    { e2.write()[key] = e1[key]; continue; }
     if (!v1[1]) {
-      // Row was deleted in e1. If it was re-added in e2 (remove-then-add,
-      // e.g., row ID recycling), carry the old value from e1 forward so the
-      // deleted row's original values are preserved in the comparison.
-      // Only do this when the row was specifically removed (not just added
-      // without values for this column).
-      if (present1[key].removed && v2[1]) {
+      // e1 deleted the row and kept its old value in v1[0]. That is the value at
+      // the start of the whole span, so keep it as the "before", whatever e2 does
+      // next: if e2 re-adds the row we get [old, new]; if e2 also removes it (or
+      // leaves it gone) we get [old, null], the original value, still removed. We
+      // only do this when e1 genuinely removed the row (a row merely added in e1
+      // with no value here has nothing to carry).
+      if (t1.removed) {
         e2.write()[key] = [v1[0], v2[1]];
       }
       continue;
@@ -556,37 +729,82 @@ function mergeTable(e1: TableDelta,  e2: CopyOnWrite<TableDelta>): TableDelta {
   const e2td = e2.read();
   const names = planNameMerge(e1.columnRenames, e2td.columnRenames);
   const columnDeltasCow = copyOnWrite(e2td.columnDeltas);
+  // A column that exists only in part 1 must still feel part 2's row removals.
+  // A deleted row has no cells afterward, so when part 2 genuinely
+  // removes a row (removed and not re-added), clear the post side of that column's
+  // cell for it. We touch only those cells, never the pre side or other rows.
+  //
+  // Rows recycled in part 2 (removed AND re-added) are deliberately left alone,
+  // and that is safe. The walk records a removal on the pre side only
+  // (addReverseAction, direction 0), so a removed row's post is already null on
+  // every column. By the time a row is recycled its orphan-column cell therefore
+  // reads [pre, null] anyway: no stale post to clear, and the new entity (which
+  // part 2 never set here) is correctly absent.
+  const removedInE2 = new Set(e2td.removeRows);
+  for (const r of e2td.addRows) { removedInE2.delete(r); }
+  const applyRemovalsToOrphanColumn = (col: ColumnDelta): ColumnDelta => {
+    let out: ColumnDelta | undefined;
+    for (const rowId of Object.keys(col) as unknown as number[]) {
+      if (removedInE2.has(Number(rowId)) && col[rowId][1] !== null) {
+        out = out || { ...col };
+        out[rowId] = [col[rowId][0], null];
+      }
+    }
+    return out || col;
+  };
   mergeNames(names, e1.columnDeltas, columnDeltasCow,
     mergeColumn.bind(null,
       getRowChanges(e1),
       getRowChanges(e2td),
       e1.mayBeIncomplete,
-      e2td.mayBeIncomplete));
-  if (columnDeltasCow.hasWrite()) {
-    e2.write();
-    e2.read().columnDeltas = columnDeltasCow.read();
-  }
+      e2td.mayBeIncomplete),
+    applyRemovalsToOrphanColumn);
   const columnRenames = names.merge;
   // All the columnar data is now merged.  What remains is to merge the summary lists of rowIds
   // that we maintain.
-  const addRows1 = new Set(e1.addRows);       // Non-transient rows we have clearly added.
-  const removeRows2 = new Set(e2.read().removeRows); // Non-transient rows we have clearly removed.
-  const transients = e1.addRows.filter(x => removeRows2.has(x));
-  const addRows = uniqueAndSorted([...e2.read().addRows, ...e1.addRows.filter(x => !removeRows2.has(x))]);
-  const removeRows = uniqueAndSorted([...e2.read().removeRows.filter(x => !addRows1.has(x)), ...e1.removeRows]);
+  const addRows1 = new Set(e1.addRows);
+  const removeRows2 = new Set(e2.read().removeRows);
+  const e1Removed = new Set(e1.removeRows);
+  const e2Added = new Set(e2.read().addRows);
+  // A transient row is one added and then removed across the two parts, so it is
+  // empty at both ends and never really existed. Judge that by the two parts
+  // together: it must be added (not removed) in e1 and removed (not added) in e2.
+  // A row both added and removed in e1 was already there at the start, so a
+  // removal in e2 leaves it removed, not transient -- calling it transient would
+  // drop its old value and break associativity. A row re-added in e2 isn't
+  // transient either.
+  const transients = e1.addRows.filter(
+    x => removeRows2.has(x) && !e1Removed.has(x) && !e2Added.has(x));
+  let addRows = uniqueAndSorted([...e2.read().addRows, ...e1.addRows.filter(x => !removeRows2.has(x))]);
+  let removeRows = uniqueAndSorted([...e2.read().removeRows.filter(x => !addRows1.has(x)), ...e1.removeRows]);
   const updateRows = uniqueAndSorted([...e1.updateRows.filter(x => !removeRows2.has(x)),
     ...e2.read().updateRows.filter(x => !addRows1.has(x))]);
-  // Remove all traces of transients (rows that were created and destroyed) from history.
-  if (transients.length) {
-    for (const [colId, columnDelta] of Object.entries(e2.read().columnDeltas)) {
+  if (e1.mayBeIncomplete || e2td.mayBeIncomplete) {
+    // Transient collapse is unsafe when cells may have been
+    // dropped -- the absent cells could be a truncated `recycled` row rather
+    // than a genuine transient. Keep such rows in both lists (recycled) and
+    // keep their cells, instead of erasing them.
+    addRows = uniqueAndSorted([...addRows, ...transients]);
+    removeRows = uniqueAndSorted([...removeRows, ...transients]);
+  } else if (transients.length) {
+    // Complete summary: erase all traces of transient rows from history. Write
+    // through columnDeltasCow (not e2.read().columnDeltas) so the erase lands on
+    // a private clone: e2.write() is a shallow copy whose .columnDeltas still
+    // aliases the caller's input until columnDeltasCow is written back below.
+    for (const [colId, columnDelta] of Object.entries(columnDeltasCow.read())) {
       const updatedColumnDelta = copyOnWrite(columnDelta);
       for (const rowId of transients) {
         delete updatedColumnDelta.write()[rowId];
       }
       if (updatedColumnDelta.hasWrite()) {
-        e2.write().columnDeltas[colId] = updatedColumnDelta.read();
+        columnDeltasCow.write()[colId] = updatedColumnDelta.read();
       }
     }
+  }
+  // Write the merged column deltas back once, onto a private copy (the shallow
+  // e2.write() shares the columnDeltas dict with the caller's input otherwise).
+  if (columnDeltasCow.hasWrite()) {
+    e2.write().columnDeltas = columnDeltasCow.read();
   }
   // We unconditionally write at this level.
   Object.assign(e2.write(), {
@@ -601,25 +819,246 @@ function mergeTable(e1: TableDelta,  e2: CopyOnWrite<TableDelta>): TableDelta {
   return e2.read();
 }
 
-/** Finally, merge a pair of summaries. */
+/**
+ * A cell pair is vacuous when its two sides are equal: it records no
+ * change. Covers `[null, null]` (cell absent at both endpoints) and
+ * `[[v], [v]]` (same value before and after). A `"?"` side is never
+ * vacuous (it asserts an unknown change, not "no change").
+ */
+function cellIsVacuous(c: CellDelta): boolean {
+  const [pre, post] = c;
+  if (pre === "?" || post === "?") { return false; }
+  if (pre === null && post === null) { return true; }
+  if (pre === null || post === null) { return false; }
+  return isEqual(pre, post);   // [v] vs [v]
+}
+
+function isEmptyTableDelta(td: TableDelta): boolean {
+  return td.addRows.length === 0 && td.removeRows.length === 0 &&
+    td.updateRows.length === 0 && td.columnRenames.length === 0 &&
+    Object.keys(td.columnDeltas).length === 0 && !td.mayBeIncomplete;
+}
+
+/**
+ * Settle a freshly merged TableDelta: the structural cleanup every merge
+ * needs and the next merge relies on. It
+ *  - fixes a cell side to "absent" at an existence boundary (a row or column
+ *    that did not exist at that endpoint);
+ *  - re-keys a removed column's cells onto its `-`-prefixed defunct name, which
+ *    `planNameMerge` then assumes is already in place;
+ *  - resolves a stray `"?"` to absent in a complete summary;
+ *  - drops `[null, null]` cells (no value at either end);
+ *  - derives `updateRows` from the cells, so it does not depend on merge order;
+ *  - puts renames and row lists in canonical order.
+ * It keeps an insignificant `[v, v]` cell: a later merge can turn that value
+ * into the "before" of a removal, so it can't be dropped yet.
+ * `canonicalizeTableDelta` drops those once merging is done.
+ */
+function settleTableDelta(td: TableDelta): TableDelta {
+  const incomplete = Boolean(td.mayBeIncomplete);
+  // Existence boundaries fix a cell side to "absent": a cell has
+  // no value at an endpoint where its row or column did not exist there.
+  //  - a column added in scope (a `[null, name]` rename) has no pre value;
+  //  - a defunct column (keyed by its `-`-prefixed name) has no post value;
+  //  - a row added in scope (in addRows, not also removed) has no pre value;
+  //  - a row removed in scope (in removeRows, not also re-added) has no post.
+  // Recycled rows (in both lists) are per-entity and exempt from the row
+  // rules. Enforcing these fixes composition that synthesized a stray `"?"`
+  // at such a boundary, and lets the later vacuous-cell drop clear anything
+  // that thereby becomes `[null, null]`.
+  const addedCols = new Set(td.columnRenames.filter(([pre]) => pre === null).map(([, post]) => post));
+  const removeSet = new Set(td.removeRows);
+  const addSet = new Set(td.addRows);
+  const addedRows = new Set(td.addRows.filter(r => !removeSet.has(r)));
+  const removedRows = new Set(td.removeRows.filter(r => !addSet.has(r)));
+  // Delta keying: a removed column's cells key under its
+  // `-`-prefixed pre-name, never the now-defunct live name. The walk can leave
+  // a cell under the live name (e.g. for a row removed before the column went
+  // defunct), and `planNameMerge` assumes the defunct keying is already in
+  // place, so enforce it here: re-key any `[pre, null]` column's live-name
+  // cells onto `-pre`, merging with an already-canonical entry (which wins).
+  // A column whose live name is occupied by a distinct entity must not have
+  // that entity's cells re-keyed onto the defunct name. That happens two ways:
+  //  - the name is re-added ([null, pre]); or
+  //  - the name is a rename target ([x, pre]): something was renamed into it,
+  //    so the live `pre` key holds the renamed-in column, not the removed one.
+  // Only a column removed and neither re-added nor renamed-into has its cells
+  // re-keyed onto `-pre`.
+  const renameTargets = new Set(
+    td.columnRenames.filter(([pre, post]) => pre !== null && post !== null).map(([, post]) => post));
+  const removedCols = new Map<string, string>();
+  for (const [pre, post] of td.columnRenames) {
+    if (pre !== null && post === null && !addedCols.has(pre) && !renameTargets.has(pre)) {
+      removedCols.set(pre, defunctTableName(pre));
+    }
+  }
+  let sourceDeltas = td.columnDeltas;
+  if (removedCols.size > 0 && Object.keys(td.columnDeltas).some(c => removedCols.has(c))) {
+    sourceDeltas = {};
+    // Canonical (non-remapped) keys first, so an existing `-pre` entry wins on
+    // any row collision with a stranded live-name cell.
+    const entries = Object.entries(td.columnDeltas)
+      .sort((a, b) => (removedCols.has(a[0]) ? 1 : 0) - (removedCols.has(b[0]) ? 1 : 0));
+    for (const [colId, cd] of entries) {
+      const target = removedCols.get(colId) ?? colId;
+      const dest = sourceDeltas[target] ?? (sourceDeltas[target] = {});
+      for (const [rowId, cell] of Object.entries(cd)) {
+        const r = Number(rowId);
+        if (!(r in dest)) { dest[r] = cell; }
+      }
+    }
+  }
+  const columnDeltas: { [colId: string]: ColumnDelta } = {};
+  for (const [colId, cd] of Object.entries(sourceDeltas)) {
+    const colNoPre = addedCols.has(colId);
+    const colNoPost = colId.startsWith("-");
+    const kept: ColumnDelta = {};
+    for (const [rowId, cell] of Object.entries(cd)) {
+      const r = Number(rowId);
+      const noPre = colNoPre || addedRows.has(r);
+      const noPost = colNoPost || removedRows.has(r);
+      let pre = noPre ? null : cell[0];
+      let post = noPost ? null : cell[1];
+      // A complete summary carries no unknowns: `"?"` only appears
+      // when the `mayBeIncomplete` flag permits dropped detail. When that flag
+      // is unset, any `"?"` is a composition artifact (a value the summary
+      // never recorded, e.g. an omitted default) with no recoverable value, so
+      // resolve it to absent. When the flag is set, `"?"` is meaningful and
+      // kept.
+      if (!incomplete) {
+        if (pre === "?") { pre = null; }
+        if (post === "?") { post = null; }
+      }
+      // `[null, null]` carries no value, so drop it. Keep everything else,
+      // including an insignificant `[v, v]`: a later merge may still need `v`.
+      if (pre === null && post === null) { continue; }
+      kept[r] = [pre, post];
+    }
+    if (Object.keys(kept).length > 0) { columnDeltas[colId] = kept; }
+  }
+  let updateRows = td.updateRows;
+  if (!incomplete) {
+    // A row is `updated` iff it persisted (not net-added, not net-removed) and
+    // its contents changed -- i.e. it carries a cell delta (section 3: contents
+    // changes live in cells, not a separate flag). Derive it from the cells
+    // rather than filtering the accumulated list, so it is associative: the
+    // accumulated updateRows can differ by composition order, the cells cannot.
+    // (Under mayBeIncomplete a real update may have had its cell dropped, so the
+    // accumulated list is kept instead.)
+    const cellRows = new Set<number>();
+    for (const cd of Object.values(columnDeltas)) {
+      for (const r of Object.keys(cd)) { cellRows.add(Number(r)); }
+    }
+    // The final return sorts via uniqueAndSorted, so no need to sort here.
+    updateRows = [...cellRows].filter(r => !addSet.has(r) && !removeSet.has(r));
+  }
+  const columnRenames = canonicalizeRenames(td.columnRenames);
+  // Presentation rule: row lists are sets, serialized sorted
+  // by rowId ascending (deduped). updateRows is already sorted when derived
+  // above; sort addRows/removeRows here too so the canonical form is
+  // order-stable regardless of the order the walk/composition accumulated them.
+  return { ...td, addRows: uniqueAndSorted(td.addRows), removeRows: uniqueAndSorted(td.removeRows),
+    columnDeltas, updateRows: uniqueAndSorted(updateRows), columnRenames };
+}
+
+/**
+ * Final cleanup of a settled TableDelta for display or comparison:
+ *  - drop the `[v, v]` cells that record no real change;
+ *  - drop any column left with no cells;
+ *  - drop from `updateRows` any row that no surviving cell justifies (it was
+ *    there only for a change that canceled out). Suppressed under
+ *    `mayBeIncomplete`, where a missing cell may be a dropped value rather than
+ *    "no change".
+ * A recycled row's equal-sided cell is significant (two entities share the id)
+ * and is kept. Row identity (add/remove/recycle) is preserved. Expects
+ * `settleTableDelta` output; running it again changes nothing.
+ */
+function canonicalizeTableDelta(td: TableDelta): TableDelta {
+  const incomplete = Boolean(td.mayBeIncomplete);
+  const addSet = new Set(td.addRows);
+  const removeSet = new Set(td.removeRows);
+  // Recycled rows (in both lists) carry per-entity cells where `null` marks an
+  // entity boundary, so their equal-sided cells are significant, never stripped.
+  const recycledRows = new Set(td.addRows.filter(r => removeSet.has(r)));
+  const columnDeltas: { [colId: string]: ColumnDelta } = {};
+  for (const [colId, cd] of Object.entries(td.columnDeltas)) {
+    const kept: ColumnDelta = {};
+    for (const [rowId, cell] of Object.entries(cd)) {
+      const r = Number(rowId);
+      if (cellIsVacuous(cell) && !recycledRows.has(r)) { continue; }
+      kept[r] = cell;
+    }
+    if (Object.keys(kept).length > 0) { columnDeltas[colId] = kept; }
+  }
+  let updateRows = td.updateRows;
+  if (!incomplete) {
+    // Re-derive from the cells that survived, so a row kept only by a
+    // now-dropped `[v, v]` cell leaves updateRows.
+    const cellRows = new Set<number>();
+    for (const cd of Object.values(columnDeltas)) {
+      for (const r of Object.keys(cd)) { cellRows.add(Number(r)); }
+    }
+    updateRows = uniqueAndSorted([...cellRows].filter(r => !addSet.has(r) && !removeSet.has(r)));
+  }
+  return { ...td, columnDeltas, updateRows };
+}
+
+/** Apply a per-table transform across a summary, canonicalize its table renames,
+ * and drop any table left with nothing to say. (A table being added or removed
+ * is already recorded in the renames, so an empty change-set for it would just
+ * be noise.) */
+function mapTableDeltas(sum: ActionSummary, fn: (td: TableDelta) => TableDelta): ActionSummary {
+  const tableDeltas: { [tableId: string]: TableDelta } = {};
+  for (const [tableId, td] of Object.entries(sum.tableDeltas)) {
+    const out = fn(td);
+    if (!isEmptyTableDelta(out)) { tableDeltas[tableId] = out; }
+  }
+  return { tableRenames: canonicalizeRenames(sum.tableRenames), tableDeltas };
+}
+
+/** Settle every table after a merge (see settleTableDelta). */
+function settleSummary(sum: ActionSummary): ActionSummary {
+  return mapTableDeltas(sum, settleTableDelta);
+}
+
+/**
+ * Merge two summaries into one covering both, with sum1 happening before sum2.
+ *
+ * It keeps cells that look like "no change" (the same value before and after).
+ * That seems wasteful, but if a later merge removes that row, the old value is
+ * what shows up as "this was here and now it's gone", so we can't drop it partway
+ * through. The result is therefore not display-ready: call canonicalizeSummary to
+ * drop those cells (concatenateSummaries does that for you once the merges are
+ * done).
+ */
 export function concatenateSummaryPair(sum1: ActionSummary, sum2: ActionSummary): ActionSummary {
   const names = planNameMerge(sum1.tableRenames, sum2.tableRenames);
   const rowChanges = mergeNames(names, sum1.tableDeltas, copyOnWrite(sum2.tableDeltas), mergeTable);
-  const sum: ActionSummary = {
+  return settleSummary({
     tableRenames: names.merge,
     tableDeltas: rowChanges,
-  };
-  return sum;
+  });
 }
 
-/** Generalize to merging a list of summaries. */
+/**
+ * Clean a summary up for display or comparison: drop the cells that record no
+ * real change (same value before and after). Merging deliberately keeps those
+ * cells (see concatenateSummaryPair), so clean up only once the merging is done.
+ * Settles first, so it is correct on any summary, not only an already-merged
+ * one. Running this twice changes nothing.
+ */
+export function canonicalizeSummary(sum: ActionSummary): ActionSummary {
+  return mapTableDeltas(settleSummary(sum), canonicalizeTableDelta);
+}
+
+/** Merge a whole list of summaries, in order, then clean up the result. */
 export function concatenateSummaries(sums: ActionSummary[]): ActionSummary {
   if (sums.length === 0) { return createEmptyActionSummary(); }
   let result = sums[0];
   for (let i = 1; i < sums.length; i++) {
     result = concatenateSummaryPair(result, sums[i]);
   }
-  return result;
+  return canonicalizeSummary(result);
 }
 
 export function getRenames(ref: ActionSummary | TableDelta) {

--- a/app/common/ActionSummarizer.ts
+++ b/app/common/ActionSummarizer.ts
@@ -1,4 +1,5 @@
 import { getEnvContent, LocalActionBundle } from "app/common/ActionBundle";
+import { chunkByLattice, chunkByOwners } from "app/common/ActionLayout";
 import { ActionSummary, ColumnDelta, createEmptyActionSummary,
   createEmptyTableDelta, defunctTableName, LabelDelta, TableDelta } from "app/common/ActionSummary";
 import { DocAction } from "app/common/DocActions";
@@ -9,10 +10,47 @@ import { CellDelta } from "app/common/TabularDiff";
 
 import clone from "lodash/clone";
 import fromPairs from "lodash/fromPairs";
+import isEqual from "lodash/isEqual";
 import keyBy from "lodash/keyBy";
-import sortBy from "lodash/sortBy";
 import toPairs from "lodash/toPairs";
 import values from "lodash/values";
+
+/**
+ * Building and composing ActionSummaries.
+ *
+ * An ActionSummary is the NET difference between two document states: which
+ * tables, columns, and rows were added, removed, renamed, or changed, and for
+ * the cells we keep, the value before and after. "Net" is the point: change a
+ * cell and change it straight back, and the summary shows nothing.
+ *
+ * How a summary is represented:
+ *  - Cells: a `[before, after]` pair. Each side is a wrapped value like `["x"]`,
+ *    or `null` (the cell did not exist at that end, e.g. its row or column was
+ *    added or removed within the span), or `"?"` (unknown; see incomplete below).
+ *  - Rows: each row id's story is told by which of `addRows` / `removeRows` /
+ *    `updateRows` it lands in. In both add and remove means recycled: the id held
+ *    one entity, then a different one, so their cells must not be merged.
+ *  - Names: table and column renames are `[before, after]` pairs (a `null` side
+ *    is an add or a remove). A removed column's cells are keyed under a
+ *    `-`-prefixed name, so they don't collide with a new column reusing the name.
+ *
+ * Composing two summaries (concatenateSummaryPair) is value-preserving: it keeps
+ * a cell that looks like no change (`[v, v]`), because a later merge can make
+ * that value matter. If a row is removed later, its old value is what shows up as
+ * "this was here and now it's gone". Such cells are dropped only at the end, by
+ * canonicalizeSummary, when the summary is read for display or comparison.
+ * Recycled rows and `"?"` are the deliberate exceptions: their equal-looking
+ * cells are real, not noise.
+ *
+ * Incomplete summaries: a bulk change over many rows is recorded only up to
+ * `maximumInlineRows`. Past that the summary keeps a sample and sets
+ * `mayBeIncomplete`, and a missing cell then reads as `"?"` (unknown) rather than
+ * "absent". Composition keeps `"?"` instead of resolving it either way.
+ *
+ * A single bundle that carries several schema changes at once is first split by
+ * the chunker (see ActionLayout) into pieces that each summarize cleanly; the
+ * per-piece summaries are then composed here.
+ */
 
 /**
  * The default maximum number of rows in a single bulk change that will be recorded
@@ -35,6 +73,12 @@ export interface ActionSummaryOptions {
    * `maximumInlineRows`.
    */
   alwaysPreserveColIds?: string[];
+  /**
+   * Ignore any per-undo ownership the engine recorded with the bundle and infer
+   * the chunk boundaries instead (the `chunkByLattice` path). Off by default, so
+   * when ownership is present it is used. Mainly for testing both paths agree.
+   */
+  ignoreUndoGrouping?: boolean;
 }
 
 export class ActionSummarizer {
@@ -254,10 +298,49 @@ export class ActionSummarizer {
  * that will be suitable for composition.
  */
 export function summarizeAction(body: LocalActionBundle, options?: ActionSummaryOptions): ActionSummary {
-  return summarizeStoredAndUndo(getEnvContent(body.stored), body.undo, options);
+  return summarizeStoredAndUndo(getEnvContent(body.stored), body.undo, options, body.undoOwner);
 }
 
+/**
+ * Build an ActionSummary from a flat (stored, undo) pair.
+ *
+ * A whole-bundle forward/reverse walk commits too early when a single bundle
+ * carries several schema changes (say, multiple renames, or a remove-then-readd
+ * at one slot). The walk can't tell an intermediate name or value, one that
+ * appeared and vanished inside the bundle, from the real before-and-after. So we
+ * first split the bundle into sub-bundles (see ActionLayout), summarize each one
+ * on its own with the walk, and compose the per-chunk summaries with
+ * `concatenateSummaries`. The chunker is here for correctness on multi-change
+ * bundles, not for speed.
+ *
+ * If the bundle carries the engine's per-undo ownership (`undoOwner`, parallel to
+ * `undo`), we chunk by it (`chunkByOwners`); otherwise by `chunkByLattice`. The
+ * lattice is the common case, not a relic: it covers all history from before
+ * ownership was added (immutable, recomputed lazily on read), plus engine-less
+ * bundles. `ignoreUndoGrouping` forces it for testing. Both feed the same walk
+ * and composition, so they agree (checked over the fuzz corpus).
+ *
+ * Aside: very old bundles (pre-~2017) recorded `stored` as only the user-facing
+ * action, with `undo` carrying the metadata-side inverses too. Neither chunker
+ * can attribute those, so they fall into a leading or trailing orphan chunk
+ * (stored=[], by position; see ActionLayout's header) and merge back as the old
+ * whole-bundle walk did.
+ *
+ * The input arrays and their action contents are not mutated.
+ */
 export function summarizeStoredAndUndo(stored: DocAction[], undo: DocAction[],
+  options?: ActionSummaryOptions, undoOwner?: readonly (number | null)[] | null): ActionSummary {
+  // `Array.isArray`, not just a presence check: a bundle round-tripped through the action history
+  // marshaller turns an absent owner list into null, and an older bundle omits it entirely.
+  const useOwners = Array.isArray(undoOwner) && undoOwner.length === undo.length &&
+    !options?.ignoreUndoGrouping;
+  const chunks = useOwners ? chunkByOwners(stored, undo, undoOwner) : chunkByLattice(stored, undo);
+  const summaries = chunks.map(c => summarizeChunkWalked(c.stored, c.undo, options));
+  return concatenateSummaries(summaries);
+}
+
+/** Walk one (stored, undo) chunk into a chunk-local ActionSummary. */
+function summarizeChunkWalked(stored: DocAction[], undo: DocAction[],
   options?: ActionSummaryOptions): ActionSummary {
   const summarizer = new ActionSummarizer(options);
   const summary = createEmptyActionSummary();
@@ -312,6 +395,37 @@ interface NameMerge {
 }
 
 /**
+ * Canonical presentation order for rename entries: sorted by pre-name
+ * ascending, with null pre-names (additions) after all non-null pre-names.
+ * Entries with equal pre-name (only possible when both
+ * pre-names are null, since non-null pre-names are injective) are tie-broken
+ * by post-name ascending, so the order is total and grouping-independent.
+ */
+function compareLabelDelta(a: LabelDelta, b: LabelDelta): number {
+  const [a0, a1] = a;
+  const [b0, b1] = b;
+  if (a0 !== b0) {
+    if (a0 === null) { return 1; }   // additions sort last
+    if (b0 === null) { return -1; }
+    return a0 < b0 ? -1 : 1;
+  }
+  const x = a1 === null ? "" : a1;
+  const y = b1 === null ? "" : b1;
+  return x < y ? -1 : x > y ? 1 : 0;
+}
+
+/**
+ * Put a rename list into canonical form: drop identity renames ([c, c], which
+ * arise from a name renamed away and back within scope) and sort into the stable
+ * presentation order so equivalent summaries always serialize the same way.
+ */
+function canonicalizeRenames(renames: LabelDelta[]): LabelDelta[] {
+  return [...renames]
+    .filter(([pre, post]) => !(pre !== null && pre === post))
+    .sort(compareLabelDelta);
+}
+
+/**
  * Looks at a pair of name change lists (could be tables or columns) and figures out what
  * changes would need to be made to a data structure keyed on those names in order to key
  * it consistently on final names.
@@ -326,11 +440,16 @@ function planNameMerge(names1: LabelDelta[], names2: LabelDelta[]): NameMerge {
   };
   const names1ByFinalName: { [name: string]: LabelDelta } = keyBy(names1, p => p[1]!);
   const names2ByInitialName: { [name: string]: LabelDelta } = keyBy(names2, p => p[0]!);
+  const names2ByFinalName: { [name: string]: LabelDelta } = keyBy(names2, p => p[1]!);
   for (const [before1, after1] of names1) {
     if (!after1) {
       if (!before1) { throw new Error("invalid name change found"); }
-      // Table/column was deleted in part 1.
-      result.dead1.add(before1);
+      // Table/column was deleted in part 1. Its delta is already keyed under
+      // the defunct name (-before1), so we only need to drop a stale entry
+      // under the live name -- unless `before1` was also re-added in part 1
+      // (a recycle), in which case the live `before1` key holds a distinct
+      // new entity that must be preserved.
+      if (!names1ByFinalName[before1]) { result.dead1.add(before1); }
       result.merge.push([before1, null]);
       continue;
     }
@@ -343,11 +462,21 @@ function planNameMerge(names1: LabelDelta[], names2: LabelDelta[]): NameMerge {
     }
     const after2 = pair2[1];
     if (!after2) {
-      // Table/column was deleted in part 2.
-      result.dead2.add(after1);
+      // Table/column was deleted in part 2. Its delta is keyed under the
+      // defunct name there, so only mark the live name dead unless `after1`
+      // was also re-added in part 2 (a recycle), where the live `after1` key
+      // holds a distinct new entity that must be preserved.
+      if (!names2ByFinalName[after1]) { result.dead2.add(after1); }
       if (before1) {
-        // Table/column existed prior to part 1, so we need to expose its history.
-        result.dead1.add(before1);
+        // Table/column existed prior to part 1 (as `before1`), was renamed to
+        // `after1` during part 1, and removed during part 2. In the combined
+        // scope it is removed, so its delta keys under the defunct name of its
+        // original name. Rekey part 1's delta (keyed by `after1`) and part 2's
+        // defunct delta (keyed by `-after1`) onto that final defunct key, so
+        // the row/cell history merges in rather than being stranded or dropped.
+        const finalKey = defunctTableName(before1);
+        result.rename1.set(after1, finalKey);
+        result.rename2.set(defunctTableName(after1), finalKey);
         result.merge.push([before1, null]);
       } else {
         // Table/column did not exist prior to part 1, so we erase it from history.
@@ -368,10 +497,20 @@ function planNameMerge(names1: LabelDelta[], names2: LabelDelta[]): NameMerge {
     result.merge.push([before2, after2]);
     // If table/column is renamed in part 2, and name was stable in part 1,
     // rekey any information about it in part 1.
-    if (before2 && after2) { result.rename1.set(before2, after2); }
+    if (before2 && after2) {
+      result.rename1.set(before2, after2);
+    } else if (before2 && !after2) {
+      // Removed in part 2, but stable (data-only delta, or untouched) in part 1.
+      // Part 1's delta is keyed by the live name `before2`; rekey it onto the
+      // defunct name so it merges with part 2's defunct delta rather than being
+      // stranded under a name that no longer exists in the combined scope.
+      result.rename1.set(before2, defunctTableName(before2));
+    }
   }
-  // For neatness, sort the merge order. Not essential.
-  result.merge = sortBy(result.merge, ([a, b]) => [a || "", b || ""]);
+  // Canonical rename order. This matters: the same order must
+  // result whether a delta was merged here or copied through untouched, or
+  // composition would not be associative on presentation.
+  result.merge.sort(compareLabelDelta);
   return result;
 }
 
@@ -384,11 +523,15 @@ function planNameMerge(names1: LabelDelta[], names2: LabelDelta[]): NameMerge {
  * @param entries: a dictionary of nested data - TableDeltas for tables, ColumnDeltas for columns.
  * @param dead: a set of keys to remove from the dictionary.
  * @param rename: changes of names to apply to the dictionary.
+ * @param mergeOnCollision: how to combine a renamed entry with a distinct entry
+ *   already occupying the target key (see below); without it, the renamed entry
+ *   overwrites and the occupant's data is lost.
  *
  * entries may be modified, and if so will be shallow-copied.
  */
 function renameAndDelete<T>(entries: CopyOnWrite<{ [name: string]: T }>, dead: Set<string>,
-  rename: Map<string, string>) {
+  rename: Map<string, string>,
+  mergeOnCollision?: (incoming: T, existing: CopyOnWrite<T>) => T) {
   if (!(dead.size || rename.size)) {
     return;
   }
@@ -404,9 +547,22 @@ function renameAndDelete<T>(entries: CopyOnWrite<{ [name: string]: T }>, dead: S
       delete entriesCopy[key];
     }
   }
-  // Move all renamed entries back in with their new names.
+  // Move all renamed entries back in with their new names. If the target name
+  // is still occupied by a distinct (non-renamed) entry, that entry and the
+  // renamed one are two facets of the same final entity -- e.g. a table whose
+  // data was recorded under its post-rename name by a calc-flush restore while
+  // its removal was recorded under the pre-rename name. They have to merge, not
+  // overwrite, or the occupant's rows/cells are dropped (breaking composition
+  // associativity). The renamed entry carried the old name, so it is the
+  // earlier facet (e1); the occupant carried the new name (e2).
   for (const [key, val] of rename.entries()) {
-    if (cache[key]) { entriesCopy[val] = cache[key]; }
+    if (!cache[key]) { continue; }
+    if (entriesCopy[val] !== undefined && mergeOnCollision) {
+      const existing = copyOnWrite(entriesCopy[val]);
+      entriesCopy[val] = mergeOnCollision(cache[key], existing);
+    } else {
+      entriesCopy[val] = cache[key];
+    }
   }
 }
 
@@ -424,17 +580,28 @@ function renameAndDelete<T>(entries: CopyOnWrite<{ [name: string]: T }>, dead: S
 function mergeNames<T>(names: NameMerge,
   entries1: { [name: string]: T },
   entries2: CopyOnWrite<{ [name: string]: T }>,
-  mergeEntry: (e1: T, e2: CopyOnWrite<T>) => T): { [name: string]: T } {
+  mergeEntry: (e1: T, e2: CopyOnWrite<T>) => T,
+  transformOrphan?: (e1: T) => T): { [name: string]: T } {
   const entries1Wrapper = copyOnWrite(entries1);
   // Update the keys of the entries1 and entries2 dictionaries to be consistent.
-  renameAndDelete(entries1Wrapper, names.dead1, names.rename1);
-  renameAndDelete(entries2, names.dead2, names.rename2);
+  // A rename whose target key is already occupied merges rather than overwrites
+  // (see renameAndDelete), using the same composition as the cross-part merge.
+  renameAndDelete(entries1Wrapper, names.dead1, names.rename1, mergeEntry);
+  renameAndDelete(entries2, names.dead2, names.rename2, mergeEntry);
 
   // Prepare the composition of the two dictionaries.
   const entries = entries2;                // Start with the second dictionary.
   for (const key of Object.keys(entries1Wrapper.read())) {  // Add material from the first.
     const e1 = entries1Wrapper.read()[key];
-    if (!entries.read()[key]) { entries.write()[key] = e1;  continue; }  // No overlap - just add and move on.
+    if (!entries.read()[key]) {
+      // entries1 has this key, entries2 does not. entries2's part-2 may
+      // still carry row-level changes (notably row removals) that must
+      // apply -- a removed row has no cells afterward. Those
+      // changes aren't in this missing entry, so transformOrphan lets the
+      // caller apply them; otherwise the entry is added unchanged.
+      entries.write()[key] = transformOrphan ? transformOrphan(e1) : e1;
+      continue;
+    }
     const e2cow = copyOnWrite(entries.read()[key]);
     const result = mergeEntry(e1, e2cow);
     if (e2cow.hasWrite()) {
@@ -488,30 +655,36 @@ function mergeColumn(present1: RowChanges, present2: RowChanges,
     let v1 = e1[key];
     let v2 = e2.read()[key];
     if (!v1 && !v2) { continue; }
-    if (present1[key].added && present2[key]?.removed) {
+    // Drop the cell only if the row is added in e1 and removed in e2, and not
+    // the reverse in either: then it is empty at both ends and never really
+    // existed. Judge by the two parts together. A row both added and removed in
+    // e1 was already there at the start, so keep its old value. And if either
+    // part may be incomplete, a missing cell could be hiding a reused row id, so
+    // don't drop it then.
+    const t1 = present1[key], t2 = present2[key];
+    if (t1.added && !t1.removed && t2?.removed && !t2?.added && !incomplete1 && !incomplete2) {
       delete e2.write()[key];
       continue;
     }
-    // A row marked "updated" in a side whose cellDelta has no entry for
-    // this column can mean two things: the column was untouched (and we
-    // can recover the value from the other side) or the summarizer
-    // deliberately dropped the cell to stay under `maximumInlineRows` (so
-    // '?' is the accurate answer). If the source summary's
-    // mayBeIncomplete flag is unset, we know it's the first case and can
-    // recover. If it's set, we don't know which case it is, and have to
-    // err on the side of uncertainty.
+    // A row marked "updated" on a side that has no cell here means one of two
+    // things: the column simply wasn't touched (so the value lives on the other
+    // side and we can copy it over), or the summarizer dropped the cell to keep a
+    // large bulk change small (so "?" for unknown is the right answer). If that
+    // side is not flagged incomplete, it's the first case and we recover the
+    // value. If it is, we can't tell, so we keep it unknown.
     const v1Untouched = v1 === undefined && !incomplete1;
     const v2Untouched = v2 === undefined && !incomplete2;
-    v1 = v1 || bulkCellFor(present1[key]);
-    v2 = v2 || bulkCellFor(present2[key]);
+    v1 = v1 || bulkCellFor(t1);
+    v2 = v2 || bulkCellFor(t2);
     if (!v2)    { e2.write()[key] = e1[key]; continue; }
     if (!v1[1]) {
-      // Row was deleted in e1. If it was re-added in e2 (remove-then-add,
-      // e.g., row ID recycling), carry the old value from e1 forward so the
-      // deleted row's original values are preserved in the comparison.
-      // Only do this when the row was specifically removed (not just added
-      // without values for this column).
-      if (present1[key].removed && v2[1]) {
+      // e1 deleted the row and kept its old value in v1[0]. That is the value at
+      // the start of the whole span, so keep it as the "before", whatever e2 does
+      // next: if e2 re-adds the row we get [old, new]; if e2 also removes it (or
+      // leaves it gone) we get [old, null], the original value, still removed. We
+      // only do this when e1 genuinely removed the row (a row merely added in e1
+      // with no value here has nothing to carry).
+      if (t1.removed) {
         e2.write()[key] = [v1[0], v2[1]];
       }
       continue;
@@ -557,37 +730,82 @@ function mergeTable(e1: TableDelta,  e2: CopyOnWrite<TableDelta>): TableDelta {
   const e2td = e2.read();
   const names = planNameMerge(e1.columnRenames, e2td.columnRenames);
   const columnDeltasCow = copyOnWrite(e2td.columnDeltas);
+  // A column that exists only in part 1 must still feel part 2's row removals.
+  // A deleted row has no cells afterward, so when part 2 genuinely
+  // removes a row (removed and not re-added), clear the post side of that column's
+  // cell for it. We touch only those cells, never the pre side or other rows.
+  //
+  // Rows recycled in part 2 (removed AND re-added) are deliberately left alone,
+  // and that is safe. The walk records a removal on the pre side only
+  // (addReverseAction, direction 0), so a removed row's post is already null on
+  // every column. By the time a row is recycled its orphan-column cell therefore
+  // reads [pre, null] anyway: no stale post to clear, and the new entity (which
+  // part 2 never set here) is correctly absent.
+  const removedInE2 = new Set(e2td.removeRows);
+  for (const r of e2td.addRows) { removedInE2.delete(r); }
+  const applyRemovalsToOrphanColumn = (col: ColumnDelta): ColumnDelta => {
+    let out: ColumnDelta | undefined;
+    for (const rowId of Object.keys(col) as unknown as number[]) {
+      if (removedInE2.has(Number(rowId)) && col[rowId][1] !== null) {
+        out = out || { ...col };
+        out[rowId] = [col[rowId][0], null];
+      }
+    }
+    return out || col;
+  };
   mergeNames(names, e1.columnDeltas, columnDeltasCow,
     mergeColumn.bind(null,
       getRowChanges(e1),
       getRowChanges(e2td),
       e1.mayBeIncomplete,
-      e2td.mayBeIncomplete));
-  if (columnDeltasCow.hasWrite()) {
-    e2.write();
-    e2.read().columnDeltas = columnDeltasCow.read();
-  }
+      e2td.mayBeIncomplete),
+    applyRemovalsToOrphanColumn);
   const columnRenames = names.merge;
   // All the columnar data is now merged.  What remains is to merge the summary lists of rowIds
   // that we maintain.
-  const addRows1 = new Set(e1.addRows);       // Non-transient rows we have clearly added.
-  const removeRows2 = new Set(e2.read().removeRows); // Non-transient rows we have clearly removed.
-  const transients = e1.addRows.filter(x => removeRows2.has(x));
-  const addRows = uniqueAndSorted([...e2.read().addRows, ...e1.addRows.filter(x => !removeRows2.has(x))]);
-  const removeRows = uniqueAndSorted([...e2.read().removeRows.filter(x => !addRows1.has(x)), ...e1.removeRows]);
+  const addRows1 = new Set(e1.addRows);
+  const removeRows2 = new Set(e2.read().removeRows);
+  const e1Removed = new Set(e1.removeRows);
+  const e2Added = new Set(e2.read().addRows);
+  // A transient row is one added and then removed across the two parts, so it is
+  // empty at both ends and never really existed. Judge that by the two parts
+  // together: it must be added (not removed) in e1 and removed (not added) in e2.
+  // A row both added and removed in e1 was already there at the start, so a
+  // removal in e2 leaves it removed, not transient -- calling it transient would
+  // drop its old value and break associativity. A row re-added in e2 isn't
+  // transient either.
+  const transients = e1.addRows.filter(
+    x => removeRows2.has(x) && !e1Removed.has(x) && !e2Added.has(x));
+  let addRows = uniqueAndSorted([...e2.read().addRows, ...e1.addRows.filter(x => !removeRows2.has(x))]);
+  let removeRows = uniqueAndSorted([...e2.read().removeRows.filter(x => !addRows1.has(x)), ...e1.removeRows]);
   const updateRows = uniqueAndSorted([...e1.updateRows.filter(x => !removeRows2.has(x)),
     ...e2.read().updateRows.filter(x => !addRows1.has(x))]);
-  // Remove all traces of transients (rows that were created and destroyed) from history.
-  if (transients.length) {
-    for (const [colId, columnDelta] of Object.entries(e2.read().columnDeltas)) {
+  if (e1.mayBeIncomplete || e2td.mayBeIncomplete) {
+    // Transient collapse is unsafe when cells may have been
+    // dropped -- the absent cells could be a truncated `recycled` row rather
+    // than a genuine transient. Keep such rows in both lists (recycled) and
+    // keep their cells, instead of erasing them.
+    addRows = uniqueAndSorted([...addRows, ...transients]);
+    removeRows = uniqueAndSorted([...removeRows, ...transients]);
+  } else if (transients.length) {
+    // Complete summary: erase all traces of transient rows from history. Write
+    // through columnDeltasCow (not e2.read().columnDeltas) so the erase lands on
+    // a private clone: e2.write() is a shallow copy whose .columnDeltas still
+    // aliases the caller's input until columnDeltasCow is written back below.
+    for (const [colId, columnDelta] of Object.entries(columnDeltasCow.read())) {
       const updatedColumnDelta = copyOnWrite(columnDelta);
       for (const rowId of transients) {
         delete updatedColumnDelta.write()[rowId];
       }
       if (updatedColumnDelta.hasWrite()) {
-        e2.write().columnDeltas[colId] = updatedColumnDelta.read();
+        columnDeltasCow.write()[colId] = updatedColumnDelta.read();
       }
     }
+  }
+  // Write the merged column deltas back once, onto a private copy (the shallow
+  // e2.write() shares the columnDeltas dict with the caller's input otherwise).
+  if (columnDeltasCow.hasWrite()) {
+    e2.write().columnDeltas = columnDeltasCow.read();
   }
   // We unconditionally write at this level.
   Object.assign(e2.write(), {
@@ -602,25 +820,246 @@ function mergeTable(e1: TableDelta,  e2: CopyOnWrite<TableDelta>): TableDelta {
   return e2.read();
 }
 
-/** Finally, merge a pair of summaries. */
+/**
+ * A cell pair is vacuous when its two sides are equal: it records no
+ * change. Covers `[null, null]` (cell absent at both endpoints) and
+ * `[[v], [v]]` (same value before and after). A `"?"` side is never
+ * vacuous (it asserts an unknown change, not "no change").
+ */
+function cellIsVacuous(c: CellDelta): boolean {
+  const [pre, post] = c;
+  if (pre === "?" || post === "?") { return false; }
+  if (pre === null && post === null) { return true; }
+  if (pre === null || post === null) { return false; }
+  return isEqual(pre, post);   // [v] vs [v]
+}
+
+function isEmptyTableDelta(td: TableDelta): boolean {
+  return td.addRows.length === 0 && td.removeRows.length === 0 &&
+    td.updateRows.length === 0 && td.columnRenames.length === 0 &&
+    Object.keys(td.columnDeltas).length === 0 && !td.mayBeIncomplete;
+}
+
+/**
+ * Settle a freshly merged TableDelta: the structural cleanup every merge
+ * needs and the next merge relies on. It
+ *  - fixes a cell side to "absent" at an existence boundary (a row or column
+ *    that did not exist at that endpoint);
+ *  - re-keys a removed column's cells onto its `-`-prefixed defunct name, which
+ *    `planNameMerge` then assumes is already in place;
+ *  - resolves a stray `"?"` to absent in a complete summary;
+ *  - drops `[null, null]` cells (no value at either end);
+ *  - derives `updateRows` from the cells, so it does not depend on merge order;
+ *  - puts renames and row lists in canonical order.
+ * It keeps an insignificant `[v, v]` cell: a later merge can turn that value
+ * into the "before" of a removal, so it can't be dropped yet.
+ * `canonicalizeTableDelta` drops those once merging is done.
+ */
+function settleTableDelta(td: TableDelta): TableDelta {
+  const incomplete = Boolean(td.mayBeIncomplete);
+  // Existence boundaries fix a cell side to "absent": a cell has
+  // no value at an endpoint where its row or column did not exist there.
+  //  - a column added in scope (a `[null, name]` rename) has no pre value;
+  //  - a defunct column (keyed by its `-`-prefixed name) has no post value;
+  //  - a row added in scope (in addRows, not also removed) has no pre value;
+  //  - a row removed in scope (in removeRows, not also re-added) has no post.
+  // Recycled rows (in both lists) are per-entity and exempt from the row
+  // rules. Enforcing these fixes composition that synthesized a stray `"?"`
+  // at such a boundary, and lets the later vacuous-cell drop clear anything
+  // that thereby becomes `[null, null]`.
+  const addedCols = new Set(td.columnRenames.filter(([pre]) => pre === null).map(([, post]) => post));
+  const removeSet = new Set(td.removeRows);
+  const addSet = new Set(td.addRows);
+  const addedRows = new Set(td.addRows.filter(r => !removeSet.has(r)));
+  const removedRows = new Set(td.removeRows.filter(r => !addSet.has(r)));
+  // Delta keying: a removed column's cells key under its
+  // `-`-prefixed pre-name, never the now-defunct live name. The walk can leave
+  // a cell under the live name (e.g. for a row removed before the column went
+  // defunct), and `planNameMerge` assumes the defunct keying is already in
+  // place, so enforce it here: re-key any `[pre, null]` column's live-name
+  // cells onto `-pre`, merging with an already-canonical entry (which wins).
+  // A column whose live name is occupied by a distinct entity must not have
+  // that entity's cells re-keyed onto the defunct name. That happens two ways:
+  //  - the name is re-added ([null, pre]); or
+  //  - the name is a rename target ([x, pre]): something was renamed into it,
+  //    so the live `pre` key holds the renamed-in column, not the removed one.
+  // Only a column removed and neither re-added nor renamed-into has its cells
+  // re-keyed onto `-pre`.
+  const renameTargets = new Set(
+    td.columnRenames.filter(([pre, post]) => pre !== null && post !== null).map(([, post]) => post));
+  const removedCols = new Map<string, string>();
+  for (const [pre, post] of td.columnRenames) {
+    if (pre !== null && post === null && !addedCols.has(pre) && !renameTargets.has(pre)) {
+      removedCols.set(pre, defunctTableName(pre));
+    }
+  }
+  let sourceDeltas = td.columnDeltas;
+  if (removedCols.size > 0 && Object.keys(td.columnDeltas).some(c => removedCols.has(c))) {
+    sourceDeltas = {};
+    // Canonical (non-remapped) keys first, so an existing `-pre` entry wins on
+    // any row collision with a stranded live-name cell.
+    const entries = Object.entries(td.columnDeltas)
+      .sort((a, b) => (removedCols.has(a[0]) ? 1 : 0) - (removedCols.has(b[0]) ? 1 : 0));
+    for (const [colId, cd] of entries) {
+      const target = removedCols.get(colId) ?? colId;
+      const dest = sourceDeltas[target] ?? (sourceDeltas[target] = {});
+      for (const [rowId, cell] of Object.entries(cd)) {
+        const r = Number(rowId);
+        if (!(r in dest)) { dest[r] = cell; }
+      }
+    }
+  }
+  const columnDeltas: { [colId: string]: ColumnDelta } = {};
+  for (const [colId, cd] of Object.entries(sourceDeltas)) {
+    const colNoPre = addedCols.has(colId);
+    const colNoPost = colId.startsWith("-");
+    const kept: ColumnDelta = {};
+    for (const [rowId, cell] of Object.entries(cd)) {
+      const r = Number(rowId);
+      const noPre = colNoPre || addedRows.has(r);
+      const noPost = colNoPost || removedRows.has(r);
+      let pre = noPre ? null : cell[0];
+      let post = noPost ? null : cell[1];
+      // A complete summary carries no unknowns: `"?"` only appears
+      // when the `mayBeIncomplete` flag permits dropped detail. When that flag
+      // is unset, any `"?"` is a composition artifact (a value the summary
+      // never recorded, e.g. an omitted default) with no recoverable value, so
+      // resolve it to absent. When the flag is set, `"?"` is meaningful and
+      // kept.
+      if (!incomplete) {
+        if (pre === "?") { pre = null; }
+        if (post === "?") { post = null; }
+      }
+      // `[null, null]` carries no value, so drop it. Keep everything else,
+      // including an insignificant `[v, v]`: a later merge may still need `v`.
+      if (pre === null && post === null) { continue; }
+      kept[r] = [pre, post];
+    }
+    if (Object.keys(kept).length > 0) { columnDeltas[colId] = kept; }
+  }
+  let updateRows = td.updateRows;
+  if (!incomplete) {
+    // A row is `updated` iff it persisted (not net-added, not net-removed) and
+    // its contents changed -- i.e. it carries a cell delta (section 3: contents
+    // changes live in cells, not a separate flag). Derive it from the cells
+    // rather than filtering the accumulated list, so it is associative: the
+    // accumulated updateRows can differ by composition order, the cells cannot.
+    // (Under mayBeIncomplete a real update may have had its cell dropped, so the
+    // accumulated list is kept instead.)
+    const cellRows = new Set<number>();
+    for (const cd of Object.values(columnDeltas)) {
+      for (const r of Object.keys(cd)) { cellRows.add(Number(r)); }
+    }
+    // The final return sorts via uniqueAndSorted, so no need to sort here.
+    updateRows = [...cellRows].filter(r => !addSet.has(r) && !removeSet.has(r));
+  }
+  const columnRenames = canonicalizeRenames(td.columnRenames);
+  // Presentation rule: row lists are sets, serialized sorted
+  // by rowId ascending (deduped). updateRows is already sorted when derived
+  // above; sort addRows/removeRows here too so the canonical form is
+  // order-stable regardless of the order the walk/composition accumulated them.
+  return { ...td, addRows: uniqueAndSorted(td.addRows), removeRows: uniqueAndSorted(td.removeRows),
+    columnDeltas, updateRows: uniqueAndSorted(updateRows), columnRenames };
+}
+
+/**
+ * Final cleanup of a settled TableDelta for display or comparison:
+ *  - drop the `[v, v]` cells that record no real change;
+ *  - drop any column left with no cells;
+ *  - drop from `updateRows` any row that no surviving cell justifies (it was
+ *    there only for a change that canceled out). Suppressed under
+ *    `mayBeIncomplete`, where a missing cell may be a dropped value rather than
+ *    "no change".
+ * A recycled row's equal-sided cell is significant (two entities share the id)
+ * and is kept. Row identity (add/remove/recycle) is preserved. Expects
+ * `settleTableDelta` output; running it again changes nothing.
+ */
+function canonicalizeTableDelta(td: TableDelta): TableDelta {
+  const incomplete = Boolean(td.mayBeIncomplete);
+  const addSet = new Set(td.addRows);
+  const removeSet = new Set(td.removeRows);
+  // Recycled rows (in both lists) carry per-entity cells where `null` marks an
+  // entity boundary, so their equal-sided cells are significant, never stripped.
+  const recycledRows = new Set(td.addRows.filter(r => removeSet.has(r)));
+  const columnDeltas: { [colId: string]: ColumnDelta } = {};
+  for (const [colId, cd] of Object.entries(td.columnDeltas)) {
+    const kept: ColumnDelta = {};
+    for (const [rowId, cell] of Object.entries(cd)) {
+      const r = Number(rowId);
+      if (cellIsVacuous(cell) && !recycledRows.has(r)) { continue; }
+      kept[r] = cell;
+    }
+    if (Object.keys(kept).length > 0) { columnDeltas[colId] = kept; }
+  }
+  let updateRows = td.updateRows;
+  if (!incomplete) {
+    // Re-derive from the cells that survived, so a row kept only by a
+    // now-dropped `[v, v]` cell leaves updateRows.
+    const cellRows = new Set<number>();
+    for (const cd of Object.values(columnDeltas)) {
+      for (const r of Object.keys(cd)) { cellRows.add(Number(r)); }
+    }
+    updateRows = uniqueAndSorted([...cellRows].filter(r => !addSet.has(r) && !removeSet.has(r)));
+  }
+  return { ...td, columnDeltas, updateRows };
+}
+
+/** Apply a per-table transform across a summary, canonicalize its table renames,
+ * and drop any table left with nothing to say. (A table being added or removed
+ * is already recorded in the renames, so an empty change-set for it would just
+ * be noise.) */
+function mapTableDeltas(sum: ActionSummary, fn: (td: TableDelta) => TableDelta): ActionSummary {
+  const tableDeltas: { [tableId: string]: TableDelta } = {};
+  for (const [tableId, td] of Object.entries(sum.tableDeltas)) {
+    const out = fn(td);
+    if (!isEmptyTableDelta(out)) { tableDeltas[tableId] = out; }
+  }
+  return { tableRenames: canonicalizeRenames(sum.tableRenames), tableDeltas };
+}
+
+/** Settle every table after a merge (see settleTableDelta). */
+function settleSummary(sum: ActionSummary): ActionSummary {
+  return mapTableDeltas(sum, settleTableDelta);
+}
+
+/**
+ * Merge two summaries into one covering both, with sum1 happening before sum2.
+ *
+ * It keeps cells that look like "no change" (the same value before and after).
+ * That seems wasteful, but if a later merge removes that row, the old value is
+ * what shows up as "this was here and now it's gone", so we can't drop it partway
+ * through. The result is therefore not display-ready: call canonicalizeSummary to
+ * drop those cells (concatenateSummaries does that for you once the merges are
+ * done).
+ */
 export function concatenateSummaryPair(sum1: ActionSummary, sum2: ActionSummary): ActionSummary {
   const names = planNameMerge(sum1.tableRenames, sum2.tableRenames);
   const rowChanges = mergeNames(names, sum1.tableDeltas, copyOnWrite(sum2.tableDeltas), mergeTable);
-  const sum: ActionSummary = {
+  return settleSummary({
     tableRenames: names.merge,
     tableDeltas: rowChanges,
-  };
-  return sum;
+  });
 }
 
-/** Generalize to merging a list of summaries. */
+/**
+ * Clean a summary up for display or comparison: drop the cells that record no
+ * real change (same value before and after). Merging deliberately keeps those
+ * cells (see concatenateSummaryPair), so clean up only once the merging is done.
+ * Settles first, so it is correct on any summary, not only an already-merged
+ * one. Running this twice changes nothing.
+ */
+export function canonicalizeSummary(sum: ActionSummary): ActionSummary {
+  return mapTableDeltas(settleSummary(sum), canonicalizeTableDelta);
+}
+
+/** Merge a whole list of summaries, in order, then clean up the result. */
 export function concatenateSummaries(sums: ActionSummary[]): ActionSummary {
   if (sums.length === 0) { return createEmptyActionSummary(); }
   let result = sums[0];
   for (let i = 1; i < sums.length; i++) {
     result = concatenateSummaryPair(result, sums[i]);
   }
-  return result;
+  return canonicalizeSummary(result);
 }
 
 export function getRenames(ref: ActionSummary | TableDelta) {

--- a/app/common/ActionSummarizer.ts
+++ b/app/common/ActionSummarizer.ts
@@ -1,5 +1,5 @@
 import { getEnvContent, LocalActionBundle } from "app/common/ActionBundle";
-import { chunkByLattice, chunkByOwners } from "app/common/ActionLayout";
+import { chunkByLattice, chunkByOwners, coalesceRecordChunks } from "app/common/ActionLayout";
 import { ActionSummary, ColumnDelta, createEmptyActionSummary,
   createEmptyTableDelta, defunctTableName, LabelDelta, TableDelta } from "app/common/ActionSummary";
 import { DocAction } from "app/common/DocActions";
@@ -11,7 +11,6 @@ import { CellDelta } from "app/common/TabularDiff";
 import clone from "lodash/clone";
 import fromPairs from "lodash/fromPairs";
 import isEqual from "lodash/isEqual";
-import keyBy from "lodash/keyBy";
 import toPairs from "lodash/toPairs";
 import values from "lodash/values";
 
@@ -59,6 +58,18 @@ import values from "lodash/values";
  */
 const MAXIMUM_INLINE_ROWS = 10;
 
+/** The bulk-change size past which a summary keeps only a sample (Infinity for no limit). */
+function maxInlineRowsOf(options?: ActionSummaryOptions): number {
+  const maxRows = options?.maximumInlineRows;
+  if (maxRows === undefined) {
+    return MAXIMUM_INLINE_ROWS;
+  } else if (maxRows === null) {
+    return Infinity;
+  } else {
+    return maxRows;
+  }
+}
+
 /**
  * Options when producing an action summary.
  */
@@ -78,7 +89,12 @@ export interface ActionSummaryOptions {
    * the chunk boundaries instead (the `chunkByLattice` path). Off by default, so
    * when ownership is present it is used. Mainly for testing both paths agree.
    */
-  ignoreUndoGrouping?: boolean;
+  testIgnoreUndoGrouping?: boolean;
+  /**
+   * Keep every chunk as the chunker produced it (no coalesceRecordChunks). For
+   * testing that the merge changes nothing.
+   */
+  testDisableChunkCoalescing?: boolean;
 }
 
 export class ActionSummarizer {
@@ -184,7 +200,7 @@ export class ActionSummarizer {
   public addAction(summary: ActionSummary, act: DocAction,
     tableData: TableData) {
     const tableId = act[1];
-    if (!summary.tableDeltas[tableId]) {
+    if (!hasOwn(summary.tableDeltas, tableId)) {
       summary.tableDeltas[tableId] = createEmptyTableDelta();
     }
     this.addForwardAction(summary, act);
@@ -227,13 +243,15 @@ export class ActionSummarizer {
 
   /** helper function to access summary changes for a specific table by name */
   private _forTable(summary: ActionSummary, tableId: string): TableDelta {
-    return summary.tableDeltas[tableId] || (summary.tableDeltas[tableId] = createEmptyTableDelta());
+    if (!hasOwn(summary.tableDeltas, tableId)) { summary.tableDeltas[tableId] = createEmptyTableDelta(); }
+    return summary.tableDeltas[tableId];
   }
 
   /** helper function to access summary changes for a specific cell by rowId and colId */
   private _forCell(td: TableDelta, rowId: number, colId: string): CellDelta {
     // null-prototype map so an arbitrary row id can't clash with an inherited name.
-    const cd = td.columnDeltas[colId] || (td.columnDeltas[colId] = Object.create(null));
+    if (!hasOwn(td.columnDeltas, colId)) { td.columnDeltas[colId] = Object.create(null); }
+    const cd = td.columnDeltas[colId];
     return cd[rowId] || (cd[rowId] = [null, null]);
   }
 
@@ -282,14 +300,7 @@ export class ActionSummarizer {
   }
 
   private _getMaxRows() {
-    const maxRows = this._options?.maximumInlineRows;
-    if (maxRows === undefined) {
-      return MAXIMUM_INLINE_ROWS;
-    } else if (maxRows === null) {
-      return Infinity;
-    } else {
-      return maxRows;
-    }
+    return maxInlineRowsOf(this._options);
   }
 }
 
@@ -317,8 +328,11 @@ export function summarizeAction(body: LocalActionBundle, options?: ActionSummary
  * `undo`), we chunk by it (`chunkByOwners`); otherwise by `chunkByLattice`. The
  * lattice is the common case, not a relic: it covers all history from before
  * ownership was added (immutable, recomputed lazily on read), plus engine-less
- * bundles. `ignoreUndoGrouping` forces it for testing. Both feed the same walk
- * and composition, so they agree (checked over the fuzz corpus).
+ * bundles. `testIgnoreUndoGrouping` forces it for testing. Either way, adjacent
+ * record-only chunks are then merged back into one (coalesceRecordChunks),
+ * since a run of row changes has no name that could appear and vanish. Both
+ * paths feed the same walk and composition, so they agree (checked over the
+ * fuzz corpus, with and without the merge).
  *
  * Aside: very old bundles (pre-~2017) recorded `stored` as only the user-facing
  * action, with `undo` carrying the metadata-side inverses too. Neither chunker
@@ -333,8 +347,11 @@ export function summarizeStoredAndUndo(stored: DocAction[], undo: DocAction[],
   // `Array.isArray`, not just a presence check: a bundle round-tripped through the action history
   // marshaller turns an absent owner list into null, and an older bundle omits it entirely.
   const useOwners = Array.isArray(undoOwner) && undoOwner.length === undo.length &&
-    !options?.ignoreUndoGrouping;
-  const chunks = useOwners ? chunkByOwners(stored, undo, undoOwner) : chunkByLattice(stored, undo);
+    !options?.testIgnoreUndoGrouping;
+  let chunks = useOwners ? chunkByOwners(stored, undo, undoOwner) : chunkByLattice(stored, undo);
+  if (!options?.testDisableChunkCoalescing) {
+    chunks = coalesceRecordChunks(chunks, undo, maxInlineRowsOf(options));
+  }
   const summaries = chunks.map(c => summarizeChunkWalked(c.stored, c.undo, options));
   return concatenateSummaries(summaries);
 }
@@ -356,7 +373,7 @@ function summarizeChunkWalked(stored: DocAction[], undo: DocAction[],
     let post = renames[1];
     if (pre === null) { continue; }
     if (post === null) { post = defunctTableName(pre); }
-    if (summary.tableDeltas[pre]) {
+    if (hasOwn(summary.tableDeltas, pre)) {
       summary.tableDeltas[post] = summary.tableDeltas[pre];
       delete summary.tableDeltas[pre];
     }
@@ -368,7 +385,7 @@ function summarizeChunkWalked(stored: DocAction[], undo: DocAction[],
       let post = renames[1];
       if (pre === null) { continue; }
       if (post === null) { post = defunctTableName(pre); }
-      if (td.columnDeltas[pre]) {
+      if (hasOwn(td.columnDeltas, pre)) {
         td.columnDeltas[post] = td.columnDeltas[pre];
         delete td.columnDeltas[pre];
       }
@@ -426,6 +443,28 @@ function canonicalizeRenames(renames: LabelDelta[]): LabelDelta[] {
 }
 
 /**
+ * Own-property test for a summary's name-keyed dictionaries. Their keys are
+ * user-chosen table and column ids, so a plain `obj[key]` test would find
+ * Object.prototype members for names like "constructor" or "toString".
+ */
+function hasOwn(obj: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+/**
+ * Index label deltas by one side (0 = pre-name, 1 = post-name), skipping null
+ * names. A Map, for the reason given at hasOwn.
+ */
+function indexBySide(names: LabelDelta[], side: 0 | 1): Map<string, LabelDelta> {
+  const index = new Map<string, LabelDelta>();
+  for (const pair of names) {
+    const key = pair[side];
+    if (key !== null) { index.set(key, pair); }
+  }
+  return index;
+}
+
+/**
  * Looks at a pair of name change lists (could be tables or columns) and figures out what
  * changes would need to be made to a data structure keyed on those names in order to key
  * it consistently on final names.
@@ -438,9 +477,9 @@ function planNameMerge(names1: LabelDelta[], names2: LabelDelta[]): NameMerge {
     rename2: new Map<string, string>(),
     merge: new Array<LabelDelta>(),
   };
-  const names1ByFinalName: { [name: string]: LabelDelta } = keyBy(names1, p => p[1]!);
-  const names2ByInitialName: { [name: string]: LabelDelta } = keyBy(names2, p => p[0]!);
-  const names2ByFinalName: { [name: string]: LabelDelta } = keyBy(names2, p => p[1]!);
+  const names1ByFinalName = indexBySide(names1, 1);
+  const names2ByInitialName = indexBySide(names2, 0);
+  const names2ByFinalName = indexBySide(names2, 1);
   for (const [before1, after1] of names1) {
     if (!after1) {
       if (!before1) { throw new Error("invalid name change found"); }
@@ -449,12 +488,12 @@ function planNameMerge(names1: LabelDelta[], names2: LabelDelta[]): NameMerge {
       // under the live name -- unless `before1` was also re-added in part 1
       // (a recycle), in which case the live `before1` key holds a distinct
       // new entity that must be preserved.
-      if (!names1ByFinalName[before1]) { result.dead1.add(before1); }
+      if (!names1ByFinalName.has(before1)) { result.dead1.add(before1); }
       result.merge.push([before1, null]);
       continue;
     }
     // At this point, we know the table/column existed at end of part 1.
-    const pair2 = names2ByInitialName[after1];
+    const pair2 = names2ByInitialName.get(after1);
     if (!pair2) {
       // Table/column's name was stable in part 2, so only change was in part 1.
       result.merge.push([before1, after1]);
@@ -466,7 +505,7 @@ function planNameMerge(names1: LabelDelta[], names2: LabelDelta[]): NameMerge {
       // defunct name there, so only mark the live name dead unless `after1`
       // was also re-added in part 2 (a recycle), where the live `after1` key
       // holds a distinct new entity that must be preserved.
-      if (!names2ByFinalName[after1]) { result.dead2.add(after1); }
+      if (!names2ByFinalName.has(after1)) { result.dead2.add(after1); }
       if (before1) {
         // Table/column existed prior to part 1 (as `before1`), was renamed to
         // `after1` during part 1, and removed during part 2. In the combined
@@ -493,7 +532,7 @@ function planNameMerge(names1: LabelDelta[], names2: LabelDelta[]): NameMerge {
   // Look through part 2 for any changes not already covered.
   for (const [before2, after2] of names2) {
     if (!before2 && !after2) { throw new Error("invalid name change found"); }
-    if (before2 && names1ByFinalName[before2]) { continue; }  // Already handled
+    if (before2 && names1ByFinalName.has(before2)) { continue; }  // Already handled
     result.merge.push([before2, after2]);
     // If table/column is renamed in part 2, and name was stable in part 1,
     // rekey any information about it in part 1.
@@ -540,10 +579,10 @@ function renameAndDelete<T>(entries: CopyOnWrite<{ [name: string]: T }>, dead: S
   // Remove all entries marked as dead.
   for (const key of dead) { delete entriesCopy[key]; }
   // Move all entries that are going to be renamed out to a cache temporarily.
-  const cache: { [name: string]: any } = {};
+  const cache = new Map<string, T>();
   for (const key of rename.keys()) {
-    if (entriesCopy[key]) {
-      cache[key] = entriesCopy[key];
+    if (hasOwn(entriesCopy, key)) {
+      cache.set(key, entriesCopy[key]);
       delete entriesCopy[key];
     }
   }
@@ -556,12 +595,13 @@ function renameAndDelete<T>(entries: CopyOnWrite<{ [name: string]: T }>, dead: S
   // associativity). The renamed entry carried the old name, so it is the
   // earlier facet (e1); the occupant carried the new name (e2).
   for (const [key, val] of rename.entries()) {
-    if (!cache[key]) { continue; }
-    if (entriesCopy[val] !== undefined && mergeOnCollision) {
+    const moved = cache.get(key);
+    if (moved === undefined) { continue; }
+    if (hasOwn(entriesCopy, val) && mergeOnCollision) {
       const existing = copyOnWrite(entriesCopy[val]);
-      entriesCopy[val] = mergeOnCollision(cache[key], existing);
+      entriesCopy[val] = mergeOnCollision(moved, existing);
     } else {
-      entriesCopy[val] = cache[key];
+      entriesCopy[val] = moved;
     }
   }
 }
@@ -593,7 +633,7 @@ function mergeNames<T>(names: NameMerge,
   const entries = entries2;                // Start with the second dictionary.
   for (const key of Object.keys(entries1Wrapper.read())) {  // Add material from the first.
     const e1 = entries1Wrapper.read()[key];
-    if (!entries.read()[key]) {
+    if (!hasOwn(entries.read(), key)) {
       // entries1 has this key, entries2 does not. entries2's part-2 may
       // still carry row-level changes (notably row removals) that must
       // apply -- a removed row has no cells afterward. Those
@@ -678,13 +718,16 @@ function mergeColumn(present1: RowChanges, present2: RowChanges,
     v2 = v2 || bulkCellFor(t2);
     if (!v2)    { e2.write()[key] = e1[key]; continue; }
     if (!v1[1]) {
-      // e1 deleted the row and kept its old value in v1[0]. That is the value at
-      // the start of the whole span, so keep it as the "before", whatever e2 does
-      // next: if e2 re-adds the row we get [old, new]; if e2 also removes it (or
-      // leaves it gone) we get [old, null], the original value, still removed. We
-      // only do this when e1 genuinely removed the row (a row merely added in e1
-      // with no value here has nothing to carry).
-      if (t1.removed) {
+      // e1's "after" side is absent: either e1 removed the row, or it recorded an
+      // old value with no forward action to give it a new one (a front calc-flush
+      // restore in a leading chunk), which really means "after unknown". Either
+      // way v1[0] is the value at the start of the whole span, so keep it as the
+      // "before" and take the "after" from e2. Keeping it is what makes the
+      // result independent of how the summaries were grouped: whether e2 carries
+      // this column at all varies with the grouping (the orphan path in
+      // mergeNames copies a whole column through). A cell with no old value has
+      // nothing to carry.
+      if (t1.removed || v1[0] !== null) {
         e2.write()[key] = [v1[0], v2[1]];
       }
       continue;
@@ -902,7 +945,8 @@ function settleTableDelta(td: TableDelta): TableDelta {
       .sort((a, b) => (removedCols.has(a[0]) ? 1 : 0) - (removedCols.has(b[0]) ? 1 : 0));
     for (const [colId, cd] of entries) {
       const target = removedCols.get(colId) ?? colId;
-      const dest = sourceDeltas[target] ?? (sourceDeltas[target] = {});
+      if (!hasOwn(sourceDeltas, target)) { sourceDeltas[target] = {}; }
+      const dest = sourceDeltas[target];
       for (const [rowId, cell] of Object.entries(cd)) {
         const r = Number(rowId);
         if (!(r in dest)) { dest[r] = cell; }
@@ -1052,14 +1096,26 @@ export function canonicalizeSummary(sum: ActionSummary): ActionSummary {
   return mapTableDeltas(settleSummary(sum), canonicalizeTableDelta);
 }
 
-/** Merge a whole list of summaries, in order, then clean up the result. */
+/**
+ * Merge a whole list of summaries, in order, then clean up the result.
+ *
+ * The merging is a balanced tree (neighbors first, then their results) rather
+ * than left to right: composition is associative (the fuzz harness checks it),
+ * so the grouping is free to choose, and the tree keeps each level's work
+ * proportional to the total size of the summaries.
+ */
 export function concatenateSummaries(sums: ActionSummary[]): ActionSummary {
   if (sums.length === 0) { return createEmptyActionSummary(); }
-  let result = sums[0];
-  for (let i = 1; i < sums.length; i++) {
-    result = concatenateSummaryPair(result, sums[i]);
+  let level = sums;
+  while (level.length > 1) {
+    const next: ActionSummary[] = [];
+    for (let i = 0; i + 1 < level.length; i += 2) {
+      next.push(concatenateSummaryPair(level[i], level[i + 1]));
+    }
+    if (level.length % 2 === 1) { next.push(level[level.length - 1]); }
+    level = next;
   }
-  return canonicalizeSummary(result);
+  return canonicalizeSummary(level[0]);
 }
 
 export function getRenames(ref: ActionSummary | TableDelta) {
@@ -1162,8 +1218,8 @@ export function rebaseSummary(ref: ActionSummary, target: ActionSummary) {
     const ancestorName = plan.targetBack.get(key) || key;
     const afterTargetName = plan.targetForward.get(ancestorName) || ancestorName;
     const afterRefName = plan.refForward.get(ancestorName) || ancestorName;
-    const afterTarget = target.tableDeltas[afterTargetName] ?? empty;
-    const afterRef = ref.tableDeltas[afterRefName] ?? empty;
+    const afterTarget = hasOwn(target.tableDeltas, afterTargetName) ? target.tableDeltas[afterTargetName] : empty;
+    const afterRef = hasOwn(ref.tableDeltas, afterRefName) ? ref.tableDeltas[afterRefName] : empty;
     rebaseTable(afterRef, afterTarget);
   }
   const deltas = copyOnWrite(target.tableDeltas);

--- a/app/common/ActionSummarizer.ts
+++ b/app/common/ActionSummarizer.ts
@@ -938,26 +938,25 @@ function settleTableDelta(td: TableDelta): TableDelta {
   }
   let sourceDeltas = td.columnDeltas;
   if (removedCols.size > 0 && Object.keys(td.columnDeltas).some(c => removedCols.has(c))) {
-    sourceDeltas = {};
+    sourceDeltas = Object.create(null);
     // Canonical (non-remapped) keys first, so an existing `-pre` entry wins on
     // any row collision with a stranded live-name cell.
     const entries = Object.entries(td.columnDeltas)
       .sort((a, b) => (removedCols.has(a[0]) ? 1 : 0) - (removedCols.has(b[0]) ? 1 : 0));
     for (const [colId, cd] of entries) {
       const target = removedCols.get(colId) ?? colId;
-      if (!hasOwn(sourceDeltas, target)) { sourceDeltas[target] = {}; }
+      if (!hasOwn(sourceDeltas, target)) { sourceDeltas[target] = Object.create(null); }
       const dest = sourceDeltas[target];
       for (const [rowId, cell] of Object.entries(cd)) {
-        const r = Number(rowId);
-        if (!(r in dest)) { dest[r] = cell; }
+        if (!hasOwn(dest, rowId)) { dest[rowId as any] = cell; }
       }
     }
   }
-  const columnDeltas: { [colId: string]: ColumnDelta } = {};
+  const columnDeltas: { [colId: string]: ColumnDelta } = Object.create(null);
   for (const [colId, cd] of Object.entries(sourceDeltas)) {
     const colNoPre = addedCols.has(colId);
     const colNoPost = colId.startsWith("-");
-    const kept: ColumnDelta = {};
+    const kept: ColumnDelta = Object.create(null);
     for (const [rowId, cell] of Object.entries(cd)) {
       const r = Number(rowId);
       const noPre = colNoPre || addedRows.has(r);
@@ -977,7 +976,7 @@ function settleTableDelta(td: TableDelta): TableDelta {
       // `[null, null]` carries no value, so drop it. Keep everything else,
       // including an insignificant `[v, v]`: a later merge may still need `v`.
       if (pre === null && post === null) { continue; }
-      kept[r] = [pre, post];
+      kept[rowId as any] = [pre, post];
     }
     if (Object.keys(kept).length > 0) { columnDeltas[colId] = kept; }
   }
@@ -1025,13 +1024,12 @@ function canonicalizeTableDelta(td: TableDelta): TableDelta {
   // Recycled rows (in both lists) carry per-entity cells where `null` marks an
   // entity boundary, so their equal-sided cells are significant, never stripped.
   const recycledRows = new Set(td.addRows.filter(r => removeSet.has(r)));
-  const columnDeltas: { [colId: string]: ColumnDelta } = {};
+  const columnDeltas: { [colId: string]: ColumnDelta } = Object.create(null);
   for (const [colId, cd] of Object.entries(td.columnDeltas)) {
-    const kept: ColumnDelta = {};
+    const kept: ColumnDelta = Object.create(null);
     for (const [rowId, cell] of Object.entries(cd)) {
-      const r = Number(rowId);
-      if (cellIsVacuous(cell) && !recycledRows.has(r)) { continue; }
-      kept[r] = cell;
+      if (cellIsVacuous(cell) && !recycledRows.has(Number(rowId))) { continue; }
+      kept[rowId as any] = cell;
     }
     if (Object.keys(kept).length > 0) { columnDeltas[colId] = kept; }
   }
@@ -1053,7 +1051,7 @@ function canonicalizeTableDelta(td: TableDelta): TableDelta {
  * is already recorded in the renames, so an empty change-set for it would just
  * be noise.) */
 function mapTableDeltas(sum: ActionSummary, fn: (td: TableDelta) => TableDelta): ActionSummary {
-  const tableDeltas: { [tableId: string]: TableDelta } = {};
+  const tableDeltas: { [tableId: string]: TableDelta } = Object.create(null);
   for (const [tableId, td] of Object.entries(sum.tableDeltas)) {
     const out = fn(td);
     if (!isEmptyTableDelta(out)) { tableDeltas[tableId] = out; }

--- a/app/common/ActionSummarizer.ts
+++ b/app/common/ActionSummarizer.ts
@@ -166,6 +166,7 @@ export class ActionSummarizer {
       this._addRow(td, act[2], act[3], 0);
     } else if (Action.isUpdateRecord(act)) { // undoing, so this is reversal of a record update
       const td = this._forTable(summary, tableId);
+      td.updateRows.push(act[2]);
       this._addRow(td, act[2], act[3], 0);
     } else if (Action.isBulkAddRecord(act)) { // undoing, this may be reversing a table delete
       const td = this._forTable(summary, tableId);

--- a/app/common/DocActions.ts
+++ b/app/common/DocActions.ts
@@ -129,9 +129,14 @@ export function getRowIds(action: DataAction): number | number[];
 export function getRowIds(action: DataAction): number | number[] { return action[2]; }
 
 // Returns the row ids in a DataAction as a list, even if the action is not a bulk action.
+// A bulk action already carries a list; a single-row action wraps its one rowId to a
+// one-element list. This is purely defensive normalization so every caller can iterate:
+// a stored DataAction always carries real numeric ids (the data engine fills in any
+// null/negative auto-assign placeholder before the action is recorded), so `null` is not
+// expected to reach here.
 export function getRowIdsFromDocAction(action: DataAction): number[] {
   const ids = action[2];
-  return (typeof ids === "number") ? [ids] : ids;
+  return Array.isArray(ids) ? ids : [ids];
 }
 
 // Returns colValues from a DataAction other than a remove action (which doesn't have colValues).

--- a/app/common/TimeQuery.ts
+++ b/app/common/TimeQuery.ts
@@ -1,4 +1,4 @@
-import { concatenateSummaries } from "app/common/ActionSummarizer";
+import { concatenateSummaryPair } from "app/common/ActionSummarizer";
 import { ActionSummary, ColumnDelta, createEmptyActionSummary, createEmptyTableDelta } from "app/common/ActionSummary";
 import { CellDelta } from "app/common/TabularDiff";
 
@@ -40,7 +40,12 @@ export class TimeCursor {
    * the TimeCursor, so we stretch further back in time.
    */
   public prepend(prevSummary: ActionSummary) {
-    this.summary = concatenateSummaries([prevSummary, this.summary]);
+    // Fold with the raw (value-preserving) pair algebra, never the canonicalizing
+    // concatenateSummaries: this is an incremental fold, and canonicalizing each
+    // step would strip an insignificant [[v],[v]] cell whose value a later step's
+    // existence boundary still needs. TimeQuery reads pre-values straight from the
+    // retained cells, so the raw form is exactly what it wants.
+    this.summary = concatenateSummaryPair(prevSummary, this.summary);
   }
 
   /**
@@ -54,7 +59,8 @@ export class TimeCursor {
     // need to clone to avoid propagating that. Look to see if
     // a safe version of concatenation could be written to save
     // cloning.
-    this.summary = concatenateSummaries([this.summary, nextSummary]);
+    // Raw pair algebra, not concatenateSummaries -- see prepend().
+    this.summary = concatenateSummaryPair(this.summary, nextSummary);
   }
 }
 

--- a/app/server/lib/ActionHistoryImpl.ts
+++ b/app/server/lib/ActionHistoryImpl.ts
@@ -85,6 +85,14 @@ export function computeActionHash(action: LocalActionBundle): string {
   encoder.marshal(action.parentActionHash);
   encoder.marshal(action.info);
   encoder.marshal(action.stored);
+  // Fold in the engine's per-undo ownership when the bundle carries it, so it is covered by the
+  // checksum too. Only when present (an array): a bundle recorded before ownership existed, or one
+  // assembled without the data engine, has none and must hash exactly as it always did. At record
+  // time the value is the in-memory array or undefined -- never the null a history round-trip would
+  // produce -- so `Array.isArray` is the right gate. Adding a field needs no migration; see _addAction.
+  if (Array.isArray(action.undoOwner)) {
+    encoder.marshal(action.undoOwner);
+  }
   const buf = encoder.dumpAsBuffer();
   shaSum.update(buf);
   return shaSum.digest("hex");
@@ -504,6 +512,9 @@ export class ActionHistoryImpl implements ActionHistory {
   private async _addAction(action: LocalActionBundle,
     branch: ActionIdentifiers): Promise<number> {
     action.parentActionHash = branch.actionHash;
+    // The hash is write-once: computed here at the origin (when unset), stored verbatim, never
+    // recomputed and compared. So computeActionHash can fold in new fields (e.g. undoOwner) without
+    // a migration -- old hashes stand, new actions just get new ones.
     if (!action.actionHash) {
       action.actionHash = computeActionHash(action);
     }

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -2151,6 +2151,9 @@ export class ActiveDoc extends EventEmitter {
           sandboxActionBundle.retValues.push(retValues);
         }
       });
+      // The engine's undoOwner covers only the entries it produced, not the on-demand ones
+      // appended above. Drop it, so the summarizer falls back to inferring the grouping.
+      delete sandboxActionBundle.undoOwner;
     }
 
     return sandboxActionBundle;

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -1,5 +1,4 @@
 import { concatenateSummaries, summarizeAction } from "app/common/ActionSummarizer";
-import { createEmptyActionSummary } from "app/common/ActionSummary";
 import { QueryFilters } from "app/common/ActiveDocAPI";
 import { ApiError } from "app/common/ApiError";
 import { BrowserSettings } from "app/common/BrowserSettings";
@@ -22,7 +21,7 @@ import {
   isRaisedException,
 } from "app/common/gristTypes";
 import { buildUrlId, parseUrlId, SHARE_KEY_PREFIX } from "app/common/gristUrls";
-import { isAffirmative, safeJsonParse } from "app/common/gutil";
+import { isAffirmative, isNonNullish, safeJsonParse } from "app/common/gutil";
 import { schema, SchemaTypes } from "app/common/schema";
 import { MetaRowRecord, MetaTableData } from "app/common/TableData";
 import {
@@ -2422,14 +2421,10 @@ export async function getChanges(
   }
   const actionNums: number[] = states.slice(rightOffset, leftOffset).map(state => state.n);
   const actions = (await activeDoc.getActions(actionNums)).reverse();
-  let totalAction = createEmptyActionSummary();
-  for (const action of actions) {
-    if (!action) { continue; }
-    const summary = summarizeAction(action, {
-      maximumInlineRows: maxRows,
-    });
-    totalAction = concatenateSummaries([totalAction, summary]);
-  }
+  // Combine the per-action summaries into one net diff for the range.
+  // concatenateSummaries drops the changes that cancel out along the way.
+  const totalAction = concatenateSummaries(
+    actions.filter(isNonNullish).map(action => summarizeAction(action, { maximumInlineRows: maxRows })));
   const result: DocStateComparison = {
     left: states[leftOffset],
     right: states[rightOffset],

--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -1,5 +1,4 @@
 import { concatenateSummaries, summarizeAction } from "app/common/ActionSummarizer";
-import { createEmptyActionSummary } from "app/common/ActionSummary";
 import { QueryFilters } from "app/common/ActiveDocAPI";
 import { ApiError } from "app/common/ApiError";
 import { BrowserSettings } from "app/common/BrowserSettings";
@@ -22,7 +21,7 @@ import {
   isRaisedException,
 } from "app/common/gristTypes";
 import { buildUrlId, parseUrlId, SHARE_KEY_PREFIX } from "app/common/gristUrls";
-import { isAffirmative, safeJsonParse } from "app/common/gutil";
+import { isAffirmative, isNonNullish, safeJsonParse } from "app/common/gutil";
 import { schema, SchemaTypes } from "app/common/schema";
 import { MetaRowRecord, MetaTableData } from "app/common/TableData";
 import {
@@ -2418,14 +2417,10 @@ export async function getChanges(
   }
   const actionNums: number[] = states.slice(rightOffset, leftOffset).map(state => state.n);
   const actions = (await activeDoc.getActions(actionNums)).reverse();
-  let totalAction = createEmptyActionSummary();
-  for (const action of actions) {
-    if (!action) { continue; }
-    const summary = summarizeAction(action, {
-      maximumInlineRows: maxRows,
-    });
-    totalAction = concatenateSummaries([totalAction, summary]);
-  }
+  // Combine the per-action summaries into one net diff for the range.
+  // concatenateSummaries drops the changes that cancel out along the way.
+  const totalAction = concatenateSummaries(
+    actions.filter(isNonNullish).map(action => summarizeAction(action, { maximumInlineRows: maxRows })));
   const result: DocStateComparison = {
     left: states[leftOffset],
     right: states[rightOffset],

--- a/app/server/lib/Sharing.ts
+++ b/app/server/lib/Sharing.ts
@@ -93,6 +93,7 @@ export class Sharing {
     const sandboxActionBundle = result.bundle;
     const accessControl = result.accessControl;
     const undo = getEnvContent(result.bundle.undo);
+    const undoOwner = sandboxActionBundle.undoOwner && getEnvContent(sandboxActionBundle.undoOwner);
 
     try {
       const isSystemAction = (userActions.length === 1 && SYSTEM_ACTIONS.has(userActions[0][0] as string));
@@ -123,6 +124,7 @@ export class Sharing {
         stored: sandboxActionBundle.stored,
         calc: sandboxActionBundle.calc,
         undo,
+        undoOwner,
         userActions,
         actionHash: null,        // Gets set below by _actionHistory.recordNext...
         parentActionHash: null,  // Gets set below by _actionHistory.recordNext...

--- a/sandbox/grist/acl.py
+++ b/sandbox/grist/acl.py
@@ -77,6 +77,9 @@ def acl_read_split(action_group):
   bundle.direct.extend((0, flag) for flag in action_group.direct)
   bundle.calc.extend((0, da) for da in action_group.calc)
   bundle.undo.extend((0, da) for da in action_group.undo)
+  # Resolve the per-undo owner map (keyed by object identity) to a list parallel to the undo
+  # actions, now that their final order is fixed. Enveloped to match bundle.undo (same envelope).
+  bundle.undo_owner.extend((0, action_group.undo_owner.get(id(da))) for da in action_group.undo)
   bundle.retValues = action_group.retValues
   return bundle
 

--- a/sandbox/grist/action_obj.py
+++ b/sandbox/grist/action_obj.py
@@ -29,12 +29,21 @@ class ActionGroup(object):
     self.summary = ActionSummary()
     self.requests = {}
 
+    # Maps id(undo_action) to the index in self.stored of the doc action whose application
+    # produced that undo action. This is the correspondence the engine knows directly, used on
+    # the server to chunk a bundle without re-inferring it (see app/common/ActionLayout.ts
+    # chunkByOwners). Keyed by object identity so it survives undo entries being reordered (the
+    # ModifyColumn pop/re-append) or front-inserted. An undo action absent from this map (notably
+    # the front calc-flush restores of a removed column/table/row) has no single owning stored
+    # action; the server attributes those to their removal just as the lattice chunker does.
+    self.undo_owner = {}
+
   def flush_calc_changes(self):
     """
     Merge the changes from self.summary into self.stored and self.undo, and clear the summary.
     """
     length_before = len(self.stored)
-    self.summary.convert_deltas_to_actions(self.stored, self.undo)
+    self.summary.convert_deltas_to_actions(self.stored, self.undo, self.undo_owner)
     count = len(self.stored) - length_before
     self.direct += [False] * count
     self.summary = ActionSummary()
@@ -45,7 +54,8 @@ class ActionGroup(object):
     remove that column from the summary.
     """
     length_before = len(self.stored)
-    self.summary.pop_column_delta_as_actions(table_id, col_id, self.stored, self.undo)
+    self.summary.pop_column_delta_as_actions(table_id, col_id, self.stored, self.undo,
+                                             self.undo_owner)
     count = len(self.stored) - length_before
     self.direct += [False] * count
 
@@ -93,6 +103,9 @@ class ActionBundle(object):
     self.direct = []          # Pairs of (envIndex, boolean)
     self.calc = []            # Pairs of (envIndex, docAction)
     self.undo = []            # Pairs of (envIndex, docAction)
+    self.undo_owner = []      # Pairs of (envIndex, owner), parallel to self.undo: the stored-action
+                              # index that produced each undo action, or None for a front
+                              # calc-flush restore (see ActionGroup.undo_owner).
     self.retValues = []
     self.rules = set()        # RowIds of ACLRule records used to construct this ActionBundle.
 
@@ -103,6 +116,7 @@ class ActionBundle(object):
       "direct":    self.direct,
       "calc":      [(env, actions.get_action_repr(a)) for (env, a) in self.calc],
       "undo":      [(env, actions.get_action_repr(a)) for (env, a) in self.undo],
+      "undoOwner": self.undo_owner,
       "retValues": self.retValues,
       "rules":     sorted(self.rules)
     }

--- a/sandbox/grist/action_obj.py
+++ b/sandbox/grist/action_obj.py
@@ -62,6 +62,9 @@ class ActionGroup(object):
   def check_sanity(self):
     if len(self.stored) != len(self.direct):
       raise AssertionError("failed to track origin of actions")
+    for owner in self.undo_owner.values():
+      if owner is not None and not 0 <= owner < len(self.stored):
+        raise AssertionError("undo_owner refers to a missing stored action")
 
   def get_repr(self):
     return {

--- a/sandbox/grist/action_summary.py
+++ b/sandbox/grist/action_summary.py
@@ -32,25 +32,27 @@ class ActionSummary(object):
       previous = col_deltas.get(row_id)
       col_deltas[row_id] = (previous[0] if previous else before, after)
 
-  def convert_deltas_to_actions(self, out_stored, out_undo):
+  def convert_deltas_to_actions(self, out_stored, out_undo, undo_owner=None):
     """
     Go through all prepared deltas, construct DocActions for them, and add them to out_stored
-    and out_undo lists.
+    and out_undo lists. If `undo_owner` is given, record into it (keyed by id(undo_action)) the
+    stored-action index each generated undo corresponds to (see ActionGroup.undo_owner).
     """
     for table_id in sorted(self._tables):
       table_delta = self._tables[table_id]
       for col_id in sorted(table_delta.column_deltas):
         column_delta = table_delta.column_deltas[col_id]
-        self._changes_to_actions(table_id, col_id, column_delta, out_stored, out_undo)
+        self._changes_to_actions(table_id, col_id, column_delta, out_stored, out_undo, undo_owner)
 
-  def pop_column_delta_as_actions(self, table_id, col_id, out_stored, out_undo):
+  def pop_column_delta_as_actions(self, table_id, col_id, out_stored, out_undo, undo_owner=None):
     """
     Remove deltas for a particular column, and convert the removed deltas to DocActions. Add
     those to out_stored and out_undo lists.
     """
     table_delta = self._tables.get(table_id)
     col_delta = table_delta and table_delta.column_deltas.pop(col_id, None)
-    return self._changes_to_actions(table_id, col_id, col_delta or {}, out_stored, out_undo)
+    return self._changes_to_actions(table_id, col_id, col_delta or {}, out_stored, out_undo,
+                                    undo_owner)
 
   def update_new_rows_map(self, table_id, temp_row_ids, final_row_ids):
     """
@@ -69,10 +71,13 @@ class ActionSummary(object):
     t = self._forTable(table_id)
     return [t.temp_row_ids.get(r, r) for r in row_ids]
 
-  def _changes_to_actions(self, table_id, col_id, column_delta, out_stored, out_undo):
+  def _changes_to_actions(self, table_id, col_id, column_delta, out_stored, out_undo,
+                          undo_owner=None):
     """
     Given a column and a dict of column_deltas for it, of the form {row_id: (before_value,
-    after_value)}, creates DocActions and adds them to out_stored and out_undo lists.
+    after_value)}, creates DocActions and adds them to out_stored and out_undo lists. If
+    `undo_owner` is given, record into it the stored-action index each generated undo corresponds
+    to (see ActionGroup.undo_owner).
     """
     if not column_delta:
       return
@@ -95,10 +100,15 @@ class ActionSummary(object):
       return actions.BulkUpdateRecord(tid if tid is not None else table_id, filtered_row_ids,
                                       {cid if cid is not None else col_id: values}).simplify()
 
+    # The stored update that records this column's recomputed (after) values, if any. A preserved
+    # row's undo restores the (before) values of that same stored update, so the two form one
+    # reversible step and share an owner.
+    stored_update_index = None
     if not defunct:
       row_ids_after = self.filter_out_gone_rows(table_id, full_row_ids)
       if row_ids_after:
         out_stored.append(update_action(row_ids_after, 1))
+        stored_update_index = len(out_stored) - 1
 
     if self.is_created(table_id, col_id) and not defunct:
       # A newly-created column, and not replacing a defunct one. Don't generate undo actions.
@@ -116,11 +126,16 @@ class ActionSummary(object):
     defunct_row_ids = [r for r in row_ids_before if r not in preserved_row_ids_set]
 
     if preserved_row_ids:
-      out_undo.append(update_action(preserved_row_ids, 0))
+      preserved_undo = update_action(preserved_row_ids, 0)
+      out_undo.append(preserved_undo)
+      if undo_owner is not None and stored_update_index is not None:
+        undo_owner[id(preserved_undo)] = stored_update_index
 
     if defunct_row_ids:
       # Insert at the front so the restore lands after the rows/columns/tables are re-added on
-      # undo. It runs last, so it uses the pre-rename names (see note above).
+      # undo. It runs last, so it uses the pre-rename names (see note above). We leave such a front
+      # restore unowned: it belongs to whatever removed the rows/column/table, which the server
+      # attributes for itself.
       out_undo.insert(0, update_action(defunct_row_ids, 0, orig_table_id, orig_col_id))
 
   def _forTable(self, table_id):

--- a/sandbox/grist/docactions.py
+++ b/sandbox/grist/docactions.py
@@ -7,6 +7,22 @@ from objtypes import strict_equal
 log = logging.getLogger(__name__)
 
 class DocActions(object):
+  # Each method here appends to out_actions.undo the inverse action(s) of the
+  # doc action it applies (e.g. RemoveColumn restores the column's data with a
+  # BulkUpdateRecord, then re-adds it with an AddColumn). The server's action
+  # summarizer relies on the exact shape of those inverses: app/common/
+  # ActionLayout.ts `expectedInverses` is a hand-kept catalogue of what each
+  # action emits here, used to split a bundle into summarizable chunks. If you
+  # change which inverse actions a method emits, or their order, update
+  # expectedInverses to match -- test/server/lib/ActionSummaryFuzz.ts checks the
+  # two stay in agreement.
+  #
+  # For freshly-applied bundles the engine also records which stored action
+  # produced each undo (out_actions.undo_owner, populated in useractions and
+  # action_summary), and the summarizer prefers that exact correspondence
+  # (chunkByOwners) over inferring it. The expectedInverses catalogue remains the
+  # fallback for any bundle without that record: all history from before undo_owner
+  # was added (a common case, not a relic), plus engine-less bundles.
   def __init__(self, engine):
     self._engine = engine
 

--- a/sandbox/grist/engine.py
+++ b/sandbox/grist/engine.py
@@ -1536,6 +1536,11 @@ class Engine(object):
       undo_actions = self.out_actions.undo[len_undo:]
       log.info("Reverting %d doc actions", len(undo_actions))
       self.user_actions.ApplyUndoActions([actions.get_action_repr(a) for a in undo_actions])
+      # The trimmed undo actions (including any the revert itself just appended) must also
+      # leave undo_owner, which is keyed by id(): a freed action's id can be reused by a
+      # later undo action, which would then inherit a stale owner.
+      for a in self.out_actions.undo[len_undo:]:
+        self.out_actions.undo_owner.pop(id(a), None)
       del self.out_actions.calc[len_calc:]
       del self.out_actions.stored[len_stored:]
       del self.out_actions.direct[len_stored:]

--- a/sandbox/grist/engine.py
+++ b/sandbox/grist/engine.py
@@ -1591,6 +1591,11 @@ class Engine(object):
       undo_actions = self.out_actions.undo[len_undo:]
       log.info("Reverting %d doc actions", len(undo_actions))
       self.user_actions.ApplyUndoActions([actions.get_action_repr(a) for a in undo_actions])
+      # The trimmed undo actions (including any the revert itself just appended) must also
+      # leave undo_owner, which is keyed by id(): a freed action's id can be reused by a
+      # later undo action, which would then inherit a stale owner.
+      for a in self.out_actions.undo[len_undo:]:
+        self.out_actions.undo_owner.pop(id(a), None)
       del self.out_actions.calc[len_calc:]
       del self.out_actions.stored[len_stored:]
       del self.out_actions.direct[len_stored:]

--- a/sandbox/grist/test_summary.py
+++ b/sandbox/grist/test_summary.py
@@ -542,6 +542,64 @@ class Address:
       [ 11,   "Amherst",  "MA"   , 1,       17.0      ],
     ])
 
+  def test_undo_owner_attribution(self):
+    # Each undo action is tagged with the index of the stored action that produced it
+    # (ActionGroup.undo_owner). Check the tagging over summary-table maintenance, where one user
+    # action fans out into several stored actions plus calc-flush restores: every owned undo
+    # belongs to a stored action on its own table, and the only unowned undos are the front
+    # restores of a removed row's formula values.
+    self.load_sample(self.sample)
+    self.apply_user_action(["CreateViewSection", 1, 0, "record", [11,12], None])
+    summary = "Address_summary_city_state"
+
+    def owners_of(out):
+      return [out.undo_owner.get(id(u)) for u in out.undo]
+
+    def check_owners(out):
+      for undo, owner in zip(out.undo, owners_of(out)):
+        if owner is None:
+          # A front calc-flush restore, inserted ahead of everything else.
+          self.assertIsInstance(undo, (actions.UpdateRecord, actions.BulkUpdateRecord))
+        else:
+          self.assertEqual(out.stored[owner].table_id, undo.table_id)
+
+    # Regroup a source row: one summary row is added and another emptied and removed. The removed
+    # row's formula values come back as unowned front restores; the rest pair up with their
+    # stored action, in particular the summary-table add/remove get their own owners rather than
+    # the source update that triggered them.
+    out = self.update_record("Address", 25, city="Salem")
+    self.assertPartialOutActions(out, {
+      "stored": [
+        actions.UpdateRecord("Address", 25, {'city': 'Salem'}),
+        actions.AddRecord(summary, 10, {'city': 'Salem', 'state': 'MA'}),
+        actions.RemoveRecord(summary, 5),
+        actions.UpdateRecord(summary, 10, {'amount': 5.0}),
+        actions.UpdateRecord(summary, 10, {'count': 1}),
+        actions.UpdateRecord(summary, 10, {'group': [25]}),
+      ],
+      "undo": [
+        actions.UpdateRecord(summary, 5, {'group': [25]}),
+        actions.UpdateRecord(summary, 5, {'count': 1}),
+        actions.UpdateRecord(summary, 5, {'amount': 5.0}),
+        actions.UpdateRecord("Address", 25, {'city': 'Bedford'}),
+        actions.RemoveRecord(summary, 10),
+        actions.AddRecord(summary, 5, {'city': 'Bedford', 'state': 'MA'}),
+      ],
+    })
+    check_owners(out)
+    self.assertEqual(owners_of(out), [None, None, None, 0, 1, 2])
+
+    # Add a source row that creates a new summary row: two adds, two owned removes.
+    out = self.add_record("Address", city="Amherst", state="MA", amount=17.0)
+    self.assertPartialOutActions(out, {
+      "undo": [
+        actions.RemoveRecord("Address", 32),
+        actions.RemoveRecord(summary, 11),
+      ],
+    })
+    check_owners(out)
+    self.assertEqual(owners_of(out), [0, 1])
+
   #----------------------------------------------------------------------
 
   @test_engine.test_undo

--- a/sandbox/grist/useractions.py
+++ b/sandbox/grist/useractions.py
@@ -253,9 +253,18 @@ class UserActions(object):
       # Convert bulk actions to single actions if possible, or None if it affects no rows.
       action = action.simplify()
     if action:
-      self._engine.out_actions.stored.append(action)
-      self._engine.out_actions.direct.append(self._indirection_level == DIRECT_ACTION)
+      out = self._engine.out_actions
+      out.stored.append(action)
+      out.direct.append(self._indirection_level == DIRECT_ACTION)
+      stored_index = len(out.stored) - 1
+      undo_start = len(out.undo)
       self._engine.apply_doc_action(action)
+      # Every undo action appended while applying this stored action is its inverse. Record the
+      # correspondence so the server need not re-infer it (see ActionGroup.undo_owner). Applying
+      # one doc action only ever appends to the undo list (the reorderings happen later, during
+      # calc flush), so the new tail is exactly this action's undos.
+      for undo_action in out.undo[undo_start:]:
+        out.undo_owner[id(undo_action)] = stored_index
 
   def _do_extra_doc_action(self, action):
     # It this is Update, Add (or Bulks), run thouse actions through ensure_column_accepts_data

--- a/sandbox/grist/useractions.py
+++ b/sandbox/grist/useractions.py
@@ -262,9 +262,11 @@ class UserActions(object):
       # Every undo action appended while applying this stored action is its inverse. Record the
       # correspondence so the server need not re-infer it (see ActionGroup.undo_owner). Applying
       # one doc action only ever appends to the undo list (the reorderings happen later, during
-      # calc flush), so the new tail is exactly this action's undos.
+      # calc flush), so the new tail is exactly this action's undos. setdefault, not assignment: if
+      # applying a doc action ever re-enters here (it does not today, checked by instrumenting the
+      # test suite), the inner call's tag is the more specific one and must win.
       for undo_action in out.undo[undo_start:]:
-        out.undo_owner[id(undo_action)] = stored_index
+        out.undo_owner.setdefault(id(undo_action), stored_index)
 
   def _do_extra_doc_action(self, action):
     # It this is Update, Add (or Bulks), run thouse actions through ensure_column_accepts_data

--- a/test/server/lib/ActionHistory.ts
+++ b/test/server/lib/ActionHistory.ts
@@ -405,6 +405,33 @@ for (const version of versions) {
   });
 }
 
+describe("computeActionHash with undo ownership", function() {
+  // The engine's per-undo ownership is folded into the action hash when present, so it is covered
+  // by the checksum -- but only when present, so actions recorded before ownership existed keep
+  // the hash they always had.
+  it("does not change the hash when ownership is absent, null, or undefined", function() {
+    const base = makeBundle(1, "one");
+    const baseline = computeActionHash(base);
+    assert.equal(computeActionHash({ ...base, undoOwner: undefined }), baseline,
+      "an explicit undefined must hash like an absent field");
+    // A history round-trip turns an absent owner list into null; that must hash like absent too,
+    // or re-verifying a pre-ownership action read back from storage would fail.
+    assert.equal(computeActionHash({ ...base, undoOwner: null } as any), baseline,
+      "a round-tripped null must hash like an absent field");
+  });
+
+  it("folds ownership into the hash when present, and is tamper-evident", function() {
+    const base = makeBundle(1, "one");
+    const withOwners = computeActionHash({ ...base, undoOwner: [0, null, 1] });
+    assert.notEqual(withOwners, computeActionHash(base),
+      "present ownership must affect the hash");
+    assert.notEqual(withOwners, computeActionHash({ ...base, undoOwner: [0, null, 2] }),
+      "altering an owner must change the hash");
+    assert.notEqual(withOwners, computeActionHash({ ...base, undoOwner: [0, 1] }),
+      "dropping an owner must change the hash");
+  });
+});
+
 describe("ActionHistoryImpl only", function() {
   // No sandboxing for quick tests.
   testUtils.withoutSandboxing();

--- a/test/server/lib/ActionSummary.ts
+++ b/test/server/lib/ActionSummary.ts
@@ -1,7 +1,11 @@
+import { chunkByLattice, chunkByOwners } from "app/common/ActionLayout";
 import {
-  ActionSummaryOptions, concatenateSummaries, rebaseSummary, summarizeAction,
+  ActionSummaryOptions, canonicalizeSummary, concatenateSummaries, concatenateSummaryPair,
+  rebaseSummary, summarizeAction, summarizeStoredAndUndo,
 } from "app/common/ActionSummarizer";
 import { ActionSummary, asTabularDiffs, createEmptyTableDelta, LabelDelta, TableDelta } from "app/common/ActionSummary";
+import { DocAction } from "app/common/DocActions";
+import { TimeCursor } from "app/common/TimeQuery";
 import { ActiveDoc } from "app/server/lib/ActiveDoc";
 import { createDocTools } from "test/server/docTools";
 import * as testUtils from "test/server/testUtils";
@@ -14,15 +18,14 @@ async function summarizeLastAction(doc: ActiveDoc, options?: ActionSummaryOption
   return summarizeAction((await doc.getRecentActionsDirect(1))[0], options);
 }
 
-/** Make a blank TableDelta object for testng */
-function makeTableDelta(name: string): TableDelta {
-  return {
-    updateRows: [],
-    removeRows: [],
-    addRows: [],
-    columnDeltas: {},
-    columnRenames: [],
-  };
+/** A TableDelta with the given fields overriding an empty one. */
+function td(o: Partial<TableDelta> = {}): TableDelta {
+  return { ...createEmptyTableDelta(), ...o };
+}
+
+/** An ActionSummary from its renames and (optional) per-table deltas. */
+function S(tableRenames: LabelDelta[], tableDeltas: ActionSummary["tableDeltas"] = {}): ActionSummary {
+  return { tableRenames, tableDeltas };
 }
 
 describe("ActionSummary", function() {
@@ -297,13 +300,13 @@ describe("ActionSummary", function() {
         [null, "Transients"],   // created in s1, removed in s2
         ["Doppelganger", null]], // removed in s1, same name created in s2
       tableDeltas: {
-        "Frogs": makeTableDelta("Frogs"),
-        "Spices": makeTableDelta("Spices"),
-        "Sharks": makeTableDelta("Sharks"),
-        "Transients": makeTableDelta("Transients"),
-        "-Dinosaurs": makeTableDelta("-Dinosaurs"),
-        "-Doppelganger": makeTableDelta("-Doppelganger"),
-        "Koalas": makeTableDelta("Koalas"),
+        "Frogs": createEmptyTableDelta(),
+        "Spices": createEmptyTableDelta(),
+        "Sharks": createEmptyTableDelta(),
+        "Transients": createEmptyTableDelta(),
+        "-Dinosaurs": createEmptyTableDelta(),
+        "-Doppelganger": createEmptyTableDelta(),
+        "Koalas": createEmptyTableDelta(),
       },
     };
     const summary2: ActionSummary = {
@@ -315,37 +318,29 @@ describe("ActionSummary", function() {
         [null, "Doppelganger"], // removed in s1, same name created in s2
         ["Koalas", "Pajamas"]],  // mentioned in s1, renamed here
       tableDeltas: {
-        "Ducks": makeTableDelta("Ducks"),
-        "Colors": makeTableDelta("Colors"),
-        "GreatWhites": makeTableDelta("GreatWhites"),
-        "Doppelganger": makeTableDelta("Doppelganger"),
-        "-Trilobytes": makeTableDelta("-Trilobytes"),
-        "-Transients": makeTableDelta("-Transients"),
+        "Ducks": createEmptyTableDelta(),
+        "Colors": createEmptyTableDelta(),
+        "GreatWhites": createEmptyTableDelta(),
+        "Doppelganger": createEmptyTableDelta(),
+        "-Trilobytes": createEmptyTableDelta(),
+        "-Transients": createEmptyTableDelta(),
       },
     };
     const summary3: ActionSummary = {
-      tableRenames: [[null, "Doppelganger"],
-        [null, "Ducks"],
-        [null, "Frogs"],
-        ["Colours", "Colors"],
+      tableRenames: [["Colours", "Colors"],
         ["Dinosaurs", null],
         ["Doppelganger", null],
         ["Fish", "GreatWhites"],
         ["Koalas", "Pajamas"],
         ["Spaces", "Spices"],
-        ["Trilobytes", null]],
-      tableDeltas: {
-        "Frogs": makeTableDelta("Frogs"),
-        "Ducks": makeTableDelta("Ducks"),
-        "Colors": makeTableDelta("Colors"),
-        "Spices": makeTableDelta("Spices"),
-        "GreatWhites": makeTableDelta("GreatWhites"),
-        "Doppelganger": makeTableDelta("Doppelganger"),
-        "-Dinosaurs": makeTableDelta("-Dinosaurs"),
-        "-Doppelganger": makeTableDelta("-Doppelganger"),
-        "-Trilobytes": makeTableDelta("-Trilobytes"),
-        "Pajamas": makeTableDelta("Pajamas"),
-      },
+        ["Trilobytes", null],
+        [null, "Doppelganger"],
+        [null, "Ducks"],
+        [null, "Frogs"]],
+      // The inputs' per-table deltas are all empty, so
+      // the composed summary omits them: table existence is conveyed by
+      // tableRenames, and an empty per-table delta carries nothing.
+      tableDeltas: {},
     };
     const result = concatenateSummariesCleanly([summary1, summary2]);
     assert.deepEqual(result, summary3);
@@ -390,11 +385,11 @@ describe("ActionSummary", function() {
           removeRows: [],
           addRows: [],
           columnDeltas: {},
-          columnRenames: [[null, "color"],
-            [null, "weight"],
-            ["age", "minutes"],
+          columnRenames: [["age", "minutes"],
             ["anger", null],
-            ["depth", null]],
+            ["depth", null],
+            [null, "color"],
+            [null, "weight"]],
         },
       },
     };
@@ -418,8 +413,9 @@ describe("ActionSummary", function() {
             },
             "-color": {
               1: [["gray"], null],
-              11: [["gray"], null],
-              12: [["gray"], null],
+              // Rows 11, 12 are added in this scope, so they had no pre-state
+              // value: a cell under the removed `color` column is [null, null]
+              // for them, and so is omitted. An added row cannot have a pre value.
             },
           },
           columnRenames: [["age", "years"], ["color", null]],
@@ -461,7 +457,8 @@ describe("ActionSummary", function() {
             },
             "-color": {
               1: [["gray"], null],
-              11: [["gray"], null],
+              // Row 11 is added in this scope: no pre-state value, so its
+              // cell under the removed `color` column is omitted.
             },
           },
           columnRenames: [["age", "minutes"], ["color", null]],
@@ -554,6 +551,33 @@ describe("ActionSummary", function() {
         [null, "Title"]]);
   });
 
+  it("summarizes a legacy-shaped bundle (orphaned metadata undos) correctly", function() {
+    // Legacy (pre-~2017) bundles recorded only the user-facing action in
+    // `stored` while `undo` also carried the metadata-side inverses. The
+    // chunker can't attribute those extra undos to a stored action, so it
+    // gathers them as orphans; concat merges them back, with no whole-bundle-
+    // walk fallback. For an AddTable, the metadata churn is the table's own
+    // creation, so the summary surfaces just the new table and its columns --
+    // exactly what the old whole-bundle walk produced (verified bundle-by-
+    // bundle against Favorite_Films.grist's real history, which has this shape
+    // at runs 1/7/9).
+    const stored: DocAction[] = [
+      ["AddTable", "Foo", [{ id: "a" }, { id: "b" }] as any],
+    ];
+    const undo: DocAction[] = [
+      ["RemoveTable", "Foo"],
+      ["RemoveRecord", "_grist_Tables", 5],
+      ["BulkRemoveRecord", "_grist_Tables_column", [10, 11]],
+    ];
+    const sum = summarizeStoredAndUndo(stored, undo, { maximumInlineRows: null });
+    // The new table is summarized with its columns; the orphaned metadata
+    // undos (the table's own creation records) are absorbed, not surfaced as
+    // spurious _grist_* deltas.
+    assert.deepEqual(sum.tableRenames, [[null, "Foo"]]);
+    assert.deepEqual(Object.keys(sum.tableDeltas), ["Foo"]);
+    assert.deepEqual(sum.tableDeltas.Foo.columnRenames, [[null, "a"], [null, "b"]]);
+  });
+
   it("summarizes partially uncached changes consistently", async function() {
     // The summaries here simulate a summarizer that dropped some cell
     // values to stay under the inline-rows limit: rows 12-14 / 15-16 are
@@ -581,7 +605,9 @@ describe("ActionSummary", function() {
             "-color": {
               1: [["gray"], null],
               10: [["yellow"], null],
-              11: [["gray"], null],
+              // Row 11 is added in this scope: no pre-state value, so its cell
+              // under the removed `color` column is omitted (an added row
+              // cannot carry a pre-value).
               // rows 12 + 13 + 14 happen not to be cached.
               15: [["white"], null],
               16: [["black"], null],
@@ -637,7 +663,7 @@ describe("ActionSummary", function() {
             "-color": {
               1: [["gray"], null],
               10: [["yellow"], null],
-              11: [["gray"], null],
+              // Row 11 is added: omitted under the removed `color` column.
               15: [["white"], null],
               16: [["black"], null],
             },
@@ -1046,3 +1072,918 @@ function concatenateSummariesCleanly(args: ActionSummary[]) {
   }
   return result;
 }
+
+// Canonical-form normalization in composition, and the lattice chunker.
+
+describe("ActionSummary canonical form", function() {
+  it("erases a transient row's orphan-column cell without mutating the input", function() {
+    // sum1 adds row 5 (no cell). sum2 removes row 5 and carries a cell for it in
+    // column A. Row 5 is transient in the combined scope, so its cell is erased.
+    // Because sum1 has no columns, mergeTable's column-level copy-on-write never
+    // fires, so without care the erase would write straight into sum2's
+    // columnDeltas dict (the shallow TableDelta copy still aliases it) and mutate
+    // the caller's input. concatenateSummariesCleanly asserts both inputs are
+    // left untouched.
+    const sum1 = S([], { T: td({ addRows: [5] }) });
+    const sum2 = S([], { T: td({ removeRows: [5], columnDeltas: { A: { 5: [["x"], ["y"]] } } }) });
+    const result = concatenateSummariesCleanly([sum1, sum2]);
+    // The transient row leaves no trace, so its table delta nets to empty.
+    assert.isUndefined(result.tableDeltas.T);
+  });
+
+  it("drops a vacuous [v,v] cell and reclassifies the row out of updateRows", function() {
+    // Oscillation: v -> w in a, w -> v in b. The combined cell is [v,v]
+    // (no net change), so it is dropped, the row leaves updateRows, and
+    // the now-empty table delta is omitted.
+    const a = S([], { T: td({ updateRows: [1], columnDeltas: { c: { 1: [["v"], ["w"]] } } }) });
+    const b = S([], { T: td({ updateRows: [1], columnDeltas: { c: { 1: [["w"], ["v"]] } } }) });
+    const result = concatenateSummariesCleanly([a, b]);
+    assert.deepEqual(result.tableDeltas, {});
+  });
+
+  it("drops empty column deltas and empty per-table deltas", function() {
+    // Transient row 5 (added in a, removed in b). Its customer cell
+    // cancels; region (recorded only by b) is stripped because the row
+    // never existed at either combined endpoint. Nothing remains.
+    const a = S([], { T: td({ addRows: [5], columnDeltas: { customer: { 5: [null, ["Alice"]] } } }) });
+    const b = S([], { T: td({ removeRows: [5], columnDeltas: {
+      customer: { 5: [["Alice"], null] }, region: { 5: [["NA"], null] } } }) });
+    const result = concatenateSummariesCleanly([a, b]);
+    assert.deepEqual(result.tableDeltas, {});
+  });
+
+  it("preserves recycled-row per-entity cells (no synthesis, no drop)", function() {
+    // Row 5 removed (old entity, colX=x) then re-added (new entity,
+    // colY=y). Recycled: row in both lists; colX stays [x,null] (old
+    // entity), colY stays [null,y] (new entity). Neither is vacuous, so
+    // neither is dropped; no "?" is introduced.
+    const a = S([], { T: td({ removeRows: [5], columnDeltas: { colX: { 5: [["x"], null] } } }) });
+    const b = S([], { T: td({ addRows: [5], columnDeltas: { colY: { 5: [null, ["y"]] } } }) });
+    const result = concatenateSummariesCleanly([a, b]);
+    const t = result.tableDeltas.T;
+    assert.deepEqual(t.addRows, [5]);
+    assert.deepEqual(t.removeRows, [5]);
+    assert.deepEqual(t.columnDeltas.colX, { 5: [["x"], null] });
+    assert.deepEqual(t.columnDeltas.colY, { 5: [null, ["y"]] });
+  });
+
+  it("keeps a row in updateRows under mayBeIncomplete even when its cell cancels", function() {
+    // Same oscillation, but the table is mayBeIncomplete: the missing
+    // cell might be a dropped value rather than "no change", so the row
+    // is not reclassified out of updateRows.
+    const a = S([], { T: td({ updateRows: [1], mayBeIncomplete: true,
+      columnDeltas: { c: { 1: [["v"], ["w"]] } } }) });
+    const b = S([], { T: td({ updateRows: [1], mayBeIncomplete: true,
+      columnDeltas: { c: { 1: [["w"], ["v"]] } } }) });
+    const result = concatenateSummariesCleanly([a, b]);
+    assert.deepEqual(result.tableDeltas.T.updateRows, [1]);
+    assert.equal(result.tableDeltas.T.mayBeIncomplete, true);
+  });
+
+  it("composition is associative with normalization (oscillation then a real change)", function() {
+    const a = S([], { T: td({ updateRows: [1], columnDeltas: { c: { 1: [["v"], ["w"]] } } }) });
+    const b = S([], { T: td({ updateRows: [1], columnDeltas: { c: { 1: [["w"], ["v"]] } } }) });
+    const c = S([], { T: td({ updateRows: [1], columnDeltas: { c: { 1: [["v"], ["u"]] } } }) });
+    const left = concatenateSummariesCleanly([concatenateSummariesCleanly([a, b]), c]);
+    const right = concatenateSummariesCleanly([a, concatenateSummariesCleanly([b, c])]);
+    assert.deepEqual(left, right);
+    assert.deepEqual(left.tableDeltas.T.columnDeltas.c, { 1: [["v"], ["u"]] });
+  });
+});
+
+// Re-keying a delta's history onto the defunct name when its entity is
+// modified/renamed in part 1 and then removed in part 2. Without this,
+// part 1's row/cell history is stranded under a name (live or renamed)
+// that no longer exists in the combined scope, and endpoint
+// reconstruction cannot recover the removed entity's pre-state contents from
+// the defunct key.
+
+describe("ActionSummary defunct re-keying on remove-after-history", function() {
+  it("merges a renamed-then-removed table's history under the defunct original name", function() {
+    // Table existed as A, renamed A->B with a row update (part 1), then
+    // B removed (part 2). Combined: A is removed, so its whole history
+    // keys under "-A" with the pre-value from before everything.
+    const part1 = S([["A", "B"]],
+      { B: td({ updateRows: [1], columnDeltas: { col: { 1: [["old"], ["new"]] } } }) });
+    const part2 = S([["B", null]],
+      { ["-B"]: td({ removeRows: [1], columnDeltas: { col: { 1: [["new"], null] } } }) });
+    const result = concatenateSummariesCleanly([part1, part2]);
+    assert.deepEqual(result.tableRenames, [["A", null]]);
+    assert.deepEqual(Object.keys(result.tableDeltas), ["-A"]);
+    assert.deepEqual(result.tableDeltas["-A"].removeRows, [1]);
+    assert.deepEqual(result.tableDeltas["-A"].columnDeltas.col, { 1: [["old"], null] });
+  });
+
+  it("re-keys a stable-but-edited table's history when it is removed in part 2", function() {
+    // Table C is untouched-but-data-edited in part 1 (no rename), then
+    // removed in part 2. Part 1's delta is keyed by the live name C and
+    // must move to "-C" to merge with part 2's defunct delta.
+    const part1 = S([],
+      { C: td({ updateRows: [1], columnDeltas: { col: { 1: [["old"], ["new"]] } } }) });
+    const part2 = S([["C", null]],
+      { ["-C"]: td({ removeRows: [1], columnDeltas: { col: { 1: [["new"], null] } } }) });
+    const result = concatenateSummariesCleanly([part1, part2]);
+    assert.deepEqual(result.tableRenames, [["C", null]]);
+    assert.deepEqual(Object.keys(result.tableDeltas), ["-C"]);
+    assert.deepEqual(result.tableDeltas["-C"].removeRows, [1]);
+    assert.deepEqual(result.tableDeltas["-C"].columnDeltas.col, { 1: [["old"], null] });
+  });
+
+  it("merges a renamed-then-removed column's history under its defunct original name", function() {
+    // Same shape one level down: column a renamed a->b with a cell edit
+    // (part 1), then b removed (part 2). The column history keys under
+    // "-a" within the (surviving) table T.
+    const part1 = S([], { T: td({ updateRows: [1],
+      columnRenames: [["a", "b"]], columnDeltas: { b: { 1: [["old"], ["new"]] } } }) });
+    const part2 = S([], { T: td({ updateRows: [1],
+      columnRenames: [["b", null]], columnDeltas: { ["-b"]: { 1: [["new"], null] } } }) });
+    const result = concatenateSummariesCleanly([part1, part2]);
+    const t = result.tableDeltas.T;
+    assert.deepEqual(t.columnRenames, [["a", null]]);
+    assert.deepEqual(Object.keys(t.columnDeltas), ["-a"]);
+    assert.deepEqual(t.columnDeltas["-a"], { 1: [["old"], null] });
+  });
+});
+
+// concat must be associative. A row
+// removed-then-readded within a scope is `recycled`, not `transient`:
+// its pre-state value must survive a later removal. The bug this guards
+// was that both the row-list (`transients`) and the cell merge treated
+// "added in left ∧ removed in right" as transient, dropping the recycled
+// row's pre-value -- so left- and right-association disagreed.
+
+describe("ActionSummary concat associativity: recycled row then table removal", function() {
+  // A: row 2 removed (had value v2). B: row 2 re-added (value a2) -- so
+  // A.B recycles row 2. C: the whole table removed (row 2 then holds a2,
+  // row 1 holds v1). True net: table existed with row 2 = v2, now gone, so
+  // -T/-c row 2 must carry [v2, null].
+  const A = S([], { T: td({ removeRows: [2], columnDeltas: { c: { 2: [["v2"], null] } } }) });
+  const B = S([], { T: td({ addRows: [2], columnDeltas: { c: { 2: [null, ["a2"]] } } }) });
+  const C = S([["T", null]], { ["-T"]: td({ removeRows: [1, 2],
+    columnRenames: [["c", null]],
+    columnDeltas: { ["-c"]: { 1: [["v1"], null], 2: [["a2"], null] } } }) });
+
+  it("(A.B).C equals A.(B.C)", function() {
+    const left = concatenateSummaryPair(concatenateSummaryPair(A, B), C);
+    const right = concatenateSummaryPair(A, concatenateSummaryPair(B, C));
+    assert.deepEqual(left, right);
+  });
+
+  it("keeps the recycled row's pre-state value through the removal", function() {
+    const left = concatenateSummaryPair(concatenateSummaryPair(A, B), C);
+    assert.deepEqual(left.tableRenames, [["T", null]]);
+    const t = left.tableDeltas["-T"];
+    assert.deepEqual(t.removeRows, [1, 2]);
+    // Row 2's original value v2 must survive (not a2, and not dropped).
+    assert.deepEqual(t.columnDeltas["-c"], { 1: [["v1"], null], 2: [["v2"], null] });
+  });
+});
+
+// concat associativity for a recycled TABLE name. When a table is removed and a
+// new one created under the same name, the old contents key under "-T" and the
+// new table under "T".
+// The bug this guards: composing the recycle ([T,null]+[null,T]) with a
+// later edit marked the live name "T" dead, deleting the *new* table's
+// delta -- so left- and right-association disagreed.
+
+describe("ActionSummary concat associativity: recycled table name", function() {
+  // A: remove table T (old contents land under "-T"). B: add a new table T
+  // with column d (recycle). C: add column e to the new T. Combined: old T
+  // removed (under "-T"), new T with columns d and e (under "T").
+  const A = S([["T", null]], { ["-T"]: td({ removeRows: [1],
+    columnRenames: [["c", null]], columnDeltas: { ["-c"]: { 1: [["old"], null] } } }) });
+  const B = S([[null, "T"]], { T: td({ columnRenames: [[null, "d"]] }) });
+  const C = S([], { T: td({ columnRenames: [[null, "e"]] }) });
+
+  it("(A.B).C equals A.(B.C)", function() {
+    const left = concatenateSummaryPair(concatenateSummaryPair(A, B), C);
+    const right = concatenateSummaryPair(A, concatenateSummaryPair(B, C));
+    assert.deepEqual(left, right);
+  });
+
+  it("keeps both the removed old table and the new recycled table", function() {
+    const left = concatenateSummaryPair(concatenateSummaryPair(A, B), C);
+    assert.deepEqual(left.tableRenames, [["T", null], [null, "T"]]);
+    // Old table's contents preserved under the defunct name.
+    assert.deepEqual(left.tableDeltas["-T"].columnDeltas["-c"], { 1: [["old"], null] });
+    // New table's column-creation entries survive (not deleted as "dead").
+    assert.deepEqual(left.tableDeltas.T.columnRenames, [[null, "d"], [null, "e"]]);
+  });
+});
+
+// concat associativity when one table is renamed into a name freed by
+// removing the previous occupant. The bug
+// this guards: composing a rename T2->T3 with a part where T3 is recycled
+// (old T3 removed, a new T3 added) marked the live name T3 dead on the
+// right-hand deltas, deleting the *new* T3 -- so left- and right-
+// association disagreed.
+
+describe("ActionSummary concat associativity: rename into a recycled name", function() {
+  // A: rename T2 -> T3. B: remove T3 (the former T2; contents land under
+  // "-T3"). C: add a new table T3 with column y. Combined: the original T2
+  // is gone (its contents under "-T2"), and a new T3 exists with column y.
+  const A = S([["T2", "T3"]]);
+  const B = S([["T3", null]], { ["-T3"]: td({ removeRows: [1],
+    columnRenames: [["x", null]], columnDeltas: { ["-x"]: { 1: [["old"], null] } } }) });
+  const C = S([[null, "T3"]], { T3: td({ columnRenames: [[null, "y"]] }) });
+
+  it("(A.B).C equals A.(B.C)", function() {
+    const left = concatenateSummaryPair(concatenateSummaryPair(A, B), C);
+    const right = concatenateSummaryPair(A, concatenateSummaryPair(B, C));
+    assert.deepEqual(left, right);
+  });
+
+  it("keeps the new T3 and routes the old T2's contents to its defunct name", function() {
+    // Check the right fold: that is the grouping where the bug deleted the
+    // new T3 (the recycle happens inside B.C before A is applied).
+    const right = concatenateSummaryPair(A, concatenateSummaryPair(B, C));
+    assert.deepEqual(right.tableRenames, [["T2", null], [null, "T3"]]);
+    // New T3's column-creation entry survives (not deleted as "dead").
+    assert.deepEqual(right.tableDeltas.T3.columnRenames, [[null, "y"]]);
+    // Original T2's contents preserved under its defunct name.
+    assert.deepEqual(right.tableDeltas["-T2"].columnDeltas["-x"], { 1: [["old"], null] });
+  });
+});
+
+// Canonical rename order: rename entries
+// sort by pre-name ascending, with additions (null pre-name) after all
+// non-null pre-names, tie-broken by post-name. concat must apply this
+// uniformly so that a delta merged here and one copied through untouched
+// end up identically ordered -- otherwise composition is not associative
+// on presentation.
+
+describe("ActionSummary concat canonical rename order", function() {
+  const EMPTY = S([], {});
+
+  it("sorts table and column renames: renames first, additions last by post-name", function() {
+    // Deliberately non-canonical input order (additions interleaved/out of order).
+    const a = S([[null, "Z"], ["B", "A"], [null, "M"]],
+      { T: td({ columnRenames: [[null, "m"], [null, "c"], ["x", "y"]] }) });
+    const r = concatenateSummaryPair(a, EMPTY);
+    assert.deepEqual(r.tableRenames, [["B", "A"], [null, "M"], [null, "Z"]]);
+    assert.deepEqual(r.tableDeltas.T.columnRenames, [["x", "y"], [null, "c"], [null, "m"]]);
+  });
+
+  it("rename order is grouping-independent (associative)", function() {
+    const a = S([], { T: td({ columnRenames: [[null, "m"], [null, "c"]] }) });
+    const b = S([], { T: td({ columnRenames: [[null, "d"]] }) });
+    const c = S([], { T: td({ columnRenames: [[null, "a"]] }) });
+    const left = concatenateSummaryPair(concatenateSummaryPair(a, b), c);
+    const right = concatenateSummaryPair(a, concatenateSummaryPair(b, c));
+    assert.deepEqual(left, right);
+    assert.deepEqual(left.tableDeltas.T.columnRenames, [[null, "a"], [null, "c"], [null, "d"], [null, "m"]]);
+  });
+});
+
+// A removed row has no cells afterward,
+// for every column -- including columns the removing summary did not
+// mention (the engine drops all-default columns from a removal's restore
+// undo). Composition must null the post side of such a column's cells at
+// the removed rows, rather than copying the earlier summary's post value
+// through a deleted row. Otherwise composition is not associative.
+
+describe("ActionSummary concat: removal reaches a column only the earlier summary recorded", function() {
+  it("nulls the post of an only-in-part-1 column at a row part 2 removes", function() {
+    // A changes column c at row 1. B removes row 1 but mentions only column
+    // x (as the engine would, having dropped all-default c from the restore).
+    // c is present only in A; row 1 is gone, so c's post must be absent.
+    const a = S([], { T: td({ updateRows: [1], columnDeltas: { c: { 1: [["old"], ["new"]] } } }) });
+    const b = S([], { T: td({ removeRows: [1], columnDeltas: { x: { 1: [["o"], null] } } }) });
+    const r = concatenateSummaryPair(a, b);
+    assert.deepEqual(r.tableDeltas.T.removeRows, [1]);
+    assert.deepEqual(r.tableDeltas.T.columnDeltas.c, { 1: [["old"], null] });
+  });
+
+  it("is associative when removing summaries omit a column the first recorded", function() {
+    const a = S([], { T: td({ updateRows: [1, 2],
+      columnDeltas: { c: { 1: [["a1"], ["b1"]], 2: [["a2"], ["b2"]] } } }) });
+    const b = S([], { T: td({ removeRows: [1], columnDeltas: { x: { 1: [["o"], null] } } }) });
+    const c = S([], { T: td({ removeRows: [2], columnDeltas: { x: { 2: [["p"], null] } } }) });
+    const left = concatenateSummaryPair(concatenateSummaryPair(a, b), c);
+    const right = concatenateSummaryPair(a, concatenateSummaryPair(b, c));
+    assert.deepEqual(left, right);
+    assert.deepEqual(left.tableDeltas.T.columnDeltas.c, { 1: [["a1"], null], 2: [["a2"], null] });
+  });
+});
+
+// Delta keying: a removed column's cells
+// key under its `-`-prefixed pre-name, never the now-defunct live name.
+// The chunk walk can leave a cell under the live name (a row removed before
+// the column went defunct), and planNameMerge assumes the defunct keying is
+// already in place. normalizeTableDelta must enforce it, or composition is
+// not associative.
+
+describe("ActionSummary canonical form: removed column re-keys live-name cells", function() {
+  it("moves a stranded live-name cell onto the column's defunct name", function() {
+    // Column c is removed (columnRenames [c, null]). Row 1's cell is stranded
+    // under the live name `c` (its row died before the column did); row 2's is
+    // already under `-c`. Normalization must put both under `-c`.
+    const x = S([], { T: td({
+      removeRows: [1],
+      columnDeltas: { "c": { 1: [["old"], null] }, "-c": { 2: [["a"], null] } },
+      columnRenames: [["c", null]],
+    }) });
+    const r = concatenateSummaryPair(x, { tableRenames: [], tableDeltas: {} });
+    assert.isUndefined(r.tableDeltas.T.columnDeltas.c, "no cell stranded under the live name");
+    assert.deepEqual(r.tableDeltas.T.columnDeltas["-c"], { 1: [["old"], null], 2: [["a"], null] });
+  });
+
+  it("does not re-key a recycled column (removed and re-added)", function() {
+    // c is removed AND re-added in scope: the live `c` key holds a distinct
+    // new entity and must be preserved, not folded into `-c`.
+    const x = S([], { T: td({
+      columnDeltas: { "c": { 3: [null, ["new"]] }, "-c": { 1: [["old"], null] } },
+      columnRenames: [["c", null], [null, "c"]],
+    }) });
+    const r = concatenateSummaryPair(x, { tableRenames: [], tableDeltas: {} });
+    assert.deepEqual(r.tableDeltas.T.columnDeltas.c, { 3: [null, ["new"]] }, "recycled column preserved");
+    assert.deepEqual(r.tableDeltas.T.columnDeltas["-c"], { 1: [["old"], null] });
+  });
+
+  it("does not re-key a column another was renamed into (rename target)", function() {
+    // Old `c2` was removed (its data is under `-c2`); `c1` is then renamed to
+    // `c2`, so the live `c2` key holds the renamed-in c1 entity. That live
+    // entity keys by its post-name `c2`, and must not be swept to
+    // `-c2` and collide with the removed old c2.
+    const x = S([], { T: td({
+      columnDeltas: { "c2": { 1: [["c1val"], [""]] }, "-c2": { 1: [["oldc2"], null] } },
+      columnRenames: [["c1", "c2"], ["c2", null]],
+    }) });
+    const r = concatenateSummaryPair(x, { tableRenames: [], tableDeltas: {} });
+    assert.deepEqual(r.tableDeltas.T.columnDeltas.c2, { 1: [["c1val"], [""]] },
+      "renamed-in entity stays under its post-name");
+    assert.deepEqual(r.tableDeltas.T.columnDeltas["-c2"], { 1: [["oldc2"], null] },
+      "removed old occupant unaffected");
+  });
+});
+
+// updateRows means "same entity persisted and its contents
+// changed". Contents changes live in cells, so updateRows is DERIVED from the
+// cells -- a persisting row with a cell delta -- not accumulated. Deriving it
+// keeps concat associative: the accumulated list can differ by composition
+// order, the cells cannot.
+describe("ActionSummary canonical form: updateRows derived from cells", function() {
+  it("marks a persisting row updated when a removed column leaves it a cell", function() {
+    // Row 4 persists; column c is removed, so row 4 keeps a `-c` cell. Even
+    // with no incoming updateRows entry, it is `updated` (its contents changed).
+    const x = S([], { T: td({ columnRenames: [["c", null]], columnDeltas: { "-c": { 4: [["v"], null] } } }) });
+    const r = canonicalizeSummary(x);
+    assert.deepEqual(r.tableDeltas.T.updateRows, [4]);
+  });
+
+  it("does not mark an added row as updated", function() {
+    const x = S([], { T: td({ addRows: [4], columnDeltas: { c: { 4: [null, ["new"]] } } }) });
+    assert.deepEqual(canonicalizeSummary(x).tableDeltas.T.updateRows, []);
+  });
+
+  it("does not mark a recycled row as updated", function() {
+    const x = S([], { T: td({ addRows: [4], removeRows: [4],
+      columnDeltas: { c: { 4: [["old"], ["new"]] } } }) });
+    assert.deepEqual(canonicalizeSummary(x).tableDeltas.T.updateRows, []);
+  });
+
+  it("drops an updateRows entry whose cell change canceled out (no cell left)", function() {
+    // Row 2 was in updateRows but its only cell oscillated back, so it has no
+    // canonical cell -- no net change, so not updated. With nothing else in the
+    // table delta, it canonicalizes to empty and is dropped entirely.
+    const x = S([], { T: td({ updateRows: [2], columnDeltas: { c: { 2: [["x"], ["x"]] } } }) });
+    assert.isUndefined(canonicalizeSummary(x).tableDeltas.T,
+      "no net change -> empty table delta -> dropped");
+  });
+});
+
+// A rename A -> B whose target B is already occupied must merge the two
+// (they are facets of the same final entity), not overwrite B and drop its
+// data. This arises when a calc-flush restore records a defunct entity's
+// data under its POST-rename name while the removal is recorded under the
+// PRE-rename name; the RenameTable then collides. Overwriting drops the
+// restored values and breaks composition associativity.
+
+describe("ActionSummary concat: rename onto an occupied key merges, not overwrites", function() {
+  it("preserves data recorded under the post-rename table name", function() {
+    // Part 1 holds the SAME table under two keys: T1 (column c removed) and a
+    // premature T2 (c's pre-values, as a calc-flush restore would key them by
+    // the final name). Part 2 renames T1 -> T2. The two T2 facets must merge:
+    // c removed + c pre-values  =>  c's values under the defunct `-c`.
+    const a = S([], {
+      T1: td({ columnRenames: [["c", null]] }),
+      T2: td({ updateRows: [2], columnDeltas: { c: { 2: [["v"], null] } } }),
+    });
+    const b = S([["T1", "T2"]]);
+    const r = concatenateSummaryPair(a, b);
+    assert.isUndefined(r.tableDeltas.T1, "T1 folded into T2");
+    assert.deepEqual(r.tableDeltas.T2.columnRenames, [["c", null]]);
+    assert.deepEqual(r.tableDeltas.T2.columnDeltas["-c"], { 2: [["v"], null] },
+      "the value recorded under the post-rename name survives, re-keyed to -c");
+    assert.isUndefined(r.tableDeltas.T2.columnDeltas.c, "nothing stranded under the live name");
+  });
+});
+
+// A row removed in part 1 carries its old value as the cell's pre side. That
+// pre is the combined pre-state value, so it must survive however part 2
+// treats the row, including when part 2 also removes it.
+describe("ActionSummary concat: a removed row's old value survives a second removal", function() {
+  it("keeps the original pre-value when both parts remove the row", function() {
+    // Part 1: row 1 recycled, old entity's c = "1", now gone. Part 2: removes
+    // row 1 (the new entity), whose c reads "" (a formula default). The
+    // combined pre-state value of c is the old entity's "1".
+    const a = S([], { T: td({ addRows: [1], removeRows: [1], columnDeltas: { c: { 1: [["1"], null] } } }) });
+    const b = S([], { T: td({ removeRows: [1], columnDeltas: { c: { 1: [[""], null] } } }) });
+    const r = concatenateSummaryPair(a, b);
+    assert.deepEqual(r.tableDeltas.T.columnDeltas.c, { 1: [["1"], null] },
+      "old entity's value preserved, not overwritten by part 2's removal pre");
+  });
+});
+
+// A defunct column (keyed by its `-`-prefixed name) does not exist
+// post-scope, so every one of its cells has no post value. concat must enforce
+// this: composition can
+// otherwise synthesize a stray `"?"` post for a recycled row in a removed
+// column, and the result then depends on grouping (not associative).
+
+describe("ActionSummary concat: a defunct column has no post-scope cells", function() {
+  it("nulls the post side of every cell in a defunct column", function() {
+    // Column c is removed (defunct, keyed `-c`). Whatever a cell's post
+    // appears to be -- a stray value or the unknown sentinel `"?"` -- the
+    // column is gone, so the post must be absent. A cell that thereby
+    // becomes [null, null] drops as vacuous.
+    const a = S([], { T: td({ removeRows: [1, 2, 3],
+      columnRenames: [["c", null]],
+      columnDeltas: { ["-c"]: { 1: [["x"], ["y"]], 2: [["z"], "?"], 3: [null, "?"] } } }) });
+    const r = concatenateSummaryPair(a, S([], {}));
+    assert.deepEqual(r.tableDeltas.T.columnDeltas["-c"], { 1: [["x"], null], 2: [["z"], null] });
+  });
+
+  it("nulls the pre side of every cell in an added column (mirror)", function() {
+    // Column c is added in scope (rename [null, c]), so it had no cells
+    // pre-scope: every pre side must be absent, whatever composition left
+    // there (here a stray `"?"`). Row 2 becomes [null, null] and drops.
+    const a = S([], { T: td({ addRows: [1],
+      columnRenames: [[null, "c"]],
+      columnDeltas: { c: { 1: ["?", ["v"]], 2: ["?", null] } } }) });
+    const r = concatenateSummaryPair(a, S([], {}));
+    assert.deepEqual(r.tableDeltas.T.columnDeltas.c, { 1: [null, ["v"]] });
+  });
+
+  it("nulls the pre of an added row's cells and the post of a removed row's", function() {
+    // Row 5 is added (no pre-state) and row 7 is removed (no post-state), so
+    // a pre value on row 5 or a post value on row 7 is impossible -- whatever
+    // composition left there (here stray values) is replaced with absence.
+    const a = S([], { T: td({ addRows: [5], removeRows: [7],
+      columnDeltas: { c: { 5: [["stray"], ["v"]], 7: [["w"], ["stray"]] } } }) });
+    const r = concatenateSummaryPair(a, S([], {}));
+    assert.deepEqual(r.tableDeltas.T.columnDeltas.c, { 5: [null, ["v"]], 7: [["w"], null] });
+  });
+
+  it("resolves a stray '?' to absent in a complete summary, but keeps it when incomplete", function() {
+    // A complete summary carries no unknowns, so a `"?"` left by
+    // composition (a value never recorded, with nothing to recover it from)
+    // resolves to absent. When mayBeIncomplete is set, `"?"` is meaningful
+    // and preserved.
+    const complete = S([], { T: td({ updateRows: [1], columnDeltas: { c: { 1: ["?", ["v"]] } } }) });
+    assert.deepEqual(concatenateSummaryPair(complete, S([], {})).tableDeltas.T.columnDeltas.c,
+      { 1: [null, ["v"]] });
+    const incomplete = S([], { T: td({ updateRows: [1], mayBeIncomplete: true,
+      columnDeltas: { c: { 1: ["?", ["v"]] } } }) });
+    assert.deepEqual(concatenateSummaryPair(incomplete, S([], {})).tableDeltas.T.columnDeltas.c,
+      { 1: ["?", ["v"]] });
+  });
+});
+
+// A type/formula conversion emits its sub-steps' inverses in reverse order
+// (a "crossing": U(s0) lands after U(s1) in the undo array). A monotone chunker
+// cannot pair them one-to-one; it must coarsen the pair into one closed chunk,
+// or it strands a real step as a spurious zero-case and breaks the value chain.
+// chunkByLattice's tier-2 objective (minimize zero-cases)
+// forces the coarsening: the split leaves the UpdateRecord unpaired (1 zero),
+// the coarsening pairs both (0 zeros).
+describe("chunkByLattice: coarsens a reversed-undo crossing", function() {
+  it("merges a ModifyColumn + UpdateRecord whose undos cross, instead of stranding one", function() {
+    const stored: DocAction[] = [
+      ["ModifyColumn", "T", "c", { type: "Bool" }],
+      ["UpdateRecord", "T", 1, { c: false }],
+    ];
+    // Crossed: undo[0] inverts stored[1] (the data), undo[1] inverts stored[0] (the type).
+    const undo: DocAction[] = [
+      ["UpdateRecord", "T", 1, { c: "0" }],
+      ["ModifyColumn", "T", "c", { type: "Text" }],
+    ];
+    const chunks = chunkByLattice(stored, undo);
+    assert.lengthOf(chunks, 1, "the crossing coarsens into a single closed chunk");
+    assert.deepEqual(chunks[0].stored, stored);
+    assert.deepEqual(chunks[0].undo, undo);
+  });
+
+  it("does not coarsen a genuine zero-case (a step that truly emitted no undo)", function() {
+    // Two updates each with their own undo, and a no-op update in between with
+    // no undo. The no-op can't be paired by coarsening (no undo exists for it),
+    // so tier 2 is indifferent and tier 3 keeps the partition fine.
+    const stored: DocAction[] = [
+      ["UpdateRecord", "T", 1, { c: 1 }],
+      ["UpdateRecord", "T", 2, { c: 2 }],   // no-op: no undo emitted
+      ["UpdateRecord", "T", 3, { c: 3 }],
+    ];
+    const undo: DocAction[] = [
+      ["UpdateRecord", "T", 1, { c: 10 }],
+      ["UpdateRecord", "T", 3, { c: 30 }],
+    ];
+    const chunks = chunkByLattice(stored, undo);
+    // Each stored keeps its own chunk; the middle one is a (genuine) zero-case.
+    assert.deepEqual(chunks.map(c => c.stored.length), [1, 1, 1]);
+    assert.deepEqual(chunks[1].undo, [], "genuine zero-case stays unpaired, not coarsened");
+  });
+});
+
+describe("chunkByLattice", function() {
+  it("returns an empty list for an empty bundle", function() {
+    assert.deepEqual(chunkByLattice([], []), []);
+  });
+
+  it("splits a bundle into one chunk per stored, pairing undos by emission order", function() {
+    const stored: DocAction[] = [
+      ["AddRecord", "T", 1, { x: 1 }],
+      ["UpdateRecord", "T", 2, { x: 9 }],
+    ];
+    const undo: DocAction[] = [
+      ["RemoveRecord", "T", 1],
+      ["UpdateRecord", "T", 2, { x: 8 }],
+    ];
+    const chunks = chunkByLattice(stored, undo);
+    assert.lengthOf(chunks, 2);
+    assert.deepEqual(chunks[0],
+      { stored: [["AddRecord", "T", 1, { x: 1 }]], undo: [["RemoveRecord", "T", 1]] });
+    assert.deepEqual(chunks[1],
+      { stored: [["UpdateRecord", "T", 2, { x: 9 }]], undo: [["UpdateRecord", "T", 2, { x: 8 }]] });
+  });
+
+  it("gives a RemoveColumn its data-restore + schema-restore undos in one chunk", function() {
+    const stored: DocAction[] = [["RemoveColumn", "T", "c"]];
+    const undo: DocAction[] = [
+      ["BulkUpdateRecord", "T", [1, 2], { c: ["a", "b"] }],   // data restore
+      ["AddColumn", "T", "c", { type: "Text" } as any],        // schema restore
+    ];
+    const chunks = chunkByLattice(stored, undo);
+    assert.lengthOf(chunks, 1);
+    assert.deepEqual(chunks[0].stored, [["RemoveColumn", "T", "c"]]);
+    assert.deepEqual(chunks[0].undo, [
+      ["BulkUpdateRecord", "T", [1, 2], { c: ["a", "b"] }],
+      ["AddColumn", "T", "c", { type: "Text" } as any],
+    ]);
+  });
+});
+
+// Shapes the lattice chunker should partition correctly: per-stored blocks
+// in stored order (the lockstep main region), the front region for a
+// defunct formula column's data restore, an adjacent table-data restore,
+// trailing orphan undos, and the no-undo case. Each asserts the exact
+// chunk-to-undo assignment, not just the summary.
+describe("chunkByLattice: shapes it should handle", function() {
+  // Helper: one chunk per stored, undos in the given order, no orphans.
+  function expectPerStored(chunks: ReturnType<typeof chunkByLattice>,
+    stored: DocAction[], undos: DocAction[][]) {
+    assert.lengthOf(chunks, stored.length);
+    chunks.forEach((c, i) => {
+      assert.deepEqual(c.stored, [stored[i]]);
+      assert.deepEqual(c.undo, undos[i]);
+    });
+  }
+
+  it("splits a long single-table record sequence into one chunk per stored", function() {
+    const stored: DocAction[] = [
+      ["AddRecord", "T", 1, { a: 1 }],
+      ["AddRecord", "T", 2, { a: 2 }],
+      ["UpdateRecord", "T", 1, { a: 9 }],
+      ["BulkAddRecord", "T", [3, 4], { a: [3, 4] }],
+      ["RemoveRecord", "T", 2],
+      ["UpdateRecord", "T", 3, { a: 30 }],
+      ["BulkRemoveRecord", "T", [3, 4]],
+      ["AddRecord", "T", 5, { a: 5 }],
+    ];
+    const undo: DocAction[] = [
+      ["RemoveRecord", "T", 1],
+      ["RemoveRecord", "T", 2],
+      ["UpdateRecord", "T", 1, { a: 1 }],
+      ["BulkRemoveRecord", "T", [3, 4]],
+      ["AddRecord", "T", 2, { a: 2 }],
+      ["UpdateRecord", "T", 3, { a: 3 }],
+      ["BulkAddRecord", "T", [3, 4], { a: [3, 4] }],
+      ["RemoveRecord", "T", 5],
+    ];
+    expectPerStored(chunkByLattice(stored, undo), stored, undo.map(u => [u]));
+  });
+
+  it("splits interleaved record ops across tables into one chunk per stored", function() {
+    const stored: DocAction[] = [
+      ["AddRecord", "T1", 1, { a: 1 }],
+      ["AddRecord", "T2", 1, { b: 1 }],
+      ["UpdateRecord", "T1", 1, { a: 9 }],
+      ["RemoveRecord", "T2", 1],
+    ];
+    const undo: DocAction[] = [
+      ["RemoveRecord", "T1", 1],
+      ["RemoveRecord", "T2", 1],
+      ["UpdateRecord", "T1", 1, { a: 1 }],
+      ["AddRecord", "T2", 1, { b: 1 }],
+    ];
+    expectPerStored(chunkByLattice(stored, undo), stored, undo.map(u => [u]));
+  });
+
+  it("attaches a defunct formula column's front data restore to its RemoveColumn", function() {
+    // The data restore for the removed (formula) column c is a front
+    // insert(0) entry, separated from its schema AddColumn (in the main
+    // region) by an unrelated record removal. The chunker must give the
+    // RemoveColumn both its front data restore and its schema restore.
+    const stored: DocAction[] = [
+      ["AddRecord", "T", 5, { a: 5 }],
+      ["RemoveColumn", "T", "c"],
+    ];
+    const undo: DocAction[] = [
+      ["BulkUpdateRecord", "T", [1, 2], { c: ["x", "y"] }],  // front: defunct c data restore
+      ["RemoveRecord", "T", 5],                              // main: inverse of AddRecord 5
+      ["AddColumn", "T", "c", {} as any],                    // main: schema restore for RemoveColumn
+    ];
+    const chunks = chunkByLattice(stored, undo);
+    assert.lengthOf(chunks, 2);
+    assert.deepEqual(chunks[0], { stored: [["AddRecord", "T", 5, { a: 5 }]], undo: [["RemoveRecord", "T", 5]] });
+    assert.deepEqual(chunks[1], { stored: [["RemoveColumn", "T", "c"]], undo: [
+      ["BulkUpdateRecord", "T", [1, 2], { c: ["x", "y"] }],
+      ["AddColumn", "T", "c", {} as any],
+    ] });
+  });
+
+  it("keeps a RemoveTable's adjacent data restore and schema restore in one chunk", function() {
+    const stored: DocAction[] = [["RemoveTable", "T"]];
+    const undo: DocAction[] = [
+      ["BulkAddRecord", "T", [1, 2], { a: ["x", "y"] }],     // data restore
+      ["AddTable", "T", [{ id: "a" }] as any],               // schema restore
+    ];
+    const chunks = chunkByLattice(stored, undo);
+    assert.lengthOf(chunks, 1);
+    assert.deepEqual(chunks[0].undo, [
+      ["BulkAddRecord", "T", [1, 2], { a: ["x", "y"] }],
+      ["AddTable", "T", [{ id: "a" }] as any],
+    ]);
+  });
+
+  it("keeps a trailing orphan undo adjacent, with its delta preserved", function() {
+    // A normal record sequence followed by an undo entry that inverts no
+    // stored action (a calc-flush restore for a column made defunct in an
+    // earlier bundle). Discarding it costs the same whether it sits alone or
+    // rides along in the last chunk (it is a ghost either way), so the lattice
+    // keeps it adjacent rather than isolating it -- a free tie-break that does
+    // not change the summary, since the orphan's delta is recorded regardless.
+    const stored: DocAction[] = [
+      ["AddRecord", "T", 1, { a: 1 }],
+      ["UpdateRecord", "T", 1, { a: 9 }],
+      ["RemoveRecord", "T", 1],
+    ];
+    const undo: DocAction[] = [
+      ["RemoveRecord", "T", 1],
+      ["UpdateRecord", "T", 1, { a: 1 }],
+      ["AddRecord", "T", 1, { a: 9 }],
+      ["BulkUpdateRecord", "T", [2, 3], { b: ["p", "q"] }],  // orphan: no owning stored
+    ];
+    const chunks = chunkByLattice(stored, undo);
+    assert.lengthOf(chunks, 3);
+    assert.deepEqual(chunks[0], { stored: [stored[0]], undo: [undo[0]] });
+    assert.deepEqual(chunks[1], { stored: [stored[1]], undo: [undo[1]] });
+    // The last real chunk carries its own inverse plus the orphan restore.
+    assert.deepEqual(chunks[2], { stored: [stored[2]], undo: [undo[2], undo[3]] });
+  });
+
+  it("gives each stored its own empty chunk when there is no undo", function() {
+    const stored: DocAction[] = [
+      ["AddRecord", "T", 1, { a: 1 }],
+      ["UpdateRecord", "T", 2, { a: 2 }],
+    ];
+    expectPerStored(chunkByLattice(stored, []), stored, [[], []]);
+  });
+
+  it("pairs a recompute with a restore over fewer rows (undo rows ⊆ stored rows)", function() {
+    // A data->formula conversion: c becomes formula "0", so the recompute
+    // touches all rows [1..5], but the restore-undo covers only the
+    // pre-existing rows [1,2,3] (rows 4,5 were just added, no prior value).
+    // The undo's rows are a subset of the recompute's -- the chunker must
+    // still pair them.
+    const stored: DocAction[] = [
+      ["ModifyColumn", "T", "c", { isFormula: true, formula: "0" } as any],
+      ["BulkUpdateRecord", "T", [1, 2, 3, 4, 5], { c: ["0", "0", "0", "0", "0"] }],
+    ];
+    const undo: DocAction[] = [
+      ["ModifyColumn", "T", "c", { isFormula: false, formula: "" } as any],
+      ["BulkUpdateRecord", "T", [1, 2, 3], { c: [null, "", ""] }],
+    ];
+    const chunks = chunkByLattice(stored, undo);
+    assert.lengthOf(chunks, 2);
+    assert.deepEqual(chunks[0].undo, [["ModifyColumn", "T", "c", { isFormula: false, formula: "" } as any]]);
+    assert.deepEqual(chunks[1].undo, [["BulkUpdateRecord", "T", [1, 2, 3], { c: [null, "", ""] }]]);
+  });
+});
+
+// chunkByOwners uses the engine's recorded per-undo ownership directly, instead
+// of inferring chunk boundaries the way the lattice does. owners[k] is the index
+// into stored of the action that produced undo[k], or null for a front
+// calc-flush restore (which is still attributed to its removal, shared with the
+// lattice via analyzeStored).
+describe("chunkByOwners", function() {
+  it("returns an empty list for an empty bundle", function() {
+    assert.deepEqual(chunkByOwners([], [], []), []);
+  });
+
+  it("makes one chunk per stored, routing each undo by its declared owner", function() {
+    const stored: DocAction[] = [
+      ["AddRecord", "T", 1, { x: 1 }],
+      ["UpdateRecord", "T", 2, { x: 9 }],
+    ];
+    const undo: DocAction[] = [
+      ["RemoveRecord", "T", 1],
+      ["UpdateRecord", "T", 2, { x: 8 }],
+    ];
+    assert.deepEqual(chunkByOwners(stored, undo, [0, 1]), [
+      { stored: [stored[0]], undo: [undo[0]] },
+      { stored: [stored[1]], undo: [undo[1]] },
+    ]);
+  });
+
+  it("splits the conversion 2-swap the lattice keeps together, since ownership is known", function() {
+    // The to-data ModifyColumn: stored is the schema change then the converted
+    // data; undo is the data restore (owns the data update) then the ModifyColumn
+    // inverse (owns the schema change), crossed. The lattice must keep these in
+    // one [2,2] chunk because it can't tell which undo is which; with ownership we
+    // split them into the two finer chunks, which compose to the same summary (the
+    // fuzz harness cross-checks that).
+    const stored: DocAction[] = [
+      ["ModifyColumn", "T", "c", { isFormula: false, formula: "" } as any],
+      ["BulkUpdateRecord", "T", [1, 2, 3], { c: ["0", "0", "0"] }],
+    ];
+    const undo: DocAction[] = [
+      ["BulkUpdateRecord", "T", [1, 2, 3], { c: [null, "", ""] }],   // owns the data update (1)
+      ["ModifyColumn", "T", "c", { isFormula: true, formula: "0" } as any],   // owns the schema (0)
+    ];
+    assert.deepEqual(chunkByOwners(stored, undo, [1, 0]), [
+      { stored: [stored[0]], undo: [undo[1]] },
+      { stored: [stored[1]], undo: [undo[0]] },
+    ]);
+  });
+
+  it("routes a null-owner front restore to its removal, the way the lattice does", function() {
+    // A removed formula column's front data restore arrives unowned (null); it must
+    // still land in the RemoveColumn's chunk, ahead of the schema restore.
+    const stored: DocAction[] = [
+      ["AddRecord", "T", 5, { a: 5 }],
+      ["RemoveColumn", "T", "c"],
+    ];
+    const undo: DocAction[] = [
+      ["BulkUpdateRecord", "T", [1, 2], { c: ["x", "y"] }],   // front: defunct c data restore (null)
+      ["RemoveRecord", "T", 5],                               // inverse of AddRecord 5 (owner 0)
+      ["AddColumn", "T", "c", {} as any],                     // schema restore for RemoveColumn (owner 1)
+    ];
+    assert.deepEqual(chunkByOwners(stored, undo, [null, 0, 1]), [
+      { stored: [stored[0]], undo: [undo[1]] },
+      { stored: [stored[1]], undo: [undo[0], undo[2]] },
+    ]);
+  });
+
+  it("does not attach a front restore to a removal whose name a rename reused", function() {
+    // T2 is renamed away and T1 renamed into the freed name before losing
+    // column c, so the front restore's pre-bundle "T2" and RemoveColumn's "T2"
+    // are different tables: the rename must veto the name match, sending the
+    // restore leading instead of into the wrong removal's chunk.
+    const stored: DocAction[] = [
+      ["RenameTable", "T2", "T3"],
+      ["RenameTable", "T1", "T2"],
+      ["RemoveColumn", "T2", "c"],
+    ];
+    const undo: DocAction[] = [
+      ["UpdateRecord", "T2", 1, { c: "x" }],   // front restore for ORIGINAL T2's c
+      ["RenameTable", "T3", "T2"],
+      ["RenameTable", "T2", "T1"],
+      ["AddColumn", "T2", "c", {} as any],
+    ];
+    assert.deepEqual(chunkByOwners(stored, undo, [null, 0, 1, 2]), [
+      { stored: [], undo: [undo[0]] },
+      { stored: [stored[0]], undo: [undo[1]] },
+      { stored: [stored[1]], undo: [undo[2]] },
+      { stored: [stored[2]], undo: [undo[3]] },
+    ]);
+  });
+
+  it("does not attach a front restore to the removal of a recycled name", function() {
+    // Column f is removed, re-added, and removed again -- no rename, so only
+    // the first-removal indexing protects this. The front restore holds the
+    // ORIGINAL f's values; attaching it to the second removal would file them
+    // under an entity whose add+remove annihilate in composition. The re-add
+    // makes the name ambiguous, so the restore goes leading.
+    const stored: DocAction[] = [
+      ["RemoveColumn", "T", "f"],
+      ["AddColumn", "T", "f", {} as any],
+      ["RemoveColumn", "T", "f"],
+    ];
+    const undo: DocAction[] = [
+      ["BulkUpdateRecord", "T", [1, 2], { f: ["x", "y"] }],   // front restore for ORIGINAL f
+      ["AddColumn", "T", "f", {} as any],
+      ["RemoveColumn", "T", "f"],
+      ["AddColumn", "T", "f", {} as any],
+    ];
+    assert.deepEqual(chunkByOwners(stored, undo, [null, 0, 1, 2]), [
+      { stored: [], undo: [undo[0]] },
+      { stored: [stored[0]], undo: [undo[1]] },
+      { stored: [stored[1]], undo: [undo[2]] },
+      { stored: [stored[2]], undo: [undo[3]] },
+    ]);
+  });
+
+  it("collects an unmatched unowned undo into a leading chunk", function() {
+    // An unowned undo carries pre-bundle names, legible only in a leading chunk.
+    const stored: DocAction[] = [["UpdateRecord", "T", 1, { a: 9 }]];
+    const undo: DocAction[] = [
+      ["UpdateRecord", "T", 1, { a: 1 }],                     // owner 0
+      ["BulkUpdateRecord", "Other", [2, 3], { b: ["p", "q"] }],   // unowned, no removal in sight
+    ];
+    assert.deepEqual(chunkByOwners(stored, undo, [0, null]), [
+      { stored: [], undo: [undo[1]] },
+      { stored: [stored[0]], undo: [undo[0]] },
+    ]);
+  });
+
+  it("treats an out-of-range owner as unowned and routes it for itself", function() {
+    // A defensive fallback: an owner index outside stored is ignored and the undo
+    // is attributed by shape instead (here, to its removal).
+    const stored: DocAction[] = [["RemoveColumn", "T", "c"]];
+    const undo: DocAction[] = [
+      ["BulkUpdateRecord", "T", [1], { c: ["x"] }],   // bogus owner 7 -> route by shape to the RemoveColumn
+      ["AddColumn", "T", "c", {} as any],
+    ];
+    assert.deepEqual(chunkByOwners(stored, undo, [7, 0]), [
+      { stored: [stored[0]], undo: [undo[0], undo[1]] },
+    ]);
+  });
+
+  it("gives each stored its own empty chunk when there is no undo", function() {
+    const stored: DocAction[] = [
+      ["AddRecord", "T", 1, { a: 1 }],
+      ["UpdateRecord", "T", 2, { a: 2 }],
+    ];
+    assert.deepEqual(chunkByOwners(stored, [], []), [
+      { stored: [stored[0]], undo: [] },
+      { stored: [stored[1]], undo: [] },
+    ]);
+  });
+});
+
+// The chunker is value-blind (shape-only): when a no-op step shares a target
+// with a real step, only the cell values would say which one a surviving undo
+// belongs to, and the chunker never inspects them. The lattice does not try to
+// resolve this at the chunk level; soundness comes from the value-preserving
+// concat downstream, which the property test exercises directly.
+
+describe("ActionSummary incremental folds: canonicalize once, not per step", function() {
+  // Regression for the DocApi and TimeQuery fix. concatenateSummaries
+  // canonicalizes its result, which strips an insignificant [[v],[v]] cell. That
+  // is safe only at the end of a fold. A consumer that folds summaries one at a
+  // time through concatenateSummaries canonicalizes between steps, and a middle
+  // step can canonicalize a value-bearing summary on its own (dropping the
+  // insignificant cell) before a later removal needs it. So consumers compose
+  // with the raw concatenateSummaryPair and canonicalize once at the end
+  // (ActionLog and DocApi's getChanges do this via concatenateSummaries;
+  // TimeCursor folds the pair directly).
+
+  const summ = (tableDeltas: { [t: string]: TableDelta }): ActionSummary => ({ tableRenames: [], tableDeltas });
+
+  // first: row 5's column A is set to the value it already holds (insignificant)
+  // while column B genuinely changes. mid: an unrelated change to another table,
+  // which is what lets a per-step fold canonicalize `first` on its own and drop
+  // A. last: row 5 is removed without carrying A's value, as a truncated bulk
+  // removal would not. A's value lives only in `first`'s insignificant cell.
+  const first = summ({ T: td({ updateRows: [5],
+    columnDeltas: { A: { 5: [["v"], ["v"]] }, B: { 5: [["x"], ["y"]] } } }) });
+  const mid = summ({ U: td({ updateRows: [1], columnDeltas: { c: { 1: [["p"], ["q"]] } } }) });
+  const last = summ({ T: td({ removeRows: [5] }) });
+  const parts = [first, mid, last];
+
+  it("a forward fold keeps a value that a per-step fold drops", function() {
+    // Correct, as the consumers now do it: fold raw, canonicalize once at the
+    // end. A's value survives the removal.
+    let raw = parts[0];
+    for (const p of parts.slice(1)) { raw = concatenateSummaryPair(raw, p); }
+    const correct = canonicalizeSummary(raw);
+    assert.deepEqual(correct.tableDeltas.T.columnDeltas.A, { 5: [["v"], null] });
+
+    // Buggy, as folding through concatenateSummaries one at a time would: the mid
+    // step canonicalizes `first` on its own and drops A before the removal needs
+    // it.
+    let perStep = parts[0];
+    for (const p of parts.slice(1)) { perStep = concatenateSummaries([perStep, p]); }
+    assert.isUndefined(perStep.tableDeltas.T?.columnDeltas?.A);
+    assert.notDeepEqual(perStep, correct);
+  });
+
+  it("TimeCursor.append folds raw, so the value survives", function() {
+    const tc = new TimeCursor(null as any);   // db is unused by prepend/append
+    tc.summary = first;
+    tc.append(mid);
+    tc.append(last);
+    assert.deepEqual(canonicalizeSummary(tc.summary).tableDeltas.T.columnDeltas.A,
+      { 5: [["v"], null] });
+  });
+});

--- a/test/server/lib/ActionSummary.ts
+++ b/test/server/lib/ActionSummary.ts
@@ -1,10 +1,11 @@
-import { chunkByLattice, chunkByOwners } from "app/common/ActionLayout";
+import { chunkByLattice, chunkByOwners, coalesceRecordChunks, LatticeStats } from "app/common/ActionLayout";
 import {
   ActionSummaryOptions, canonicalizeSummary, concatenateSummaries, concatenateSummaryPair,
   rebaseSummary, summarizeAction, summarizeStoredAndUndo,
 } from "app/common/ActionSummarizer";
 import { ActionSummary, asTabularDiffs, createEmptyTableDelta, LabelDelta, TableDelta } from "app/common/ActionSummary";
 import { DocAction } from "app/common/DocActions";
+import { CellDelta } from "app/common/TabularDiff";
 import { TimeCursor } from "app/common/TimeQuery";
 import { ActiveDoc } from "app/server/lib/ActiveDoc";
 import { createDocTools } from "test/server/docTools";
@@ -1985,5 +1986,167 @@ describe("ActionSummary incremental folds: canonicalize once, not per step", fun
     tc.append(last);
     assert.deepEqual(canonicalizeSummary(tc.summary).tableDeltas.T.columnDeltas.A,
       { 5: [["v"], null] });
+  });
+});
+
+describe("ActionSummary: names that collide with Object.prototype", function() {
+  // Table and column ids are user-chosen, so the name-keyed dictionaries in a
+  // summary must not answer lookups from Object.prototype ("toString",
+  // "constructor", "hasOwnProperty", ...). The cell helper is needed because a
+  // literal with such a key also defeats TypeScript's contextual typing.
+  const cell = (pre: [any] | null, post: [any] | null): CellDelta => [pre, post];
+
+  it("renames a column named toString without conjuring a delta", function() {
+    const sum1 = S([], { T: td({ updateRows: [1], columnDeltas: { A: { 1: cell([1], [2]) } } }) });
+    const sum2 = S([], { T: td({ columnRenames: [["toString", "X"]] }) });
+    const out = concatenateSummaries([sum1, sum2]);
+    assert.deepEqual(out.tableDeltas.T.columnDeltas, { A: { 1: cell([1], [2]) } });
+    assert.deepEqual(out.tableDeltas.T.columnRenames, [["toString", "X"]]);
+  });
+
+  it("keeps a column named constructor when another column is removed", function() {
+    const sum = S([], { T: td({ updateRows: [1], columnRenames: [["B", null]],
+      columnDeltas: { constructor: { 1: cell([1], [2]) }, B: { 1: cell([3], null) } } }) });
+    const out = canonicalizeSummary(sum);
+    assert.deepEqual(out.tableDeltas.T.columnDeltas,
+      { "constructor": { 1: cell([1], [2]) }, "-B": { 1: cell([3], null) } });
+  });
+
+  it("keeps a column named hasOwnProperty added in the first part", function() {
+    const sum1 = S([], { T: td({ addRows: [1], columnRenames: [[null, "hasOwnProperty"]],
+      columnDeltas: { hasOwnProperty: { 1: cell(null, [5]) } } }) });
+    const sum2 = S([], { T: td({ updateRows: [2], columnDeltas: { A: { 2: cell([1], [2]) } } }) });
+    const out = concatenateSummaries([sum1, sum2]);
+    assert.deepEqual(out.tableDeltas.T.columnRenames, [[null, "hasOwnProperty"]]);
+    assert.deepEqual(out.tableDeltas.T.columnDeltas,
+      { hasOwnProperty: { 1: cell(null, [5]) }, A: { 2: cell([1], [2]) } });
+  });
+
+  it("walks a table named constructor", function() {
+    const stored: DocAction[] = [
+      ["AddTable", "constructor", []],
+      ["AddColumn", "constructor", "valueOf", { type: "Int", isFormula: false, formula: "" }],
+      ["AddRecord", "constructor", 1, { valueOf: 7 }],
+    ];
+    const undo: DocAction[] = [
+      ["RemoveRecord", "constructor", 1],
+      ["RemoveColumn", "constructor", "valueOf"],
+      ["RemoveTable", "constructor"],
+    ];
+    const out = summarizeStoredAndUndo(stored, undo, undefined, [2, 1, 0]);
+    assert.deepEqual(out.tableRenames, [[null, "constructor"]]);
+    // Index with a widened key: TypeScript would otherwise resolve `.constructor`
+    // to Object.prototype's, just as the summarizer must not.
+    const delta = out.tableDeltas["constructor" as string];
+    assert.deepEqual(delta.addRows, [1]);
+    assert.deepEqual(delta.columnDeltas, { valueOf: { 1: cell(null, [7]) } });
+  });
+});
+
+describe("ActionSummary concat: a leading restore's old value survives any grouping", function() {
+  // A front calc-flush restore in a leading chunk records an old value with no
+  // forward action to give it a new one: [old, null] on a row the chunk does not
+  // remove. Whether the next summary carries that column at all depends on the
+  // grouping, and the old value must survive either way. Here the column is
+  // removed at the end, so it must show up as removed data.
+  const cell = (pre: [any] | null, post: [any] | null): CellDelta => [pre, post];
+  const restore = S([], { T2: td({ updateRows: [3], columnDeltas: { c5: { 3: cell(["v3"], null) } } }) });
+  const rename = S([["T2", "T1"]]);
+  const removals = S([], { T1: td({ updateRows: [3], removeRows: [1],
+    columnDeltas: { c4: { 3: cell(["a"], ["b"]) }, c5: { 1: cell(["x"], null) } } }) });
+  const dropColumn = S([], { T1: td({ columnRenames: [["c5", null]] }) });
+  const sums = [restore, rename, removals, dropColumn];
+
+  it("agrees between the balanced tree, a left fold and a right fold", function() {
+    const tree = concatenateSummaries(sums);
+    const left = canonicalizeSummary(sums.slice(1).reduce((acc, s) => concatenateSummaryPair(acc, s), sums[0]));
+    let right = sums[sums.length - 1];
+    for (let i = sums.length - 2; i >= 0; i--) { right = concatenateSummaryPair(sums[i], right); }
+    assert.deepEqual(tree.tableDeltas.T1.columnDeltas["-c5"], { 1: cell(["x"], null), 3: cell(["v3"], null) });
+    assert.deepEqual(left, tree);
+    assert.deepEqual(canonicalizeSummary(right), tree);
+  });
+
+  it("keeps the value when the later summary carries the column but not the cell", function() {
+    // The grouping that used to lose the cell: the restore composed with a
+    // summary that already has a `c5` column (from other rows).
+    const pair = concatenateSummaryPair(restore, concatenateSummaryPair(rename, removals));
+    assert.deepEqual(pair.tableDeltas.T1.columnDeltas.c5[3], cell(["v3"], null));
+  });
+});
+
+describe("coalesceRecordChunks", function() {
+  const upd = (t: string, r: number, v: string): DocAction => ["UpdateRecord", t, r, { A: v }];
+  const chunkOf = (stored: DocAction[], undo: DocAction[]) => ({ stored, undo });
+
+  it("merges a run of record chunks and keeps undo in bundle order", function() {
+    const stored = [upd("T", 1, "a"), upd("T", 2, "b"), upd("T", 1, "c")];
+    const undo = [upd("T", 1, "0"), upd("T", 2, "0"), upd("T", 1, "a")];
+    const chunks = stored.map((s, i) => chunkOf([s], [undo[i]]));
+    // Present the undo entries out of order within the chunks, as a chunker
+    // attributing front restores might.
+    const merged = coalesceRecordChunks([chunks[2], chunks[0], chunks[1]], undo);
+    assert.lengthOf(merged, 1);
+    assert.deepEqual(merged[0].stored, [stored[2], stored[0], stored[1]]);
+    assert.deepEqual(merged[0].undo, undo);
+  });
+
+  it("cuts at a schema action and never merges a stored-empty chunk", function() {
+    const front = chunkOf([], [upd("T", 9, "old")]);
+    const a = chunkOf([upd("T", 1, "a")], [upd("T", 1, "0")]);
+    const schema = chunkOf([["AddColumn", "T", "B", { type: "Text", isFormula: false, formula: "" }]],
+      [["RemoveColumn", "T", "B"]]);
+    const b = chunkOf([upd("T", 2, "b")], [upd("T", 2, "0")]);
+    const c = chunkOf([upd("T", 3, "c")], [upd("T", 3, "0")]);
+    const undo = [front.undo[0], a.undo[0], schema.undo[0], b.undo[0], c.undo[0]];
+    const merged = coalesceRecordChunks([front, a, schema, b, c], undo);
+    assert.deepEqual(merged.map(m => m.stored.length), [0, 1, 1, 2]);
+    assert.deepEqual(merged[3].stored, [b.stored[0], c.stored[0]]);
+  });
+
+  it("cuts where a run would churn a row it touched, or touch a row it churned", function() {
+    const add: DocAction = ["AddRecord", "T", 5, { A: "new" }];
+    const remove: DocAction = ["RemoveRecord", "T", 5];
+    const chunks = [
+      chunkOf([add], [["RemoveRecord", "T", 5]]),
+      chunkOf([upd("T", 5, "x")], [upd("T", 5, "new")]),       // touches a row the run added: cut
+      chunkOf([remove], [["AddRecord", "T", 5, { A: "x" }]]),   // removes a row the run touched: cut
+      chunkOf([upd("T", 6, "y")], [upd("T", 6, "0")]),           // an unrelated row: merges
+    ];
+    const undo = chunks.map(c => c.undo[0]);
+    const merged = coalesceRecordChunks(chunks, undo);
+    assert.deepEqual(merged.map(m => m.stored.length), [1, 1, 2]);
+    // Updates of the same rows, a formula cascade, merge freely.
+    const cascade = [1, 2, 3].map(i => chunkOf([upd("T", 5, `v${i}`)], [upd("T", 5, `v${i - 1}`)]));
+    assert.deepEqual(coalesceRecordChunks(cascade, cascade.map(c => c.undo[0])).map(m => m.stored.length), [3]);
+  });
+
+  it("leaves a chunk with an action over the inline limit alone", function() {
+    const big: DocAction = ["BulkUpdateRecord", "T", [1, 2, 3], { A: ["a", "b", "c"] }];
+    const chunks = [
+      chunkOf([upd("T", 1, "a")], [upd("T", 1, "0")]),
+      chunkOf([big], [["BulkUpdateRecord", "T", [1, 2, 3], { A: ["0", "0", "0"] }]]),
+      chunkOf([upd("T", 2, "b")], [upd("T", 2, "0")]),
+    ];
+    const undo = chunks.map(c => c.undo[0]);
+    assert.deepEqual(coalesceRecordChunks(chunks, undo, 2).map(m => m.stored.length), [1, 1, 1]);
+    assert.deepEqual(coalesceRecordChunks(chunks, undo, 3).map(m => m.stored.length), [3]);
+  });
+});
+
+describe("chunkByLattice stats", function() {
+  it("settles about one grid point per action on a well-formed bundle", function() {
+    const stored: DocAction[] = [];
+    const undo: DocAction[] = [];
+    for (let i = 1; i <= 50; i++) {
+      stored.push(["UpdateRecord", "T", i, { A: "a" }]);
+      undo.push(["UpdateRecord", "T", i, { A: "0" }]);
+    }
+    const stats: LatticeStats = { settled: 0 };
+    assert.lengthOf(chunkByLattice(stored, undo, stats), 50);
+    // The pairing is a straight diagonal: the start, one point per action, and
+    // the far corner, plus a few neighbors reached at equal score.
+    assert.isAtLeast(stats.settled, 51);
+    assert.isBelow(stats.settled, 2 * (stored.length + undo.length));
   });
 });

--- a/test/server/lib/ActionSummary.ts
+++ b/test/server/lib/ActionSummary.ts
@@ -1,9 +1,10 @@
 import { chunkByLattice, chunkByOwners, coalesceRecordChunks, LatticeStats } from "app/common/ActionLayout";
 import {
-  ActionSummaryOptions, canonicalizeSummary, concatenateSummaries, concatenateSummaryPair,
-  rebaseSummary, summarizeAction, summarizeStoredAndUndo,
+  ActionSummarizer, ActionSummaryOptions, canonicalizeSummary, concatenateSummaries,
+  concatenateSummaryPair, rebaseSummary, summarizeAction, summarizeStoredAndUndo,
 } from "app/common/ActionSummarizer";
-import { ActionSummary, asTabularDiffs, createEmptyTableDelta, LabelDelta, TableDelta } from "app/common/ActionSummary";
+import { ActionSummary, asTabularDiffs, createEmptyActionSummary, createEmptyTableDelta,
+  LabelDelta, TableDelta } from "app/common/ActionSummary";
 import { DocAction } from "app/common/DocActions";
 import { CellDelta } from "app/common/TabularDiff";
 import { TimeCursor } from "app/common/TimeQuery";
@@ -2072,6 +2073,19 @@ describe("ActionSummary concat: a leading restore's old value survives any group
     // summary that already has a `c5` column (from other rows).
     const pair = concatenateSummaryPair(restore, concatenateSummaryPair(rename, removals));
     assert.deepEqual(pair.tableDeltas.T1.columnDeltas.c5[3], cell(["v3"], null));
+  });
+
+  it("builds the same restore from a single-row undo as from a bulk one", function() {
+    // The tests above hand-build `restore`. The walk must reach it whichever
+    // way the restore is written, since the merges above reach the cell only
+    // through `updateRows`.
+    const walk = (act: DocAction) => {
+      const summary = createEmptyActionSummary();
+      new ActionSummarizer().addReverseAction(summary, act);
+      return summary;
+    };
+    assert.deepEqual(walk(["UpdateRecord", "T2", 3, { c5: "v3" }]), restore);
+    assert.deepEqual(walk(["BulkUpdateRecord", "T2", [3], { c5: ["v3"] }]), restore);
   });
 });
 

--- a/test/server/lib/ActionSummaryFuzz.ts
+++ b/test/server/lib/ActionSummaryFuzz.ts
@@ -63,11 +63,11 @@ function pickInt(rng: Rng, lo: number, hi: number): number { return lo + Math.fl
 // type coercion.
 function randomValue(rng: Rng, tag: string): any {
   const r = rng();
+  if (r < 0.08) { return ""; }                  // empty string (Text default)
   if (r < 0.16) {                                // encoded list (ChoiceList-style)
-    return r < 0.08 ? ["L"] :                       // empty list (the list default)
+    return r < 0.12 ? ["L"] :                       // empty list (the list default)
       ["L", String(pickInt(rng, 1, 9)), pickInt(rng, 1, 9)];
   }
-  if (r < 0.14) { return ""; }                  // empty string (Text default)
   if (r < 0.22) { return null; }                // SQL NULL (a value, not absence)
   if (r < 0.30) { return 0; }                   // numeric default
   if (r < 0.38) { return pickInt(rng, 1, 9); }  // small number
@@ -438,10 +438,14 @@ function softenSummary(sum: ActionSummary, other: ActionSummary): ActionSummary 
 }
 
 // A canonical snapshot of every user table's data (rows, columns, computed
-// values). Used to enforce the oracle's same-final-state precondition:
-// per-action and combined modes must reach the SAME final document state, or
-// comparing their summaries is meaningless. Type changes especially can
-// in principle make the two modes diverge; such scenarios are skipped.
+// values) plus each column's type/isFormula. Used to enforce the oracle's
+// same-final-state precondition: per-action and combined modes must reach the
+// SAME final document state, or comparing their summaries is meaningless. Type
+// changes especially can in principle make the two modes diverge; such
+// scenarios are skipped. The engine's formula->data type guess is batch-
+// sensitive, and that divergence is invisible in row data when the table ends
+// with no surviving rows -- so we fold column type/isFormula into the snapshot,
+// keyed by table+colId, to let the precondition skip those scenarios too.
 async function docSnapshot(doc: ActiveDoc, session: any): Promise<string> {
   const tables = (await doc.fetchTable(session, "_grist_Tables", true)).tableData as any;
   const tableIds: string[] = (tables[3].tableId || []).filter((t: any) => typeof t === "string");
@@ -449,6 +453,20 @@ async function docSnapshot(doc: ActiveDoc, session: any): Promise<string> {
   for (const t of [...tableIds].sort()) {
     out[t] = canon((await doc.fetchTable(session, t, true)).tableData);
   }
+  // Column type/isFormula, keyed by table+colId, so a metadata-only divergence
+  // (no surviving rows to expose it) still trips the same-final-state gate.
+  const refToTableId: { [ref: number]: string } = {};
+  tables[2].forEach((ref: number, i: number) => { refToTableId[ref] = tables[3].tableId[i]; });
+  const colData = (await doc.fetchTable(session, "_grist_Tables_column", true)).tableData as any;
+  const cols = colData[3];
+  const colMeta: { [key: string]: any } = {};
+  colData[2].forEach((_ref: number, i: number) => {
+    const tbl = refToTableId[cols.parentId[i]];
+    if (tbl && tableIds.includes(tbl)) {
+      colMeta[`${tbl}.${cols.colId[i]}`] = [cols.type[i], cols.isFormula[i]];
+    }
+  });
+  out.__colMeta__ = canon(colMeta);
   return JSON.stringify(out);
 }
 

--- a/test/server/lib/ActionSummaryFuzz.ts
+++ b/test/server/lib/ActionSummaryFuzz.ts
@@ -1,0 +1,1034 @@
+/**
+ * Property test for chunking + concatenation, with the engine as its own ground
+ * truth at two granularities:
+ *   - Mode A (reference): apply each user action as its own bundle,
+ *     summarize each, and concatenate. One action per bundle is the
+ *     finest granularity the engine produces, so it needs no chunking
+ *     judgement -- this is the trusted answer.
+ *   - Mode B (under test): apply the same sequence as one bundle, and
+ *     summarize it (which chunks then concatenates). The bundle carries the
+ *     engine's per-undo ownership, so this goes through chunkByOwners; each
+ *     bundle is also summarized via chunkByLattice and the two are required to
+ *     agree (see summarizeBundle), so both chunkers are under test at once.
+ *
+ * If chunking and concatenation are correct, Mode B == Mode A for every
+ * sequence. We also check that concatenation is associative over the
+ * per-action summaries (grouping must not matter).
+ *
+ * Runs are random (seeded). Tune via env: FUZZ_RUNS, FUZZ_SEED.
+ */
+
+import { getEnvContent } from "app/common/ActionBundle";
+import { ActionSummaryOptions, canonicalizeSummary, concatenateSummaries, concatenateSummaryPair,
+  summarizeStoredAndUndo } from "app/common/ActionSummarizer";
+import { ActionSummary, TableDelta } from "app/common/ActionSummary";
+import { DocAction, UserAction } from "app/common/DocActions";
+import { CellDelta } from "app/common/TabularDiff";
+import { ActiveDoc } from "app/server/lib/ActiveDoc";
+import { createDocTools } from "test/server/docTools";
+import * as testUtils from "test/server/testUtils";
+import { assert } from "test/server/testUtils";
+
+// One scenario's raw engine output at the two granularities the oracle compares:
+// each action as its own bundle (Mode A) and the whole sequence as one (Mode B).
+// `undoOwner` is the engine's per-undo ownership (see ActionBundle), carried
+// through so the summarizer takes its chunkByOwners path -- the whole oracle thus
+// runs over the owner-driven chunking, and `summarizeBundle` cross-checks it
+// against the lattice.
+interface RawBundle {
+  stored: DocAction[];
+  undo: DocAction[];
+  undoOwner?: (number | null)[];
+}
+
+// ---- seeded PRNG (mulberry32) ----
+function mulberry32(seed: number) {
+  let t = seed >>> 0;
+  return function() {
+    t = (t + 0x6D2B79F5) | 0;
+    let x = Math.imul(t ^ (t >>> 15), 1 | t);
+    x = (x + Math.imul(x ^ (x >>> 7), 61 | x)) ^ x;
+    return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type Rng = () => number;
+function pick<T>(rng: Rng, arr: T[]): T { return arr[Math.floor(rng() * arr.length)]; }
+function pickInt(rng: Rng, lo: number, hi: number): number { return lo + Math.floor(rng() * (hi - lo + 1)); }
+
+// A varied cell value, biased to include the "hard" values: the empty string
+// and 0 (column defaults the engine omits), SQL NULL (a value distinct from
+// absence), booleans and numbers (type-mixing), and otherwise a near-unique
+// string. Exercises default omission, the [null]-vs-absent distinction, and
+// type coercion.
+function randomValue(rng: Rng, tag: string): any {
+  const r = rng();
+  if (r < 0.16) {                                // encoded list (ChoiceList-style)
+    return r < 0.08 ? ["L"] :                       // empty list (the list default)
+      ["L", String(pickInt(rng, 1, 9)), pickInt(rng, 1, 9)];
+  }
+  if (r < 0.14) { return ""; }                  // empty string (Text default)
+  if (r < 0.22) { return null; }                // SQL NULL (a value, not absence)
+  if (r < 0.30) { return 0; }                   // numeric default
+  if (r < 0.38) { return pickInt(rng, 1, 9); }  // small number
+  if (r < 0.44) { return rng() < 0.5; }         // boolean
+  if (r < 0.50) { return String(pickInt(rng, 0, 9)); } // string digit: "0" vs 0 type collision
+  return `${tag}${pickInt(rng, 1, 99999)}`;     // near-unique string
+}
+
+// Constant / id-based formulas that never break under renames or removals.
+const FORMULAS = ["0", "''", "1+1", "$id", "$id*2"];
+
+// ---- a model of the doc, so we only generate valid actions ----
+//
+// The model deliberately RECYCLES names and rowIds: a removed/renamed-away
+// table or column name returns to a pool, as does a removed rowId, and later
+// actions draw from those pools with probability REUSE_P. This is what forces
+// the naming-identity-change and rowId-recycle shapes that monotonic counters
+// would never produce, the exact case chunking exists to handle.
+interface TableModel {
+  cols: string[]; rows: number[]; nextRow: number; freedRows: number[];
+  formulaCols: Set<string>;   // columns currently holding a formula (no stored data)
+}
+
+// The population is always adversarial -- there is no mild mode. We drop the
+// plain-edit filler that summarizes cleanly and concentrate the operations
+// that have actually produced bugs: renames, name/row recycling, formula<->
+// data conversions, and type changes, over several wide tables with list-
+// encoded values and aggressive name reuse, so the hard interactions stack.
+const REUSE_P = 0.85;   // high reuse -> recycle tangles bite hardest
+
+class DocModel {
+  public tables = new Map<string, TableModel>();
+  public nextTable = 1;
+  public nextCol = 1;
+  public freedTables: string[] = [];   // table names removed/renamed-away, free to reuse
+  public freedCols: string[] = [];     // column names removed/renamed-away, free to reuse
+
+  // Draw a table name: sometimes reuse a freed (and not-currently-live) name,
+  // forcing remove-then-readd of the same slot; else mint a fresh one.
+  public drawTableName(rng: Rng): string {
+    const free = this.freedTables.filter(n => !this.tables.has(n));
+    if (free.length && rng() < REUSE_P) {
+      const n = pick(rng, free);
+      this.freedTables = this.freedTables.filter(x => x !== n);
+      return n;
+    }
+    return `T${this.nextTable++}`;
+  }
+
+  // Draw a column name not in `exclude`: reuse a freed one (same-table column
+  // ids must stay distinct, so the caller passes the live set), else fresh.
+  public drawColName(rng: Rng, exclude: Set<string>): string {
+    const free = this.freedCols.filter(n => !exclude.has(n));
+    if (free.length && rng() < REUSE_P) {
+      const n = pick(rng, free);
+      this.freedCols = this.freedCols.filter(x => x !== n);
+      return n;
+    }
+    return `c${this.nextCol++}`;
+  }
+
+  // Draw a rowId for a table: reuse a freed (removed) rowId, else fresh.
+  public drawRowId(rng: Rng, tm: TableModel): number {
+    const live = new Set(tm.rows);
+    const free = tm.freedRows.filter(r => !live.has(r));
+    if (free.length && rng() < REUSE_P) {
+      const r = pick(rng, free);
+      tm.freedRows = tm.freedRows.filter(x => x !== r);
+      return r;
+    }
+    return tm.nextRow++;
+  }
+
+  public freeTableName(id: string) { this.freedTables.push(id); }
+  public freeColName(c: string) { this.freedCols.push(c); }
+
+  public addTable(rng: Rng): { id: string; cols: string[] } {
+    const id = this.drawTableName(rng);
+    const used = new Set<string>();
+    const cols: string[] = [];
+    const nCols = pickInt(rng, 2, 4);   // wider tables = more churn surface
+    for (let i = 0; i < nCols; i++) { const c = this.drawColName(rng, used); used.add(c); cols.push(c); }
+    this.tables.set(id, { cols: [...cols], rows: [], nextRow: 1, freedRows: [], formulaCols: new Set() });
+    return { id, cols };
+  }
+}
+
+// Build the random setup as concrete user actions plus a seeded model.
+function randomSetup(rng: Rng): { setup: UserAction[]; model: DocModel } {
+  const model = new DocModel();
+  const setup: UserAction[] = [];
+  const nTables = pickInt(rng, 2, 3);
+  for (let t = 0; t < nTables; t++) {
+    const { id, cols } = model.addTable(rng);
+    setup.push(["AddTable", id, cols.map(c => ({ id: c }))]);
+    const tm = model.tables.get(id)!;
+    const nRows = pickInt(rng, 3, 5);
+    for (let r = 0; r < nRows; r++) {
+      const rowId = tm.nextRow++;
+      tm.rows.push(rowId);
+      const values: { [c: string]: any } = {};
+      for (const c of tm.cols) { values[c] = randomValue(rng, `v${rowId}_${c}_`); }
+      setup.push(["AddRecord", id, rowId, values]);
+    }
+  }
+  return { setup, model };
+}
+
+// One random *valid* action against the current model; mutates the model
+// to reflect the action so the rest of the sequence stays valid. Returns
+// undefined if no valid action of the chosen kind is available.
+function randomAction(rng: Rng, model: DocModel): UserAction | undefined {
+  const tableIds = [...model.tables.keys()];
+  if (tableIds.length === 0) { return undefined; }
+  // Values are only ever set for data columns; setting a value on a formula
+  // column would convert it (a separate, deliberately-generated trick).
+  const dataCols = (t: TableModel) => t.cols.filter(c => !t.formulaCols.has(c));
+  // Black-hat weighting: bias hard toward the operations that proved hardest --
+  // column remove/rename/recompose (recycle sources & sinks), table renames
+  // (which strand calc-flush restores under the post-rename name), and
+  // formula/type conversions (reversed-undo). Plain updates are de-emphasized.
+  // No plain-edit padding. Just enough update/add to create restorable data
+  // and recycle rowIds; everything else is the hard schema churn -- recycled
+  // column and table names, renames into freed names, formula<->data
+  // conversions (reversed undo), and type changes.
+  const kinds = ["removeCol", "removeCol", "addCol", "addFormulaCol",
+    "renameCol", "renameCol", "renameCol",
+    "removeTable", "addTable",
+    "renameTable", "renameTable", "renameTable", "renameTable",
+    "modifyColType", "modifyColType",
+    "toggleFormula", "toggleFormula",
+    "convertFormulaToData", "convertFormulaToData", "convertFormulaToData",
+    "remove", "bulkRemove", "add", "bulkAdd", "update"];
+  const kind = pick(rng, kinds);
+  const tid = pick(rng, tableIds);
+  const tm = model.tables.get(tid)!;
+
+  switch (kind) {
+    case "update": {
+      const cols = dataCols(tm);
+      if (tm.rows.length === 0 || cols.length === 0) { return undefined; }
+      const row = pick(rng, tm.rows);
+      const col = pick(rng, cols);
+      return ["UpdateRecord", tid, row, { [col]: randomValue(rng, `u${row}_${col}_`) }];
+    }
+    case "add": {
+      if (tm.cols.length === 0) { return undefined; }
+      const rowId = model.drawRowId(rng, tm);
+      tm.rows.push(rowId);
+      const values: { [c: string]: any } = {};
+      for (const c of dataCols(tm)) { values[c] = randomValue(rng, `a${rowId}_${c}_`); }
+      return ["AddRecord", tid, rowId, values];
+    }
+    case "remove": {
+      if (tm.rows.length === 0) { return undefined; }
+      const row = pick(rng, tm.rows);
+      tm.rows = tm.rows.filter(r => r !== row);
+      tm.freedRows.push(row);
+      return ["RemoveRecord", tid, row];
+    }
+    case "addCol": {
+      const col = model.drawColName(rng, new Set(tm.cols));
+      tm.cols.push(col);
+      return ["AddColumn", tid, col, {}];
+    }
+    case "removeCol": {
+      if (tm.cols.length <= 1) { return undefined; }
+      const col = pick(rng, tm.cols);
+      tm.cols = tm.cols.filter(c => c !== col);
+      tm.formulaCols.delete(col);
+      model.freeColName(col);
+      return ["RemoveColumn", tid, col];
+    }
+    case "renameCol": {
+      if (tm.cols.length === 0) { return undefined; }
+      const col = pick(rng, tm.cols);
+      const newCol = model.drawColName(rng, new Set(tm.cols));
+      tm.cols = tm.cols.map(c => c === col ? newCol : c);
+      if (tm.formulaCols.delete(col)) { tm.formulaCols.add(newCol); }
+      model.freeColName(col);
+      return ["RenameColumn", tid, col, newCol];
+    }
+    case "addTable": {
+      const { id, cols } = model.addTable(rng);
+      return ["AddTable", id, cols.map(c => ({ id: c }))];
+    }
+    case "removeTable": {
+      if (model.tables.size <= 1) { return undefined; }
+      model.tables.delete(tid);
+      model.freeTableName(tid);
+      for (const c of tm.cols) { model.freeColName(c); }
+      return ["RemoveTable", tid];
+    }
+    case "renameTable": {
+      const newId = model.drawTableName(rng);
+      if (newId === tid) { return undefined; }
+      model.tables.set(newId, tm);
+      model.tables.delete(tid);
+      model.freeTableName(tid);
+      return ["RenameTable", tid, newId];
+    }
+    case "bulkAdd": {
+      if (tm.cols.length === 0) { return undefined; }
+      const n = pickInt(rng, 2, 4);
+      const ids: number[] = [];
+      for (let i = 0; i < n; i++) { const id = model.drawRowId(rng, tm); ids.push(id); tm.rows.push(id); }
+      const values: { [c: string]: any[] } = {};
+      for (const c of dataCols(tm)) { values[c] = ids.map(id => randomValue(rng, `b${id}_${c}_`)); }
+      return ["BulkAddRecord", tid, ids, values];
+    }
+    case "bulkRemove": {
+      if (tm.rows.length < 2) { return undefined; }
+      const n = Math.min(pickInt(rng, 2, 3), tm.rows.length);
+      const ids = tm.rows.slice(0, n);
+      tm.rows = tm.rows.slice(n);
+      for (const r of ids) { tm.freedRows.push(r); }
+      return ["BulkRemoveRecord", tid, ids];
+    }
+    case "addFormulaCol": {
+      // A real formula column: no stored data, recomputed on every row change
+      // (exercises calc-flush, front-stray undos, the newly-created-no-undo case).
+      const col = model.drawColName(rng, new Set(tm.cols));
+      tm.cols.push(col);
+      tm.formulaCols.add(col);
+      return ["AddColumn", tid, col, { isFormula: true, formula: pick(rng, FORMULAS) }];
+    }
+    case "modifyColType": {
+      // Type change on a data column -- forces a type/data cascade and a
+      // conversion of the stored values.
+      const cols = dataCols(tm);
+      if (cols.length === 0) { return undefined; }
+      const col = pick(rng, cols);
+      return ["ModifyColumn", tid, col, { type: pick(rng, ["Text", "Numeric", "Int", "Bool", "Any"]) }];
+    }
+    case "toggleFormula": {
+      // Turn a data column into a formula column (it loses its stored data).
+      const cols = dataCols(tm);
+      if (cols.length === 0) { return undefined; }
+      const col = pick(rng, cols);
+      tm.formulaCols.add(col);
+      return ["ModifyColumn", tid, col, { isFormula: true, formula: pick(rng, FORMULAS) }];
+    }
+    case "convertFormulaToData": {
+      // Turn a formula column into a data column the way Grist actually does it:
+      // ModifyColumn with isFormula:false and an empty formula freezes the
+      // formula's current values as stored data (the reversed-undo / null-vs-value
+      // case). Writing a literal to one cell does not convert a non-empty formula
+      // column -- the engine rejects that with "Can't save value to formula
+      // column" -- so the conversion must go through ModifyColumn.
+      if (tm.formulaCols.size === 0) { return undefined; }
+      const col = pick(rng, [...tm.formulaCols]);
+      tm.formulaCols.delete(col);
+      return ["ModifyColumn", tid, col, { isFormula: false, formula: "" }];
+    }
+  }
+  return undefined;
+}
+
+function randomSequence(rng: Rng, model: DocModel): UserAction[] {
+  const len = pickInt(rng, 8, 20);
+  const out: UserAction[] = [];
+  for (let i = 0; i < len && out.length < len; i++) {
+    const a = randomAction(rng, model);
+    if (a) { out.push(a); }
+  }
+  return out;
+}
+
+// Canonicalize for order-insensitive comparison (object keys sorted).
+function canon(v: any): any {
+  if (v === null || typeof v !== "object") { return v; }
+  if (Array.isArray(v)) { return v.map(canon); }
+  const out: any = {};
+  for (const k of Object.keys(v).sort()) { out[k] = canon(v[k]); }
+  return out;
+}
+function eq(a: ActionSummary, b: ActionSummary): boolean {
+  return JSON.stringify(canon(a)) === JSON.stringify(canon(b));
+}
+// Lenient comparison accepting only negligible default-at-a-removed-boundary
+// differences (the engine's default-value omission); a real value mismatch
+// still fails. The softening is relative to the other side (see softenSummary):
+// a default value is dropped only where the other summary records nothing there,
+// so two different present values -- even two distinct type-defaults like "" and
+// 0 -- never collapse together and a corrupted value stays visible.
+function eqSoft(a: ActionSummary, b: ActionSummary): boolean {
+  return eq(softenSummary(a, b), softenSummary(b, a));
+}
+
+// "Don't sweat the small stuff" filter.
+//
+// The engine omits a column's value from a removed row's (or removed column's)
+// restore when that value is the column type's default (null for Any, "" for
+// Text, 0 for Numeric/Int, false for Bool). So the combined bundle never carries
+// such a cell, while a per-action concat may record it from an earlier explicit
+// write. The difference is exactly one default value at a boundary where the
+// cell is going away anyway -- it carries no recoverable information and does
+// not affect endpoint reconstruction. `softenSummary` drops such a default cell
+// side, but only where the other summary records nothing there ("absent"). This
+// is deliberately relative: nulling defaults on each side independently would
+// also equate two different present defaults (e.g. "" with 0), masking a
+// corrupted value. By only dropping a default opposite an absent side, a real
+// value difference -- including a different default, or a non-default the engine
+// would never omit -- stays visible.
+function isDefaultScalar(side: CellDelta[0]): boolean {
+  if (!Array.isArray(side) || side.length !== 1) { return false; }
+  const v = side[0];
+  return v === null || v === "" || v === 0 || v === false;
+}
+
+// A side counts as "absent" on the other summary if that cell is missing
+// entirely or records null on this side, so a default here lines up with nothing
+// there.
+function softenTableDelta(td: TableDelta, otherTd?: TableDelta): TableDelta {
+  const addSet = new Set(td.addRows);
+  const remSet = new Set(td.removeRows);
+  const removedRows = new Set(td.removeRows.filter(r => !addSet.has(r)));
+  const addedRows = new Set(td.addRows.filter(r => !remSet.has(r)));
+  const recycledRows = new Set(td.addRows.filter(r => remSet.has(r)));
+  const addedCols = new Set(td.columnRenames.filter(([pre]) => pre === null).map(([, post]) => post));
+  const columnDeltas: { [colId: string]: { [rowId: number]: CellDelta } } = {};
+  for (const [colId, cd] of Object.entries(td.columnDeltas)) {
+    const defunctCol = colId.startsWith("-");
+    const addedCol = addedCols.has(colId);
+    const otherCd = otherTd?.columnDeltas[colId];
+    const kept: { [rowId: number]: CellDelta } = {};
+    for (const [rowId, cell] of Object.entries(cd)) {
+      const r = Number(rowId);
+      const recycled = recycledRows.has(r);
+      const otherCell = otherCd?.[r];
+      const otherPreAbsent = (otherCell?.[0] ?? null) === null;
+      const otherPostAbsent = (otherCell?.[1] ?? null) === null;
+      let [pre, post] = cell;
+      // Drop a default value at an existence boundary -- what the engine omits --
+      // but only where the other summary records nothing there, so it lines up
+      // with an absence rather than overwriting a different value the other side
+      // carries. A non-default value is never touched (losing it would be real).
+      if ((defunctCol || removedRows.has(r) || recycled) && isDefaultScalar(pre) && otherPreAbsent) {
+        pre = null;
+      }
+      if ((addedCol || addedRows.has(r) || recycled) && isDefaultScalar(post) && otherPostAbsent) {
+        post = null;
+      }
+      if (pre === null && post === null) { continue; }   // vacuous after normalizing
+      kept[r] = [pre, post];
+    }
+    if (Object.keys(kept).length > 0) { columnDeltas[colId] = kept; }
+  }
+  // updateRows is derived from cells, so after dropping negligible cells we must
+  // re-derive it: a row whose only cell was a default-at-a-boundary is no longer
+  // "really updated", and a lingering updateRows entry would read as a difference.
+  const updateRows = [...new Set(
+    Object.values(columnDeltas).flatMap(cd => Object.keys(cd).map(Number)))]
+    .filter(r => !addSet.has(r) && !remSet.has(r)).sort((a, b) => a - b);
+  return { ...td, columnDeltas, updateRows };
+}
+
+/**
+ * Drop negligible default-at-a-boundary cells for lenient comparison, relative to
+ * `other`: a default side is dropped only where `other` records nothing there.
+ */
+function softenSummary(sum: ActionSummary, other: ActionSummary): ActionSummary {
+  const tableDeltas: { [tableId: string]: TableDelta } = {};
+  for (const [tableId, td] of Object.entries(sum.tableDeltas)) {
+    tableDeltas[tableId] = softenTableDelta(td, other.tableDeltas[tableId]);
+  }
+  return { ...sum, tableDeltas };
+}
+
+// A canonical snapshot of every user table's data (rows, columns, computed
+// values). Used to enforce the oracle's same-final-state precondition:
+// per-action and combined modes must reach the SAME final document state, or
+// comparing their summaries is meaningless. Type changes especially can
+// in principle make the two modes diverge; such scenarios are skipped.
+async function docSnapshot(doc: ActiveDoc, session: any): Promise<string> {
+  const tables = (await doc.fetchTable(session, "_grist_Tables", true)).tableData as any;
+  const tableIds: string[] = (tables[3].tableId || []).filter((t: any) => typeof t === "string");
+  const out: { [t: string]: any } = {};
+  for (const t of [...tableIds].sort()) {
+    out[t] = canon((await doc.fetchTable(session, t, true)).tableData);
+  }
+  return JSON.stringify(out);
+}
+
+// A second precondition: the bundle's own undo must round-trip. Some bundles
+// (e.g. a column made into a formula, removed, and its table renamed in one
+// batch) emit an undo the engine itself cannot apply -- it throws, or leaves
+// the wrong state (a known engine bug). A summary
+// derives the pre-state from the undo, so when the undo is invalid there is no
+// well-defined transition to check; such scenarios are skipped. `doc` is left
+// mutated (the undo is applied), so the caller must be done with it.
+async function undoRoundTrips(doc: ActiveDoc, session: any,
+  before: string, undo: any[]): Promise<boolean> {
+  try {
+    await doc.applyUserActions(session, [["ApplyUndoActions", undo]]);
+    return (await docSnapshot(doc, session)) === before;
+  } catch (e) {
+    return false;
+  }
+}
+
+// Disable bulk truncation so per-action and combined paths summarize
+// comparably (a batched bulk would otherwise be sampled differently
+// than many small per-action bulks -- a spurious diff).
+const SUMMARY_OPTS = { maximumInlineRows: null };
+
+// Summarize a raw bundle the way production does -- using the engine's per-undo
+// ownership when present (the chunkByOwners path). When ownership is present,
+// also summarize via the lattice (ignoreUndoGrouping) and assert the two paths
+// agree, so every scenario the oracle checks doubles as a check that the engine's
+// recorded grouping matches the one the lattice infers. Returns the owner-path
+// summary, which the oracle then compares against the per-action reference.
+function summarizeBundle(b: RawBundle, opts: ActionSummaryOptions = SUMMARY_OPTS): ActionSummary {
+  const byOwners = summarizeStoredAndUndo(b.stored, b.undo, opts, b.undoOwner);
+  if (b.undoOwner !== undefined) {
+    const byLattice = summarizeStoredAndUndo(b.stored, b.undo, { ...opts, ignoreUndoGrouping: true });
+    assert.isTrue(eqSoft(byOwners, byLattice),
+      `owner-driven and lattice chunking disagree on the same bundle\n` +
+      `stored=${JSON.stringify(b.stored)}\nundo=${JSON.stringify(b.undo)}\n` +
+      `undoOwner=${JSON.stringify(b.undoOwner)}\n` +
+      `byOwners=${JSON.stringify(byOwners)}\nbyLattice=${JSON.stringify(byLattice)}`);
+  }
+  return byOwners;
+}
+
+// Drive the engine through one scenario and return the raw (stored, undo)
+// bundles at both granularities the oracle compares: each action as its own
+// bundle (Mode A) and the whole sequence as one bundle (Mode B). Returns null
+// when a precondition makes the comparison meaningless -- an empty sequence,
+// the two modes reaching different final states, or a bundle whose undo the
+// engine cannot replay -- or when a generated action turns out invalid.
+async function runScenario(doc: ActiveDoc, session: any,
+  setup: UserAction[], actions: UserAction[]):
+Promise<{ perAction: RawBundle[]; combined: RawBundle } | null> {
+  if (actions.length === 0) { return null; }
+  try {
+    // The caller supplies an empty doc, reused across scenarios so the engine
+    // boots once. One doc also serves both modes: run Mode B (the whole sequence
+    // as one bundle) first, then undo back to the post-setup state (the undo
+    // round-trip check doubles as the reset), then run Mode A (each action as
+    // its own bundle). A second doc would only re-apply the same setup.
+    await doc.applyUserActions(session, setup);
+    const beforeActions = await docSnapshot(doc, session);
+
+    // Mode B: the whole sequence as one bundle.
+    await doc.applyUserActions(session, actions);
+    const cb = (await doc.getRecentActionsDirect(1))[0];
+    const combined: RawBundle =
+      { stored: getEnvContent(cb.stored), undo: cb.undo, undoOwner: cb.undoOwner };
+    const afterCombined = await docSnapshot(doc, session);
+
+    // The bundle's undo must round-trip to the pre-state, else there is no
+    // well-defined transition to summarize. This also restores the post-setup
+    // state for Mode A.
+    if (!await undoRoundTrips(doc, session, beforeActions, cb.undo)) { return null; }
+
+    // Mode A: each action as its own bundle, from the same post-setup state.
+    const perAction: RawBundle[] = [];
+    for (const a of actions) {
+      await doc.applyUserActions(session, [a]);
+      const b = (await doc.getRecentActionsDirect(1))[0];
+      perAction.push({ stored: getEnvContent(b.stored), undo: b.undo, undoOwner: b.undoOwner });
+    }
+    // Both modes must reach the same final state, else comparing summaries is
+    // meaningless.
+    if (await docSnapshot(doc, session) !== afterCombined) { return null; }
+    return { perAction, combined };
+  } catch (err) {
+    return null;   // an occasional invalid generated action
+  }
+}
+
+// The chunk+concat oracle, run on a doc already set up: applying `edits` as one
+// bundle (Mode B) must summarize to the same thing as applying each edit on its
+// own and composing (Mode A), and the combined undo must round-trip. Returns the
+// combined summary so a caller can add its own checks. Used by the cascade and
+// import tests below.
+async function assertConsistent(doc: ActiveDoc, session: any,
+  edits: UserAction[], opts: ActionSummaryOptions = SUMMARY_OPTS): Promise<ActionSummary> {
+  const before = await docSnapshot(doc, session);
+  await doc.applyUserActions(session, edits);
+  const cb = (await doc.getRecentActionsDirect(1))[0];
+  const combined = summarizeBundle(
+    { stored: getEnvContent(cb.stored), undo: cb.undo, undoOwner: cb.undoOwner }, opts);
+  const afterCombined = await docSnapshot(doc, session);
+  assert.isTrue(await undoRoundTrips(doc, session, before, cb.undo),
+    "the combined bundle's undo must round-trip");
+  const perAction: ActionSummary[] = [];
+  for (const a of edits) {
+    await doc.applyUserActions(session, [a]);
+    const b = (await doc.getRecentActionsDirect(1))[0];
+    perAction.push(summarizeBundle(
+      { stored: getEnvContent(b.stored), undo: b.undo, undoOwner: b.undoOwner }, opts));
+  }
+  assert.strictEqual(await docSnapshot(doc, session), afterCombined,
+    "both modes must reach the same final state");
+  const reference = concatenateSummaries(perAction);
+  assert.isTrue(eqSoft(combined, reference),
+    `combined-bundle summary disagrees with per-action reference\n` +
+    `combined=${JSON.stringify(combined)}\nreference=${JSON.stringify(reference)}`);
+  return combined;
+}
+
+describe("ActionSummary fuzz: chunk + concat consistency", function() {
+  this.timeout(600000);
+  testUtils.setTmpLogLevel("error");
+  const docTools = createDocTools();
+
+  const N_RUNS = parseInt(process.env.FUZZ_RUNS || "20", 10);
+  // Sweep several seeds by default. Different trajectories hit different
+  // recycle/rename/conversion tangles, so seed diversity buys more coverage than
+  // depth on one seed -- this is what the retired cached corpora gave, now drawn
+  // fresh on every run. Kept modest on purpose: this is a supplementary net (the
+  // unit suite pins every known case), so each build samples a slice and coverage
+  // accumulates across builds. Raise FUZZ_RUNS for a deeper local sweep, or pin a
+  // single seed with FUZZ_SEED to reproduce a failure.
+  const SEEDS = process.env.FUZZ_SEED ? [parseInt(process.env.FUZZ_SEED, 10)] : [1, 2, 3];
+
+  it(`combined == per-action, and concat associative (${N_RUNS} runs x ${SEEDS.length} seed(s))`,
+    async function() {
+      const session = docTools.createFakeSession();
+      // Booting the data engine dominates the per-scenario cost, so boot once:
+      // reuse a single doc and reset it (remove every user table) between
+      // scenarios. The generated tables have no cross-table references, so the
+      // removals are order-independent. Validated to give the same checked and
+      // skipped counts as a fresh doc per scenario, so the reset leaves nothing
+      // that affects the oracle.
+      let doc = await docTools.createDoc("fuzz.grist");
+      let k = 0;
+      const resetDoc = async () => {
+        const meta = (await doc.fetchTable(session, "_grist_Tables", true)).tableData as any;
+        const ids: string[] = (meta[3].tableId || []).filter((t: any) => typeof t === "string");
+        if (ids.length) { await doc.applyUserActions(session, ids.map(t => ["RemoveTable", t])); }
+      };
+
+      let checked = 0;
+      let skipped = 0;
+      for (const seed of SEEDS) {
+        const rng = mulberry32(seed);
+        for (let run = 0; run < N_RUNS; run++, k++) {
+          const { setup, model } = randomSetup(rng);
+          const actions = randomSequence(rng, model);
+          // Start each scenario from an empty doc. runScenario already skips a
+          // generated bundle that errors in the engine; if such a bundle left
+          // the doc unusable, resetDoc throws here, so replace the doc rather
+          // than let one bad draw abort the rest of the sweep.
+          try { await resetDoc(); } catch (e) { doc = await docTools.createDoc(`fuzz-${k}.grist`); }
+          const sc = await runScenario(doc, session, setup, actions);
+          if (!sc) { skipped++; continue; }
+
+          const perAction = sc.perAction.map(b => summarizeBundle(b));
+          const combined = summarizeBundle(sc.combined);
+          const reference = concatenateSummaries(perAction);
+          assert.isTrue(eqSoft(combined, reference),
+            `seed ${seed} run ${run}: combined-bundle summary disagrees with ` +
+            `per-action reference.\nactions=${JSON.stringify(actions)}\n` +
+            `combined=${JSON.stringify(combined)}\nreference=${JSON.stringify(reference)}`);
+
+          // Associativity: a left-fold and a right-fold of the per-action
+          // summaries must agree (grouping must not matter).
+          if (perAction.length >= 2) {
+            let rightFold = perAction[perAction.length - 1];
+            for (let i = perAction.length - 2; i >= 0; i--) {
+              rightFold = concatenateSummaryPair(perAction[i], rightFold);
+            }
+            assert.isTrue(eqSoft(reference, canonicalizeSummary(rightFold)),
+              `seed ${seed} run ${run}: concat not associative.\n` +
+              `actions=${JSON.stringify(actions)}\n` +
+              `leftFold=${JSON.stringify(reference)}\nrightFold=${JSON.stringify(rightFold)}`);
+          }
+          checked++;
+        }
+      }
+      console.log(`fuzz: ${checked} scenarios checked, ${skipped} skipped ` +
+        `(${N_RUNS} runs x seeds ${SEEDS.join(",")})`);
+      assert.isAbove(checked, 0, "no scenarios were checked");
+    });
+});
+
+describe("ActionSummary: feature scenarios", function() {
+  this.timeout(60000);
+  testUtils.setTmpLogLevel("error");
+  const docTools = createDocTools();
+  const session = docTools.createFakeSession();
+
+  // Find a row id in a metadata table by matching a column (and optionally a
+  // second one), e.g. the tableRef of "Src" or the colRef of "Cat" under it.
+  const refOf = (meta: any, col: string, value: any, also?: [string, any]): number => {
+    const rowIds: number[] = meta[2];
+    const vals: any[] = meta[3][col];
+    const alsoVals: any[] | undefined = also && meta[3][also[0]];
+    for (let i = 0; i < rowIds.length; i++) {
+      if (vals[i] === value && (!also || alsoVals![i] === also[1])) { return rowIds[i]; }
+    }
+    throw new Error(`ref not found: ${col}=${value}`);
+  };
+
+  describe("computed-table cascades", function() {
+    // A doc with table Src grouped into a summary by Cat. Src also has a formula
+    // column, so a source edit recomputes both the formula column and the summary
+    // aggregates. Seed groups: a={1,2}, b={3}, c={4}.
+    const makeSummaryDoc = async (name: string): Promise<ActiveDoc> => {
+      const doc = await docTools.createDoc(name);
+      await doc.applyUserActions(session, [
+        ["AddTable", "Src", [
+          { id: "Cat", type: "Text" },
+          { id: "Amt", type: "Numeric" },
+          { id: "Dbl", type: "Numeric", isFormula: true, formula: "$Amt * 2" },
+        ]],
+        ["BulkAddRecord", "Src", [1, 2, 3, 4], { Cat: ["a", "a", "b", "c"], Amt: [10, 20, 30, 40] }],
+      ]);
+      const tables = (await doc.fetchTable(session, "_grist_Tables", true)).tableData as any;
+      const cols = (await doc.fetchTable(session, "_grist_Tables_column", true)).tableData as any;
+      const srcRef = refOf(tables, "tableId", "Src");
+      const catRef = refOf(cols, "colId", "Cat", ["parentId", srcRef]);
+      await doc.applyUserActions(session, [["CreateViewSection", srcRef, 0, "record", [catRef], null]]);
+      return doc;
+    };
+
+    // A doc with People and a Tasks table that References People and carries a
+    // cross-table formula ($Owner.Name). Editing People recomputes that formula in
+    // Tasks, a cross-table cascade with calc-flush restores, the same family as a
+    // summary table's aggregates.
+    const makeRefDoc = async (name: string): Promise<ActiveDoc> => {
+      const doc = await docTools.createDoc(name);
+      await doc.applyUserActions(session, [
+        ["AddTable", "People", [{ id: "Name", type: "Text" }]],
+        ["BulkAddRecord", "People", [1, 2], { Name: ["Alice", "Bob"] }],
+        ["AddTable", "Tasks", [
+          { id: "Title", type: "Text" },
+          { id: "Owner", type: "Ref:People" },
+          { id: "OwnerName", type: "Any", isFormula: true, formula: "$Owner.Name" },
+        ]],
+        ["BulkAddRecord", "Tasks", [1, 2, 3], { Title: ["t1", "t2", "t3"], Owner: [1, 1, 2] }],
+      ]);
+      return doc;
+    };
+
+    // The bug this exercises: a removed group's recomputed aggregates (formula
+    // columns) were dropped, because their calc-flush restores scattered into
+    // chunks past the removal. A new group appears, a surviving group's aggregates
+    // recompute, and a group is removed, all in one bundle.
+    it("keeps a removed group's aggregates, with a formula column in the mix", async function() {
+      const doc = await makeSummaryDoc("summary1.grist");
+      const combined = await assertConsistent(doc, session, [
+        ["AddRecord", "Src", 5, { Cat: "d", Amt: 100 }],   // a new group "d" appears
+        ["UpdateRecord", "Src", 1, { Amt: 15 }],           // group "a" sum and Dbl recompute
+        ["BulkRemoveRecord", "Src", [3]],                  // last "b" row gone, group removed
+      ]);
+      // Sanity: the cascade happened, so the test is not vacuous. The summary table
+      // is a table other than Src that the edits never named.
+      assert.isNotEmpty(Object.keys(combined.tableDeltas).filter(t => t !== "Src"),
+        "the summary table should appear in the combined summary");
+    });
+
+    // Several groups removed in one bundle: their summary rows are restored
+    // together, which exercises the all-rows-defunct branch of the front-restore
+    // attribution (a BulkUpdateRecord over more than one removed row).
+    it("keeps the aggregates of several groups removed at once", async function() {
+      const doc = await makeSummaryDoc("summary2.grist");
+      await assertConsistent(doc, session, [
+        ["UpdateRecord", "Src", 1, { Amt: 25 }],   // group "a" aggregates recompute
+        ["BulkRemoveRecord", "Src", [3, 4]],       // groups "b" and "c" both vanish
+      ]);
+    });
+
+    // A cross-table Ref cascade: editing People recomputes OwnerName across the
+    // Tasks that reference it, a referenced Person is removed (its dependents
+    // recompute), and a Task is removed (its own formula value must survive). The
+    // removed-row front-restore handling should generalize here from summary tables.
+    it("keeps formula values across a cross-table Ref cascade", async function() {
+      const doc = await makeRefDoc("refs.grist");
+      const combined = await assertConsistent(doc, session, [
+        ["UpdateRecord", "People", 1, { Name: "Alice2" }],  // Tasks 1,2 OwnerName recompute
+        ["RemoveRecord", "People", 2],                       // Task 3's $Owner.Name recomputes
+        ["RemoveRecord", "Tasks", 3],                        // a Task removed; its formula restore
+      ]);
+      assert.isNotEmpty(Object.keys(combined.tableDeltas),
+        "the cascade should touch at least one table");
+    });
+
+    // Two SEPARATE remove stored actions in one bundle, both on Src with its Dbl
+    // formula column. The engine accumulates the whole bundle's summary and emits
+    // ONE front BulkUpdateRecord restoring Dbl for rows 1 and 2 together -- a
+    // restore spanning two distinct removals. restoreOwner attributes that whole
+    // entry to the first row's owner, so this checks a restore whose rows do not
+    // all belong to one removal still composes correctly (the all-rows-defunct
+    // single-owner assumption).
+    it("composes when two separate removes share one merged front restore", async function() {
+      const doc = await makeSummaryDoc("summary3.grist");
+      await assertConsistent(doc, session, [
+        ["RemoveRecord", "Src", 1],
+        ["RemoveRecord", "Src", 2],
+      ]);
+    });
+  });
+
+  describe("imports", function() {
+    // A table loaded with data, the way an import lands it before any edits.
+    const makeDataDoc = async (name: string): Promise<ActiveDoc> => {
+      const doc = await docTools.createDoc(name);
+      await doc.applyUserActions(session, [
+        ["AddTable", "Data", [{ id: "A", type: "Text" }, { id: "B", type: "Text" }]],
+        ["BulkAddRecord", "Data", [1, 2, 3], { A: ["a1", "a2", "a3"], B: ["10", "20", "30"] }],
+      ]);
+      return doc;
+    };
+
+    // Imports lean on ReplaceTableData, which the fuzzer never generates. It wipes
+    // a table and re-adds, so even a row that keeps its id reads as recycled rather
+    // than updated. Here a replace lands new data (rows 1 and 2 kept with new
+    // values, row 3 dropped, row 4 added) and a type guess converts column B, the
+    // shape an import finalize produces, in one bundle.
+    it("ReplaceTableData composes with a type guess", async function() {
+      const doc = await makeDataDoc("import1.grist");
+      await assertConsistent(doc, session, [
+        ["ReplaceTableData", "Data", [1, 2, 4],
+          { A: ["a1", "a2x", "a4"], B: ["10", "25", "40"] }],
+        ["ModifyColumn", "Data", "B", { type: "Numeric" }],   // a type guess on imported data
+      ]);
+    });
+
+    // A replace over the data, then a row removed, stressing the recycle-everything
+    // behavior in composition.
+    it("a replace then a removal composes", async function() {
+      const doc = await makeDataDoc("import2.grist");
+      await assertConsistent(doc, session, [
+        ["ReplaceTableData", "Data", [1, 2, 3, 4],
+          { A: ["b1", "b2", "b3", "b4"], B: ["1", "2", "3", "4"] }],
+        ["RemoveRecord", "Data", 2],
+      ]);
+    });
+  });
+
+  describe("tricky shapes", function() {
+    const makeFormulaDoc = async (name: string): Promise<ActiveDoc> => {
+      const doc = await docTools.createDoc(name);
+      await doc.applyUserActions(session, [
+        ["AddTable", "T", [{ id: "Amt", type: "Numeric" },
+          { id: "Dbl", type: "Numeric", isFormula: true, formula: "$Amt * 2" }]],
+        ["BulkAddRecord", "T", [1, 2, 3], { Amt: [10, 20, 30] }],
+      ]);
+      return doc;
+    };
+
+    // A recycled row (removed then re-added under the same id) carries a formula
+    // column. The removed-row front-restore fix deliberately excludes recycles, so
+    // this confirms a recycle still composes correctly rather than misfiring.
+    it("recycles a row that has a formula column", async function() {
+      const doc = await makeFormulaDoc("recycle.grist");
+      await assertConsistent(doc, session, [
+        ["RemoveRecord", "T", 2],
+        ["AddRecord", "T", 2, { Amt: 99 }],
+        ["UpdateRecord", "T", 1, { Amt: 11 }],
+      ]);
+    });
+
+    // A column renamed away and back within one bundle, with an edit under the
+    // interim name. The net is an identity rename plus a cell change, and the cell
+    // must end up keyed under the original name.
+    it("renames a column away and back with an update in between", async function() {
+      const doc = await docTools.createDoc("renamecycle.grist");
+      await doc.applyUserActions(session, [
+        ["AddTable", "T", [{ id: "c", type: "Text" }]],
+        ["AddRecord", "T", 1, { c: "x" }],
+      ]);
+      await assertConsistent(doc, session, [
+        ["RenameColumn", "T", "c", "d"],
+        ["UpdateRecord", "T", 1, { d: "y" }],
+        ["RenameColumn", "T", "d", "c"],
+      ]);
+    });
+
+    // A row updated and then removed in the same bundle, with a formula column.
+    // The removed row's recorded pre-state must be the value from before the update.
+    it("updates then removes a row with a formula column", async function() {
+      const doc = await makeFormulaDoc("updateremove.grist");
+      await assertConsistent(doc, session, [
+        ["UpdateRecord", "T", 2, { Amt: 77 }],
+        ["RemoveRecord", "T", 2],
+      ]);
+    });
+
+    // A value changed and changed straight back within one bundle nets to nothing,
+    // including the formula column it drives. Canonicalization drops the resulting
+    // [v, v] cells, so the row is not reported as updated. This pins the intended
+    // behavior that a no-op net change does not surface as a change (and so, e.g.,
+    // does not fire a webhook); summarize on main left the row in updateRows.
+    it("nets out a within-bundle change-then-revert", async function() {
+      const doc = await makeFormulaDoc("revert.grist");
+      const combined = await assertConsistent(doc, session, [
+        ["UpdateRecord", "T", 1, { Amt: 999 }],   // Amt and its Dbl formula change
+        ["UpdateRecord", "T", 1, { Amt: 10 }],     // ...and revert to the seeded value
+      ]);
+      const d = combined.tableDeltas.T;
+      assert.isTrue(
+        !d || (d.updateRows.length === 0 && Object.keys(d.columnDeltas).length === 0),
+        "a change-then-revert must net to no recorded change");
+    });
+  });
+
+  describe("truncation (mayBeIncomplete)", function() {
+    const LIMIT: ActionSummaryOptions = { maximumInlineRows: 5 };   // bulks over 5 rows truncate
+    const ids = Array.from({ length: 12 }, (_, i) => i + 1);
+
+    // A table with more rows than the limit, so a bulk over it truncates and sets
+    // mayBeIncomplete. Bulk actions keep the same shape in both oracle modes, so
+    // the deterministic sampling matches and the comparison stays meaningful (the
+    // doc's final state is unaffected by truncation, so the precondition holds).
+    const makeBulkDoc = async (name: string): Promise<ActiveDoc> => {
+      const doc = await docTools.createDoc(name);
+      await doc.applyUserActions(session, [
+        ["AddTable", "T", [{ id: "A", type: "Text" }]],
+        ["BulkAddRecord", "T", ids, { A: ids.map(i => `v${i}`) }],
+      ]);
+      return doc;
+    };
+
+    it("a truncated bulk update then a bulk remove of sampled rows", async function() {
+      const doc = await makeBulkDoc("trunc1.grist");
+      await assertConsistent(doc, session, [
+        ["BulkUpdateRecord", "T", ids, { A: ids.map(i => `w${i}`) }],
+        ["BulkRemoveRecord", "T", [1, 2]],
+      ], LIMIT);
+    });
+
+    it("a truncated bulk update then a remove of a non-sampled row", async function() {
+      const doc = await makeBulkDoc("trunc2.grist");
+      await assertConsistent(doc, session, [
+        ["BulkUpdateRecord", "T", ids, { A: ids.map(i => `w${i}`) }],
+        ["RemoveRecord", "T", 7],   // row 7 is dropped by truncation, not in the sample
+      ], LIMIT);
+    });
+
+    it("a truncated bulk add then a bulk remove of a subset", async function() {
+      const doc = await makeBulkDoc("trunc3.grist");
+      const newIds = Array.from({ length: 12 }, (_, i) => i + 101);
+      await assertConsistent(doc, session, [
+        ["BulkAddRecord", "T", newIds, { A: newIds.map(i => `a${i}`) }],
+        ["BulkRemoveRecord", "T", [103, 107, 110]],
+      ], LIMIT);
+    });
+
+    it("a bulk remove then a bulk add reusing ids (recycle at scale)", async function() {
+      const doc = await makeBulkDoc("trunc4.grist");
+      await assertConsistent(doc, session, [
+        ["BulkRemoveRecord", "T", ids],
+        ["BulkAddRecord", "T", ids, { A: ids.map(i => `r${i}`) }],
+      ], LIMIT);
+    });
+
+    // Truncation combined with a column rename: the truncated update's sampled
+    // cells must re-key onto the new column name. A rename has no recompute, so
+    // both oracle modes sample the same rows and the comparison stays meaningful.
+    it("a truncated bulk update then a column rename", async function() {
+      const doc = await makeBulkDoc("trunc5.grist");
+      await assertConsistent(doc, session, [
+        ["BulkUpdateRecord", "T", ids, { A: ids.map(i => `w${i}`) }],
+        ["RenameColumn", "T", "A", "B"],
+      ], LIMIT);
+    });
+
+    // Truncation combined with a rename AND a removal of sampled rows, so the
+    // incomplete delta is re-keyed and then has some posts nulled.
+    it("a truncated bulk update then a rename then a remove", async function() {
+      const doc = await makeBulkDoc("trunc6.grist");
+      await assertConsistent(doc, session, [
+        ["BulkUpdateRecord", "T", ids, { A: ids.map(i => `w${i}`) }],
+        ["RenameColumn", "T", "A", "B"],
+        ["BulkRemoveRecord", "T", [1, 2]],
+      ], LIMIT);
+    });
+
+    // Note on a case deliberately not tested here: a truncated bulk update on a
+    // *formula* table. The formula's calc-flush adds a second set of cells that the
+    // combined and per-action paths sample differently, so the two summaries
+    // disagree on which formula values are known versus "?". That is a precision
+    // difference within the mayBeIncomplete contract, not value corruption (neither
+    // side reports a wrong concrete value), so the two-mode oracle cannot judge it.
+    // It is the same sampling slack that makes the live fuzzer disable truncation.
+  });
+
+  // Confirms the engine actually ships per-undo ownership, that it survives the
+  // round-trip through the action history (where getRecentActionsDirect reads
+  // it), and that it lines up with what the lattice infers -- so the oracle above
+  // is genuinely exercising the owner-driven path, not silently falling back.
+  describe("engine-provided undo ownership", function() {
+    it("ships a well-formed undoOwner that drives chunkByOwners", async function() {
+      const doc = await docTools.createDoc("ownership.grist");
+      await doc.applyUserActions(session, [
+        ["AddTable", "T", [{ id: "Amt", type: "Numeric" },
+          { id: "Dbl", type: "Numeric", isFormula: true, formula: "$Amt * 2" }]],
+        ["BulkAddRecord", "T", [1, 2, 3], { Amt: [10, 20, 30] }],
+      ]);
+      // A bundle mixing a formula->data conversion (the crossed-undo case), a
+      // record update that recomputes the formula column, and a removal whose
+      // formula value is restored at the front -- the shapes ownership matters for.
+      await doc.applyUserActions(session, [
+        ["ModifyColumn", "T", "Dbl", { isFormula: false, formula: "" }],
+        ["UpdateRecord", "T", 1, { Amt: 15 }],
+        ["RemoveRecord", "T", 2],
+      ]);
+      const cb = (await doc.getRecentActionsDirect(1))[0];
+
+      // Present, parallel to undo, and not vacuous: a real bundle has owned undos.
+      assert.isDefined(cb.undoOwner, "the bundle should carry undoOwner");
+      assert.strictEqual(cb.undoOwner!.length, cb.undo.length,
+        "undoOwner must be parallel to undo");
+      const owners = cb.undoOwner!;
+      assert.isAbove(owners.filter(o => o !== null).length, 0,
+        "at least one undo should name a concrete owner");
+      // Every concrete owner indexes a real stored action.
+      const nStored = getEnvContent(cb.stored).length;
+      for (const o of owners) {
+        if (o !== null) { assert.isTrue(o >= 0 && o < nStored, `owner ${o} out of range`); }
+      }
+
+      // The owner-driven summary matches the lattice's on the same bundle, and
+      // both match the per-action reference.
+      const stored = getEnvContent(cb.stored);
+      const byOwners = summarizeStoredAndUndo(stored, cb.undo, SUMMARY_OPTS, owners);
+      const byLattice = summarizeStoredAndUndo(stored, cb.undo,
+        { ...SUMMARY_OPTS, ignoreUndoGrouping: true });
+      assert.isTrue(eqSoft(byOwners, byLattice),
+        "owner-driven and lattice summaries must agree");
+    });
+  });
+});
+
+// The oracle's lenient comparison must tolerate the engine's default-omission (a
+// default value on one side vs absence on the other) WITHOUT masking a genuine
+// value difference. Nulling defaults on each side independently would collapse
+// two different type-defaults (e.g. "" and 0) at the same boundary into "equal"
+// and hide a corrupted recycled-row value, so the softening is done relative to
+// the other side instead.
+describe("eqSoft (oracle tolerance)", function() {
+  // A recycled row (id 5 in both the add and remove lists) carrying one cell for
+  // column A, with a given post side.
+  const recycledWith = (post: CellDelta[1]): ActionSummary => ({
+    tableRenames: [],
+    tableDeltas: {
+      T: {
+        addRows: [5], removeRows: [5], updateRows: [], columnRenames: [],
+        columnDeltas: { A: { 5: [["x"], post] } },
+      },
+    },
+  });
+
+  it("tolerates a default value opposite an absent side", function() {
+    // The engine may omit a default ("" for Text) where an explicit write
+    // recorded it, so these are equivalent and must compare equal.
+    assert.isTrue(eqSoft(recycledWith([""]), recycledWith(null)));
+  });
+
+  it("does not equate two different defaults at the same boundary", function() {
+    // "" and 0 are both type-defaults but are different values; collapsing them
+    // would hide a corrupted recycled-row value.
+    assert.isFalse(eqSoft(recycledWith([""]), recycledWith([0])));
+  });
+
+  it("still flags a non-default value opposite an absence", function() {
+    assert.isFalse(eqSoft(recycledWith(["y"]), recycledWith(null)));
+  });
+});

--- a/test/server/lib/ActionSummaryFuzz.ts
+++ b/test/server/lib/ActionSummaryFuzz.ts
@@ -19,6 +19,7 @@
  */
 
 import { getEnvContent } from "app/common/ActionBundle";
+import { chunkByLattice, LatticeStats } from "app/common/ActionLayout";
 import { ActionSummaryOptions, canonicalizeSummary, concatenateSummaries, concatenateSummaryPair,
   summarizeStoredAndUndo } from "app/common/ActionSummarizer";
 import { ActionSummary, TableDelta } from "app/common/ActionSummary";
@@ -494,21 +495,102 @@ const SUMMARY_OPTS = { maximumInlineRows: null };
 
 // Summarize a raw bundle the way production does -- using the engine's per-undo
 // ownership when present (the chunkByOwners path). When ownership is present,
-// also summarize via the lattice (ignoreUndoGrouping) and assert the two paths
+// also summarize via the lattice (testIgnoreUndoGrouping) and assert the two paths
 // agree, so every scenario the oracle checks doubles as a check that the engine's
 // recorded grouping matches the one the lattice infers. Returns the owner-path
 // summary, which the oracle then compares against the per-action reference.
+// The lattice search settles about one grid point per action when the inverse
+// catalogue recognizes every undo shape, and only an unrecognized shape can make
+// it wander. Every bundle the oracle sees is held to this bound.
+const LATTICE_SETTLED_FACTOR = 4;
+let worstSettledRatio = 0;
+function checkLatticeStats(b: RawBundle) {
+  const stats: LatticeStats = { settled: 0 };
+  chunkByLattice(b.stored, b.undo, stats);
+  const ratio = stats.settled / (b.stored.length + b.undo.length + 1);
+  worstSettledRatio = Math.max(worstSettledRatio, ratio);
+  assert.isAtMost(ratio, LATTICE_SETTLED_FACTOR,
+    `lattice settled ${stats.settled} points for ${b.stored.length} stored + ${b.undo.length} undo\n` +
+    `stored=${JSON.stringify(b.stored)}\nundo=${JSON.stringify(b.undo)}`);
+}
+
 function summarizeBundle(b: RawBundle, opts: ActionSummaryOptions = SUMMARY_OPTS): ActionSummary {
+  checkLatticeStats(b);
   const byOwners = summarizeStoredAndUndo(b.stored, b.undo, opts, b.undoOwner);
   if (b.undoOwner !== undefined) {
-    const byLattice = summarizeStoredAndUndo(b.stored, b.undo, { ...opts, ignoreUndoGrouping: true });
+    const byLattice = summarizeStoredAndUndo(b.stored, b.undo, { ...opts, testIgnoreUndoGrouping: true });
     assert.isTrue(eqSoft(byOwners, byLattice),
       `owner-driven and lattice chunking disagree on the same bundle\n` +
       `stored=${JSON.stringify(b.stored)}\nundo=${JSON.stringify(b.undo)}\n` +
       `undoOwner=${JSON.stringify(b.undoOwner)}\n` +
       `byOwners=${JSON.stringify(byOwners)}\nbyLattice=${JSON.stringify(byLattice)}`);
+    // Merging adjacent record-only chunks must change nothing, on either path.
+    // Only checked without truncation: which cells a truncated summary samples
+    // depends on the grouping, so under truncation two groupings are both valid
+    // (the oracle check above) without being identical.
+    if (opts.maximumInlineRows !== null) { return byOwners; }
+    const fineOwners = summarizeStoredAndUndo(b.stored, b.undo,
+      { ...opts, testDisableChunkCoalescing: true }, b.undoOwner);
+    assert.isTrue(eqSoft(byOwners, fineOwners),
+      `coalescing record chunks changed the owner-path summary\n` +
+      `stored=${JSON.stringify(b.stored)}\nundo=${JSON.stringify(b.undo)}\n` +
+      `undoOwner=${JSON.stringify(b.undoOwner)}\n` +
+      `coalesced=${JSON.stringify(byOwners)}\nfine=${JSON.stringify(fineOwners)}`);
+    const fineLattice = summarizeStoredAndUndo(b.stored, b.undo,
+      { ...opts, testIgnoreUndoGrouping: true, testDisableChunkCoalescing: true });
+    assert.isTrue(eqSoft(byLattice, fineLattice),
+      `coalescing record chunks changed the lattice-path summary\n` +
+      `stored=${JSON.stringify(b.stored)}\nundo=${JSON.stringify(b.undo)}\n` +
+      `coalesced=${JSON.stringify(byLattice)}\nfine=${JSON.stringify(fineLattice)}`);
   }
   return byOwners;
+}
+
+// Like eqSoft, but a cell side recorded as "?" (unknown, which only truncation
+// produces) matches anything, and rows either side keeps as recycled, the
+// row-level form of unknown, are left out. Under truncation, one fold order may
+// pin down a value another has to leave unknown, so they agree only up to
+// unknowns; they must never disagree on a value both know.
+function eqUpToUnknown(a: ActionSummary, b: ActionSummary): boolean {
+  const sa = softenSummary(a, b), sb = softenSummary(b, a);
+  const same = (x: any, y: any) => JSON.stringify(canon(x)) === JSON.stringify(canon(y));
+  const sameCell = (x: CellDelta | undefined, y: CellDelta | undefined): boolean => {
+    if (!x || !y) { return !x && !y; }
+    return [0, 1].every(i => x[i] === "?" || y[i] === "?" || same(x[i], y[i]));
+  };
+  if (!same(sa.tableRenames, sb.tableRenames)) { return false; }
+  const tables = new Set([...Object.keys(sa.tableDeltas), ...Object.keys(sb.tableDeltas)]);
+  for (const t of tables) {
+    const ta = sa.tableDeltas[t], tb = sb.tableDeltas[t];
+    if (!ta || !tb) { return false; }
+    const recycled = new Set([ta, tb].flatMap(td => td.addRows.filter(r => td.removeRows.includes(r))));
+    const known = (rows: number[]) => rows.filter(r => !recycled.has(r));
+    if (!same([known(ta.addRows), known(ta.removeRows), known(ta.updateRows), ta.columnRenames],
+      [known(tb.addRows), known(tb.removeRows), known(tb.updateRows), tb.columnRenames])) {
+      return false;
+    }
+    const cols = new Set([...Object.keys(ta.columnDeltas), ...Object.keys(tb.columnDeltas)]);
+    for (const c of cols) {
+      const ca = ta.columnDeltas[c] ?? {}, cb = tb.columnDeltas[c] ?? {};
+      const rows = new Set([...Object.keys(ca), ...Object.keys(cb)].map(Number));
+      for (const r of rows) {
+        if (recycled.has(r)) { continue; }
+        if (!sameCell(ca[r], cb[r])) { return false; }
+      }
+    }
+  }
+  return true;
+}
+
+// A strict left-to-right fold, then clean up.
+function foldLeft(sums: ActionSummary[]): ActionSummary {
+  return canonicalizeSummary(sums.slice(1).reduce((acc, s) => concatenateSummaryPair(acc, s), sums[0]));
+}
+// The same, right to left.
+function foldRight(sums: ActionSummary[]): ActionSummary {
+  let acc = sums[sums.length - 1];
+  for (let i = sums.length - 2; i >= 0; i--) { acc = concatenateSummaryPair(sums[i], acc); }
+  return canonicalizeSummary(acc);
 }
 
 // Drive the engine through one scenario and return the raw (stored, undo)
@@ -644,23 +726,34 @@ describe("ActionSummary fuzz: chunk + concat consistency", function() {
             `per-action reference.\nactions=${JSON.stringify(actions)}\n` +
             `combined=${JSON.stringify(combined)}\nreference=${JSON.stringify(reference)}`);
 
-          // Associativity: a left-fold and a right-fold of the per-action
-          // summaries must agree (grouping must not matter).
+          // Associativity: the tree fold of concatenateSummaries, a left fold and
+          // a right fold must all agree (grouping must not matter).
           if (perAction.length >= 2) {
-            let rightFold = perAction[perAction.length - 1];
-            for (let i = perAction.length - 2; i >= 0; i--) {
-              rightFold = concatenateSummaryPair(perAction[i], rightFold);
-            }
-            assert.isTrue(eqSoft(reference, canonicalizeSummary(rightFold)),
+            const leftFold = foldLeft(perAction);
+            const rightFold = foldRight(perAction);
+            assert.isTrue(eqSoft(reference, leftFold) && eqSoft(reference, rightFold),
               `seed ${seed} run ${run}: concat not associative.\n` +
               `actions=${JSON.stringify(actions)}\n` +
-              `leftFold=${JSON.stringify(reference)}\nrightFold=${JSON.stringify(rightFold)}`);
+              `treeFold=${JSON.stringify(reference)}\nleftFold=${JSON.stringify(leftFold)}\n` +
+              `rightFold=${JSON.stringify(rightFold)}`);
+            // Under truncation the folds agree only up to unknowns.
+            const truncated = sc.perAction.map(
+              b => summarizeStoredAndUndo(b.stored, b.undo, { maximumInlineRows: 2 }, b.undoOwner));
+            const treeT = concatenateSummaries(truncated);
+            const leftT = foldLeft(truncated);
+            const rightT = foldRight(truncated);
+            assert.isTrue(eqUpToUnknown(treeT, leftT) && eqUpToUnknown(treeT, rightT),
+              `seed ${seed} run ${run}: concat not associative under truncation.\n` +
+              `actions=${JSON.stringify(actions)}\n` +
+              `treeFold=${JSON.stringify(treeT)}\nleftFold=${JSON.stringify(leftT)}\n` +
+              `rightFold=${JSON.stringify(rightT)}`);
           }
           checked++;
         }
       }
       console.log(`fuzz: ${checked} scenarios checked, ${skipped} skipped ` +
-        `(${N_RUNS} runs x seeds ${SEEDS.join(",")})`);
+        `(${N_RUNS} runs x seeds ${SEEDS.join(",")}); ` +
+        `worst lattice settled/(N+M+1) ratio ${worstSettledRatio.toFixed(2)}`);
       assert.isAbove(checked, 0, "no scenarios were checked");
     });
 });
@@ -904,6 +997,25 @@ describe("ActionSummary: feature scenarios", function() {
       return doc;
     };
 
+    it("a truncated cascade of bulk updates over the same rows", async function() {
+      // A formula cascade. Pins that coalesceRecordChunks must not merge truncated
+      // updates into one walk: the merged walk composes differently.
+      const doc = await makeBulkDoc("trunc0.grist");
+      await assertConsistent(doc, session, [
+        ["BulkUpdateRecord", "T", ids, { A: ids.map(i => `w${i}`) }],
+        ["BulkUpdateRecord", "T", ids, { A: ids.map(i => `x${i}`) }],
+        ["BulkUpdateRecord", "T", ids.slice(3), { A: ids.slice(3).map(i => `y${i}`) }],
+      ], LIMIT);
+    });
+
+    it("a truncated bulk update then a small update of a non-sampled row", async function() {
+      const doc = await makeBulkDoc("trunc0b.grist");
+      await assertConsistent(doc, session, [
+        ["BulkUpdateRecord", "T", ids, { A: ids.map(i => `w${i}`) }],
+        ["UpdateRecord", "T", 11, { A: "z11" }],
+      ], LIMIT);
+    });
+
     it("a truncated bulk update then a bulk remove of sampled rows", async function() {
       const doc = await makeBulkDoc("trunc1.grist");
       await assertConsistent(doc, session, [
@@ -1008,7 +1120,7 @@ describe("ActionSummary: feature scenarios", function() {
       const stored = getEnvContent(cb.stored);
       const byOwners = summarizeStoredAndUndo(stored, cb.undo, SUMMARY_OPTS, owners);
       const byLattice = summarizeStoredAndUndo(stored, cb.undo,
-        { ...SUMMARY_OPTS, ignoreUndoGrouping: true });
+        { ...SUMMARY_OPTS, testIgnoreUndoGrouping: true });
       assert.isTrue(eqSoft(byOwners, byLattice),
         "owner-driven and lattice summaries must agree");
     });

--- a/test/server/lib/ActionSummaryPerf.ts
+++ b/test/server/lib/ActionSummaryPerf.ts
@@ -1,0 +1,93 @@
+/**
+ * Performance guard for summarizing large bundles.
+ *
+ * The chunk-then-compose design has two places that can go quadratic in the
+ * action count, the lattice search and the fold, and the correctness suites use
+ * bundles far too small to notice. The shapes here are the ones that hurt: many
+ * actions on one table (a formula cascade), many actions across many tables, and
+ * a schema-heavy bundle. Each is timed on both paths: with the engine's undo
+ * ownership (every bundle written from now on) and without it (all existing
+ * history, which the Action Log and the compare endpoint summarize).
+ *
+ * The bounds are loose, several times a developer machine, so they catch a
+ * regression to quadratic behavior rather than measure anything.
+ */
+import { chunkByLattice, LatticeStats } from "app/common/ActionLayout";
+import { summarizeStoredAndUndo } from "app/common/ActionSummarizer";
+import { DocAction } from "app/common/DocActions";
+import { assert } from "test/server/testUtils";
+
+interface Bundle { stored: DocAction[]; undo: DocAction[]; owners: number[]; }
+
+function rows(n: number) { return Array.from({ length: n }, (_, i) => i + 1); }
+function vals(n: number, tag: string) { return Array.from({ length: n }, (_, i) => `${tag}${i}`); }
+
+// A formula cascade: N bulk updates on one table, R rows each, each with its
+// own bulk-update inverse.
+function recalc(N: number, R: number): Bundle {
+  const b: Bundle = { stored: [], undo: [], owners: [] };
+  for (let i = 0; i < N; i++) {
+    b.stored.push(["BulkUpdateRecord", "T", rows(R), { ["C" + i]: vals(R, "new") }]);
+    b.undo.push(["BulkUpdateRecord", "T", rows(R), { ["C" + i]: vals(R, "old") }]);
+    b.owners.push(i);
+  }
+  return b;
+}
+
+// A schema-heavy bundle: N column removals on a table of R rows, each restoring
+// the column's data and then the column.
+function removeCols(N: number, R: number): Bundle {
+  const b: Bundle = { stored: [], undo: [], owners: [] };
+  for (let i = 0; i < N; i++) {
+    b.stored.push(["RemoveColumn", "T", "C" + i]);
+    b.undo.push(["BulkUpdateRecord", "T", rows(R), { ["C" + i]: vals(R, "old") }]);
+    b.undo.push(["AddColumn", "T", "C" + i, { type: "Text", isFormula: false, formula: "" }]);
+    b.owners.push(i, i);
+  }
+  return b;
+}
+
+// Many small updates spread over many tables.
+function manyTables(N: number): Bundle {
+  const b: Bundle = { stored: [], undo: [], owners: [] };
+  for (let i = 0; i < N; i++) {
+    const t = "T" + (i % 50);
+    b.stored.push(["UpdateRecord", t, i + 1, { A: "new" + i }]);
+    b.undo.push(["UpdateRecord", t, i + 1, { A: "old" + i }]);
+    b.owners.push(i);
+  }
+  return b;
+}
+
+function timed(fn: () => void): number {
+  const start = Date.now();
+  fn();
+  return Date.now() - start;
+}
+
+describe("ActionSummary performance", function() {
+  this.timeout(120000);
+
+  const cases: [string, Bundle, number][] = [
+    // name, bundle, bound (ms) for each path
+    ["500 recalcs of 100 rows on one table", recalc(500, 100), 1500],
+    ["200 recalcs of 5000 rows on one table", recalc(200, 5000), 5000],
+    ["200 column removals on a 100-row table", removeCols(200, 100), 1500],
+    ["2000 updates across 50 tables", manyTables(2000), 1500],
+  ];
+
+  for (const [name, bundle, bound] of cases) {
+    it(`summarizes ${name} in bounded time`, function() {
+      const withOwners = timed(() => summarizeStoredAndUndo(bundle.stored, bundle.undo, undefined, bundle.owners));
+      const withoutOwners = timed(() => summarizeStoredAndUndo(bundle.stored, bundle.undo));
+      assert.isBelow(withOwners, bound, `with ownership took ${withOwners}ms`);
+      assert.isBelow(withoutOwners, bound, `without ownership (lattice) took ${withoutOwners}ms`);
+      // The search must stay close to linear on these shapes too (see the fuzz
+      // harness for the same bound over the random corpus).
+      const stats: LatticeStats = { settled: 0 };
+      chunkByLattice(bundle.stored, bundle.undo, stats);
+      assert.isAtMost(stats.settled, 4 * (bundle.stored.length + bundle.undo.length + 1),
+        `lattice settled ${stats.settled} points`);
+    });
+  }
+});


### PR DESCRIPTION
Concatenating action summaries, or summarizing a bundle with several schema changes, could produce wrong results: a single pass over a bundle can't distinguish a name that appeared and vanished mid-bundle from one at the boundary, so it mishandles recycled names, renames, and type conversions. Web-client edits don't produce such bundles, but new features will.

The fix has two parts:

* Going forward, the data engine tags each undo entry with the stored action that produced it (an `undoOwner` list that rides along into the action history, and is covered by the action hash when present, so existing hashes are unchanged). `chunkByOwners` then splits bundles trivially by tag.
* For existing history, which has no tags, ActionLayout adds a lattice chunker: chunking becomes a least-cost path over a (stored x undo) grid, priced against the inverse shapes the engine actually emits.

Summary concatenation is reworked to canonicalize renames, preserve recycled entities, and route removed rows onto the right defunct names. A fuzz harness drives chunk-then-concat against a live summary oracle, cross-checks the two chunkers, and unit tests pin the tricky shapes.

Also included: the "changed rows only" comparison filter now keeps locally-added rows, which fixes a flaky test.

Related: this investigation turned up a data engine bug, fixed in #2387.
