### PR TITLE
Make docker tests wait for a genuinely ready server

### DIFF
--- a/test/nbrowser/testUtils.ts
+++ b/test/nbrowser/testUtils.ts
@@ -305,7 +305,11 @@ export function setupRequirement(options: TestSuiteOptions) {
           await api.newOrg({ name: `Test${suffix} Grist`, domain: orgName });
           isNew = true;
         } catch (e) {
-          // Assume the org already exists.
+          // The org may already exist. Any other failure matters, since it
+          // would leave the site without the permissions set up below.
+          if (!String(e).match("Domain already in use")) {
+            throw e;
+          }
         }
         if (isNew) {
           await api.updateOrgPermissions(orgName, {

--- a/test/test_under_docker.sh
+++ b/test/test_under_docker.sh
@@ -57,7 +57,10 @@ DOCKER_PID="$!"
 
 echo "[waiting for server]"
 while true; do
-  curl -s http://localhost:$PORT/status && break
+  # Wait for a healthy response specifically. RestartShell opens the port
+  # before the server is ready, answering /status with a 503 "starting"
+  # error until then, so insist on a 200 response that says "alive".
+  if curl -fs http://localhost:$PORT/status | grep -q alive; then break; fi
   sleep 1
 done
 echo ""


### PR DESCRIPTION
Since #2265, Grist images open their port before the server is ready, answering /status with a 503 "starting" error until then. The wait loop in test_under_docker.sh accepted any response at all, so tests could start too early. The org setup hook then failed silently, leaving the first test to die with a confusing 403. This is what broke the daily grist-ee builds, which have the slowest startup.

The wait loop now insists on a 200 response saying "alive", and the org setup hook only swallows the error it expects.
