### PR TITLE
Fix formula traceback color in dark mode

### DIFF
--- a/app/client/widgets/TextEditor.css
+++ b/app/client/widgets/TextEditor.css
@@ -125,6 +125,7 @@
 
 .error_details {
   background-color: #F8EAD5;  /* 20% of color-warning-bg */
+  color: black;
   font-family: 'Monaco', 'Menlo', monospace;
   font-size: 12px;
   white-space: pre-wrap;


### PR DESCRIPTION
## Summary

Fixes #2367.

Formula traceback details use a light warning-tinted background, but the text color was inherited. In dark mode that means the traceback can inherit light text and become unreadable on the light background. This sets the traceback details text color explicitly to black, matching the existing formula error summary styling.

## Checks

- `git diff --check`
- `npx --yes postcss-cli@11.0.1 app/client/widgets/TextEditor.css --no-map --output /tmp/grist-texteditor.css`
- Contrast sanity check: `#efefef` on `#F8EAD5` is `1.03:1`; black on `#F8EAD5` is `17.72:1`

Note: `npx --yes prettier@3.6.2 --check app/client/widgets/TextEditor.css` reports existing formatting differences in the legacy CSS file, so I did not reformat the whole file for this one-line fix.
