### PR TITLE
Let formulas create related rows during calculation

### DIFF
--- a/sandbox/grist/engine.py
+++ b/sandbox/grist/engine.py
@@ -167,6 +167,17 @@ class Engine(object):
     # Contains Edges (node1, node2, relation) already seen during formula accesses.
     self._recompute_edge_set = set()
 
+    # Tables the cell currently being evaluated has read and added to, keyed by (node, row_id), to
+    # detect a cell that both reads and adds the same table (see note_table_read). Each cell's entry
+    # is cleared when it finishes evaluating, so this only holds cells on the evaluation stack.
+    self._cell_reads = {}
+    self._cell_adds = {}
+
+    # Set by UserTable.lookupRecords/lookupOne while a user-level lookup runs, so the resulting
+    # _LookupRelation is marked user-level. Only user readers get un-done when rows are added to the
+    # looked-up table mid-calculation (see _LookupRelation.invalidate_affected_keys).
+    self._lookup_is_user_level = False
+
     # Sanity-check counter to check if we are making progress.
     self._recompute_done_counter = 0
 
@@ -550,6 +561,10 @@ class Engine(object):
     self._is_node_exception_reported = set()
     self._recompute_edge_set = set()
     self._cell_required_error = None
+    # Note: _cell_reads/_cell_adds are deliberately NOT reset here. They are cleared per-cell in
+    # _recompute_one_cell's finally, so they hold only cells on the evaluation stack. Resetting them
+    # per-pass would wipe an in-progress cell's record when a side effect (lookupOrAddDerived)
+    # triggers a nested pass -- e.g. during get_formula_value, which evaluates outside the loop.
 
   def _post_update(self):
     """
@@ -693,6 +708,26 @@ class Engine(object):
     a = self._triggering_doc_action
     return a and getattr(a, 'table_id', None) == table_id
 
+  def note_table_read(self, table_id):
+    # A cell may not both read and add to the same table in one evaluation: there is no consistent
+    # order for the two, so we report a circular reference. Coarse by design: we don't check whether
+    # the add actually depends on the read.
+    cell = (self._current_node, self._current_row_id)
+    if table_id in self._cell_adds.get(cell, ()):
+      raise depend.CircularRefError(
+        "Circular reference: a formula cannot read %s and add rows to it in the same formula"
+        % table_id)
+    self._cell_reads.setdefault(cell, set()).add(table_id)
+
+  def note_table_add(self, table_id):
+    # Mirror of note_table_read for the lookupOrAddDerived side.
+    cell = (self._current_node, self._current_row_id)
+    if table_id in self._cell_reads.get(cell, ()):
+      raise depend.CircularRefError(
+        "Circular reference: a formula cannot read %s and add rows to it in the same formula"
+        % table_id)
+    self._cell_adds.setdefault(cell, set()).add(table_id)
+
   def bring_col_up_to_date(self, col_obj):
     """
     Public interface to recompute a column if it is dirty. It also generates a calc or stored
@@ -749,13 +784,26 @@ class Engine(object):
       # This is a nested evaluation.  If there are in fact any cells to evaluate,
       # this must result in an OrderError.  We let engine._recompute_step
       # take care of figuring this out.
+      if (node.col_id.startswith('#lookup#')
+          and node.table_id in self._cell_adds.get(
+            (self._current_node, self._current_row_id), ())):
+        # A lookup index dirtied by a row this cell just added (via lookupOrAddDerived) is brought
+        # up to date now rather than deferred, which would undo the add and never converge. Scoped
+        # to that table so ordinary nested lookups still defer via OrderError, as we do below.
+        saved_row_id = self._current_row_id
+        try:
+          self._recompute_step(node, allow_evaluation=True, require_rows=row_ids)
+          return
+        except OrderError:
+          pass
+        finally:
+          self._current_row_id = saved_row_id
       self._recompute_step(node, allow_evaluation=False, require_rows=row_ids)
     else:
       # Sometimes _use_node is called from outside _update_loop.  In this case,
       # we start an _update_loop to compute whatever is required.  Otherwise
       # nested dependencies would not get computed.
       self._update_loop([WorkItem(node, row_ids, [])], ignore_other_changes=True)
-
 
   def _recompute_step(self, node, allow_evaluation=True, require_rows=None): # pylint: disable=too-many-statements
     """
@@ -953,6 +1001,11 @@ class Engine(object):
     """
     self._current_row_id = row_id
 
+    # Clear this cell's read/add record so a re-evaluation isn't seen as a false circular ref.
+    cell = (self._current_node, row_id)
+    self._cell_reads.pop(cell, None)
+    self._cell_adds.pop(cell, None)
+
     # Baffling, but keeping a reference to current generated "usercode" module protects against a
     # seeming garbage-collection bug: if during formula evaluation the module gets regenerated
     # (e.g. a side-effect causes a formula column to change to non-formula), the stale-module
@@ -1015,6 +1068,11 @@ class Engine(object):
           return objtypes.RaisedException(regular_error, include_details, user_input=value)
         else:
           return objtypes.RaisedException(regular_error, include_details)
+      finally:
+        # This cell is done evaluating; drop its read/add record so it doesn't accumulate (only
+        # cells currently on the evaluation stack need theirs, for the note_table_read check).
+        self._cell_reads.pop(cell, None)
+        self._cell_adds.pop(cell, None)
 
   def convert_action_values(self, action):
     """
@@ -1116,6 +1174,14 @@ class Engine(object):
     include_self = col_obj.is_formula() or (col_obj.has_formula() and recompute_data_col)
     self.dep_graph.invalidate_deps(col_obj.node, row_ids, self.recompute_map,
                                    include_self=include_self)
+
+  def undo_done_rows(self, node, rows):
+    # A user-level lookup of a table that just gained rows: referring cells that already finished
+    # this pass read the stale result, so un-mark them as done to force recomputation against the
+    # new rows (see _LookupRelation.invalidate_affected_keys).
+    done = self._recompute_done_map.get(node)
+    if done:
+      done.difference_update(rows)
 
   def prevent_recalc(self, node, row_ids, should_prevent):
     prevented = self._prevent_recompute_map.setdefault(node, set())

--- a/sandbox/grist/lookup.py
+++ b/sandbox/grist/lookup.py
@@ -382,6 +382,8 @@ class _RelationTracker(object):
     if engine._is_current_node_formula:
       rel = self._get_relation(engine._current_node)
       rel._add_lookup(engine._current_row_id, key)
+      if engine._lookup_is_user_level:
+        rel.user_level = True
     else:
       rel = None
 
@@ -428,6 +430,11 @@ class _LookupRelation(relation.Relation):
     self._relation_tracker = relation_tracker
     self._referring_node = referring_node
 
+    # True once a user-level lookup (UserTable.lookupRecords/lookupOne) uses this relation. Only
+    # such relations un-do their finished referring rows when the looked-up table gains rows mid-
+    # calculation; the engine's own derived/summary reads are left alone.
+    self.user_level = False
+
     # Maps referring rows to keys, where multiple rows may map to the same key AND one row may
     # map to multiple keys (if a formula does multiple lookup calls).
     self._row_key_map = twowaymap.TwoWayMap(left=set, right=set)
@@ -456,6 +463,10 @@ class _LookupRelation(relation.Relation):
     affected_rows = self.get_affected_rows_by_keys(affected_keys - self._invalidated_keys_cache)
     if affected_rows:
       node = self._referring_node
+      # If a user-level referring cell already finished this pass, it read the stale lookup result,
+      # so un-mark it as done to force recomputation against the rows that were just added.
+      if self.user_level:
+        engine.undo_done_rows(node, affected_rows)
       engine.invalidate_records(node.table_id, affected_rows, col_ids=(node.col_id,))
       self._invalidated_keys_cache.update(affected_keys)
 

--- a/sandbox/grist/table.py
+++ b/sandbox/grist/table.py
@@ -100,7 +100,14 @@ class UserTable(object):
 
     Learn more about [lookupRecords](references-lookups.md#lookuprecords).
     """
-    return self.table.lookup_records(**field_value_pairs)
+    engine = self.table._engine
+    engine.note_table_read(self.table.table_id)
+    prev = engine._lookup_is_user_level
+    engine._lookup_is_user_level = True
+    try:
+      return self.table.lookup_records(**field_value_pairs)
+    finally:
+      engine._lookup_is_user_level = prev
 
   def lookupOne(self, **field_value_pairs):
     # pylint: disable=line-too-long
@@ -133,7 +140,14 @@ class UserTable(object):
     Rates.lookupOne(Person=$id, order_by="-Date")      # Rate with the latest Date.
     ```
     """
-    return self.table.lookup_one_record(**field_value_pairs)
+    engine = self.table._engine
+    engine.note_table_read(self.table.table_id)
+    prev = engine._lookup_is_user_level
+    engine._lookup_is_user_level = True
+    try:
+      return self.table.lookup_one_record(**field_value_pairs)
+    finally:
+      engine._lookup_is_user_level = prev
 
   def lookupOrAddDerived(self, **kwargs):
     return self.table.lookupOrAddDerived(**kwargs)
@@ -601,6 +615,8 @@ class Table(object):
   def lookupOrAddDerived(self, **kwargs):
     record = self.lookup_one_record(**kwargs)
     if not record._row_id and not self._engine.is_triggered_by_table_action(self.table_id):
+      # note_table_add reports a circular reference if this cell has already read the table.
+      self._engine.note_table_add(self.table_id)
       record._row_id = self._engine.user_actions.AddRecord(self.table_id, None, kwargs)
     return record
 

--- a/sandbox/grist/test_formula_error.py
+++ b/sandbox/grist/test_formula_error.py
@@ -6,6 +6,7 @@ import depend
 import test_engine
 import testutil
 import objtypes
+from schema import RecalcWhen
 
 
 class TestErrorMessage(test_engine.EngineTestCase):
@@ -277,8 +278,26 @@ return 0
     ])
 
   def test_undo_side_effects(self):
-    # Ensures that side-effects (i.e. generated doc actions) produced while evaluating
-    # get_formula_errors() get reverted.
+    # Side-effects produced while probing a cell's value get reverted. (We call get_formula_value
+    # directly; get_formula_error, which delegates to it, refuses to probe a non-error trigger cell.)
+    # A NEVER-recalc formula doesn't run during calculation, so its row isn't pre-created: probing
+    # creates it, and the probe must undo that.
+    self.apply_user_action(['AddTable', 'Address', [{'id': 'city', 'type': 'Text'}]])
+    self.apply_user_action(['AddTable', 'Foo', []])
+    self.apply_user_action(['AddColumn', 'Foo', 'B', {
+      'type': 'Any', 'isFormula': False,
+      'formula': "Address.lookupOrAddDerived(city='x')", 'recalcWhen': RecalcWhen.NEVER}])
+    self.add_record('Foo')
+
+    # NEVER means B did not run, so no Address row exists yet.
+    self.assertTableData('Address', cols="subset", data=[['id', 'city']])
+    # Probing the cell runs B, which creates Address[1]; get_formula_value then reverts the add.
+    self.assertEqual(str(self.engine.get_formula_value('Foo', 'B', 1)), "Address[1]")
+    self.assertTableData('Address', cols="subset", data=[['id', 'city']])
+
+  def test_self_referential_lookup_or_add(self):
+    # A key computed from the table's own contents (str(len(Address.all))) reads the table this
+    # formula adds to: a circular reference. It errors and adds no rows.
     sample = testutil.parse_test_sample({
       "SCHEMA": [
         [1, "Address", [
@@ -286,8 +305,6 @@ return 0
           [12, "state",       "Text",       False, "", "", ""],
         ]],
         [2, "Foo", [
-          # Note: the formula below is a terrible example of a formula, which intentionally
-          # creates a new record every time it evaluates.
           [21, "B",           "Any",        True,
             "Address.lookupOrAddDerived(city=str(len(Address.all)))", "", ""],
         ]]
@@ -298,17 +315,38 @@ return 0
     })
 
     self.load_sample(sample)
-    self.assertTableData('Address', data=[
-      ['id',  'city', 'state'],
-      [1,     '0',      ''],
-    ])
-    # Note that evaluating the formula again would add a new record (Address[2]), but when done as
-    # part of get_formula_error(), that action gets undone.
-    self.assertEqual(str(self.engine.get_formula_error('Foo', 'B', 1)), "Address[2]")
-    self.assertTableData('Address', data=[
-      ['id',  'city', 'state'],
-      [1,     '0',      ''],
-    ])
+    # The cell errors with a circular reference, and reading the table to compute a key for it
+    # leaves it empty (no rows added).
+    cell = objtypes.decode_object(self.engine.fetch_table('Foo').columns['B'][0])
+    self.assertIsInstance(cell, objtypes.RaisedException)
+    self.assertIsInstance(cell.error, depend.CircularRefError)
+    self.assertTableData('Address', cols="all", data=[['id', 'city', 'state']])
+    self.assertEqual(objtypes.decode_object(self.engine.fetch_table('Foo').columns['B'][0]).__class__,
+                     objtypes.RaisedException(Exception()).__class__)
+
+  def test_get_formula_value_matches_stored_for_read_and_add(self):
+    # get_formula_value must report the same thing as the cell's real (stored) value. A formula that
+    # both reads a table and adds to it is a circular reference; probing the cell must report that,
+    # not a phantom success value. (The probe runs outside the update loop, where a side effect used
+    # to trigger a pass that reset the read/add tracking and hid the cycle.)
+    sample = testutil.parse_test_sample({
+      "SCHEMA": [
+        [1, "Child", [[11, "Name", "Text", False, "", "", ""]]],
+        [2, "Foo", [
+          [21, "B", "Any", True, "Child.lookupOrAddDerived(Name='x')\nreturn len(Child.all)", "", ""],
+        ]],
+      ],
+      "DATA": {"Foo": [["id"], [1]]},
+    })
+    self.load_sample(sample)
+    stored = objtypes.decode_object(self.engine.fetch_table('Foo').columns['B'][0])
+    self.assertIsInstance(stored, objtypes.RaisedException)
+    self.assertIsInstance(stored.error, depend.CircularRefError)
+    # The probe agrees: same circular-reference error, and it leaves no phantom row behind.
+    probe = self.engine.get_formula_value('Foo', 'B', 1)
+    self.assertIsInstance(probe, objtypes.RaisedException)
+    self.assertIsInstance(probe.error, depend.CircularRefError)
+    self.assertTableData('Child', cols="all", data=[['id', 'Name']])
 
   def test_formula_reading_from_an_errored_formula(self):
     # There was a bug whereby if one formula (call it D) referred to
@@ -386,37 +424,6 @@ return 0
       [ 1,   1., errVal, errVal],
       [ 2,   2., errVal, errVal],
       [ 3,   3., errVal, errVal],
-    ])
-
-  def test_undo_side_effects_with_reordering(self):
-    # As for test_undo_side_effects, but now after creating a row in a
-    # formula we try to access a cell that hasn't been recomputed yet.
-    # That will result in the formula evalution being abandoned, the
-    # desired cell being calculated, then the formula being retried.
-    # All going well, we should end up with one row, not two.
-    sample = testutil.parse_test_sample({
-      "SCHEMA": [
-        [1, "Address", [
-          [11, "city",        "Text",       False, "", "", ""],
-          [12, "state",       "Text",       False, "", "", ""],
-        ]],
-        [2, "Foo", [
-          # Note: the formula below is a terrible example of a formula, which intentionally
-          # creates a new record every time it evaluates.
-          [21, "B",           "Any",        True,
-            "Address.lookupOrAddDerived(city=str(len(Address.all)))\nreturn $C", "", ""],
-          [22, "C",           "Numeric",    True, "42", "", ""],
-        ]]
-      ],
-      "DATA": {
-        "Foo": [["id"], [1]]
-      }
-    })
-
-    self.load_sample(sample)
-    self.assertTableData('Address', data=[
-      ['id',  'city', 'state'],
-      [1,     '0',      ''],
     ])
 
   def test_attribute_error(self):

--- a/sandbox/grist/test_side_effects.py
+++ b/sandbox/grist/test_side_effects.py
@@ -1,9 +1,11 @@
 # This test verifies behavior when a formula produces side effects. The prime example is
 # lookupOrAddDerived() function, which adds new records (and is the basis for summary tables).
 
+import engine as engine_module
 import objtypes
 import test_engine
 import testutil
+import useractions
 
 class TestSideEffects(test_engine.EngineTestCase):
   address_table_data = [
@@ -62,6 +64,83 @@ class TestSideEffects(test_engine.EngineTestCase):
     ])
 
 
+  def test_multiple_adds_same_table(self):
+    # One cell calling lookupOrAddDerived twice on the same table adds both rows.
+    self.load_sample(self.sample)
+
+    formula = '''
+Schools.lookupOrAddDerived(city=$city + "-A")
+Schools.lookupOrAddDerived(city=$city + "-B")
+return None
+'''
+    self.add_column('Address', 'A', formula=formula)
+
+    # Each of the two existing Address rows should have created two Schools rows.
+    self.assertTableData('Schools', cols="subset", data=[
+      ["id", "city",       "name"],
+      [1,    "Boston",     "MIT"],
+      [2,    "New York",   "NYU"],
+      [3,    "New York-A", ""],
+      [4,    "New York-B", ""],
+      [5,    "Albany-A",   ""],
+      [6,    "Albany-B",   ""],
+    ])
+
+    # A no-op repeat (same key twice) must also be fine, and not add duplicates.
+    formula2 = '''
+Schools.lookupOrAddDerived(city=$city + "-A")
+Schools.lookupOrAddDerived(city=$city + "-A")
+return None
+'''
+    self.add_column('Address', 'B', formula=formula2)
+    # No new rows beyond the -A ones already present.
+    self.assertTableData('Schools', cols="subset", data=[
+      ["id", "city",       "name"],
+      [1,    "Boston",     "MIT"],
+      [2,    "New York",   "NYU"],
+      [3,    "New York-A", ""],
+      [4,    "New York-B", ""],
+      [5,    "Albany-A",   ""],
+      [6,    "Albany-B",   ""],
+    ])
+
+  def test_multiple_adds_via_new_record(self):
+    # The runtime path: column exists, then a new record triggers the two adds.
+    self.load_sample(self.sample)
+
+    formula = '''
+Schools.lookupOrAddDerived(city=$city + "-A")
+Schools.lookupOrAddDerived(city=$city + "-B")
+return None
+'''
+    self.add_column('Address', 'A', formula=formula)
+    # Adding a brand-new Address row should create two Schools rows for it.
+    self.add_record('Address', city="Reno")
+    reno = [r for r in self.engine.fetch_table('Schools').columns['city'] if str(r).startswith("Reno")]
+    self.assertEqual(sorted(reno), ["Reno-A", "Reno-B"])
+
+  def test_multiple_adds_on_empty_then_record(self):
+    # Even closer to the runtime: column added to a table with no rows, then a record inserted.
+    self.apply_user_action(['AddTable', 'Parent', [
+      {'id': 'Name', 'type': 'Text'},
+    ]])
+    self.apply_user_action(['AddTable', 'Child', [
+      {'id': 'Name', 'type': 'Text'},
+      {'id': 'Parent', 'type': 'Ref:Parent'},
+    ]])
+    formula = '''
+Child.lookupOrAddDerived(Parent=$id, Name="A")
+Child.lookupOrAddDerived(Parent=$id, Name="B")
+return None
+'''
+    self.add_column('Parent', 'make', formula=formula)
+    self.add_record('Parent', Name="P1")
+    self.assertTableData('Child', cols="subset", data=[
+      ["id", "Name", "Parent"],
+      [1,    "A",    1],
+      [2,    "B",    1],
+    ])
+
   def test_calc_actions_in_side_effect_rollback(self):
     self.load_sample(self.sample)
 
@@ -115,3 +194,59 @@ return None
       [3, "Albany", "", "ALBANY"],
       [4, "aaa", "", "AAA"],
     ])
+
+  # Regression test: recreating a table (RemoveTable + AddTable) must leave no orphaned view/page.
+  # Reopening first forces the recreated view onto a new row id instead of reusing the removed
+  # view's id -- the circumstance in which the orphan was originally left behind.
+
+  _USER = {
+    'Name': 'Foo', 'UserID': 1, 'UserRef': '1', 'LinkKey': {}, 'Origin': None,
+    'Email': 'foo@example.com', 'Access': 'owners', 'SessionID': 'u1',
+    'IsLoggedIn': True, 'ShareRef': None,
+  }
+
+  def _apply(self, *reprs):
+    return self.engine.apply_user_actions(
+      [useractions.from_repr(a) for a in reprs], self._USER)
+
+  def _reopen(self):
+    # Reopen the doc: load stored state into a fresh engine and Calculate.
+    meta_tables = self.engine.fetch_table('_grist_Tables')
+    meta_columns = self.engine.fetch_table('_grist_Tables_column')
+    other = {t: self.engine.fetch_table(t) for t in self.engine.tables
+             if t not in ('_grist_Tables', '_grist_Tables_column')}
+    self.engine = engine_module.Engine()
+    self.engine.load_meta_tables(meta_tables, meta_columns)
+    for data in other.values():
+      self.engine.load_table(data)
+    self._apply(['Calculate'])
+
+  def test_recreate_table_leaves_no_orphan_view(self):
+    self._apply(["InitNewDoc"])
+    self._apply(["AddEmptyTable", None])
+    self._reopen()
+
+    # Recreate Table1 in a single bundle, as replacing a table does.
+    self._apply(
+      ["RemoveTable", "Table1"],
+      ["AddTable", "Table1", [
+        {"id": "Toggle", "type": "Bool"},
+        {"id": "Another", "type": "Text"},
+        {"id": "User_Access", "type": "Text", "isFormula": False, "formula": "user.Email"},
+      ]],
+      ["AddRecord", "Table1", None, {"Another": "hello"}],
+    )
+
+    # Exactly one view and page must remain: no orphan left by RemoveTable.
+    views = list(self.engine.docmodel.views.all)
+    pages = list(self.engine.docmodel.pages.all)
+    self.assertEqual([(v.name, v.type) for v in views], [("Table1", "raw_data")])
+    self.assertEqual(len(pages), 1)
+
+    table = self.engine.docmodel.tables.lookupOne(tableId="Table1")
+    self.assertEqual(table.primaryViewId._row_id, views[0].id)
+    self.assertEqual(pages[0].viewRef._row_id, views[0].id)
+    record_sections = [s for s in self.engine.docmodel.view_sections.all
+                       if s.parentId._row_id == views[0].id]
+    self.assertEqual(len(record_sections), 1)
+    self.assertEqual(record_sections[0].tableRef.tableId, "Table1")

--- a/sandbox/grist/test_side_effects_adversarial.py
+++ b/sandbox/grist/test_side_effects_adversarial.py
@@ -1,0 +1,296 @@
+"""Adversarial stress tests for the eager-lookup-index fix (multiple lookupOrAddDerived per cell)."""
+import objtypes
+import test_engine
+from schema import RecalcWhen
+
+
+class TestSideEffectsAdversarial(test_engine.EngineTestCase):
+
+  def _two_tables(self, make_formula):
+    self.apply_user_action(['AddTable', 'Parent', [{'id': 'Name', 'type': 'Text'}]])
+    self.apply_user_action(['AddTable', 'Child', [
+      {'id': 'Name', 'type': 'Text'},
+      {'id': 'Parent', 'type': 'Ref:Parent'},
+    ]])
+    self.add_column('Parent', 'make', formula=make_formula)
+
+  def test_many_adds_one_cell(self):
+    # Stress: 50 distinct adds to the same table from a single cell (loop).
+    self._two_tables(
+      'for i in range(50):\n'
+      '    Child.lookupOrAddDerived(Parent=$id, Name="C%03d" % i)\n'
+      'return None')
+    self.add_record('Parent', Name="P1")
+    names = sorted(r.Name for r in self.engine.docmodel.get_table('Child').lookupRecords())
+    self.assertEqual(len(names), 50)
+    self.assertEqual(names[0], "C000")
+    self.assertEqual(names[-1], "C049")
+
+  def test_multiple_adds_then_raise_rolls_back_all(self):
+    # If a cell adds several rows and then errors, ALL of them must be rolled back.
+    self._two_tables(
+      'Child.lookupOrAddDerived(Parent=$id, Name="A")\n'
+      'Child.lookupOrAddDerived(Parent=$id, Name="B")\n'
+      'Child.lookupOrAddDerived(Parent=$id, Name="C")\n'
+      'raise Exception("boom")')
+    self.add_record('Parent', Name="P1")
+    # No Child rows should survive the rollback.
+    self.assertEqual(list(self.engine.docmodel.get_table('Child').lookupRecords()), [])
+    # And the cell holds the error.
+    val = self.engine.fetch_table('Parent').columns['make'][0]
+    self.assertEqual(objtypes.decode_object(val).__class__, objtypes.RaisedException(Exception()).__class__)
+
+  def test_conditional_partial_adds(self):
+    # Mix of executed and skipped calls; only executed ones create rows.
+    self._two_tables(
+      'Child.lookupOrAddDerived(Parent=$id, Name="A")\n'
+      '(Child.lookupOrAddDerived(Parent=$id, Name="B") if $Name == "yes" else None)\n'
+      'Child.lookupOrAddDerived(Parent=$id, Name="C")\n'
+      'return None')
+    self.add_record('Parent', Name="no")
+    self.add_record('Parent', Name="yes")
+    got = sorted((r.Name, r.Parent.id) for r in self.engine.docmodel.get_table('Child').lookupRecords())
+    self.assertEqual(got, [("A", 1), ("A", 2), ("B", 2), ("C", 1), ("C", 2)])
+
+  def test_chain_across_three_tables(self):
+    # A cell adds to Child; Child has a formula that adds to GrandChild: a chain of side effects
+    # propagating across tables in one update pass.
+    self.apply_user_action(['AddTable', 'Parent', [{'id': 'Name', 'type': 'Text'}]])
+    self.apply_user_action(['AddTable', 'Child', [
+      {'id': 'Name', 'type': 'Text'},
+      {'id': 'Parent', 'type': 'Ref:Parent'},
+    ]])
+    self.apply_user_action(['AddTable', 'GrandChild', [
+      {'id': 'Tag', 'type': 'Text'},
+      {'id': 'Child', 'type': 'Ref:Child'},
+    ]])
+    # Child cell creates two grandchildren per child.
+    self.add_column('Child', 'spawn', formula=(
+      'GrandChild.lookupOrAddDerived(Child=$id, Tag=$Name + "-x")\n'
+      'GrandChild.lookupOrAddDerived(Child=$id, Tag=$Name + "-y")\n'
+      'return None'))
+    self.add_column('Parent', 'make', formula=(
+      'Child.lookupOrAddDerived(Parent=$id, Name="K")\n'
+      'Child.lookupOrAddDerived(Parent=$id, Name="L")\n'
+      'return None'))
+    self.add_record('Parent', Name="P1")
+    children = sorted(r.Name for r in self.engine.docmodel.get_table('Child').lookupRecords())
+    grand = sorted(r.Tag for r in self.engine.docmodel.get_table('GrandChild').lookupRecords())
+    self.assertEqual(children, ["K", "L"])
+    self.assertEqual(grand, ["K-x", "K-y", "L-x", "L-y"])
+
+  # --- Trigger formulas (data columns with recalcWhen) calling lookupOrAddDerived ----------------
+  # A trigger column stores its formula's result, so the formula must return a value (unlike a
+  # regular formula column, where a bare statement block is fine). Triggers fire on new records and
+  # manual updates (RecalcWhen.MANUAL_UPDATES).
+
+  def _trigger_setup(self, formula):
+    self.apply_user_action(['AddTable', 'Parent', [
+      {'id': 'Name', 'type': 'Text'},
+      {'id': 'Txt', 'type': 'Text'},
+    ]])
+    self.apply_user_action(['AddTable', 'Child', [
+      {'id': 'Name', 'type': 'Text'},
+      {'id': 'Parent', 'type': 'Ref:Parent'},
+    ]])
+    self.add_column('Parent', 'make', type='Any', isFormula=False, formula=formula,
+                    recalcWhen=RecalcWhen.MANUAL_UPDATES)
+
+  def test_trigger_formula_multiple_adds(self):
+    # A trigger formula that loops over a delimited field and creates one Child per line.
+    self._trigger_setup(
+      "for x in ($Txt or '').split(','):\n"
+      "    x = x.strip()\n"
+      "    if x:\n"
+      "        Child.lookupOrAddDerived(Parent=$id, Name=x)\n"
+      "return None")
+    self.add_record('Parent', Name="P1", Txt="a, b, c")
+    self.assertTableData('Child', cols="subset", data=[
+      ["id", "Name", "Parent"],
+      [1,    "a",    1],
+      [2,    "b",    1],
+      [3,    "c",    1],
+    ])
+
+  def test_trigger_formula_listcomp_value(self):
+    # The returned-list form: the cell stores the list of created references.
+    self._trigger_setup(
+      "[Child.lookupOrAddDerived(Parent=$id, Name=x.strip())"
+      " for x in ($Txt or '').split(',') if x.strip()]")
+    self.add_record('Parent', Name="P1", Txt="a, b")
+    self.assertTableData('Child', cols="subset", data=[
+      ["id", "Name", "Parent"],
+      [1,    "a",    1],
+      [2,    "b",    1],
+    ])
+
+  def test_trigger_formula_refires_on_update(self):
+    # A trigger with MANUAL_UPDATES fires again when the source field is edited; new lines get added
+    # (lookupOrAddDerived is add-only, so previously-created rows remain).
+    self._trigger_setup(
+      "for x in ($Txt or '').split(','):\n"
+      "    x = x.strip()\n"
+      "    if x:\n"
+      "        Child.lookupOrAddDerived(Parent=$id, Name=x)\n"
+      "return None")
+    self.add_record('Parent', Name="P1", Txt="a, b")
+    self.update_record('Parent', 1, Txt="a, b, c")
+    self.assertTableData('Child', cols="subset", data=[
+      ["id", "Name", "Parent"],
+      [1,    "a",    1],
+      [2,    "b",    1],
+      [3,    "c",    1],
+    ])
+
+  def test_trigger_formula_without_return_is_error(self):
+    # A trigger formula that yields no value is a build error: the cell holds the error and no rows
+    # are created (the side effect rolls back).
+    self._trigger_setup(
+      "for x in ($Txt or '').split(','):\n"
+      "    if x.strip():\n"
+      "        Child.lookupOrAddDerived(Parent=$id, Name=x.strip())")
+    self.add_record('Parent', Name="P1", Txt="a, b, c")
+    # No Child rows.
+    self.assertTableData('Child', cols="subset", data=[["id", "Name", "Parent"]])
+    # The cell holds an error value.
+    val = self.engine.fetch_table('Parent').columns['make'][0]
+    self.assertEqual(objtypes.decode_object(val).__class__,
+                     objtypes.RaisedException(Exception()).__class__)
+
+  # The supported shape is: ensure rows in one column, read them in a DOWNSTREAM column. A cell may
+  # not both add to and read the same table (see test_same_cell_add_and_read_is_circular below).
+
+  def test_downstream_orderby_formula(self):
+    # Adder column ensures rows; a downstream column reads them ordered by a formula column (S=-Base).
+    self.apply_user_action(['AddTable', 'Parent', [{'id': 'Name', 'type': 'Text'}]])
+    self.apply_user_action(['AddTable', 'Child', [
+      {'id': 'Name', 'type': 'Text'},
+      {'id': 'Parent', 'type': 'Ref:Parent'},
+      {'id': 'Base', 'type': 'Numeric'},
+      {'id': 'S', 'type': 'Numeric', 'isFormula': True, 'formula': '-$Base'},
+    ]])
+    self.add_column('Parent', 'make', formula=(
+      '[Child.lookupOrAddDerived(Parent=$id, Name=n, Base=b)'
+      ' for n, b in [("A", 1), ("B", 3), ("C", 2)]]'))
+    self.add_column('Parent', 'ordered', formula=(
+      '",".join(r.Name for r in Child.lookupRecords(Parent=$id, order_by="S"))'))
+    self.add_record('Parent', Name="P1")
+    # Ordered by -Base: B(-3), C(-2), A(-1).
+    self.assertEqual(self.engine.fetch_table('Parent').columns['ordered'][0], "B,C,A")
+
+  def test_downstream_keyby_formula(self):
+    # Downstream read keyed on a formula column (Tag = Name.lower()).
+    self.apply_user_action(['AddTable', 'Parent', [{'id': 'Name', 'type': 'Text'}]])
+    self.apply_user_action(['AddTable', 'Child', [
+      {'id': 'Name', 'type': 'Text'},
+      {'id': 'Parent', 'type': 'Ref:Parent'},
+      {'id': 'Tag', 'type': 'Text', 'isFormula': True, 'formula': '($Name or "").lower()'},
+    ]])
+    self.add_column('Parent', 'make', formula='Child.lookupOrAddDerived(Parent=$id, Name="Hello")')
+    self.add_column('Parent', 'found', formula='len(Child.lookupRecords(Tag="hello"))')
+    self.add_record('Parent', Name="P1")
+    self.assertEqual(self.engine.fetch_table('Parent').columns['found'][0], 1)
+
+  def test_downstream_orderby_multi_column(self):
+    # Downstream read ordered by a data column (Grp) and a formula column (S = -Base).
+    self.apply_user_action(['AddTable', 'Parent', [{'id': 'Name', 'type': 'Text'}]])
+    self.apply_user_action(['AddTable', 'Child', [
+      {'id': 'Name', 'type': 'Text'}, {'id': 'Parent', 'type': 'Ref:Parent'},
+      {'id': 'Grp', 'type': 'Text'}, {'id': 'Base', 'type': 'Numeric'},
+      {'id': 'S', 'type': 'Numeric', 'isFormula': True, 'formula': '-$Base'},
+    ]])
+    self.add_column('Parent', 'make', formula=(
+      '[Child.lookupOrAddDerived(Parent=$id, Name=n, Grp=g, Base=b)'
+      ' for n, g, b in [("x", "a", 1), ("y", "a", 2), ("z", "b", 5)]]'))
+    self.add_column('Parent', 'ordered', formula=(
+      '",".join(r.Name for r in Child.lookupRecords(Parent=$id, order_by=("Grp", "S")))'))
+    self.add_record('Parent', Name="P1")
+    # Grp "a" sorted by S: y(-2), x(-1); then Grp "b": z.
+    self.assertEqual(self.engine.fetch_table('Parent').columns['ordered'][0], "y,x,z")
+
+  def test_downstream_multilevel_formula_sort(self):
+    # Downstream read ordered by a formula that depends on another formula (A = B*10, B = -Base).
+    self.apply_user_action(['AddTable', 'Parent', [{'id': 'Name', 'type': 'Text'}]])
+    self.apply_user_action(['AddTable', 'Child', [
+      {'id': 'Name', 'type': 'Text'}, {'id': 'Parent', 'type': 'Ref:Parent'},
+      {'id': 'Base', 'type': 'Numeric'},
+      {'id': 'B', 'type': 'Numeric', 'isFormula': True, 'formula': '-$Base'},
+      {'id': 'A', 'type': 'Numeric', 'isFormula': True, 'formula': '$B * 10'},
+    ]])
+    self.add_column('Parent', 'make', formula=(
+      '[Child.lookupOrAddDerived(Parent=$id, Name=n, Base=b) for n, b in [("x", 1), ("y", 2)]]'))
+    self.add_column('Parent', 'ordered', formula=(
+      '",".join(r.Name for r in Child.lookupRecords(Parent=$id, order_by="A"))'))
+    self.add_record('Parent', Name="P1")
+    # A = -Base*10: x -> -10, y -> -20. Ascending: y(-20), x(-10).
+    self.assertEqual(self.engine.fetch_table('Parent').columns['ordered'][0], "y,x")
+
+  def test_downstream_read_across_tables(self):
+    # Two levels of derived tables: each level's adder ensures rows in the next, and a downstream
+    # column reads them ordered by a formula column.
+    self.apply_user_action(['AddTable', 'Parent', [{'id': 'Name', 'type': 'Text'}]])
+    for lvl in (1, 2):
+      self.apply_user_action(['AddTable', 'L%d' % lvl, [
+        {'id': 'Name', 'type': 'Text'}, {'id': 'Up', 'type': 'Numeric'},
+        {'id': 'Base', 'type': 'Numeric'},
+        {'id': 'S', 'type': 'Numeric', 'isFormula': True, 'formula': '-$Base'}]])
+    self.add_column('L1', 'make', formula=(
+      '[L2.lookupOrAddDerived(Up=$id, Name=n, Base=b) for n, b in [("a", 1), ("b", 2)]]'))
+    self.add_column('L1', 'kids', formula='",".join(r.Name for r in L2.lookupRecords(Up=$id, order_by="S"))')
+    self.add_column('Parent', 'make', formula='L1.lookupOrAddDerived(Up=$id, Name="p", Base=1)')
+    self.add_column('Parent', 'kids', formula='",".join(r.Name for r in L1.lookupRecords(Up=$id, order_by="S"))')
+    self.add_record('Parent', Name="P1")
+    self.assertEqual(self.engine.fetch_table('L1').columns['kids'][0], "b,a")
+    self.assertEqual(self.engine.fetch_table('Parent').columns['kids'][0], "p")
+
+  def test_same_cell_add_and_read_is_circular(self):
+    # A cell that both adds to and reads the same table is a circular reference, not a value.
+    # (Use a downstream column to read instead.)
+    self.apply_user_action(['AddTable', 'Parent', [{'id': 'Name', 'type': 'Text'}]])
+    self.apply_user_action(['AddTable', 'Child', [
+      {'id': 'Name', 'type': 'Text'}, {'id': 'Parent', 'type': 'Ref:Parent'},
+    ]])
+    self.add_column('Parent', 'make', formula=(
+      'Child.lookupOrAddDerived(Parent=$id, Name="x")\n'
+      'return len(Child.lookupRecords(Parent=$id))'))
+    self.add_record('Parent', Name="P1")
+    val = self.engine.fetch_table('Parent').columns['make'][0]
+    self.assertEqual(objtypes.decode_object(val).__class__,
+                     objtypes.RaisedException(Exception()).__class__)
+
+  def test_bounded_mutual_recursion_terminates(self):
+    # Two tables whose formulas each add to the other, with fixed keys so only finitely many rows
+    # are possible. Must settle to a stable state (asserted exactly), not hang.
+    self.apply_user_action(['AddTable', 'A', [{'id': 'N', 'type': 'Text'}]])
+    self.apply_user_action(['AddTable', 'B', [{'id': 'N', 'type': 'Text'}]])
+    # Fixed keys: A always makes B "b", B always makes A "a". Finite rows.
+    self.add_column('A', 'mk', formula='B.lookupOrAddDerived(N="b")\nreturn None')
+    self.add_column('B', 'mk', formula='A.lookupOrAddDerived(N="a")\nreturn None')
+    # Seed an A row: A "seed" -> B "b" -> A "a" -> B "b" (exists), so it settles here.
+    self.add_record('A', N="seed")
+    self.assertTableData('A', cols="subset", data=[
+      ["id", "N"],
+      [1,    "seed"],
+      [2,    "a"],
+    ])
+    self.assertTableData('B', cols="subset", data=[
+      ["id", "N"],
+      [1,    "b"],
+    ])
+
+  def test_add_then_defer_retries_to_single_row(self):
+    # A cell that adds a row and then reads a not-yet-computed value defers until that value is
+    # ready. Deferring rolls back the add, so the retry must end with exactly one row, not two.
+    # ("Aaa" sorts before "Zed", so Aaa.make runs first and reads Zed.uf while it is still dirty.)
+    self.apply_user_action(['AddTable', 'Aaa', [{'id': 'make', 'type': 'Any', 'isFormula': True,
+      'formula': 'Child.lookupOrAddDerived(Name="x")\nreturn Zed.lookupOne(seed=10).uf'}]])
+    self.apply_user_action(['AddTable', 'Child', [{'id': 'Name', 'type': 'Text'}]])
+    self.apply_user_action(['AddTable', 'Zed', [
+      {'id': 'seed', 'type': 'Numeric'},
+      {'id': 'uf', 'type': 'Numeric', 'isFormula': True, 'formula': '$seed * 2'},
+    ]])
+    self.add_record('Zed', seed=10)
+    self.add_record('Aaa')
+    # The cell succeeded on retry (uf = seed * 2), and the add ran exactly once.
+    self.assertEqual(self.engine.fetch_table('Aaa').columns['make'][0], 20.0)
+    self.assertTableData('Child', cols="subset", data=[["id", "Name"], [1, "x"]])


### PR DESCRIPTION
A formula can now create rows in a related table with `lookupOrAddDerived` and have the rest of the document see them. On stock Grist this can work for a single call done carefully, or fail with `data engine not making progress updating dependencies`. The case that motivates it is nested-form data entry: take a few values from one record and turn each into its own row in a related table. Something like this:

    [Roles.lookupOrAddDerived(Project=$id, Name=n) for n in names]

Three changes in the engine make this work:

1. Several `lookupOrAddDerived` calls in one cell. Adding a row marks that table's lookup index out of date, and a later call in the same cell used to trip over the stale index. The index is now refreshed right where it is needed, instead of being deferred to a later pass.

2. A reader sees rows added after it ran. If one cell reads a derived table and another cell later adds rows to it, the reader now recomputes against the new rows instead of keeping a stale value. This is scoped tightly. A finished reader is recomputed only when the change is a lookup of the very table it read, and only when its own read was a user-level lookup. The engine's summary and derived machinery reads through internal paths rather than user lookups, so it is left alone and does no extra work.

3. Looking up a table you also add to, in one cell, is now a clear error. Adding rows and then doing a fresh lookup of that same table (with `lookupRecords`, `lookupOne`, or `.all`) used to hang or return a silently wrong result. It is now reported as a circular reference. The same goes for a self-referential key such as `lookupOrAddDerived(city=str(len(Address.all)))`, which reads the table to decide what to add to it. This does not touch the common case of creating one row and reading its values. The record that `lookupOrAddDerived` returns, and its stored fields, are fine to use, exactly as before. Reading one of the new row's own formula columns in the same cell still does not work, but that limitation predates this change. What is caught here is a fresh lookup of the table you are adding to. Read the new rows in a downstream cell instead.

A note on scope. Calculation finds the fixed point of a dependency graph. Creating rows fits that model only when the rows to create are determined by inputs that do not themselves depend on the created rows, so the result settles to one answer regardless of evaluation order. That well-formed case is what this change supports.

This change treats a created row as data: once made, it persists. Whether a row should instead disappear when the value that produced it changes is a separate decision, and the model does not settle it. A created row can be read two ways. It can be persistent data that you keep and reference. It can also be a view that exists only while its source does, the way summary tables drop a group once its last source row is gone. Because neither reading is forced, this change adds no removal. If created rows are later meant to behave as a view, the summary machinery already does reference-counted removal and is the right place to build on.

Tests:

* `test_side_effects.py`: several adds to the same table in one cell, including the empty-target path where the index is created during the triggering record.

* `test_side_effects_adversarial.py`: stress and edge cases, the downstream read-back pattern (sorted, keyed, multi-level, across tables), a bounded cycle that settles, trigger formulas, and same-cell read-and-add reported as circular.

* `test_formula_error.py`: test_undo_side_effects keeps its original purpose, that side effects from a value probe get reverted, now using a NEVER-recalc trigger formula whose row is not pre-created. A new test covers the self-referential `lookupOrAddDerived` formula now being a circular reference. The old `test_undo_side_effects_with_reordering` is removed, because its formula is now circular and the reorder-on-side-effect scenario can no longer be written with it.

The full Python engine suite passes with no new failures.

Heavily machine assisted.
