### PR TITLE
Remove old "reachable" self-check and fix redirect when personal orgs are disabled

### DIFF
--- a/app/client/models/AdminChecks.ts
+++ b/app/client/models/AdminChecks.ts
@@ -193,10 +193,6 @@ from the network."),
     info: t("It is good practice not to run Grist as the root user."),
   },
 
-  "reachable": {
-    info: t("The main page of Grist should be available."),
-  },
-
   "home-url": {
     info: t("APP_HOME_URL is the base URL where users and integrations reach \
 this Grist server. Auth callbacks, API links, and email notifications \

--- a/app/common/BootProbe.ts
+++ b/app/common/BootProbe.ts
@@ -24,7 +24,6 @@ export type BootProbeIds =
   "boot-key" |
   "health-check" |
   "home-url" |
-  "reachable" |
   "host-header" |
   "sandboxing" |
   "system-user" |

--- a/app/server/lib/BootProbes.ts
+++ b/app/server/lib/BootProbes.ts
@@ -70,7 +70,6 @@ export class BootProbes {
   }
 
   private _addProbes() {
-    this._probes.push(_homeUrlReachableProbe);
     this._probes.push(_homeUrlProbe);
     this._probes.push(_statusCheckProbe);
     this._probes.push(_userProbe);
@@ -114,36 +113,6 @@ const _admins: Probe = {
       return {
         status: "fault",
         details: { error: String(e) },
-      };
-    }
-  },
-};
-
-const _homeUrlReachableProbe: Probe = {
-  id: "reachable",
-  name: "Is home page available at expected URL",
-  apply: async (server, req) => {
-    const url = server.getHomeInternalUrl();
-    const details: Record<string, any> = {
-      url,
-    };
-    try {
-      const resp = await fetch(url);
-      details.status = resp.status;
-      if (resp.status !== 200) {
-        throw new ApiError(await resp.text(), resp.status);
-      }
-      return {
-        status: "success",
-        details,
-      };
-    } catch (e) {
-      return {
-        details: {
-          ...details,
-          error: String(e),
-        },
-        status: "fault",
       };
     }
   },

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -4,7 +4,7 @@ import { delay } from "app/common/delay";
 import { encodeUrl, getSlugIfNeeded, GristDeploymentType, GristDeploymentTypes,
   GristLoadConfig, IGristUrlState, isOrgInPathOnly, LatestVersionAvailable, parseSubdomain,
   sanitizePathTail } from "app/common/gristUrls";
-import { extractOrgParts, getOrgUrlInfo } from "app/common/gristUrls";
+import { extractOrgParts, getOrgUrlInfo, getSingleOrg } from "app/common/gristUrls";
 import { isAffirmative } from "app/common/gutil";
 import { UserProfile } from "app/common/LoginSessionAPI";
 import { SandboxInfo } from "app/common/SandboxInfo";
@@ -58,7 +58,8 @@ import { createGristJobs, GristJobs } from "app/server/lib/GristJobs";
 import { DocTemplate, GristLoginMiddleware, GristLoginSystem, GristServer, RequestWithGrist,
   ResourceUrlOptions } from "app/server/lib/GristServer";
 import { initGristSessions, SessionStore } from "app/server/lib/gristSessions";
-import { getBootKey, getForceLogin, getHomeUrl, getInService } from "app/server/lib/gristSettings";
+import { getBootKey, getForceLogin, getHomeUrl, getInService,
+  getPersonalOrgsEnabled } from "app/server/lib/gristSettings";
 import { IAssistant } from "app/server/lib/IAssistant";
 import { IAuditLogger } from "app/server/lib/IAuditLogger";
 import { IBilling } from "app/server/lib/IBilling";
@@ -2516,6 +2517,13 @@ export class FlexServer implements GristServer {
     const mreq = req as RequestWithLogin;
     if (mreq.org || !mreq.userId) { return next(); }
 
+    // When personal orgs are disabled, the personal/merged org is unreachable. Redirect to
+    // /welcome/start instead, which forces login when unauthenticated and sends signed-in
+    // users to a team site or /welcome/teams.
+    if (!getPersonalOrgsEnabled()) {
+      return resp.redirect(getOrgUrl(mreq, "/welcome/start"));
+    }
+
     // Redirect anonymous users to the merged org.
     if (!mreq.userIsAuthorized) {
       const redirectUrl = this.getMergedOrgUrl(mreq);
@@ -2709,7 +2717,7 @@ export class FlexServer implements GristServer {
     const orgs = this._dbManager.unwrapQueryResult(
       await this._dbManager.getOrgs(getScope(mreq), { ignoreEveryoneShares: true }),
     );
-    if (orgs.length > 1) {
+    if (orgs.length > 1 || (!getPersonalOrgsEnabled() && !getSingleOrg())) {
       resp.redirect(getOrgUrl(mreq, "/welcome/teams"));
     } else {
       resp.redirect(redirectToMergedOrg ? this.getMergedOrgUrl(mreq) : getOrgUrl(mreq));

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -2510,8 +2510,11 @@ export class FlexServer implements GristServer {
   }
 
   /**
-   * Middleware that redirects a request with a userId but without an org to an org-specific URL,
-   * after looking up the first org for this userId in DB.
+   * Middleware for org-less requests with a userId. Redirects to an org-specific URL so the rest
+   * of the app has an org to work with.
+   *
+   * When personal orgs are disabled, redirects to /welcome/start. Otherwise, redirects to the
+   * personal org.
    */
   private async _redirectToOrg(req: express.Request, resp: express.Response, next: express.NextFunction) {
     const mreq = req as RequestWithLogin;
@@ -2534,6 +2537,10 @@ export class FlexServer implements GristServer {
     // We have a userId, but the request is for an unknown org. Redirect to an org that's
     // available to the user. This matters in dev, and in prod when visiting a generic URL, which
     // will here redirect to e.g. the user's personal org.
+    //
+    // TODO: This appears to always redirect to the personal org (getMergedOrgs always adds the
+    // merged org to the front of the returned orgs). Check if it's safe to replace this with the
+    // branch above.
     const result = await this._dbManager.getMergedOrgs({ userId: mreq.userId });
     const orgs = (result.status === 200) ? result.data : null;
     const subdomain = orgs && orgs.length > 0 ? orgs[0].domain : null;

--- a/test/nbrowser/AdminPanel.ts
+++ b/test/nbrowser/AdminPanel.ts
@@ -244,13 +244,6 @@ describe("AdminPanel", function() {
   it("should show various self checks", async function() {
     await driver.get(`${server.getHost()}/admin`);
     await gu.waitForAdminPanel();
-    await gu.waitToPass(
-      async () => {
-        assert.equal(await driver.find(".test-admin-panel-item-name-probe-reachable").isDisplayed(), true);
-        assert.match(await driver.find(".test-admin-panel-item-value-probe-reachable").getText(), /✅/);
-      },
-      3000,
-    );
     assert.equal(await driver.find(".test-admin-panel-item-name-probe-system-user").isDisplayed(), true);
     await gu.waitToPass(
       async () => assert.match(await driver.find(".test-admin-panel-item-value-probe-system-user").getText(), /✅/),
@@ -491,7 +484,7 @@ describe("AdminPanel", function() {
 
     it("should show admin page when boot key is valid", async function() {
       await driver.get(`${server.getHost()}/admin?boot-key=lala`);
-      await driver.findContentWait("div", /Is home page available/, 2000);
+      await driver.findContentWait("div", /Is an internal health check passing/, 2000);
     });
   });
 });

--- a/test/nbrowser/BootPage.ts
+++ b/test/nbrowser/BootPage.ts
@@ -296,7 +296,7 @@ describe("BootPage", function() {
     it("allows access to /admin with boot-key param", async function() {
       await driver.get(`${server.getHost()}/admin?boot-key=${bootKey}`);
       await gu.waitForAdminPanel();
-      await driver.findContentWait("div", /Is home page available/, 2000);
+      await driver.findContentWait("div", /Is an internal health check passing/, 2000);
     });
 
     it("can restore service via Admin Panel", async function() {

--- a/test/server/lib/RedirectToOrg.ts
+++ b/test/server/lib/RedirectToOrg.ts
@@ -1,0 +1,115 @@
+import { getCanAnyoneCreateOrgs, getPersonalOrgsEnabled } from "app/server/lib/gristSettings";
+import { TestServer } from "test/gen-server/apiUtils";
+import * as testUtils from "test/server/testUtils";
+
+import { assert } from "chai";
+import fetch from "node-fetch";
+
+/**
+ * Exercises the root-path ("/") redirect performed by FlexServer._redirectToOrg, and the
+ * follow-on routing done by _redirectToHomeOrWelcomePage at /welcome/start.
+ *
+ * The key scenario: when personal orgs are disabled (GRIST_PERSONAL_ORGS=false), visitors must NOT
+ * be sent to the personal/merged org (/o/docs), which would render a "Personal orgs are
+ * disabled" error. Instead they go through /welcome/start, which forces login when unauthenticated
+ * and routes signed-in users to a team site or /welcome/teams.
+ */
+describe("RedirectToOrg", function() {
+  testUtils.setTmpLogLevel("error");
+
+  // node-fetch with redirect: "manual" exposes the 3xx status and Location header without following.
+  async function getRedirect(url: string, cookie?: string) {
+    const resp = await fetch(url, {
+      redirect: "manual",
+      headers: cookie ? { Cookie: cookie } : {},
+    });
+    return { status: resp.status, location: resp.headers.get("location") || "" };
+  }
+
+  // Establish a logged-in session for the given user, and return its Cookie header.
+  async function cookieFor(server: TestServer, email: string, name: string) {
+    const login = await server.getCookieLogin("docs", { email, name });
+    return login.headers.Cookie;
+  }
+
+  const setupTestServer = (env: Record<string, string>) => {
+    let serverUrl: string;
+    let oldEnv: testUtils.EnvironmentSnapshot;
+    let server: TestServer;
+
+    beforeEach(async function() {
+      oldEnv = new testUtils.EnvironmentSnapshot();
+      Object.assign(process.env, env);
+      // These settings are memoized; clear the caches so the new env values take effect.
+      getPersonalOrgsEnabled.cache.clear();
+      getCanAnyoneCreateOrgs.cache.clear();
+      server = new TestServer(this);
+      serverUrl = await server.start();
+    });
+
+    afterEach(async function() {
+      oldEnv.restore();
+      getPersonalOrgsEnabled.cache.clear();
+      getCanAnyoneCreateOrgs.cache.clear();
+      await server.stop();
+    });
+
+    return {
+      url: () => serverUrl,
+      server: () => server,
+    };
+  };
+
+  describe("with personal orgs disabled (org-in-path)", function() {
+    const ctx = setupTestServer({ GRIST_PERSONAL_ORGS: "false", GRIST_ORG_IN_PATH: "true" });
+
+    it("redirects anonymous / to /welcome/start (not the disabled personal org)", async function() {
+      const { status, location } = await getRedirect(`${ctx.url()}/`);
+      assert.equal(status, 302);
+      assert.match(location, /\/welcome\/start$/);
+      assert.notInclude(location, "/o/docs");
+    });
+
+    it("redirects signed-in / to /welcome/start", async function() {
+      const cookie = await cookieFor(ctx.server(), "chimpy@getgrist.com", "Chimpy");
+      const { status, location } = await getRedirect(`${ctx.url()}/`, cookie);
+      assert.equal(status, 302);
+      assert.match(location, /\/welcome\/start$/);
+      assert.notInclude(location, "/o/docs");
+    });
+
+    it("routes a signed-in user with no team site from /welcome/start to /welcome/teams " +
+      "(no loop back to /)", async function() {
+      // Ham only owns a personal org. Without the fix, the fallback would send Ham to the disabled
+      // personal org, which redirects back to "/" and loops.
+      const cookie = await cookieFor(ctx.server(), "ham@getgrist.com", "Ham");
+      const { status, location } = await getRedirect(`${ctx.url()}/welcome/start`, cookie);
+      assert.equal(status, 302);
+      assert.match(location, /\/welcome\/teams$/);
+      assert.notInclude(location, "/o/docs");
+    });
+  });
+
+  describe("with personal orgs enabled (org-in-path)", function() {
+    const ctx = setupTestServer({ GRIST_PERSONAL_ORGS: "true", GRIST_ORG_IN_PATH: "true" });
+
+    it("still redirects anonymous / to the merged org", async function() {
+      const { status, location } = await getRedirect(`${ctx.url()}/`);
+      assert.equal(status, 302);
+      assert.match(location, /\/o\/docs\//);
+      assert.notInclude(location, "/welcome/start");
+    });
+  });
+
+  describe("single-org mode with personal orgs disabled", function() {
+    const ctx = setupTestServer({ GRIST_SINGLE_ORG: "docs", GRIST_PERSONAL_ORGS: "false" });
+
+    it("does not reroute / to /welcome/start (single org is pinned)", async function() {
+      // In single-org mode the org is always set, so _redirectToOrg returns early and the app
+      // page renders normally rather than rerouting to the welcome flow.
+      const { status, location } = await getRedirect(`${ctx.url()}/`);
+      assert.equal(status, 200);
+      assert.notInclude(location, "/welcome/start");
+    });
+  });
+});

--- a/test/server/lib/RedirectToOrg.ts
+++ b/test/server/lib/RedirectToOrg.ts
@@ -27,8 +27,8 @@ describe("RedirectToOrg", function() {
   }
 
   // Establish a logged-in session for the given user, and return its Cookie header.
-  async function cookieFor(server: TestServer, email: string, name: string) {
-    const login = await server.getCookieLogin("docs", { email, name });
+  async function cookieFor(server: TestServer, email: string, name: string, org: string = "docs") {
+    const login = await server.getCookieLogin(org, { email, name });
     return login.headers.Cookie;
   }
 
@@ -102,12 +102,11 @@ describe("RedirectToOrg", function() {
   });
 
   describe("single-org mode with personal orgs disabled", function() {
-    const ctx = setupTestServer({ GRIST_SINGLE_ORG: "docs", GRIST_PERSONAL_ORGS: "false" });
+    const ctx = setupTestServer({ GRIST_SINGLE_ORG: "nasa", GRIST_PERSONAL_ORGS: "false" });
 
     it("does not reroute / to /welcome/start (single org is pinned)", async function() {
-      // In single-org mode the org is always set, so _redirectToOrg returns early and the app
-      // page renders normally rather than rerouting to the welcome flow.
-      const { status, location } = await getRedirect(`${ctx.url()}/`);
+      const cookie = await cookieFor(ctx.server(), "chimpy@getgrist.com", "Chimpy", "nasa");
+      const { status, location } = await getRedirect(`${ctx.url()}/`, cookie);
       assert.equal(status, 200);
       assert.notInclude(location, "/welcome/start");
     });


### PR DESCRIPTION
## Context

This addresses two unrelated issues:

1. Removes the old "reachable" boot probe:
   The `reachable` self-check did a plain fetch of the internal home URL and
   reported a "fault" on any non-200 response. When anonymous access is disabled
   the home page redirects to login (a non-200), so the probe reported a false
   failure.

2. Fixes the redirect on "/" when personal orgs are disabled:
   On installs where personal orgs are disabled via GRIST_PERSONAL_ORGS, visiting
   "/" landed the visitor on the personal/merged org (/o/docs), which renders
   a "Personal orgs are disabled" error. The sign-in buttons there use the current
   URL (/o/docs) as the post-login target, so after logging in the user was redirected
   right back to the same error page.

## Proposed solution

1. The "reachable" boot probe is redundant with the `health-check` probe (which hits /status),
   so remove it entirely.

2. Visits to "/" when personal sites are disabled now redirect to /welcome/start instead, which
   forces login when unauthenticated and sends signed-in users to a team site or /welcome/teams,
   never landing on the disabled personal site. An additional guard in _redirectToHomeOrWelcomePage
   prevents a signed-in user with no team site from endlessly looping on "/".

   Single-org installs (GRIST_SINGLE_ORG) are unaffected.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->