### PR TITLE
Fix undo failing for certain bundles with renames

### DIFF
--- a/sandbox/grist/action_summary.py
+++ b/sandbox/grist/action_summary.py
@@ -80,12 +80,20 @@ class ActionSummary(object):
                           if not equal_encoding(before, after))
 
     defunct = is_defunct(table_id) or is_defunct(col_id)
+    # The front restore (defunct branch below) is inserted at the front of the undo list, which
+    # undo replays in reverse -- so it runs last, after any RenameTable/RenameColumn has been
+    # rolled back. It must use the pre-rename names, or it targets a name that no longer exists
+    # and undo fails. Resolve them now, before root_name() rewrites table_id/col_id below.
+    table_delta = self._tables[table_id]
+    orig_table_id = self._table_renames.original_name(table_id)
+    orig_col_id = table_delta.column_renames.original_name(col_id)
     table_id = root_name(table_id)
     col_id = root_name(col_id)
 
-    def update_action(filtered_row_ids, delta_index):
+    def update_action(filtered_row_ids, delta_index, tid=None, cid=None):
       values = [column_delta[r][delta_index] for r in filtered_row_ids]
-      return actions.BulkUpdateRecord(table_id, filtered_row_ids, {col_id: values}).simplify()
+      return actions.BulkUpdateRecord(tid if tid is not None else table_id, filtered_row_ids,
+                                      {cid if cid is not None else col_id: values}).simplify()
 
     if not defunct:
       row_ids_after = self.filter_out_gone_rows(table_id, full_row_ids)
@@ -111,9 +119,9 @@ class ActionSummary(object):
       out_undo.append(update_action(preserved_row_ids, 0))
 
     if defunct_row_ids:
-      # Updates for deleted rows/columns/tables should come after they're re-added.
-      # So we need to insert the undos *before*.
-      out_undo.insert(0, update_action(defunct_row_ids, 0))
+      # Insert at the front so the restore lands after the rows/columns/tables are re-added on
+      # undo. It runs last, so it uses the pre-rename names (see note above).
+      out_undo.insert(0, update_action(defunct_row_ids, 0, orig_table_id, orig_col_id))
 
   def _forTable(self, table_id):
     return self._tables.get(table_id) or self._tables.setdefault(table_id, TableDelta())
@@ -201,6 +209,14 @@ class LabelRenames(object):
 
   def is_created(self, latest_name):
     return self._new_to_old.get(latest_name, latest_name) is None
+
+  def original_name(self, latest_name):
+    """
+    The name this entity had before any renames recorded here, or the current name (defunct
+    marker stripped) if it was never renamed or was created within this set.
+    """
+    original = self._new_to_old.get(latest_name, latest_name)
+    return root_name(latest_name) if original is None else original
 
 
 def defunct_name(name):

--- a/sandbox/grist/test_undo_rename.py
+++ b/sandbox/grist/test_undo_rename.py
@@ -36,7 +36,7 @@ class TestUndoRename(test_engine.EngineTestCase):
     self.apply_user_action(["AddRecord", "T1", 2, {"c1": "world"}])
 
   def test_convert_remove_column_then_rename_table(self):
-    # The exact reproduction from plans/ENGINE_BUG.md: turn a column into a formula (its stored
+    # Turn a column into a formula (its stored
     # values are set aside), remove it, and rename its table -- all in one bundle. Before the fix,
     # undo failed with KeyError 'T2'.
     self.make_one_column_table()

--- a/sandbox/grist/test_undo_rename.py
+++ b/sandbox/grist/test_undo_rename.py
@@ -1,0 +1,83 @@
+# pylint: disable=line-too-long
+"""
+Regression tests for an undo that failed after a table or column rename in the same bundle.
+
+When a bundle removes an entity whose stored values were set aside (a formula conversion discards
+a column's data; removing that column then defers putting the data back), the engine emits a
+"front restore" -- a deferred undo that re-applies those values. It is inserted at the *front* of
+the undo list, and undo replays the list in reverse, so the front restore is the *last* undo
+action applied. By the time it runs, every direct action's undo has already run, including the
+rollback of any RenameTable/RenameColumn in the bundle, so the entity is back to the name it had
+before the bundle. The restore therefore has to refer to the table and column by their
+*pre-rename* names. Stamping it with the post-rename name made undo fail with a KeyError on a
+name that no longer existed, leaving the document stuck (the batch could not be rolled back).
+"""
+import test_engine
+import useractions
+
+
+class TestUndoRename(test_engine.EngineTestCase):
+
+  def apply_bundle(self, *user_actions):
+    """Apply several user actions as a single bundle (one undo step), like a real batch edit."""
+    return self.engine.apply_user_actions([useractions.from_repr(a) for a in user_actions])
+
+  def assert_bundle_round_trips(self, *user_actions):
+    """Apply the bundle, then undo it, and require the document to return to its prior state."""
+    before = self.getFullEngineData()
+    out_actions = self.apply_bundle(*user_actions)
+    # The undo must apply cleanly (the bug threw a KeyError here) and restore the prior state.
+    self.apply_undo_actions(out_actions.undo)
+    self.assertEqualDocData(self.getFullEngineData(), before)
+
+  def make_one_column_table(self):
+    self.apply_user_action(["AddTable", "T1", [{"id": "c1", "type": "Text"}]])
+    self.apply_user_action(["AddRecord", "T1", 1, {"c1": "hello"}])
+    self.apply_user_action(["AddRecord", "T1", 2, {"c1": "world"}])
+
+  def test_convert_remove_column_then_rename_table(self):
+    # The exact reproduction from plans/ENGINE_BUG.md: turn a column into a formula (its stored
+    # values are set aside), remove it, and rename its table -- all in one bundle. Before the fix,
+    # undo failed with KeyError 'T2'.
+    self.make_one_column_table()
+    self.assert_bundle_round_trips(
+      ["ModifyColumn", "T1", "c1", {"isFormula": True, "formula": "'z'"}],
+      ["RemoveColumn", "T1", "c1"],
+      ["RenameTable", "T1", "T2"],
+    )
+
+  def test_convert_remove_column_then_rename_table_chain(self):
+    # A rename chain (T1 -> T2 -> T3) must still resolve back to the original name, not just the
+    # immediately-previous one.
+    self.make_one_column_table()
+    self.assert_bundle_round_trips(
+      ["ModifyColumn", "T1", "c1", {"isFormula": True, "formula": "'z'"}],
+      ["RemoveColumn", "T1", "c1"],
+      ["RenameTable", "T1", "T2"],
+      ["RenameTable", "T2", "T3"],
+    )
+
+  def test_rename_then_convert_remove_column(self):
+    # The column analog: rename a column, then convert and remove it in the same bundle. The front
+    # restore must use the column's pre-rename name. Before the fix, undo failed with KeyError 'c2'.
+    self.make_one_column_table()
+    self.assert_bundle_round_trips(
+      ["RenameColumn", "T1", "c1", "c2"],
+      ["ModifyColumn", "T1", "c2", {"isFormula": True, "formula": "'z'"}],
+      ["RemoveColumn", "T1", "c2"],
+    )
+
+  def test_rename_both_table_and_column(self):
+    # Both a column and its table are renamed in the bundle that removes the column; the restore
+    # must use the pre-rename names for both.
+    self.make_one_column_table()
+    self.assert_bundle_round_trips(
+      ["RenameColumn", "T1", "c1", "c2"],
+      ["ModifyColumn", "T1", "c2", {"isFormula": True, "formula": "'z'"}],
+      ["RemoveColumn", "T1", "c2"],
+      ["RenameTable", "T1", "T2"],
+    )
+
+
+if __name__ == "__main__":
+  test_engine.main()


### PR DESCRIPTION
Certain edits could in principle produce an Undo that the data engine refuses to apply. If a single step both renamed a table (or column) and removed a column whose data had just been set aside -- for example, converting a column to a formula and deleting it, then renaming its table, all at once -- the Undo would throw an error inside the engine and leavethe document unchanged.

The cause: to undo a removal like that, the engine restores the set-aside values with a step that runs last during Undo, after the rename has already been rolled back. That step was recorded with the table and column's *new* names, which no longer exist by the time it runs, so the lookup failed. Record it with the pre-rename names instead, resolved from the renames the engine already tracks.

In practice, this problem doesn't arise for users editing documents via the web client, since actions would happen separately rather than in the same bundle.

Adds regression tests for the table rename, a rename chain, the column-rename analog, and a combined case.
