### PR TITLE
Recommend getgrist.com auth during quick setup

### DIFF
--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -21,7 +21,6 @@ import {
   peekSetupReturnFromGetGristCom,
 } from "app/client/ui/GetGristComProvider";
 import { ApplyResult } from "app/client/ui/QuickSetupContinueButton";
-import { quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
 import { cssCardSurface } from "app/client/ui/SettingsLayout";
 import { cssHeroCard } from "app/client/ui/SetupCard";
 import { basicButton, bigBasicButton, bigPrimaryButton, textButton } from "app/client/ui2018/buttons";
@@ -73,8 +72,13 @@ interface AuthenticationSectionOptions {
 
 export class AuthenticationSection extends Disposable implements ConfigSection {
   /**
+   * True when a real auth provider is active or pending (will be active after restart).
+   */
+  public hasConfiguredAuth: Computed<boolean>;
+
+  /**
    * True when authentication is in a state the user can proceed with:
-   * a real provider is active, configured, or pending — or the user acknowledged no-auth.
+   * a real provider is active or pending, or the user acknowledged no-auth.
    */
   public canProceed: Computed<boolean>;
 
@@ -180,14 +184,16 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
   constructor(private _options: AuthenticationSectionOptions) {
     super();
 
-    this.canProceed = Computed.create(this, (use) => {
-      if (use(noAuthAcknowledged)) { return true; }
+    this.hasConfiguredAuth = Computed.create(this, (use) => {
       if (use(this._hasActiveOnRestartProvider)) { return true; }
       const providers = use(this._displayProviders);
-      if (providers.some(p => (p.isActive || p.isConfigured) && isRealProvider(p.key))) { return true; }
+      if (providers.some(p => p.isActive && isRealProvider(p.key))) { return true; }
       const loginSystemId = use(this._loginSystemId);
       return !!loginSystemId && isRealProvider(loginSystemId);
     });
+
+    this.canProceed = Computed.create(this, use =>
+      use(noAuthAcknowledged) || use(this.hasConfiguredAuth));
 
     // Evaluate every branch: short-circuit returns drop subscriptions to
     // later deps, leaving `isDirty` stale once an early truthy branch flips.
@@ -325,11 +331,9 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
 
   public buildDom() {
     return [
-      this._inAdminPanel ? null : quickSetupStepHeader({
-        icon: "AddUser",
-        title: t("Authentication"),
-        description: t("Choose how users sign in to Grist."),
-      }),
+      this._inAdminPanel ? null : cssAuthIntro(
+        t("Choose how people sign in. You can change this anytime after setup."),
+      ),
       dom.domComputed((use) => {
         const providers = use(this._displayProviders);
         const loginSystemId = use(this._loginSystemId);
@@ -388,6 +392,7 @@ export class AuthenticationSection extends Disposable implements ConfigSection {
       },
       recentlyConfigured: this._recentlyConfigured,
       loginSystemId,
+      inAdminPanel: this._inAdminPanel,
     });
   }
 
@@ -807,6 +812,8 @@ export interface ProviderListContext {
   collapsible?: boolean;
   /** When true, collapse the list when the no-auth checkbox is acknowledged. */
   collapseOnNoAuth?: boolean;
+  /** Defaults to "Available methods"/"Other authentication methods". */
+  title?: string;
 }
 
 export interface AuthSectionContext {
@@ -816,6 +823,8 @@ export interface AuthSectionContext {
   /** The login system ID from the boot probe (e.g. "minimal", "boot-key").
    *  When set to a non-real provider key, shows the no-auth hero. */
   loginSystemId?: string;
+  /** Defaults to true. */
+  inAdminPanel?: boolean;
 }
 
 /**
@@ -832,6 +841,21 @@ export function buildAuthSection(
     providers.find(p => p.isActive && isRealProvider(p.key)) ??
     providers.find(p => p.willBeActive && isRealProvider(p.key)) ??
     null;
+
+  const getgrist = providers.find(p => p.key === GETGRIST_COM_PROVIDER_KEY);
+  if (!ctx.inAdminPanel && !hero && getgrist) {
+    const heroEl = buildRecommendedCard(getgrist, ctx.heroCtx, ctx.listCtx);
+    const otherProviders = providers.filter(p => p.key !== GETGRIST_COM_PROVIDER_KEY);
+    const listEl = buildProviderList(otherProviders, recentlyConfigured, {
+      ...ctx.listCtx,
+      collapsible: true,
+      title: t("Or connect your own identity provider"),
+    });
+    return dom("div",
+      heroEl,
+      cssOtherMethods(listEl),
+    );
+  }
 
   // Show the no-auth hero when no real provider is active or pending. This covers:
   // - Boot probe reports a non-real provider (minimal, boot-key)
@@ -894,6 +918,36 @@ function buildHeroAdminRow(ctx: HeroCardContext) {
       ctx.onChangeAdmin ? dom.on("click", ctx.onChangeAdmin) : null,
       testId("change-admin"),
     ),
+  );
+}
+
+function buildRecommendedCard(
+  provider: AuthProvider,
+  heroCtx: HeroCardContext,
+  listCtx: ProviderListContext,
+): HTMLElement {
+  const meta = getGristComProviderMeta();
+  return cssRecommendedCard(
+    testId("hero-card"),
+    testId("hero-nudge"),
+    cssRecommendedHeader(
+      cssGMark("G"),
+      badge(meta.recommendedBadge, "-primary", "badge-recommended"),
+    ),
+    cssHeroProviderName(provider.name, dom.style("margin-bottom", "12px")),
+    cssHeroHighlight(
+      cssHeroHighlightCheck(icon("Tick")),
+      cssHeroHighlightBody(meta.recommendedHighlight),
+    ),
+    cssHeroDescription(meta.recommendedDesc),
+    cssHeroActions(
+      bigPrimaryButton(
+        meta.recommendedConfigure,
+        dom.on("click", () => listCtx.onConfigure?.(provider)),
+        testId("getgrist-cta"),
+      ),
+    ),
+    buildHeroAdminRow(heroCtx),
   );
 }
 
@@ -1045,7 +1099,7 @@ function buildProviderList(
 
   if (!ctx.collapsible && !ctx.collapseOnNoAuth) {
     return dom("div",
-      cssProviderListHeader(t("Available methods"), testId("provider-list-header")),
+      cssProviderListHeader(ctx.title ?? t("Available methods"), testId("provider-list-header")),
       buildCards(),
     );
   }
@@ -1059,7 +1113,7 @@ function buildProviderList(
     noAuthListener ? dom.autoDispose(noAuthListener) : null,
     cssProviderListHeaderClickable(
       dom.domComputed(collapsed, c => cssCollapseIcon(c ? "Expand" : "Collapse")),
-      t("Other authentication methods"),
+      ctx.title ?? t("Other authentication methods"),
       dom.on("click", toggle),
       dom.on("keydown", (ev: KeyboardEvent) => {
         if (ev.key === "Enter" || ev.key === " ") {
@@ -1117,6 +1171,72 @@ const cssHeroActions = styled("div", `
   display: flex;
   gap: 8px;
   margin-top: 12px;
+`);
+
+const cssAuthIntro = styled("div", `
+  font-size: ${vars.mediumFontSize};
+  color: ${theme.lightText};
+  line-height: 1.5;
+  margin-bottom: 20px;
+`);
+
+const cssRecommendedCard = styled(cssHeroCard, `
+  border: 2px solid ${theme.controlPrimaryBg};
+  margin-bottom: 24px;
+`);
+
+const cssRecommendedHeader = styled("div", `
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+`);
+
+const cssGMark = styled("div", `
+  width: 24px;
+  height: 24px;
+  flex: none;
+  border-radius: 6px;
+  background-color: ${theme.controlPrimaryBg};
+  color: ${theme.controlPrimaryFg};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+  font-size: 15px;
+`);
+
+const cssHeroHighlight = styled("div", `
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin: 0 0 12px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  border: 1px solid ${theme.controlPrimaryBg};
+  background-color: ${theme.selectionOpaqueBg};
+`);
+
+const cssOtherMethods = styled("div", `
+  margin-top: 8px;
+`);
+
+const cssHeroHighlightCheck = styled("div", `
+  width: 28px;
+  height: 28px;
+  flex: none;
+  border-radius: 50%;
+  background-color: ${theme.controlPrimaryBg};
+  --icon-color: ${theme.controlPrimaryFg};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`);
+
+const cssHeroHighlightBody = styled("div", `
+  font-size: ${vars.mediumFontSize};
+  line-height: 1.5;
+  color: ${theme.text};
 `);
 
 const cssNoAuthCheckbox = styled("div", `

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -69,9 +69,15 @@ export function confirmNoAuthAcknowledgement(onConfirm: () => void): void {
     return {
       title: t("Skip authentication setup?"),
       body: dom("div",
-        dom("p",
-          t("Anyone who can reach this server can access all data without signing in. \
+        cssWell(
+          cssWell.cls("-warning"),
+          cssIconWrapper(icon("Warning")),
+          cssWellContent(
+            dom("p",
+              t("Anyone who can reach this server can access all data without signing in. \
 You can configure authentication later from the admin panel."),
+            ),
+          ),
         ),
         cssNoAuthCheckbox(
           labeledSquareCheckbox(ack,

--- a/app/client/ui/AuthenticationSection.ts
+++ b/app/client/ui/AuthenticationSection.ts
@@ -57,6 +57,40 @@ const noAuthAcknowledged = localStorageBoolObs(
   installationId ? `noAuthAcknowledged:${installationId}` : "noAuthAcknowledged",
 );
 
+/**
+ * Prompt the admin to acknowledge that the server has no authentication
+ * before continuing past the Quick Setup auth step without configuring a
+ * provider.
+ */
+export function confirmNoAuthAcknowledgement(onConfirm: () => void): void {
+  saveModal((_ctl, owner) => {
+    const ack = Observable.create(owner, false);
+    const saveDisabled = Computed.create(owner, use => !use(ack));
+    return {
+      title: t("Skip authentication setup?"),
+      body: dom("div",
+        dom("p",
+          t("Anyone who can reach this server can access all data without signing in. \
+You can configure authentication later from the admin panel."),
+        ),
+        cssNoAuthCheckbox(
+          labeledSquareCheckbox(ack,
+            t("I understand this server has no authentication"),
+            testId("no-auth-acknowledge"),
+          ),
+        ),
+      ),
+      saveLabel: t("Continue without authentication"),
+      saveDisabled,
+      saveFunc: async () => {
+        noAuthAcknowledged.set(true);
+        onConfirm();
+      },
+      width: "normal" as const,
+    };
+  });
+}
+
 interface AuthenticationSectionOptions {
   appModel: AppModel;
   loginSystemId?: Observable<string | undefined>;

--- a/app/client/ui/GetGristComProvider.ts
+++ b/app/client/ui/GetGristComProvider.ts
@@ -83,6 +83,11 @@ export function getGristComProviderMeta() {
     heroDesc: t("Your server uses getgrist.com authentication. \
 Users sign in with their getgrist.com account."),
     docsUrl: commonUrls.signInWithGristDocs,
+    recommendedBadge: t("Recommended"),
+    recommendedHighlight: t("Ideal for testing and prototyping. Sign in with a getgrist.com account, \
+with no identity provider to configure."),
+    recommendedDesc: t("You can switch to OIDC, SAML, or another method at any time."),
+    recommendedConfigure: t("Use getgrist.com sign-in"),
   };
 }
 

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -5,7 +5,7 @@ import { reportError } from "app/client/models/errors";
 import { getHomeUrl } from "app/client/models/homeUrl";
 import { buildAdminAccessDeniedCard } from "app/client/ui/AdminAccessDeniedCard";
 import { cssFadeUp, cssFadeUpGristLogo, cssFadeUpHeading, cssFadeUpSubHeading } from "app/client/ui/AdminPanelCss";
-import { AuthenticationSection } from "app/client/ui/AuthenticationSection";
+import { AuthenticationSection, confirmNoAuthAcknowledgement } from "app/client/ui/AuthenticationSection";
 import { BackupsSection } from "app/client/ui/BackupsSection";
 import { DraftChangesManager } from "app/client/ui/DraftChanges";
 import { peekSetupReturnFromGetGristCom, SetupReturnStep } from "app/client/ui/GetGristComProvider";
@@ -174,7 +174,7 @@ export class QuickSetup extends Disposable {
           () => cssAuthSkipRow(
             textButton(
               t("Set up later"),
-              dom.on("click", () => this._advanceStep()),
+              dom.on("click", () => confirmNoAuthAcknowledgement(() => this._advanceStep())),
               testId("auth-skip"),
             ),
           ),

--- a/app/client/ui/QuickSetup.ts
+++ b/app/client/ui/QuickSetup.ts
@@ -13,6 +13,7 @@ import { PermissionsSetupSection } from "app/client/ui/PermissionsSetupSection";
 import { quickSetupContinueButton, QuickSetupSection } from "app/client/ui/QuickSetupContinueButton";
 import { QuickSetupServerStep } from "app/client/ui/QuickSetupServerStep";
 import { SANDBOX_PROBE_ID, SandboxSetupSection } from "app/client/ui/SandboxSection";
+import { textButton } from "app/client/ui2018/buttons";
 import { Stepper } from "app/client/ui2018/Stepper";
 import { InstallAPIImpl } from "app/common/InstallAPI";
 
@@ -164,7 +165,20 @@ export class QuickSetup extends Disposable {
       };
       return dom("div",
         section.buildDom(),
-        quickSetupContinueButton(step, () => this._advanceStep(), testId("auth-continue")),
+        dom.maybe(
+          section.hasConfiguredAuth,
+          () => quickSetupContinueButton(step, () => this._advanceStep(), testId("auth-continue")),
+        ),
+        dom.maybe(
+          use => !use(section.hasConfiguredAuth),
+          () => cssAuthSkipRow(
+            textButton(
+              t("Set up later"),
+              dom.on("click", () => this._advanceStep()),
+              testId("auth-skip"),
+            ),
+          ),
+        ),
       );
     });
   }
@@ -202,4 +216,9 @@ const cssStepContent = styled("div", `
   animation: ${cssFadeUp} 0.5s ease 0.24s both;
   margin: 24px auto;
   max-width: 520px;
+`);
+
+const cssAuthSkipRow = styled("div", `
+  text-align: center;
+  margin-top: 20px;
 `);

--- a/test/nbrowser/QuickSetupAuth.ts
+++ b/test/nbrowser/QuickSetupAuth.ts
@@ -156,9 +156,22 @@ describe("QuickSetupAuth", function() {
       assert.lengthOf(await driver.findAll(".test-quick-setup-auth-continue"), 0);
     });
 
-    it("should advance to the Backups step when 'Set up later' is clicked", async function() {
+    it("should show a no auth confirmation modal when 'Set up later' is clicked", async function() {
       await navigateToAuthStep();
       await driver.findWait(".test-quick-setup-auth-skip", 2000).click();
+
+      // Modal opens with Save disabled until the acknowledgement is ticked.
+      const confirm = await driver.findWait(".test-modal-confirm", 2000);
+      assert.equal(await confirm.getAttribute("disabled"), "true");
+      await driver.find(".test-admin-auth-no-auth-acknowledge").click();
+      await gu.waitToPass(async () => {
+        assert.notEqual(await confirm.getAttribute("disabled"), "true");
+      }, 2000);
+    });
+
+    it("should advance to the 'Backups' step when 'Continue' is clicked in the no auth modal", async function() {
+      const confirm = await driver.findWait(".test-modal-confirm", 2000);
+      await confirm.click();
       await driver.findWait(".test-quick-setup-backups-continue", 2000);
     });
 

--- a/test/nbrowser/QuickSetupAuth.ts
+++ b/test/nbrowser/QuickSetupAuth.ts
@@ -51,6 +51,29 @@ async function openConfigureModal(): Promise<void> {
   await driver.findWait(".test-admin-auth-modal-header", 2000);
 }
 
+async function openWizardGetGristModal(): Promise<void> {
+  // In the wizard, getgrist.com is presented as the recommended hero card
+  // (with a CTA) when no real provider is active; otherwise -- e.g. when an
+  // earlier suite left a real provider active -- it appears as a regular
+  // provider row with a Configure button. Handle both so the helper is robust
+  // to suite ordering. The section re-renders when async fetches land, so
+  // retry the lookup and click together.
+  await gu.waitToPass(async () => {
+    const ctas = await driver.findAll(".test-admin-auth-getgrist-cta");
+    if (ctas.length > 0) {
+      await ctas[0].click();
+      return;
+    }
+    const header = await driver.find(".test-admin-auth-provider-list-header");
+    if (await header.getAttribute("aria-expanded") === "false") {
+      await header.click();
+    }
+    const row = await driver.findContent(".test-admin-auth-provider-row", /getgrist/i);
+    await row.find(".test-admin-auth-configure-button").click();
+  }, 4000);
+  await driver.findWait(".test-admin-auth-modal-header", 2000);
+}
+
 async function cancelConfigureModal(): Promise<void> {
   await driver.find(".test-admin-auth-modal-cancel").click();
   await driver.wait(async () => !(await isModalOpen()), 2000);
@@ -82,68 +105,68 @@ describe("QuickSetupAuth", function() {
   }
 
   describe("default-email-set", function() {
-    it("should show auth section on the Authentication step", async function() {
+    it("should show the getgrist.com recommended card on the Authentication step", async function() {
       await navigateToAuthStep();
 
-      // Should show the hero card with the no-auth warning.
+      // The wizard promotes getgrist.com as the recommended option when
+      // nothing real is configured (instead of the admin panel's no-auth
+      // warning).
       await gu.waitToPass(async () => {
-        const heroText = await driver.findWait(".test-admin-auth-hero-card", 2000).getText();
-        assert.match(heroText, /No authentication/);
+        const nudge = await driver.findWait(".test-admin-auth-hero-nudge", 2000);
+        assert.match(await nudge.getText(), /Ideal for testing/);
       }, 2000);
+      assert.isTrue(await driver.find(".test-admin-auth-badge-recommended").isDisplayed());
+      assert.isTrue(await driver.find(".test-admin-auth-getgrist-cta").isDisplayed());
 
-      // Should show provider rows.
-      const rows = await driver.findAll(".test-admin-auth-provider-row");
-      assert.isAtLeast(rows.length, 2);
+      // The one-line intro replaces the old step header.
+      assert.match(await driver.find("body").getText(), /Choose how people sign in/);
     });
 
-    it("should disable Continue button when no auth is configured", async function() {
+    it("should exclude getgrist.com from the 'connect your own' list", async function() {
       await navigateToAuthStep();
+      await driver.findWait(".test-admin-auth-hero-nudge", 2000);
 
-      await gu.waitToPass(async () => {
-        const heroText = await driver.findWait(".test-admin-auth-hero-card", 2000).getText();
-        assert.match(heroText, /No authentication/);
-      }, 2000);
-
-      // Continue button should be present but disabled.
-      const continueBtn = await driver.findWait(".test-quick-setup-auth-continue", 2000);
-      assert.equal(await continueBtn.getAttribute("disabled"), "true");
-    });
-
-    it("should enable Continue and collapse providers after acknowledging no-auth", async function() {
-      // Check the "I understand" checkbox.
-      await driver.findWait(".test-admin-auth-no-auth-acknowledge", 2000).click();
-
-      // Continue button should now be enabled.
-      const continueBtn = await driver.find(".test-quick-setup-auth-continue");
-      await gu.waitToPass(async () => {
-        assert.equal(await continueBtn.getAttribute("disabled"), null);
-      }, 1000);
-
-      // Provider list should be collapsed.
-      const header = await driver.find(".test-admin-auth-provider-list-header");
-      assert.equal(await header.getAttribute("aria-expanded"), "false");
-
-      // Provider rows should not be visible.
-      assert.lengthOf(await driver.findAll(".test-admin-auth-provider-row"), 0);
-    });
-
-    it("should keep providers collapsed after page reload when no-auth is acknowledged", async function() {
-      // Reload the page — noAuthAcknowledged is persisted in localStorage.
-      await navigateToAuthStep();
-
-      await gu.waitToPass(async () => {
-        await driver.findWait(".test-admin-auth-hero-card", 2000);
-      }, 2000);
-
-      // Provider list should still be collapsed from the previous acknowledgment.
+      // Expand the collapsible "Or connect your own identity provider" list.
+      // Wrap the text read in waitToPass: the step content fades in (opacity
+      // animates from 0), and Selenium's getText returns "" until it settles.
       const header = await driver.findWait(".test-admin-auth-provider-list-header", 2000);
-      assert.equal(await header.getAttribute("aria-expanded"), "false");
-      assert.lengthOf(await driver.findAll(".test-admin-auth-provider-row"), 0);
+      await gu.waitToPass(async () => {
+        assert.match(await header.getText(), /connect your own identity provider/i);
+      }, 2000);
+      if (await header.getAttribute("aria-expanded") === "false") {
+        await header.click();
+      }
 
-      // Uncheck to clean up for later tests.
-      await driver.find(".test-admin-auth-no-auth-acknowledge").click();
-      // Clear localStorage so it doesn't affect other test suites.
-      await driver.executeScript("window.localStorage.removeItem('noAuthAcknowledged');");
+      await gu.waitToPass(async () => {
+        const rowText = (await Promise.all(
+          (await driver.findAll(".test-admin-auth-provider-row")).map(r => r.getText()),
+        )).join("\n");
+        assert.match(rowText, /OIDC/);
+        assert.match(rowText, /SAML/);
+        // getgrist.com is the hero card here, never a row in this list.
+        assert.notMatch(rowText, /getgrist/i);
+      }, 2000);
+    });
+
+    it("should show 'Set up later' (not Continue) when no auth is configured", async function() {
+      await navigateToAuthStep();
+      await driver.findWait(".test-admin-auth-hero-nudge", 2000);
+
+      await driver.findWait(".test-quick-setup-auth-skip", 2000);
+      assert.lengthOf(await driver.findAll(".test-quick-setup-auth-continue"), 0);
+    });
+
+    it("should advance to the Backups step when 'Set up later' is clicked", async function() {
+      await navigateToAuthStep();
+      await driver.findWait(".test-quick-setup-auth-skip", 2000).click();
+      await driver.findWait(".test-quick-setup-backups-continue", 2000);
+    });
+
+    it("should open the getgrist.com configure modal from the CTA", async function() {
+      await navigateToAuthStep();
+      await openWizardGetGristModal();
+      assert.isTrue(await isModalOpen());
+      await cancelConfigureModal();
     });
 
     it("should show access denied card to a non-admin visitor", async function() {
@@ -349,7 +372,9 @@ describe("QuickSetupAuth", function() {
       await clearBreadcrumb();
       assert.isNull(await readBreadcrumb(), "should start unarmed");
 
-      await openConfigureModal();
+      // In the wizard, getgrist.com is the recommended hero card, so its
+      // modal is opened via the CTA rather than a provider row.
+      await openWizardGetGristModal();
       assert.equal(await readBreadcrumb(), "auth",
         "opening from the wizard should arm the breadcrumb");
 


### PR DESCRIPTION
## Context

The authentication step of quick setup currently makes no recommendation for which provider to use.

## Proposed solution

Show a new hero card in the authentication step of quick setup recommending getgrist.com authentication, with the other authentication providers listed below it. The card is only shown when no other authentication provider is configured.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
