### PR TITLE
Adds a telemetry toggle to the "Quick Setup" flow. 

### DIFF
--- a/app/client/ui/AdminPanel.ts
+++ b/app/client/ui/AdminPanel.ts
@@ -217,7 +217,8 @@ class AdminInstallationPanel extends Disposable {
     notifier: this._appModel.notifier,
   });
 
-  private _permissionsModel = PermissionsToggleModel.create(this);
+  // Hide telemetry toggle, as the admin panel exposes it through SupportGristPage
+  private _permissionsModel = PermissionsToggleModel.create(this, { excludeToggles: ["telemetry"] });
 
   private _drafts = DraftChangesManager.create(this);
 

--- a/app/client/ui/PermissionsSetupSection.ts
+++ b/app/client/ui/PermissionsSetupSection.ts
@@ -2,11 +2,8 @@ import { makeT } from "app/client/lib/localization";
 import { getHomeUrl } from "app/client/models/homeUrl";
 import { cssWell, cssWellContent } from "app/client/ui/AdminPanelCss";
 import {
-  getEnvLockedVars,
-  hasEnvLocked,
   PermissionsToggleModel,
   PresetName,
-  TOGGLE_DEFS,
 } from "app/client/ui/PermissionsToggleModel";
 import { quickSetupStepHeader } from "app/client/ui/QuickSetupStepHeader";
 import { cssQuickSetupCard, cssShadowedPrimaryButton, cssValueLabel } from "app/client/ui/SettingsLayout";
@@ -187,7 +184,7 @@ export function buildPermissionsCard(
         ),
       ),
 
-      ...TOGGLE_DEFS.map(({ key, permKey, label, description }) => {
+      ...model.toggleDefs.map(({ key, permKey, label, description }) => {
         const locked = status[permKey].source === "environment-variable";
         const conflict = model.hasConflict(key);
         return cssPermissionRow(
@@ -209,12 +206,12 @@ export function buildPermissionsCard(
         );
       }),
 
-      hasEnvLocked(status) ? cssWell(cssWell.cls("-warning"),
+      model.hasEnvLocked() ? cssWell(cssWell.cls("-warning"),
         cssWellContent(
           t("Some settings are controlled by environment variables and cannot be \
 changed here: {{vars}}. To modify them, update the corresponding variables \
 in your server configuration and restart.",
-          { vars: getEnvLockedVars(status).join(", ") }),
+          { vars: model.getEnvLockedVars().join(", ") }),
         ),
         testId("env-warning"),
       ) : null,

--- a/app/client/ui/PermissionsToggleModel.ts
+++ b/app/client/ui/PermissionsToggleModel.ts
@@ -35,6 +35,7 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
     personalSites: Observable.create<boolean>(this, false),
     anonAccess: Observable.create<boolean>(this, false),
     playground: Observable.create<boolean>(this, false),
+    telemetry: Observable.create<boolean>(this, false),
   };
 
   /** True when any toggle has drifted from its server value. */
@@ -55,6 +56,7 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
     personalSites: Observable.create<boolean>(this, false),
     anonAccess: Observable.create<boolean>(this, false),
     playground: Observable.create<boolean>(this, false),
+    telemetry: Observable.create<boolean>(this, false),
   };
 
   private _installAPI: InstallAPI;
@@ -135,6 +137,9 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
         GRIST_FORCE_LOGIN: String(!this.toggles.anonAccess.get()),
         GRIST_ANON_PLAYGROUND: String(this.toggles.playground.get()),
       },
+      telemetry: {
+        telemetryLevel: this.toggles.telemetry.get() ? "limited" : "off",
+      },
     });
     if (this.isDisposed()) { return; }
     for (const { key } of TOGGLE_DEFS) {
@@ -149,6 +154,7 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
     this._setBoth("personalSites", s.personalOrgs.value ?? true);
     this._setBoth("anonAccess", !(s.forceLogin.value ?? false));
     this._setBoth("playground", s.anonPlayground.value ?? true);
+    this._setBoth("telemetry", s.telemetry.value ?? true);
     this.status.set(s);
   }
 
@@ -163,7 +169,7 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
   }
 }
 
-export type ToggleKey = "teamSites" | "personalSites" | "anonAccess" | "playground";
+export type ToggleKey = "teamSites" | "personalSites" | "anonAccess" | "playground" | "telemetry";
 export type PresetName = "locked" | "recommended" | "open";
 export type PermissionKey = keyof Omit<PermissionsStatus, "singleOrg">;
 
@@ -176,9 +182,9 @@ export interface ToggleDef {
 }
 
 export const PRESETS: Record<PresetName, Record<ToggleKey, boolean>> = {
-  locked: { teamSites: false, personalSites: false, anonAccess: false, playground: false },
-  recommended: { teamSites: false, personalSites: true, anonAccess: true, playground: false },
-  open: { teamSites: true, personalSites: true, anonAccess: true, playground: true },
+  locked: { teamSites: false, personalSites: false, anonAccess: false, playground: false, telemetry: false },
+  recommended: { teamSites: false, personalSites: true, anonAccess: true, playground: false, telemetry: true },
+  open: { teamSites: true, personalSites: true, anonAccess: true, playground: true, telemetry: true },
 };
 
 // Pre-typed entries so the presetDetector Computed doesn't widen back to
@@ -220,6 +226,14 @@ This is needed for link sharing and published forms."),
     label: () => t("Allow anonymous playground"),
     description: () => t("Visitors who aren't signed in can create and edit documents \
 in a temporary playground. Turn off to require sign-in before creating any documents."),
+  },
+  {
+    key: "telemetry",
+    permKey: "telemetry",
+    envVar: "GRIST_TELEMETRY_LEVEL",
+    label: () => t("Share product telemetry"),
+    description: () => t("Sends anonymous usage metrics to Grist Labs. \
+No document contents are collected. Configurable anytime from the admin panel."),
   },
 ];
 

--- a/app/client/ui/PermissionsToggleModel.ts
+++ b/app/client/ui/PermissionsToggleModel.ts
@@ -2,6 +2,7 @@ import { makeT } from "app/client/lib/localization";
 import { reportError } from "app/client/models/AppModel";
 import { getHomeUrl } from "app/client/models/homeUrl";
 import { ConfigSection, DraftChangeDescription } from "app/client/ui/DraftChanges";
+import { InstallPrefs } from "app/common/Install";
 import { InstallAPI, InstallAPIImpl, PermissionsStatus } from "app/common/InstallAPI";
 import { getGristConfig } from "app/common/urlUtils";
 
@@ -10,13 +11,16 @@ import { Computed, Disposable, Observable } from "grainjs";
 const t = makeT("PermissionsToggleModel");
 
 /**
- * Shared model for the four install-wide permission toggles
- * (team sites / personal sites / anon access / playground).
+ * Shared model for the install-wide permission toggles
+ * (team sites / personal sites / anon access / playground)
+ * plus the telemetry opt-in toggle.
  *
  * Used by both QuickSetup's "Apply & restart" card and the admin
  * panel's Security Settings rows. Owns loading from the server,
  * dirty tracking against server values, env-locked detection,
  * preset application, and the `apply()` that persists changes.
+ *
+ * Consumers can hide individual toggles via `opts.excludeToggles`.
  *
  * Implements ConfigSection so it can be registered with the admin
  * panel's DraftChangesManager and participate in the unified
@@ -49,6 +53,10 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
   /** Resolves after the initial server fetch lands in `status`. */
   public readonly loaded: Promise<void>;
 
+  // Toggle definitions available / in use on this model instance.
+  // Omits any toggles that are excluded by `excludeToggles`
+  public readonly toggleDefs: ToggleDef[];
+
   // Last known server value for each toggle. Used for dirty tracking and
   // for `describeChange()` so the banner shows the new value, not the old.
   private _serverValues: Record<ToggleKey, Observable<boolean>> = {
@@ -59,11 +67,16 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
     telemetry: Observable.create<boolean>(this, false),
   };
 
+  private _toggleKeys: Set<ToggleKey>;
   private _installAPI: InstallAPI;
 
-  constructor(opts: { installAPI?: InstallAPI } = {}) {
+  constructor(opts: { installAPI?: InstallAPI; excludeToggles?: ToggleKey[] } = {}) {
     super();
     this._installAPI = opts.installAPI ?? new InstallAPIImpl(getHomeUrl());
+
+    const excluded = new Set(opts.excludeToggles ?? []);
+    this.toggleDefs = TOGGLE_DEFS.filter(d => !excluded.has(d.key));
+    this._toggleKeys = new Set(this.toggleDefs.map(d => d.key));
 
     this.loaded = this._load();
     this.loaded.catch(reportError);
@@ -71,7 +84,7 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
     this.isDirty = Computed.create(this, (use) => {
       const status = use(this.status);
       if (!status) { return false; }
-      return TOGGLE_DEFS.some(({ key }) => {
+      return this.toggleDefs.some(({ key }) => {
         if (this._isEnvLocked(status, key)) { return false; }
         return use(this.toggles[key]) !== use(this._serverValues[key]);
       });
@@ -79,7 +92,7 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
 
     this.describeChange = Computed.create(this, (use) => {
       const status = use(this.status);
-      const changed = TOGGLE_DEFS
+      const changed = this.toggleDefs
         .filter(({ key }) => !status || !this._isEnvLocked(status, key))
         .filter(({ key }) => use(this.toggles[key]) !== use(this._serverValues[key]))
         .map(({ key, label }) => `${label()}: ${use(this.toggles[key]) ? t("on") : t("off")}`);
@@ -90,6 +103,7 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
       const status = use(this.status);
       for (const [name, values] of PRESET_ENTRIES) {
         if (values.every(([k, v]) => {
+          if (!this._toggleKeys.has(k)) { return true; }
           if (status && this._isEnvLocked(status, k)) { return true; }
           return use(this.toggles[k]) === v;
         })) {
@@ -105,9 +119,24 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
     const status = this.status.get();
     for (const [toggleName, toggleValue] of Object.entries(PRESETS[preset])) {
       const key = toggleName as ToggleKey;
+      if (!this._toggleKeys.has(key)) { continue; }
       if (status && this._isEnvLocked(status, key)) { continue; }
       this.toggles[key].set(toggleValue);
     }
+  }
+
+  public hasEnvLocked(): boolean {
+    const status = this.status.get();
+    if (!status) { return false; }
+    return this.toggleDefs.some(({ permKey }) => status[permKey].source === "environment-variable");
+  }
+
+  public getEnvLockedVars(): string[] {
+    const status = this.status.get();
+    if (!status) { return []; }
+    return this.toggleDefs
+      .filter(({ permKey }) => status[permKey].source === "environment-variable")
+      .map(({ envVar }) => envVar);
   }
 
   public isEnvLocked(key: ToggleKey): boolean {
@@ -130,19 +159,25 @@ export class PermissionsToggleModel extends Disposable implements ConfigSection 
   // panel routes through DraftChangesManager, which only calls apply()
   // on dirty sections, so the unconditional write is harmless there.
   public async apply(): Promise<void> {
-    await this._installAPI.updateInstallPrefs({
+    const update: Partial<InstallPrefs> = {
       envVars: {
         GRIST_ORG_CREATION_ANYONE: String(this.toggles.teamSites.get()),
         GRIST_PERSONAL_ORGS: String(this.toggles.personalSites.get()),
         GRIST_FORCE_LOGIN: String(!this.toggles.anonAccess.get()),
         GRIST_ANON_PLAYGROUND: String(this.toggles.playground.get()),
       },
-      telemetry: {
+    };
+    if (this._toggleKeys.has("telemetry")) {
+      // Guarded so a consumer that excludes telemetry (e.g. the admin panel,
+      // which routes telemetry through SupportGristPage) doesn't clobber the
+      // user's existing telemetry choice with this model's hidden default.
+      update.telemetry = {
         telemetryLevel: this.toggles.telemetry.get() ? "limited" : "off",
-      },
-    });
+      };
+    }
+    await this._installAPI.updateInstallPrefs(update);
     if (this.isDisposed()) { return; }
-    for (const { key } of TOGGLE_DEFS) {
+    for (const { key } of this.toggleDefs) {
       this._serverValues[key].set(this.toggles[key].get());
     }
   }
@@ -238,13 +273,3 @@ No document contents are collected. Configurable anytime from the admin panel.")
 ];
 
 const TOGGLE_DEF_BY_KEY = new Map<ToggleKey, ToggleDef>(TOGGLE_DEFS.map(d => [d.key, d]));
-
-export function hasEnvLocked(status: PermissionsStatus): boolean {
-  return TOGGLE_DEFS.some(({ permKey }) => status[permKey].source === "environment-variable");
-}
-
-export function getEnvLockedVars(status: PermissionsStatus): string[] {
-  return TOGGLE_DEFS
-    .filter(({ permKey }) => status[permKey].source === "environment-variable")
-    .map(({ envVar }) => envVar);
-}

--- a/app/common/InstallAPI.ts
+++ b/app/common/InstallAPI.ts
@@ -38,6 +38,7 @@ export interface PermissionsStatus {
   personalOrgs: PermissionSetting;
   forceLogin: PermissionSetting;
   anonPlayground: PermissionSetting;
+  telemetry: PermissionSetting;
 }
 
 export interface InstallAPI {

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -27,13 +27,13 @@ import {
   invalidateReloadableSettings,
 } from "app/server/lib/gristSettings";
 import log from "app/server/lib/log";
-import { getTelemetryPrefs } from "app/server/lib/Telemetry";
 import {
   getScope,
   sendOkReply,
   sendReply,
   stringParam,
 } from "app/server/lib/requestUtils";
+import { getTelemetryPrefs } from "app/server/lib/Telemetry";
 import { updateGristServerLatestVersion } from "app/server/lib/updateChecker";
 
 import {

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -27,6 +27,7 @@ import {
   invalidateReloadableSettings,
 } from "app/server/lib/gristSettings";
 import log from "app/server/lib/log";
+import { getTelemetryPrefs } from "app/server/lib/Telemetry";
 import {
   getScope,
   sendOkReply,
@@ -144,11 +145,16 @@ export function attachEarlyEndpoints(options: AttachOptions) {
     expressWrap(async (_req, res) => {
       const toPrefSource = (s: "env" | "db" | undefined): PrefSource | undefined =>
         s === "env" ? "environment-variable" : s === "db" ? "preferences" : undefined;
+      const telemetryPrefs = await getTelemetryPrefs(gristServer.getHomeDBManager());
       const status: PermissionsStatus = {
         orgCreationAnyone: { value: getCanAnyoneCreateOrgs(), source: toPrefSource(getCanAnyoneCreateOrgsSource()) },
         personalOrgs: { value: getPersonalOrgsEnabled(), source: toPrefSource(getPersonalOrgsEnabledSource()) },
         forceLogin: { value: getForceLogin(), source: toPrefSource(getForceLoginSource()) },
         anonPlayground: { value: getAnonPlaygroundEnabled(), source: toPrefSource(getAnonPlaygroundEnabledSource()) },
+        telemetry: {
+          value: telemetryPrefs.telemetryLevel.value !== "off",
+          source: telemetryPrefs.telemetryLevel.source,
+        },
       };
       return sendOkReply(null, res, status);
     }),

--- a/test/nbrowser/AdminPanelPermissions.ts
+++ b/test/nbrowser/AdminPanelPermissions.ts
@@ -45,15 +45,16 @@ describe("AdminPanelPermissions", function() {
     );
   }
 
-  it("groups the four toggles under one Default-permissions row", async function() {
+  it("groups the toggles under one Default-permissions row", async function() {
     await driver.get(`${server.getHost()}/admin`);
     await gu.waitForAdminPanel();
     const item = await driver.findWait(".test-admin-panel-item-default-permissions", 3000);
     assert.equal(await item.isDisplayed(), true);
     // Status display should name a preset once loaded. With a clean DB
-    // and no env overrides, all four defaults are on → preset = Open.
-    // (The wizard applies "Recommended" on load; the admin panel shows
-    // the actual server state.)
+    // and no env overrides, the four permission defaults are on but
+    // telemetry defaults to off — so no preset matches exactly and the
+    // status reads "Custom". (The wizard applies "Recommended" on load;
+    // the admin panel shows the actual server state.)
     await gu.waitToPass(async () => {
       assert.match(await item.getText(), /\b(Open|Recommended|Locked down|Custom)\b/);
     }, 3000);
@@ -134,6 +135,44 @@ describe("AdminPanelPermissions", function() {
 
     delete process.env.GRIST_FORCE_LOGIN;
     await server.restart();
+  });
+
+  it("persists telemetry preference and reflects it without a restart", async function() {
+    session = await gu.session().personalSite.login();
+    installApi = session.createApi(InstallAPIImpl);
+
+    await driver.get(`${server.getHost()}/admin`);
+    await gu.waitForAdminPanel();
+    await expandPermissionsItem();
+
+    // Telemetry defaults to off; flip it on.
+    assert.isFalse(await isToggleChecked("telemetry"));
+    await driver.find(".test-permissions-setup-perm-telemetry label").click();
+    assert.isTrue(await isToggleChecked("telemetry"));
+
+    // Restart banner should show the telemetry change with its label.
+    const banner = await driver.findWait(".test-admin-panel-draft-changes", 2000);
+    await gu.waitToPass(async () => {
+      const text = await banner.getText();
+      assert.match(text, /Permissions/);
+      assert.match(text, /Share product telemetry/);
+    }, 3000);
+
+    // Apply via no-restart button — same DraftChangesManager path used above.
+    await driver.findWait(".test-admin-panel-apply-no-restart", 3000);
+    await gu.waitToPass(async () => {
+      await driver.find(".test-admin-panel-apply-no-restart").click();
+    }, 3000);
+    await gu.waitToPass(async () => {
+      assert.isFalse(await driver.find(".test-admin-panel-draft-changes").isPresent());
+    }, 5000);
+
+    // Telemetry reads through getTelemetryPrefs which queries the DB on
+    // every request, so the new value is reflected immediately — no
+    // server restart needed (unlike the env-var-backed toggles above).
+    const status = await installApi.getPermissionsStatus();
+    assert.equal(status.telemetry.value, true);
+    assert.equal(status.telemetry.source, "preferences");
   });
 
   async function isToggleChecked(permKey: string): Promise<boolean> {

--- a/test/nbrowser/AdminPanelPermissions.ts
+++ b/test/nbrowser/AdminPanelPermissions.ts
@@ -45,19 +45,29 @@ describe("AdminPanelPermissions", function() {
     );
   }
 
-  it("groups the toggles under one Default-permissions row", async function() {
+  it("groups the toggles under one Default-permissions row, omitting telemetry", async function() {
     await driver.get(`${server.getHost()}/admin`);
     await gu.waitForAdminPanel();
     const item = await driver.findWait(".test-admin-panel-item-default-permissions", 3000);
     assert.equal(await item.isDisplayed(), true);
     // Status display should name a preset once loaded. With a clean DB
-    // and no env overrides, the four permission defaults are on but
-    // telemetry defaults to off — so no preset matches exactly and the
-    // status reads "Custom". (The wizard applies "Recommended" on load;
-    // the admin panel shows the actual server state.)
+    // and no env overrides, the four permission defaults are on → preset
+    // = "Open". Telemetry is excluded from this card (it lives in the
+    // SupportGristPage instead) so its off-by-default state doesn't
+    // disqualify the Open match. (The wizard applies "Recommended" on
+    // load; the admin panel shows the actual server state.)
     await gu.waitToPass(async () => {
       assert.match(await item.getText(), /\b(Open|Recommended|Locked down|Custom)\b/);
     }, 3000);
+
+    // The telemetry toggle is excluded from the admin panel's card.
+    await expandPermissionsItem();
+    assert.isFalse(await driver.find(".test-permissions-setup-perm-telemetry").isPresent());
+    // The four permission toggles are still rendered.
+    assert.isTrue(await driver.find(".test-permissions-setup-perm-orgCreationAnyone").isPresent());
+    assert.isTrue(await driver.find(".test-permissions-setup-perm-personalOrgs").isPresent());
+    assert.isTrue(await driver.find(".test-permissions-setup-perm-forceLogin").isPresent());
+    assert.isTrue(await driver.find(".test-permissions-setup-perm-anonPlayground").isPresent());
   });
 
   it("flags a draft change and persists via apply-without-restart", async function() {
@@ -135,44 +145,6 @@ describe("AdminPanelPermissions", function() {
 
     delete process.env.GRIST_FORCE_LOGIN;
     await server.restart();
-  });
-
-  it("persists telemetry preference and reflects it without a restart", async function() {
-    session = await gu.session().personalSite.login();
-    installApi = session.createApi(InstallAPIImpl);
-
-    await driver.get(`${server.getHost()}/admin`);
-    await gu.waitForAdminPanel();
-    await expandPermissionsItem();
-
-    // Telemetry defaults to off; flip it on.
-    assert.isFalse(await isToggleChecked("telemetry"));
-    await driver.find(".test-permissions-setup-perm-telemetry label").click();
-    assert.isTrue(await isToggleChecked("telemetry"));
-
-    // Restart banner should show the telemetry change with its label.
-    const banner = await driver.findWait(".test-admin-panel-draft-changes", 2000);
-    await gu.waitToPass(async () => {
-      const text = await banner.getText();
-      assert.match(text, /Permissions/);
-      assert.match(text, /Share product telemetry/);
-    }, 3000);
-
-    // Apply via no-restart button — same DraftChangesManager path used above.
-    await driver.findWait(".test-admin-panel-apply-no-restart", 3000);
-    await gu.waitToPass(async () => {
-      await driver.find(".test-admin-panel-apply-no-restart").click();
-    }, 3000);
-    await gu.waitToPass(async () => {
-      assert.isFalse(await driver.find(".test-admin-panel-draft-changes").isPresent());
-    }, 5000);
-
-    // Telemetry reads through getTelemetryPrefs which queries the DB on
-    // every request, so the new value is reflected immediately — no
-    // server restart needed (unlike the env-var-backed toggles above).
-    const status = await installApi.getPermissionsStatus();
-    assert.equal(status.telemetry.value, true);
-    assert.equal(status.telemetry.source, "preferences");
   });
 
   async function isToggleChecked(permKey: string): Promise<boolean> {

--- a/test/nbrowser/QuickSetupApply.ts
+++ b/test/nbrowser/QuickSetupApply.ts
@@ -39,6 +39,7 @@ describe("QuickSetupApply", function() {
     assert.isTrue(await isToggleChecked("personalOrgs"));
     assert.isTrue(await isToggleChecked("forceLogin"));
     assert.isFalse(await isToggleChecked("anonPlayground"));
+    assert.isTrue(await isToggleChecked("telemetry"));
 
     // No env badges, env warning, or single-org warning should be visible.
     assert.isFalse(await driver.find(".test-permissions-setup-env-warning").isPresent());
@@ -51,6 +52,7 @@ describe("QuickSetupApply", function() {
     assert.isTrue(await isToggleChecked("personalOrgs"));
     assert.isTrue(await isToggleChecked("forceLogin"));
     assert.isTrue(await isToggleChecked("anonPlayground"));
+    assert.isTrue(await isToggleChecked("telemetry"));
 
     // Click "Locked down" preset — all toggles should be off.
     await driver.find(".test-permissions-setup-preset-locked").click();
@@ -58,6 +60,7 @@ describe("QuickSetupApply", function() {
     assert.isFalse(await isToggleChecked("personalOrgs"));
     assert.isFalse(await isToggleChecked("forceLogin"));
     assert.isFalse(await isToggleChecked("anonPlayground"));
+    assert.isFalse(await isToggleChecked("telemetry"));
   });
 
   it("should return defaults before any permissions are saved", async function() {
@@ -70,12 +73,18 @@ describe("QuickSetupApply", function() {
     assert.equal(status.forceLogin.source, undefined);
     assert.equal(status.anonPlayground.value, true);
     assert.equal(status.anonPlayground.source, undefined);
+    // Telemetry defaults to "off". getTelemetryPrefs reports source = "preferences"
+    // even when no value is persisted (no equivalent of the appSettings tri-state
+    // used by the other toggles).
+    assert.equal(status.telemetry.value, false);
+    assert.equal(status.telemetry.source, "preferences");
   });
 
   it("should report env-locked toggles via API and disable them in UI", async function() {
     // Set some vars via real environment and restart.
     process.env.GRIST_FORCE_LOGIN = "true";
     process.env.GRIST_ANON_PLAYGROUND = "false";
+    process.env.GRIST_TELEMETRY_LEVEL = "limited";
     await server.restart();
     session = await gu.session().personalSite.login();
 
@@ -85,6 +94,8 @@ describe("QuickSetupApply", function() {
     assert.equal(status.forceLogin.source, "environment-variable");
     assert.equal(status.anonPlayground.value, false);
     assert.equal(status.anonPlayground.source, "environment-variable");
+    assert.equal(status.telemetry.value, true);
+    assert.equal(status.telemetry.source, "environment-variable");
     // The others should still be defaults (no source).
     assert.equal(status.orgCreationAnyone.source, undefined);
     assert.equal(status.personalOrgs.source, undefined);
@@ -93,22 +104,30 @@ describe("QuickSetupApply", function() {
     await navigateToStep();
     assert.isTrue(await isToggleDisabled("forceLogin"));
     assert.isTrue(await isToggleDisabled("anonPlayground"));
+    assert.isTrue(await isToggleDisabled("telemetry"));
     assert.isFalse(await isToggleDisabled("orgCreationAnyone"));
     assert.isFalse(await isToggleDisabled("personalOrgs"));
 
     // Should show "Environment" badges on locked toggles only.
-    assert.lengthOf(await driver.findAll(".test-permissions-setup-env-badge"), 2);
+    assert.lengthOf(await driver.findAll(".test-permissions-setup-env-badge"), 3);
     assert.isTrue(await hasBadge("forceLogin"));
     assert.isTrue(await hasBadge("anonPlayground"));
+    assert.isTrue(await hasBadge("telemetry"));
     assert.isFalse(await hasBadge("orgCreationAnyone"));
     assert.isFalse(await hasBadge("personalOrgs"));
 
-    // Should show the env warning well.
-    assert.isTrue(await driver.find(".test-permissions-setup-env-warning").isPresent());
+    // Should show the env warning well naming each locked var.
+    const warning = await driver.find(".test-permissions-setup-env-warning");
+    assert.isTrue(await warning.isPresent());
+    const warningText = await warning.getText();
+    assert.include(warningText, "GRIST_FORCE_LOGIN");
+    assert.include(warningText, "GRIST_ANON_PLAYGROUND");
+    assert.include(warningText, "GRIST_TELEMETRY_LEVEL");
 
     // Restore env and restart for subsequent tests.
     delete process.env.GRIST_FORCE_LOGIN;
     delete process.env.GRIST_ANON_PLAYGROUND;
+    delete process.env.GRIST_TELEMETRY_LEVEL;
     await server.restart();
   });
 
@@ -128,11 +147,13 @@ describe("QuickSetupApply", function() {
     assert.isFalse(await hasConflictBadge("orgCreationAnyone"));
     assert.isFalse(await hasConflictBadge("forceLogin"));
     assert.isFalse(await hasConflictBadge("anonPlayground"));
+    assert.isFalse(await hasConflictBadge("telemetry"));
 
     // Other toggles should remain normal (not disabled, no badges).
     assert.isFalse(await isToggleDisabled("orgCreationAnyone"));
     assert.isFalse(await isToggleDisabled("forceLogin"));
     assert.isFalse(await isToggleDisabled("anonPlayground"));
+    assert.isFalse(await isToggleDisabled("telemetry"));
     assert.lengthOf(await driver.findAll(".test-permissions-setup-env-badge"), 0);
 
     // Single-org warning should explain the conflict.
@@ -165,6 +186,7 @@ describe("QuickSetupApply", function() {
     assert.isFalse(await hasConflictBadge("orgCreationAnyone"));
     assert.isFalse(await hasConflictBadge("forceLogin"));
     assert.isFalse(await hasConflictBadge("anonPlayground"));
+    assert.isFalse(await hasConflictBadge("telemetry"));
 
     // No env badges.
     assert.lengthOf(await driver.findAll(".test-permissions-setup-env-badge"), 0);
@@ -175,6 +197,7 @@ describe("QuickSetupApply", function() {
     assert.isFalse(await isToggleDisabled("personalOrgs"));
     assert.isFalse(await isToggleDisabled("forceLogin"));
     assert.isFalse(await isToggleDisabled("anonPlayground"));
+    assert.isFalse(await isToggleDisabled("telemetry"));
 
     // Recommended preset should still be active.
     assert.isTrue(await isPresetActive("recommended"));
@@ -192,6 +215,9 @@ describe("QuickSetupApply", function() {
     assert.isUndefined(before.personalOrgs.source);
     assert.isUndefined(before.forceLogin.source);
     assert.isUndefined(before.anonPlayground.source);
+    // Telemetry source is always "preferences" before env override (see test 2).
+    assert.equal(before.telemetry.value, false);
+    assert.equal(before.telemetry.source, "preferences");
 
     await navigateToStep();
 
@@ -222,6 +248,9 @@ describe("QuickSetupApply", function() {
     assert.equal(status.forceLogin.source, "preferences");
     assert.equal(status.anonPlayground.value, true);
     assert.equal(status.anonPlayground.source, "preferences");
+    // Open preset enabled telemetry → level "limited" persisted.
+    assert.equal(status.telemetry.value, true);
+    assert.equal(status.telemetry.source, "preferences");
   });
 
   async function navigateToStep() {


### PR DESCRIPTION
## Context

Currently, a user has to enter the admin panel or manually set an environment variable to enable telemetry. Hiding the option makes it less likely that it will be possible to gather useful telemetry.

## Proposed solution

This adds a telemetry toggle to the quick setup flow, giving the user the option when they're first setting up their Grist installation.

## Has this been tested?

- [X] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<img width="391" height="514" alt="image" src="https://github.com/user-attachments/assets/740c36d6-b351-4981-97de-03e1c210a695" />

