### PR TITLE
Allow widgets to share instance location origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,6 @@ Grist can be configured in many ways. Here are the main environment variables it
 | GRIST_OPEN_GRAPH_PREVIEW_IMAGE | the URL of the preview image when sharing the link on websites like social medias or chat applications. |
 | GRIST_TELEMETRY_LEVEL | the telemetry level. Can be set to: `off` (default), `limited`, or `full`. |
 | GRIST_THROTTLE_CPU | if set, CPU throttling is enabled |
-| GRIST_TRUST_PLUGINS | if set, plugins are expect to be served from the same host as the rest of the Grist app, rather than from a distinct host. Ordinarily, plugins are served from a distinct host so that the cookies used by the Grist app are not automatically available to them. Enable this only if you understand the security implications. |
 | GRIST_USER_ROOT | an extra path to look for plugins in - Grist will scan for plugins in `$GRIST_USER_ROOT/plugins`. |
 | GRIST_UI_FEATURES | comma-separated list of UI features to enable. Allowed names of parts: `helpCenter`, `billing`, `templates`, `createSite`, `multiSite`, `multiAccounts`, `importFromAirtable`, `sendToDrive`, `tutorials`, `supportGrist`, `themes`, `automations`. If a part also exists in GRIST_HIDE_UI_ELEMENTS, it won't be enabled. Note: `importFromAirtable` and `automations` are enabled by default even without being listed here; use GRIST_HIDE_UI_ELEMENTS to disable them. |
 | GRIST_UNTRUSTED_PORT | if set, plugins will be served from the given port. This is an alternative to setting APP_UNTRUSTED_URL. |

--- a/app/client/components/WidgetFrame.ts
+++ b/app/client/components/WidgetFrame.ts
@@ -112,6 +112,11 @@ export class WidgetFrame extends DisposableWithEvents {
 
   private _url: Observable<string>;
   /**
+   * Value for the iframe "sandbox" attribute, or null when the iframe should not be sandboxed.
+   * Used to isolate same-origin widgets from Grist's session (see _sandboxAttrFor).
+   */
+  private _sandbox: Observable<string | null>;
+  /**
    * If the widget URL is empty, it also means that we are showing the empty page.
    */
   private _isEmpty: Observable<boolean>;
@@ -148,9 +153,17 @@ export class WidgetFrame extends DisposableWithEvents {
     const maybeUrl = Computed.create(this, use => use(this._widget)?.url || this._options.url);
 
     // Url to widget or empty page with access level and preferences.
-    this._url = Computed.create(this, this._widget, maybeUrl, (use, widget, url) => {
+    this._url = Computed.create(
+      this,
+      use => this._urlWithAccess(use(maybeUrl)) || this._getEmptyWidgetPage(),
+    );
+
+    // Decide whether the iframe needs to be sandboxed. Untrusted (non-plugin/bundled) widgets
+    // whose URL is within Grist's own site get an opaque origin so they can't share Grist's
+    // session (see _sandboxAttrFor and widgetUrlSharesGristSession).
+    this._sandbox = Computed.create(this, this._widget, maybeUrl, (use, widget, url) => {
       const fromPlugin = Boolean(widget?.url && widget.source?.pluginId);
-      return this._urlWithAccess(url, fromPlugin) || this._getEmptyWidgetPage();
+      return this._sandboxAttrFor(url, fromPlugin);
     });
 
     // Iframe is empty when url is not set.
@@ -222,6 +235,9 @@ export class WidgetFrame extends DisposableWithEvents {
       dom.style("visibility", use => use(this._visible) ? "visible" : "hidden"),
       dom.cls("clipboard_allow_focus"),
       dom.cls("custom_view"),
+      // Sandbox same-origin widgets so they get an opaque origin and can't share Grist's session.
+      // This is bound before "src" so the attribute is in place before the iframe navigates.
+      dom.attr("sandbox", this._sandbox),
       dom.attr("src", this._url),
       // Allow widgets to write to the clipboard via the Clipboard API.
       { allow: "clipboard-write" },
@@ -233,7 +249,7 @@ export class WidgetFrame extends DisposableWithEvents {
   }
 
   // Appends access level to query string.
-  private _urlWithAccess(url: string | null, fromPlugin: boolean): string | null {
+  private _urlWithAccess(url: string | null): string | null {
     if (!url) {
       return url;
     }
@@ -245,18 +261,40 @@ export class WidgetFrame extends DisposableWithEvents {
       console.error(e);
       return null;
     }
-    // Untrusted (non-plugin/bundled) widget URLs must not point into Grist's own site, so that a
-    // page XSS can't be weaponized and shared via a widget URL (see disallowCustomWidgetUrl).
-    if (!fromPlugin && disallowCustomWidgetUrl(urlObj)) {
-      console.warn(`WidgetFrame: refusing custom widget URL within Grist's own site: ${url}`);
-      return null;
-    }
     urlObj.searchParams.append("access", this._options.access);
     urlObj.searchParams.append("readonly", String(this._options.readonly));
     // Append user and document preferences to query string.
     const settingsParams = new URLSearchParams(this._options.preferences);
     settingsParams.forEach((value, key) => urlObj.searchParams.append(key, value));
     return sanitizeHttpUrl(urlObj.href);
+  }
+
+  /**
+   * Returns the value for the iframe "sandbox" attribute, or null if the iframe should not be
+   * sandboxed.
+   *
+   * Untrusted (non-plugin/bundled) widgets whose URL points into Grist's own site are loaded in a
+   * sandbox WITHOUT "allow-same-origin". This gives them an opaque origin, so even though the URL
+   * is on Grist's site, the widget cannot read Grist's cookies, localStorage, or make credentialed
+   * same-origin requests - i.e. it does not share the user's session. This lets such widgets (e.g.
+   * public forms) be embedded while neutralizing the risk that a page XSS gets weaponized and
+   * shared via a widget URL (the original motivation of commit f579977c8).
+   *
+   * Cross-origin widgets are already isolated by the browser's same-origin policy, and trusted
+   * plugin/bundled widgets are exempt, so neither is sandboxed (which avoids breaking widgets that
+   * rely on their own origin's storage).
+   */
+  private _sandboxAttrFor(url: string | null, fromPlugin: boolean): string | null {
+    if (!url || fromPlugin) {
+      return null;
+    }
+    let urlObj: URL;
+    try {
+      urlObj = new URL(url);
+    } catch (e) {
+      return null;
+    }
+    return widgetUrlSharesGristSession(urlObj) ? WIDGET_SANDBOX_ISOLATED : null;
   }
 
   private _getEmptyWidgetPage(): string {
@@ -894,19 +932,30 @@ function reencodeAsAny(value: CellValue, typeInfo: GristTypeInfo): CellValue {
 }
 
 /**
+ * Sandbox flags for same-origin widgets. Notably this does NOT include "allow-same-origin", which
+ * is what forces an opaque origin and isolates the widget from Grist's session. "allow-scripts"
+ * is safe to grant without "allow-same-origin": the combination of the two would let a same-origin
+ * frame remove its own sandbox attribute and escape, but on its own it cannot.
+ */
+const WIDGET_SANDBOX_ISOLATED =
+  "allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-downloads allow-modals";
+
+/**
  * Custom widgets are intended to be served cross-origin; return true if this URL is not, i.e. it
- * points back into Grist's own site.
+ * points back into Grist's own site and would therefore share Grist's session (cookies, storage,
+ * credentialed same-origin requests) if loaded without isolation.
  *
- * It's safer to disallow such widgets so that custom widget URLs don't become a vector to exploit
- * XSS. In other words, if there is an XSS vulnerability where a Grist page can be tricked to run
- * untrusted JS, we don't want to make such an attack sharable via a custom widget URL, where it
- * could affect all collaborators.
+ * Such widgets are not refused (that would break legitimate use cases like embedding public forms),
+ * but are loaded in a sandboxed iframe with an opaque origin (see _sandboxAttrFor). This keeps
+ * custom widget URLs from becoming a vector to exploit XSS: if there is an XSS vulnerability where
+ * a Grist page can be tricked to run untrusted JS, we don't want such an attack to gain access to
+ * the viewer's session just by being shared via a custom widget URL.
  *
  * "Grist's own site" is the page's own origin, plus, when orgs are subdomains, any host under
  * gristConfig.baseDomain (sibling subdomains, which can share Grist's session). baseDomain is
  * dotted (".example.com") in that case, and a bare host or empty otherwise.
  */
-export function disallowCustomWidgetUrl(widgetUrl: URL): boolean {
+export function widgetUrlSharesGristSession(widgetUrl: URL): boolean {
   // This check could be bypassed by a trailing period (e.g. "example.com." vs "example.com"), but
   // that's not actually considered same-origin, so should not be exploitable.
   if (widgetUrl.origin === location.origin) {

--- a/app/client/components/WidgetFrame.ts
+++ b/app/client/components/WidgetFrame.ts
@@ -162,8 +162,7 @@ export class WidgetFrame extends DisposableWithEvents {
     // whose URL is within Grist's own site get an opaque origin so they can't share Grist's
     // session (see _sandboxAttrFor and widgetUrlSharesGristSession).
     this._sandbox = Computed.create(this, this._widget, maybeUrl, (use, widget, url) => {
-      const fromPlugin = Boolean(widget?.url && widget.source?.pluginId);
-      return this._sandboxAttrFor(url, fromPlugin);
+      return this._sandboxAttrFor(url);
     });
 
     // Iframe is empty when url is not set.
@@ -284,8 +283,8 @@ export class WidgetFrame extends DisposableWithEvents {
    * plugin/bundled widgets are exempt, so neither is sandboxed (which avoids breaking widgets that
    * rely on their own origin's storage).
    */
-  private _sandboxAttrFor(url: string | null, fromPlugin: boolean): string | null {
-    if (!url || fromPlugin) {
+  private _sandboxAttrFor(url: string | null): string | null {
+    if (!url) {
       return null;
     }
     let urlObj: URL;

--- a/app/client/lib/localization.ts
+++ b/app/client/lib/localization.ts
@@ -64,10 +64,20 @@ export async function setupLocale() {
   }
 }
 
+function extractLangFromCookie() {
+  try {
+    return document.cookie.match(/grist_user_locale=([^;]+)/)?.[1];
+  } catch (e) {
+    // If an exception occurred, that's because the cookie access is denied, and most probably
+    // because we are in a sandbox'ed iframe.
+    return undefined;
+  }
+}
+
 export function detectCurrentLang() {
   const { userLocale, supportedLngs } = getGristConfig();
   const detected = userLocale ||
-    document.cookie.match(/grist_user_locale=([^;]+)/)?.[1] ||
+    extractLangFromCookie() ||
     window.navigator.language ||
     "en";
   const supportedList = supportedLngs ?? ["en"];

--- a/app/client/ui/FormAPI.ts
+++ b/app/client/ui/FormAPI.ts
@@ -142,7 +142,13 @@ type CreateAttachmentOptions = CreateAttachmentCommonOptions & FormTarget;
 
 export class FormAPIImpl extends BaseAPI implements FormAPI {
   constructor(private _homeUrl: string, options: IOptions = {}) {
-    super(options);
+    // Use "same-origin" credentials so that forms work when embedded as a same-origin custom
+    // widget: such widgets are sandboxed into an opaque origin (see WidgetFrame), which makes the
+    // form's API requests cross-origin. A credentialed cross-origin request would be blocked by
+    // CORS, and isn't needed - public form submission is authorized by the share key, not the
+    // user's session. When the form is loaded normally (its own page on Grist's origin), the
+    // requests are same-origin and cookies are still sent.
+    super({ credentials: "same-origin", ...options });
   }
 
   public async getForm(options: GetFormOptions): Promise<Form> {

--- a/app/common/BaseAPI.ts
+++ b/app/common/BaseAPI.ts
@@ -8,6 +8,11 @@ export interface IOptions {
   fetch?: typeof fetch;
   newFormData?: () => FormData;  // constructor for FormData depends on platform.
   extraParameters?: Map<string, string>;  // if set, add query parameters to requests.
+  // Credentials mode for requests. Defaults to "include" (send cookies even cross-origin). Use
+  // "same-origin" for APIs that may be called from a sandboxed/opaque origin (e.g. public forms
+  // embedded as same-origin widgets), where a credentialed cross-origin request would be blocked
+  // by CORS and isn't needed anyway.
+  credentials?: RequestCredentials;
 }
 
 /**
@@ -53,10 +58,12 @@ export class BaseAPI {
   protected newFormData: () => FormData;
   private _headers: Record<string, string>;
   private _extraParameters?: Map<string, string>;
+  private _credentials: RequestCredentials;
 
   constructor(public readonly options: IOptions = {}) {
     this.fetch = options.fetch || tbind(window.fetch, window);
     this.newFormData = options.newFormData || (() => new FormData());
+    this._credentials = options.credentials || "include";
     this._headers = {
       "Content-Type": "application/json",
       "X-Requested-With": "XMLHttpRequest",
@@ -141,7 +148,7 @@ export class BaseAPI {
   }
 
   private async _doRequest(input: string, init: RequestInit): Promise<Response> {
-    init = Object.assign({ headers: this._headers, credentials: "include" }, init);
+    init = Object.assign({ headers: this._headers, credentials: this._credentials }, init);
     if (this._extraParameters) {
       const url = new URL(input);
       for (const [key, val] of this._extraParameters.entries()) {

--- a/app/common/gristUrls.ts
+++ b/app/common/gristUrls.ts
@@ -297,15 +297,8 @@ function isOwnInternalUrlHost(host?: string) {
  * as a custom domain, a native domain, or a plugin domain.
  */
 export function getHostType(host: string, options: {
-  baseDomain?: string, pluginUrl?: string
-}): "native" | "custom" | "plugin" {
-  if (options.pluginUrl) {
-    const url = new URL(options.pluginUrl);
-    if (url.host.toLowerCase() === host.toLowerCase()) {
-      return "plugin";
-    }
-  }
-
+  baseDomain?: string
+}): "native" | "custom" {
   const hostname = host.split(":")[0];
   if (!options.baseDomain) { return "native"; }
   if (
@@ -326,11 +319,9 @@ export function getOrgUrlInfo(newOrg: string, currentHost: string, options: OrgU
     return { orgInPath: newOrg };
   }
   const hostType = getHostType(currentHost, options);
-  if (hostType !== "plugin") {
-    const hostname = currentHost.split(":")[0];
-    if (!options.baseDomain || hostname === "localhost") {
-      return { orgInPath: newOrg };
-    }
+  const hostname = currentHost.split(":")[0];
+  if (!options.baseDomain || hostname === "localhost") {
+    return { orgInPath: newOrg };
   }
   if (newOrg === options.org && hostType !== "native") {
     return {};

--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -926,7 +926,7 @@ export class FlexServer implements GristServer {
   // Prepare cache for managing org-to-host relationship.
   public addHosts() {
     if (this._check("hosts", "homedb")) { return; }
-    this._hosts = new Hosts(this._defaultBaseDomain, this._dbManager, this);
+    this._hosts = new Hosts(this._defaultBaseDomain, this._dbManager);
   }
 
   /**
@@ -1966,22 +1966,7 @@ export class FlexServer implements GristServer {
   }
 
   public async finalizePlugins(userPort: number | null) {
-    if (isAffirmative(process.env.GRIST_TRUST_PLUGINS)) {
-      this._pluginUrl = this.getDefaultHomeUrl();
-    } else if (userPort !== null) {
-      // If plugin content is served from same host but on different port,
-      // run webserver on that port
-      const ports = await this.startCopy("pluginServer", userPort);
-      // If Grist is running on a desktop, directly on the host, it
-      // can be convenient to leave the user port free for the OS to
-      // allocate by using GRIST_UNTRUSTED_PORT=0. But we do need to
-      // remember how to contact it.
-      if (process.env.APP_UNTRUSTED_URL === undefined) {
-        const url = new URL(this.getOwnUrl());
-        url.port = String(userPort || ports.serverPort);
-        this._pluginUrl = url.href;
-      }
-    }
+    this._pluginUrl = this.getDefaultHomeUrl();
     this.info.push(["pluginUrl", this._pluginUrl]);
     this.info.push(["willServePlugins", this._servesPlugins]);
     this._pluginUrlReady = true;

--- a/app/server/lib/extractOrg.ts
+++ b/app/server/lib/extractOrg.ts
@@ -1,10 +1,8 @@
 import { ApiError } from "app/common/ApiError";
 import { mapGetOrSet, MapWithTTL } from "app/common/AsyncCreate";
 import { extractOrgParts, getHostType, getSingleOrg } from "app/common/gristUrls";
-import { isAffirmative } from "app/common/gutil";
 import { Organization } from "app/gen-server/entity/Organization";
 import { HomeDBManager } from "app/gen-server/lib/homedb/HomeDBManager";
-import { GristServer } from "app/server/lib/GristServer";
 import { getOriginUrl } from "app/server/lib/requestUtils";
 
 import { IncomingMessage } from "http";
@@ -43,8 +41,7 @@ export class Hosts {
   private _org2host = new MapWithTTL<string, Promise<string | undefined>>(ORG_HOST_CACHE_TTL);
 
   // baseDomain should start with ".". It may be undefined for localhost or single-org mode.
-  constructor(private _baseDomain: string | undefined, private _dbManager: HomeDBManager,
-    private _gristServer: GristServer | undefined) {
+  constructor(private _baseDomain: string | undefined, private _dbManager: HomeDBManager) {
   }
 
   /**
@@ -99,8 +96,6 @@ export class Hosts {
           `'${parts.orgFromPath}' does not match '${parts.orgFromHost}'`, 400);
       }
       return { org: parts.subdomain || "", url: parts.pathRemainder, isCustomHost: false };
-    } else if (hostType === "plugin") {
-      return { org: "", url: parts.pathRemainder, isCustomHost: false };
     } else {
       // Otherwise check for a custom host.
       const org = await mapGetOrSet(this._host2org, hostname, async () => {
@@ -168,8 +163,6 @@ export class Hosts {
   }
 
   private _getHostType(host: string) {
-    const pluginUrl = isAffirmative(process.env.GRIST_TRUST_PLUGINS) ?
-      undefined : this._gristServer?.getPluginUrl();
-    return getHostType(host, { baseDomain: this._baseDomain, pluginUrl });
+    return getHostType(host, { baseDomain: this._baseDomain });
   }
 }

--- a/test/common/gristUrls.ts
+++ b/test/common/gristUrls.ts
@@ -120,11 +120,6 @@ describe("gristUrls", function() {
       assert.equal(getHostType("foo.getgrist.com:8080", defaultOptions), "native");
     });
 
-    it('should interpret plugin domain as "plugin"', function() {
-      assert.equal(getHostType("plugin.getgrist.com", defaultOptions), "plugin");
-      assert.equal(getHostType("PLUGIN.getgrist.com", { pluginUrl: "https://pLuGin.getgrist.com" }), "plugin");
-    });
-
     it('should interpret other domains as "custom"', function() {
       assert.equal(getHostType("foo.com", defaultOptions), "custom");
       assert.equal(getHostType("foo.bar.com", defaultOptions), "custom");

--- a/test/nbrowser/CustomWidgets.ts
+++ b/test/nbrowser/CustomWidgets.ts
@@ -312,21 +312,26 @@ describe("CustomWidgets", function() {
       await gu.undo(6);
     });
 
-    it("should refuse a custom widget URL on Grist's own origin", async () => {
-      // A cross-origin URL loads normally.
+    it("should sandbox a custom widget URL on Grist's own origin", async () => {
+      // A cross-origin URL loads normally and is not sandboxed (it's already origin-isolated).
       await gu.setCustomWidgetUrl(`${widgetServerUrl}/200`);
       assert.equal(await content(), "OK");
+      assert.isNull(await getCustomWidgetFrame().getAttribute("sandbox"));
 
-      // A URL on Grist's own origin is refused (the XSS guard), so the empty widget page
-      // is shown instead of the URL we set.
+      // A URL on Grist's own origin is allowed (so use cases like public forms keep working), but
+      // is loaded in a sandbox WITHOUT allow-same-origin. This gives it an opaque origin, so it
+      // can't share Grist's session even though the URL is on Grist's site.
       const pageOrigin = new URL(await driver.getCurrentUrl()).origin;
       await gu.setCustomWidgetUrl(`${pageOrigin}/200`);
-      assert.match(await getCustomWidgetFrame().getAttribute("src"), /\/custom-widget\.html/);
-      assert.isTrue((await content()).startsWith("Custom widget"));
+      assert.match(await getCustomWidgetFrame().getAttribute("src"), new RegExp(`^${pageOrigin}/200`));
+      const sandbox = await getCustomWidgetFrame().getAttribute("sandbox");
+      assert.include(sandbox, "allow-scripts");
+      assert.notInclude(sandbox, "allow-same-origin");
 
       // Restore the empty Custom URL state for the following tests.
       await gu.setCustomWidgetUrl("");
       assert.isTrue((await content()).startsWith("Custom widget"));
+      assert.isNull(await getCustomWidgetFrame().getAttribute("sandbox"));
     });
 
     it("should support theme variables", async () => {

--- a/test/server/lib/extractOrg.ts
+++ b/test/server/lib/extractOrg.ts
@@ -29,8 +29,6 @@ describe("extractOrg", function() {
         },
       },
     },
-  } as any, {
-    getPluginUrl() { return "https://prod.grist-usercontent.com"; },
   } as any);
 
   before(async () => {


### PR DESCRIPTION
## Context

- Since version 1.7.14 (https://github.com/gristlabs/grist-core/pull/2262), the calendar served by default is the bundled one. The motivations are described in the PR.
  - The drawback for system administrators is to serve the plugins through a different domain
- Since version 1.7.15, widget can't serve a page sharing the same domain as the document ([commit](https://github.com/gristlabs/grist-core/commit/f579977c))
  - The release note mention this: *Disallow same-origin custom-widget URLs. A new disallowCustomWidgetUrl() helper refuses widgets whose URL is same-origin or on Grist's configured base domain, as defense in depth against an XSS payload being weaponized through a widget URL. ([commit](https://github.com/gristlabs/grist-core/commit/f579977c))*

## Proposed solution

1. Use the [iframe's `sandbox` property](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#sandbox) and **omit** the `allow-same-origin` value so the cookies and the parent window access are denied to the widget, whether the widget share the same domain or not.
2. Remove the `GRIST_TRUST_PLUGINS` property, the plugins are now served from the same domain as for the instance (which I think simplifies lots of things)

You can check the results:
1. For a form embedded as a widget in this preview: https://grist--core-allow-widget-share-instance-location-origin-4e5364.fly.dev/4CpNMemLQwt2/Test-forms-in-widget/p/1
2. For the calendar working and sandboxed (you must check using the browser console as described in the event details): https://grist--core-allow-widget-share-instance-location-origin-4e5364.fly.dev/nB83aPQ8aGSU/Test-calendar/p/2

Few drawbacks through:
- with the forms, not all API are supported, like the `/log` endpoint. I tend to think it is not such a problem?

Do you see more things that should raise my attention regarding the security or of the non-regressions?

## TODO
- [ ] Check whether we should keep or not the `APP_UNTRUSTED_URL` config env variable
- [ ] Idem for `GRIST_UNTRUSTED_PORT`
- [ ] Add a test to check that public forms can be included as widgets
- [ ] Do my own review, specifically check `widgetUrlSharesGristSession`
- [ ] Cleanup (lots of AI verbosity)

## Related issues

- Fixes #2376 
- And fixes this issue: https://community.getgrist.com/t/in-v1-7-15-self-hosted-forms-built-and-published-will-not-show-as-custom-widgets-anymore/13985

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
