### PR TITLE
Stop test database reads from landing on the wrong database

### DIFF
--- a/app/server/lib/dbUtils.ts
+++ b/app/server/lib/dbUtils.ts
@@ -51,6 +51,25 @@ export function getConnectionName() {
 }
 
 /**
+ * Create and initialize a connection for the given settings, setting the sqlite
+ * busy timeout we rely on when several connections share a database file.
+ */
+export async function createConnection(settings: DataSourceOptions): Promise<DataSource> {
+  const dataSource = new DataSource(settings);
+  await dataSource.initialize();
+  if (settings.type === "sqlite") {
+    // When using Sqlite, set a busy timeout of 3s to tolerate a little
+    // interference from connections made by tests. Logging doesn't show
+    // any particularly slow queries, but bad luck is possible.
+    // This doesn't affect when Postgres is in use. It also doesn't have
+    // any impact when there is a single connection to the db, as is the
+    // case when Grist is run as a single process.
+    await dataSource.query("PRAGMA busy_timeout = 3000");
+  }
+  return dataSource;
+}
+
+/**
  * Get a connection to db if one exists, or create one. Serialized to
  * avoid duplication.
  */
@@ -86,17 +105,7 @@ export async function getOrCreateConnection(): Promise<DataSource> {
         settings = getTypeORMSettings({ extra: { options: "-c jit=off" } });
       }
 
-      gristDataSource = new DataSource(settings);
-      await gristDataSource.initialize();
-      if (settings.type === "sqlite") {
-        // When using Sqlite, set a busy timeout of 3s to tolerate a little
-        // interference from connections made by tests. Logging doesn't show
-        // any particularly slow queries, but bad luck is possible.
-        // This doesn't affect when Postgres is in use. It also doesn't have
-        // any impact when there is a single connection to the db, as is the
-        // case when Grist is run as a single process.
-        await gristDataSource.query("PRAGMA busy_timeout = 3000");
-      }
+      gristDataSource = await createConnection(settings);
     }
     return gristDataSource;
   });

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -1,12 +1,13 @@
 import { parseUrlId } from "app/common/gristUrls";
 import { HomeDBManager } from "app/gen-server/lib/homedb/HomeDBManager";
+import { createConnection, getOrCreateConnection, getTypeORMSettings } from "app/server/lib/dbUtils";
 import { StorageCoordinator } from "app/server/lib/GristServer";
 
+import { DataSource } from "typeorm";
+
 export async function getDatabase(typeormDb?: string): Promise<HomeDBManager> {
-  const origTypeormDB = process.env.TYPEORM_DATABASE;
-  if (typeormDb) {
-    process.env.TYPEORM_DATABASE = typeormDb;
-  }
+  const database = typeormDb || process.env.TYPEORM_DATABASE;
+  const connection = await getConnectionFor(database);
 
   // Used when a document is deleted, HomeDBManager tries to delete forks from S3 and filesystem.
   // We mock that here and just delete from home DB.
@@ -17,10 +18,45 @@ export async function getDatabase(typeormDb?: string): Promise<HomeDBManager> {
     },
   };
   const db = new HomeDBManager(storageCoordinator);
-  await db.connect();
+  db.connectTo(connection);
   await db.initializeSpecialIds();
-  if (origTypeormDB) {
-    process.env.TYPEORM_DATABASE = origTypeormDB;
-  }
   return db;
+}
+
+// Dedicated connections for callers whose database isn't the shared one,
+// keyed by database so we open each only once.
+const extraConnections = new Map<string, DataSource>();
+
+async function getConnectionFor(database: string | undefined): Promise<DataSource> {
+  const shared = await getSharedConnection(database);
+  if (!database || shared.options.database === database) {
+    return shared;
+  }
+  // The shared connection is bound to a different database (an earlier suite
+  // connected first), so open a dedicated one for the caller's database.
+  let connection = extraConnections.get(database);
+  if (!connection?.isInitialized) {
+    connection = await createConnection(getTypeORMSettings({ name: `test-${database}`, database }));
+    extraConnections.set(database, connection);
+  }
+  return connection;
+}
+
+// getOrCreateConnection() caches one process-global connection (shared with any
+// in-process server), binding it to TYPEORM_DATABASE the first time it connects.
+// Make sure it sees `database` for that initial bind, so we don't accidentally
+// point the shared connection at the wrong database.
+async function getSharedConnection(database: string | undefined): Promise<DataSource> {
+  if (!database) { return getOrCreateConnection(); }
+  const orig = process.env.TYPEORM_DATABASE;
+  process.env.TYPEORM_DATABASE = database;
+  try {
+    return await getOrCreateConnection();
+  } finally {
+    if (orig === undefined) {
+      delete process.env.TYPEORM_DATABASE;
+    } else {
+      process.env.TYPEORM_DATABASE = orig;
+    }
+  }
 }


### PR DESCRIPTION
Some of the share tests in DocApiMisc passed on their own but failed when they ran after certain other suites.

Here is what was going on. The test helper getDatabase() hands back a connection to the home database. Under the hood it reuses a single connection that the first suite to ask for one sets up, and that connection stays pointed at whatever database that first suite happened to use. Each DocApiMisc share test runs its server in a separate process that writes to its own freshly seeded database, but getDatabase() was still reading from the earlier suite's database. So the share the server had just created was nowhere to be found, and the test failed.

Now getDatabase() checks whether that shared connection points at the database the caller actually wants. When it does not, the caller gets its own connection to the right database, and the shared one is left alone for everyone else. A small cache keeps us from opening the same connection more than once.
