### PR TITLE
ACL: fix condition editors rendering blank in Firefox at <100% zoom

### DIFF
--- a/app/client/aclui/ACLFormulaEditor.ts
+++ b/app/client/aclui/ACLFormulaEditor.ts
@@ -33,7 +33,8 @@ export function aclFormulaEditor(options: ACLFormulaOptions) {
   const themeListener = gristThemeObs().addListener((newTheme) => {
     setAceTheme(newTheme);
   });
-  // ACE editor resizes automatically when maxLines is set.
+  // With maxLines set, the ACE editor normally resizes automatically, but see the heal()
+  // logic below for a case where it gets stuck.
   editor.setOptions({ enableLiveAutocompletion: true, maxLines: 10 });
   editor.renderer.setShowGutter(false);       // Default line numbers to hidden
   editor.renderer.setPadding(5);
@@ -97,8 +98,38 @@ export function aclFormulaEditor(options: ACLFormulaOptions) {
     options.customiseEditor(editor);
   }
 
+  // The editor is created while editorElem is detached, so ACE's initial render bails out and
+  // parks its pending changes with nothing left scheduled to flush them. With maxLines set, ACE
+  // controls the element's height itself, so the editor can get stuck at zero height with its
+  // content invisible and effectively uneditable (in Firefox this happens reliably at <100%
+  // browser zoom; see #2082). Watch for the element getting laid out and heal it then.
+  let healTimer: ReturnType<typeof setTimeout> | undefined;
+  const heal = () => {
+    healTimer = undefined;
+    if (editorElem.clientWidth === 0 || editorElem.clientHeight > 0) {
+      return;
+    }
+    const renderer = editor.renderer as any;
+    if (renderer.lineHeight > 1) {
+      // Escape ACE's zero-height trap: with a zero cached height, $renderChanges detours to
+      // onResize(), which ignores a zero measured height and bails out before rendering, so no
+      // number of resize()/updateFull() calls can recover. $autosize() sets the container
+      // height directly and refreshes the cached size; the forced updateFull() then repaints
+      // the text layers.
+      renderer.$autosize();
+      renderer.updateFull(true);
+    }
+    if (editorElem.clientHeight === 0) {
+      // ACE's font metrics may not be measured yet (lineHeight <= 1); try again shortly.
+      healTimer = setTimeout(heal, 50);
+    }
+  };
+  const resizeObserver = new ResizeObserver(heal);
+  resizeObserver.observe(editorElem);
+
   return cssConditionInputAce(
     dom.autoDispose(themeListener ?? null),
+    dom.onDispose(() => { resizeObserver.disconnect(); if (healTimer) { clearTimeout(healTimer); } }),
     cssConditionInputAce.cls("-disabled", options.readOnly),
     // ACE editor calls preventDefault on clicks into the scrollbar area, which prevents focus
     // being set when the click happens to be into there. To ensure we can focus on such clicks

--- a/app/client/aclui/ACLFormulaEditor.ts
+++ b/app/client/aclui/ACLFormulaEditor.ts
@@ -105,7 +105,12 @@ export function aclFormulaEditor(options: ACLFormulaOptions) {
   // browser zoom; see #2082). Watch for the element getting laid out and heal it then.
   let healTimer: ReturnType<typeof setTimeout> | undefined;
   const heal = () => {
-    healTimer = undefined;
+    // Cancel any pending retry, so that concurrent ResizeObserver and timer invocations
+    // collapse into a single retry chain (a no-op when called from the timer itself).
+    if (healTimer !== undefined) {
+      clearTimeout(healTimer);
+      healTimer = undefined;
+    }
     if (editorElem.clientWidth === 0 || editorElem.clientHeight > 0) {
       return;
     }


### PR DESCRIPTION
The ACL formula editors are built with ace.edit() on a detached element, relying on the maxLines option for sizing. ACE's initial render bails out on a detached element and parks its pending changes with nothing scheduled to flush them. In Firefox with browser zoom below 100%, the post-attach layout can leave the editor with a cached height of zero, and once there ACE cannot recover on its own: with a zero cached height, render passes detour to onResize(), which ignores a zero measured height and returns before rendering, so resize(true)/updateFull(true) have no effect. The editor stays blank and effectively uneditable until something else forces a real resize (e.g. opening devtools, which is the workaround reporters found).

Fix: observe the editor element; when it is laid out with nonzero width but zero height, escape the trap with renderer.\() followed by a forced updateFull(), retrying briefly in case ACE has not yet measured its font metrics.

Reproduced deterministically on Windows with Firefox ESR 140.10 and release 151.0.4 by setting browser zoom to 90% (or 80%) on the Grist origin, then: create empty document, Access Rules, Enable Access Rules, Continue. Before the fix a condition editor rendered blank in 7/7 trials (also when bulk-adding conditions); after the fix, 0 blanks in 12/12, with no change in behavior at 100% zoom. Not reproducible on Linux, where font metric rounding differs. Chromium-based browsers unaffected.

Fixes #2082
