### PR TITLE
Fix Locale doc setting description to mention only number formats

### DIFF
--- a/app/client/ui/DocumentSettings.ts
+++ b/app/client/ui/DocumentSettings.ts
@@ -93,7 +93,7 @@ export class DocSettingsPage extends Disposable {
         SectionItem({
           id: "locale",
           name: t("Locale"),
-          description: t("For number and date formats"),
+          description: t("For number formats"),
           value: dom.create(cssLocalePicker, this._locale),
         }),
         SectionItem({


### PR DESCRIPTION
The Locale document setting only affects number formatting (via Intl.NumberFormat) and the default currency. Date formatting uses the per-column date format and the document time zone, not the locale. Update the description text accordingly.
