### PR TITLE
Focus back panels after user interactions in them, instead of current widget

### DIFF
--- a/app/client/components/KeyboardFocusHighlighter.ts
+++ b/app/client/components/KeyboardFocusHighlighter.ts
@@ -36,10 +36,13 @@ export class KeyboardFocusHighlighter extends Disposable {
 export const kbFocusHighlighterClass = "kb-focus-highlighter-group";
 
 const cssKeyboardUser = styled("div", `
-  & .${kbFocusHighlighterClass} :is(a, input, textarea, select, button, [tabindex="0"]):focus-visible {
+  & .${kbFocusHighlighterClass} :is(a, input, textarea, select, button, [tabindex="0"]):focus-visible,
+  & .${kbFocusHighlighterClass}:focus-visible {
     outline: 3px solid ${components.kbFocusHighlight} !important;
   }
 `);
+
+export const whenKeyboardUserBodyCls = cssKeyboardUser.className;
 
 export const isKeyboardUser = () => {
   return document.documentElement.classList.contains(cssKeyboardUser.className);

--- a/app/client/components/RegionFocusSwitcher.ts
+++ b/app/client/components/RegionFocusSwitcher.ts
@@ -7,7 +7,7 @@ import {
   kbFocusHighlighterClass,
 } from "app/client/components/KeyboardFocusHighlighter";
 import { FocusLayer } from "app/client/lib/FocusLayer";
-import { enableTabTrap, isFocusable } from "app/client/lib/focusUtils";
+import { enableTabTrap, isFocusable, isMousetrapIgnoredElement } from "app/client/lib/focusUtils";
 import { makeT } from "app/client/lib/localization";
 import { App } from "app/client/ui/App";
 import { SpecialDocPage } from "app/common/gristUrls";
@@ -147,6 +147,26 @@ export class RegionFocusSwitcher extends Disposable {
         }
         return false;
       }),
+      dom.on("focusin", () => {
+        if (isKeyboardUser()) {
+          this._savePrevElementState(this._state.get().region);
+        }
+      }),
+      // When pressing Escape inside inputs, we "reset" the focused element state early to prevent
+      // a loop between the focusin listener above, and the _onClipboardFocus code. The loop would
+      // cause pressing Escape resulting in removing focus, then instantly re-focusing the input.
+      dom.on("keydown", (event) => {
+        if (
+          event.key === "Escape" &&
+          !event.ctrlKey && !event.shiftKey && !event.altKey && !event.metaKey &&
+          isMousetrapIgnoredElement(event.target)
+        ) {
+          const current = this._state.get().region;
+          if (current?.type === "panel") {
+            this._prevFocusedElements[current.id] = null;
+          }
+        }
+      }, { useCapture: true }),
     ];
   }
 

--- a/app/client/components/RegionFocusSwitcher.ts
+++ b/app/client/components/RegionFocusSwitcher.ts
@@ -1,14 +1,16 @@
 import BaseView from "app/client/components/BaseView";
 import * as commands from "app/client/components/commands";
 import { GristDoc } from "app/client/components/GristDoc";
-import { kbFocusHighlighterClass } from "app/client/components/KeyboardFocusHighlighter";
+import {
+  highlightKeyboardFocus,
+  kbFocusHighlighterClass,
+} from "app/client/components/KeyboardFocusHighlighter";
 import { FocusLayer } from "app/client/lib/FocusLayer";
 import { enableTabTrap, isFocusable } from "app/client/lib/focusUtils";
 import { makeT } from "app/client/lib/localization";
 import { App } from "app/client/ui/App";
 import { SpecialDocPage } from "app/common/gristUrls";
 import { mod } from "app/common/gutil";
-import { components } from "app/common/ThemePrefs";
 
 import { Disposable, dom, Holder, Observable, styled, UseCBOwner } from "grainjs";
 import isEqual from "lodash/isEqual";
@@ -68,15 +70,18 @@ export class RegionFocusSwitcher extends Disposable {
       nextRegion: () => {
         this._logCommand("nextRegion");
         this._maybeNotifyAboutCreatorPanel();
+        highlightKeyboardFocus();
         return this._cycle("next");
       },
       prevRegion: () => {
         this._logCommand("prevRegion");
         this._maybeNotifyAboutCreatorPanel();
+        highlightKeyboardFocus();
         return this._cycle("prev");
       },
       creatorPanel: () => {
         this._logCommand("creatorPanel");
+        highlightKeyboardFocus();
         return this._toggleCreatorPanel();
       },
       cancel: this._onEscapeKeypress.bind(this),
@@ -115,6 +120,7 @@ export class RegionFocusSwitcher extends Disposable {
           "region"),
       dom.attr("aria-label", ariaLabel),
       dom.attr(ATTRS.regionId, id),
+      dom.cls(cssPanel.className),
       dom.cls(kbFocusHighlighterClass, (use) => {
         // highlight focused elements everywhere except in the grist doc views
         return id !== "main" ?
@@ -137,10 +143,6 @@ export class RegionFocusSwitcher extends Disposable {
           return this._canTabThroughMainRegion(use);
         }
         return false;
-      }),
-      cssFocusedPanel.cls("-focused", (use) => {
-        const current = use(this._state);
-        return current.initiator?.type === "cycle" && current.region?.type === "panel" && current.region.id === id;
       }),
     ];
   }
@@ -352,7 +354,6 @@ export class RegionFocusSwitcher extends Disposable {
       undefined;
 
     this._tabTrap.clear();
-    removeFocusRings();
     removeTabIndexes();
     if (!mouseEvent) {
       this._savePrevElementState(prev.region);
@@ -513,7 +514,6 @@ export const viewCommands = (commandsObject: Record<string, Function>, context: 
 
 const ATTRS = {
   regionId: "data-grist-region-id",
-  focusedElement: "data-grist-region-focused-el",
 };
 
 /**
@@ -527,12 +527,6 @@ const focusPanel = (panel: PanelRegion, child: HTMLElement | null, gristDoc: Gri
 
   // Child element found: focus it if we actually can
   if (child && child !== panelElement && child.isConnected && isFocusable(child)) {
-    // Visually highlight the element with similar styles than panel focus,
-    // only for this time. This is here just to help the user better see the visual change when he switches panels.
-    child.setAttribute(ATTRS.focusedElement, "true");
-    child.addEventListener("blur", () => {
-      child.removeAttribute(ATTRS.focusedElement);
-    }, { once: true });
     child.focus?.();
   } else {
     // No child to focus found: just focus the panel
@@ -692,15 +686,6 @@ const containsActiveElement = (el: HTMLElement | null): boolean => {
   return el?.contains(document.activeElement) && document.activeElement !== el || false;
 };
 
-/**
- * Remove the visual highlight on elements that are styled as focused elements of panels.
- */
-const removeFocusRings = () => {
-  document.querySelectorAll(`[${ATTRS.focusedElement}]`).forEach((el) => {
-    el.removeAttribute(ATTRS.focusedElement);
-  });
-};
-
 const removeTabIndexes = () => {
   document.querySelectorAll(`[${ATTRS.regionId}]`).forEach((el) => {
     el.removeAttribute("tabindex");
@@ -725,13 +710,6 @@ const isSpecialPage = (doc: GristDoc | null) => {
   return false;
 };
 
-export const cssFocusedPanel = styled("div", `
-  &-focused:focus {
-    outline: 3px solid ${components.kbFocusHighlight} !important;
-    outline-offset: -3px !important;
-  }
-
-  &-focused [${ATTRS.focusedElement}]:focus {
-    outline: 3px solid ${components.kbFocusHighlight} !important;
-  }
+export const cssPanel = styled("div", `
+  outline-offset: -3px !important;
 `);

--- a/app/client/components/RegionFocusSwitcher.ts
+++ b/app/client/components/RegionFocusSwitcher.ts
@@ -3,6 +3,7 @@ import * as commands from "app/client/components/commands";
 import { GristDoc } from "app/client/components/GristDoc";
 import {
   highlightKeyboardFocus,
+  isKeyboardUser,
   kbFocusHighlighterClass,
 } from "app/client/components/KeyboardFocusHighlighter";
 import { FocusLayer } from "app/client/lib/FocusLayer";
@@ -70,6 +71,8 @@ export class RegionFocusSwitcher extends Disposable {
       nextRegion: () => {
         this._logCommand("nextRegion");
         this._maybeNotifyAboutCreatorPanel();
+        // "Highlighting" keyboard focus sets the `isKeyboardUser` flag that is later used to decide where to move focus
+        // between panels and the active section, when pressing the Escape key or when the clipboard regains focus.
         highlightKeyboardFocus();
         return this._cycle("next");
       },
@@ -89,10 +92,10 @@ export class RegionFocusSwitcher extends Disposable {
 
     this.autoDispose(this._state.addListener(this._onStateChange.bind(this)));
 
-    const focusActiveSection = () => this.focusActiveSection();
-    this._app?.on("clipboard_focus", focusActiveSection);
+    const onClipboardFocus = this._onClipboardFocus.bind(this);
+    this._app?.on("clipboard_focus", onClipboardFocus);
     this.onDispose(() => {
-      this._app?.off("clipboard_focus", focusActiveSection);
+      this._app?.off("clipboard_focus", onClipboardFocus);
       this.reset();
     });
   }
@@ -205,6 +208,19 @@ export class RegionFocusSwitcher extends Disposable {
     this._focusRegion(undefined);
   }
 
+  /**
+   * Called when the clipboard regains focus, for example after a dropdown menu or modal closes.
+   *
+   * If the user was in a panel before the overlay opened, re-focus that panel instead of the active section.
+   */
+  private _onClipboardFocus() {
+    const current = this._state.get().region;
+    if (current?.type === "panel" && isKeyboardUser()) {
+      return focusPanel(current, this._prevFocusedElements[current.id] as HTMLElement | null, this._getGristDoc());
+    }
+    return this.focusActiveSection();
+  }
+
   private _focusRegion(
     region: Region | undefined,
     options: { initiator?: StateUpdateInitiator } = {},
@@ -283,17 +299,19 @@ export class RegionFocusSwitcher extends Disposable {
   /**
    * This is registered as a `cancel` command when the RegionFocusSwitcher is created.
    *
-   * That means this is called when pressing Escape in no particular setting.
+   * On escape keypress, we either focus back the panel itself,
+   * or reset the focus to the active section if already focused on the panel.
+   *
    * Any `cancel` command registered by other code after loading the page will take precedence over this one.
    * So, this doesn't get called when in a modal, a popup menu, etc., as those have their own cancel callback.
    */
   private _onEscapeKeypress() {
-    const { region: current, initiator } = this._state.get();
+    const { region: current } = this._state.get();
     // Do nothing if we are not focused on a panel
     if (current?.type !== "panel") {
       return;
     }
-    const comesFromKeyboard = initiator?.type === "cycle";
+
     const panelElement = getPanelElement(current.id);
     if (!panelElement) {
       return;
@@ -315,7 +333,7 @@ export class RegionFocusSwitcher extends Disposable {
       // If user presses escape again, we also want to focus the panel.
       (activeElement === document.body)
     ) {
-      if (comesFromKeyboard) {
+      if (isKeyboardUser()) {
         focusPanelElement(panelElement);
         if (activeElementIsInPanel) {
           this._prevFocusedElements[current.id] = null;

--- a/app/client/components/RegionFocusSwitcher.ts
+++ b/app/client/components/RegionFocusSwitcher.ts
@@ -236,7 +236,7 @@ export class RegionFocusSwitcher extends Disposable {
   private _onClipboardFocus() {
     const current = this._state.get().region;
     if (current?.type === "panel" && isKeyboardUser()) {
-      return focusPanel(current, this._prevFocusedElements[current.id] as HTMLElement | null, this._getGristDoc());
+      return this._focusPanel(current);
     }
     return this.focusActiveSection();
   }
@@ -260,6 +260,38 @@ export class RegionFocusSwitcher extends Disposable {
     }
 
     this._state.set({ region, initiator: options.initiator });
+  }
+
+  /**
+   * Keyboard-focus the given panel itself or the previously focused child element inside it.
+   *
+   * Works in 3 steps:
+   *   - trap the Tab key inside the panel to prevent focusing back the view layout by mistake
+   *   - focus the panel or the previous child
+   *   - make the Tab key available for normal browser navigation, instead of being captured by widget commands
+   */
+  private _focusPanel(panel: PanelRegion) {
+    const panelElement = getPanelElement(panel.id);
+    if (!panelElement) {
+      return;
+    }
+
+    this._tabTrap.autoDispose(enableTabTrap(panelElement));
+
+    const child = this._prevFocusedElements[panel.id] as HTMLElement | null;
+    // Child element found: focus it if we actually can
+    if (child && child !== panelElement && child.isConnected && isFocusable(child)) {
+      child.focus?.();
+    } else {
+      // No child to focus found: just focus the panel
+      focusPanelElement(panelElement);
+    }
+
+    const gristDoc = this._getGristDoc();
+    if (gristDoc) {
+      // Creator panel is a special case "related to the view"
+      escapeViewLayout(gristDoc, panel.id === "right");
+    }
   }
 
   private _cycle(direction: "next" | "prev") {
@@ -408,12 +440,7 @@ export class RegionFocusSwitcher extends Disposable {
     //   - actually focus the panel dom element, or its previously focused child,
     //   - make the Tab key available for normal browser navigation in the panel (see `escapeViewLayout`)
     if (!mouseEvent && isPanel && panelElement && current.region) {
-      this._tabTrap.autoDispose(enableTabTrap(panelElement));
-      focusPanel(
-        current.region as PanelRegion,
-        this._prevFocusedElements[current.region.id as Panel] as HTMLElement | null,
-        gristDoc,
-      );
+      this._focusPanel(current.region as PanelRegion);
 
     // If clicking on a panel: only make sure view layout commands are disabled,
     // making the Tab key available for normal browser navigation (see `escapeViewLayout`)
@@ -552,29 +579,6 @@ export const viewCommands = (commandsObject: Record<string, Function>, context: 
 
 const ATTRS = {
   regionId: "data-grist-region-id",
-};
-
-/**
- * Focus the given panel dom element (or the given element inside it, if any), and let the grist doc view know about it.
- */
-const focusPanel = (panel: PanelRegion, child: HTMLElement | null, gristDoc: GristDoc | null) => {
-  const panelElement = getPanelElement(panel.id);
-  if (!panelElement) {
-    return;
-  }
-
-  // Child element found: focus it if we actually can
-  if (child && child !== panelElement && child.isConnected && isFocusable(child)) {
-    child.focus?.();
-  } else {
-    // No child to focus found: just focus the panel
-    focusPanelElement(panelElement);
-  }
-
-  if (gristDoc) {
-    // Creator panel is a special case "related to the view"
-    escapeViewLayout(gristDoc, panel.id === "right");
-  }
 };
 
 const focusPanelElement = (panelElement: HTMLElement) => {

--- a/app/client/lib/focusUtils.ts
+++ b/app/client/lib/focusUtils.ts
@@ -316,3 +316,10 @@ const focusableSelectors = [
 ];
 
 export const focusableSelectorsString = focusableSelectors.join(",");
+
+export const isMousetrapIgnoredElement = (el: EventTarget | null): boolean => {
+  if (!(el instanceof HTMLElement) || el.classList.contains("mousetrap")) {
+    return false;
+  }
+  return ["INPUT", "TEXTAREA", "SELECT"].includes(el.tagName) || el.isContentEditable;
+};

--- a/app/client/ui/DocMenuCss.ts
+++ b/app/client/ui/DocMenuCss.ts
@@ -1,4 +1,5 @@
-import { cssFocusedPanel } from "app/client/components/RegionFocusSwitcher";
+import { whenKeyboardUserBodyCls } from "app/client/components/KeyboardFocusHighlighter";
+import { cssPanel } from "app/client/components/RegionFocusSwitcher";
 import { transientInput } from "app/client/ui/transientInput";
 import { bigBasicButton } from "app/client/ui2018/buttons";
 import { mediaSmall, theme, vars } from "app/client/ui2018/cssVars";
@@ -125,7 +126,7 @@ export const stickyHeader = styled(headerWrap, `
   margin-bottom: 0px;
   padding: 13px 0px 24px 0px;
   border-top: 3px solid transparent;
-  .${cssFocusedPanel.className}-focused:focus & {
+  .${whenKeyboardUserBodyCls} .${cssPanel.className}:focus & {
     border-top-color: ${components.kbFocusHighlight};
   }
 `);

--- a/test/nbrowser/RegionFocusSwitcher.ts
+++ b/test/nbrowser/RegionFocusSwitcher.ts
@@ -46,6 +46,12 @@ const toggleCreatorPanelFocus = async () => {
   await gu.sendKeys(Key.chord(modKey, Key.ALT, "o"));
 };
 
+const tabUntilFocused = async (selector: string, direction: "forward" | "backward" = "forward") => {
+  while (!(await driver.switchTo().activeElement().matches(selector))) {
+    await gu.sendKeys(direction === "forward" ? Key.TAB : Key.chord(Key.SHIFT, Key.TAB));
+  }
+};
+
 const panelMatchs = {
   left: ".test-left-panel",
   top: ".test-top-header",
@@ -53,7 +59,7 @@ const panelMatchs = {
   main: ".test-main-content",
 };
 const assertPanelFocus = async (panel: "left" | "top" | "right" | "main", expected: boolean = true) => {
-  assert.equal(await gu.hasFocus(panelMatchs[panel]), expected);
+  await gu.waitToPass(async () => assert.equal(await gu.hasFocus(panelMatchs[panel]), expected), 200);
 };
 
 const assertSectionFocus = async (sectionId: number, expected: boolean = true) => {
@@ -108,7 +114,7 @@ const assertCycleThroughRegions = async ({ sections = 1 }: { sections?: number }
 };
 
 describe("RegionFocusSwitcher", function() {
-  this.timeout(60000);
+  this.timeout(30000);
   const cleanup = setupTestSuite();
 
   it("should tab though elements in non-document pages", async () => {
@@ -262,13 +268,60 @@ describe("RegionFocusSwitcher", function() {
 
     // Click on an input on the top panel
     await driver.find(".test-bc-doc").click();
-    await driver.sendKeys(Key.TAB);
     assert.isTrue(await isNormalElementFocused(".test-top-header"));
 
-    // in that case (mouse click) when pressing esc, we directly focus back to view section
+    // Since we used the mouse to focus the input, pressing Esc should exit early to the active view section
     await driver.sendKeys(Key.ESCAPE);
     await assertPanelFocus("top", false);
     await expectClipboardFocus(true, 0);
+  });
+
+  it("should switch to keyboard-user mode after using tab inside a panel", async function() {
+    const session = await gu.session().teamSite.login();
+    await session.tempNewDoc(cleanup);
+
+    // We do the same as the previous test, but now we press Tab after clicking the input.
+    // We should stay in "keyboard user" mode, and now, pressing Esc should first focus back the panel itself,
+    // then the active view section when pressed again.
+    const docInput = await driver.find(".test-bc-doc");
+    await docInput.click();
+    assert.isTrue(await isNormalElementFocused(".test-top-header"));
+
+    await driver.sendKeys(Key.TAB);
+    assert.isTrue(await isNormalElementFocused(".test-top-header"));
+    assert.isTrue(
+      await driver.switchTo().activeElement().getId() != await docInput.getId(),
+      "focus should not have stayed on the doc input after pressing Tab",
+    );
+
+    await driver.sendKeys(Key.ESCAPE);
+    await assertPanelFocus("top");
+
+    await driver.sendKeys(Key.ESCAPE);
+    await assertPanelFocus("top", false);
+    await expectClipboardFocus(true);
+  });
+
+  it("should stay focused in a panel after a keyboard-user action", async function() {
+    const session = await gu.session().teamSite.login();
+    await session.tempNewDoc(cleanup);
+    await toggleCreatorPanelFocus();
+    await assertPanelFocus("right");
+
+    // submit a value in an input that stays as-is on submit: focus should stay on the input
+    await tabUntilFocused("#row-height-max-input");
+    await driver.find("#row-height-max-input").sendKeys("4");
+    await driver.sendKeys(Key.ENTER);
+    await gu.waitForServer();
+    assert.equal(await driver.switchTo().activeElement().getId(), await driver.find("#row-height-max-input").getId());
+
+    // submit a value in an input that disappears on submit (even if for just a millisecond):
+    // focus should fallback to the panel
+    await tabUntilFocused("#right-widget-title-input", "backward");
+    await driver.find("#right-widget-title-input").sendKeys("testing one two");
+    await driver.sendKeys(Key.ENTER);
+    await gu.waitForServer();
+    await assertPanelFocus("right");
   });
 
   it("should focus a section-region when clicking on it", async function() {


### PR DESCRIPTION
## Context

Before this commit, anytime a user interaction resulted in a "clipboard focus" event, keyboard focus would be set back to the active view section (current widget). Even in the cases when the user interacted with keyboard, from a panel. So, while keyboard navigation was possible, it became pretty cumbersome for a good amount of use cases, making us having to navigate back to where we were quite often.

## Proposed solution

This tries to better track user interactions so that we correctly focus back the proper elements on the page. We now either:

- focus back the active section (as before), if we notice the user is not a "keyboard user",
- or focus back the element we just interacted with in the panel,
- or focus back the panel itself, if the element we just interacted with got removed following the interaction. Note that this behavior will also get some improvements in later pull requests.


## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

Before, when modifying a widget title, or its max height, focus always goes back on the widget after submission:

https://github.com/user-attachments/assets/4bfd144e-cac3-4cc6-a4c2-01e88a942c08

After, focus stays on the input after modifying max height correctly. And, since the widget title input actually gets `disabled` on submission for a few milliseconds, focus doesn't stay on it, but at least it stays on the panel. This behavior on temporarily disabled interactive elements will be improved in a later PR.

https://github.com/user-attachments/assets/9c55c79d-2ed5-44cf-915e-11f01038d250
