### PR TITLE
New keyboard "jump" commands

### DIFF
--- a/app/client/components/Forms/MappedFieldsConfig.ts
+++ b/app/client/components/Forms/MappedFieldsConfig.ts
@@ -1,4 +1,6 @@
 import { allCommands } from "app/client/components/commands";
+import { fixOutlineOverflow } from "app/client/components/KeyboardFocusHighlighter";
+import { kbJumperAnchor } from "app/client/components/RegionFocusSwitcher";
 import { makeT } from "app/client/lib/localization";
 import { ColumnRec, ViewSectionRec } from "app/client/models/DocModel";
 import { basicButton, cssButton, primaryButton } from "app/client/ui2018/buttons";
@@ -69,6 +71,8 @@ export class MappedFieldsConfig extends Disposable {
 
     return [
       dom("div", { "role": "group", "aria-labelledby": "mapped-fields-label" },
+        kbJumperAnchor,
+        fixOutlineOverflow,
         cssHeader(
           cssFieldListHeader(
             dom.text(t("Mapped")),
@@ -105,6 +109,8 @@ export class MappedFieldsConfig extends Disposable {
         ),
       ),
       dom("div", { "role": "group", "aria-labelledby": "unmapped-fields-label" },
+        kbJumperAnchor,
+        fixOutlineOverflow,
         cssHeader(
           cssFieldListHeader(
             dom.text(t("Unmapped")),

--- a/app/client/components/KeyboardFocusHighlighter.ts
+++ b/app/client/components/KeyboardFocusHighlighter.ts
@@ -36,7 +36,7 @@ export class KeyboardFocusHighlighter extends Disposable {
 export const kbFocusHighlighterClass = "kb-focus-highlighter-group";
 
 const cssKeyboardUser = styled("div", `
-  & .${kbFocusHighlighterClass} :is(a, input, textarea, select, button, [tabindex="0"]):focus-visible {
+  & .${kbFocusHighlighterClass} :is(a, input, textarea, select, button, [tabindex="0"], .kb_jumper_anchor):focus-visible {
     outline: 3px solid ${components.kbFocusHighlight} !important;
   }
 `);
@@ -59,3 +59,13 @@ export const cssWhenKeyboardUser = styled("div", `
     display: none;
   }
 `);
+
+const cssOutlineInside = styled("div", `
+  outline-offset: -3px !important;
+`);
+
+/**
+ * We often hide overflows in Grist and that makes our outlines hard to see.
+ * This helper allows to easily make the focus ring visible in those cases.
+ * */
+export const fixOutlineOverflow = () => dom.cls(cssOutlineInside.className);

--- a/app/client/components/RegionFocusSwitcher.ts
+++ b/app/client/components/RegionFocusSwitcher.ts
@@ -792,6 +792,10 @@ export const kbJumperAnchor = (): DomElementArg => ([
   (el) => {
     if (!isProgrammaticallyFocusable(el, true) && el.getAttribute("tabindex") === null) {
       el.setAttribute("tabindex", "-1");
+      // Make sure mouse clicks on anchors don't interfere with the Clipboard.
+      // Without this, clicking an anchor area, then pressing Ctrl+v to paste something inside a cell wouldn't
+      // work, as the focus wouldn't be on the hidden clipboard element but would be on the clicked anchor area)
+      el.classList.add("ignore_tabindex");
     }
   },
 ]);

--- a/app/client/components/RegionFocusSwitcher.ts
+++ b/app/client/components/RegionFocusSwitcher.ts
@@ -1,21 +1,26 @@
 import BaseView from "app/client/components/BaseView";
 import * as commands from "app/client/components/commands";
 import { GristDoc } from "app/client/components/GristDoc";
-import { kbFocusHighlighterClass } from "app/client/components/KeyboardFocusHighlighter";
+import { highlightKeyboardFocus, kbFocusHighlighterClass } from "app/client/components/KeyboardFocusHighlighter";
 import { FocusLayer } from "app/client/lib/FocusLayer";
-import { enableTabTrap, isFocusable } from "app/client/lib/focusUtils";
+import {
+  enableTabTrap,
+  focusAdjacentFocusable,
+  isProgrammaticallyFocusable,
+  isUserFocusable,
+} from "app/client/lib/focusUtils";
 import { makeT } from "app/client/lib/localization";
 import { App } from "app/client/ui/App";
 import { SpecialDocPage } from "app/common/gristUrls";
 import { mod } from "app/common/gutil";
 import { components } from "app/common/ThemePrefs";
 
-import { Disposable, dom, Holder, Observable, styled, UseCBOwner } from "grainjs";
+import { Disposable, dom, DomElementArg, Holder, Observable, styled, UseCBOwner } from "grainjs";
 import isEqual from "lodash/isEqual";
 
 const t = makeT("RegionFocusSwitcher");
 
-export type Panel = "left" | "top" | "right" | "main";
+export type Panel = "left" | "top" | "right" | "main" | `section-header-${string}`;
 interface PanelRegion {
   type: "panel",
   id: Panel // this matches a dom element id
@@ -25,7 +30,7 @@ interface SectionRegion {
   id?: number // this matches a grist document view section id. If none is provided, it means "view layout" is focused.
 }
 type Region = PanelRegion | SectionRegion;
-type StateUpdateInitiator = { type: "cycle" } | { type: "mouse", event?: MouseEvent };
+type StateUpdateInitiator = { type: "cycle" } | { type: "jump" } | { type: "mouse", event?: MouseEvent };
 interface State {
   region?: Region;
   initiator?: StateUpdateInitiator;
@@ -46,7 +51,7 @@ export class RegionFocusSwitcher extends Disposable {
   private _tabTrap = Holder.create(this);
 
   private get _gristDocObs() { return this._app?.pageModel?.gristDoc; }
-  // Previously focused elements for each panel (not used for view section ids)
+  // Previously focused elements for each panel or section header (not used for view section ids)
   private _prevFocusedElements: Record<Panel, Element | null> = {
     left: null,
     top: null,
@@ -79,6 +84,9 @@ export class RegionFocusSwitcher extends Disposable {
         this._logCommand("creatorPanel");
         return this._toggleCreatorPanel();
       },
+      nextJumpTarget: () => this._jump("next"),
+      prevJumpTarget: () => this._jump("prev"),
+      focusSectionHeader: () => this._jump("next"),
       cancel: this._onEscapeKeypress.bind(this),
     }, this, true));
 
@@ -140,7 +148,8 @@ export class RegionFocusSwitcher extends Disposable {
       }),
       cssFocusedPanel.cls("-focused", (use) => {
         const current = use(this._state);
-        return current.initiator?.type === "cycle" && current.region?.type === "panel" && current.region.id === id;
+        return (current.initiator?.type === "cycle" || current.initiator?.type === "jump") &&
+          current.region?.type === "panel" && current.region.id === id;
       }),
     ];
   }
@@ -291,7 +300,7 @@ export class RegionFocusSwitcher extends Disposable {
     if (current?.type !== "panel") {
       return;
     }
-    const comesFromKeyboard = initiator?.type === "cycle";
+    const comesFromKeyboard = initiator?.type === "cycle" || initiator?.type === "jump";
     const panelElement = getPanelElement(current.id);
     if (!panelElement) {
       return;
@@ -417,6 +426,40 @@ export class RegionFocusSwitcher extends Disposable {
     return this._focusRegion({ type: "panel", id: "right" }, { initiator: { type: "cycle" } });
   }
 
+  private _jump(direction: "next" | "prev") {
+    const current = this._state.get().region;
+    if (isPagePanel(current?.id)) {
+      const panelElement = getPanelElement(current.id);
+      if (!panelElement) {
+        return;
+      }
+      highlightKeyboardFocus();
+      focusAdjacentFocusable(panelElement, direction === "next" ? 1 : -1, {
+        matching: `.${kbJumperClass}`,
+        onlyUserFocusable: false,
+        loop: true,
+      });
+      return;
+    }
+    const gristDoc = this._getGristDoc();
+    if (!gristDoc) {
+      return;
+    }
+    highlightKeyboardFocus();
+    if (isSectionHeaderPanel(current?.id)) {
+      this._focusRegion(
+        { type: "section", id: gristDoc.viewModel.activeSectionId() },
+        { initiator: { type: "jump" } },
+      );
+    }
+    if (current?.type === "section" || current === undefined) {
+      this._focusRegion(
+        { type: "panel", id: `section-header-${gristDoc.viewModel.activeSectionId()}` },
+        { initiator: { type: "jump" } },
+      );
+    }
+  }
+
   private _canTabThroughMainRegion(use: UseCBOwner) {
     const gristDoc = this._gristDocObs ? use(this._gristDocObs) : null;
     if (!gristDoc) {
@@ -526,7 +569,7 @@ const focusPanel = (panel: PanelRegion, child: HTMLElement | null, gristDoc: Gri
   }
 
   // Child element found: focus it if we actually can
-  if (child && child !== panelElement && child.isConnected && isFocusable(child)) {
+  if (child && child !== panelElement && child.isConnected && isUserFocusable(child)) {
     // Visually highlight the element with similar styles than panel focus,
     // only for this time. This is here just to help the user better see the visual change when he switches panels.
     child.setAttribute(ATTRS.focusedElement, "true");
@@ -724,6 +767,35 @@ const isSpecialPage = (doc: GristDoc | null) => {
   }
   return false;
 };
+
+const isPagePanel = (id: Region["id"]) => {
+  return id === "left" || id === "top" || id === "main" || id === "right";
+};
+
+const isSectionHeaderPanel = (id: Region["id"]) => {
+  return typeof id === "string" && id.startsWith("section-header-");
+};
+
+/**
+ * Add this class to elements you want to be able to jump to/from with the nextJumpTarget and prevJumpTarget commands
+ *
+ * Note that using @see kbJumperAnchor is preferred over this as it also makes sure the element is focusable,
+ * but this can be handy for specific use cases where kbJumperAnchor doesn't fit.
+ */
+export const kbJumperClass = "kb_jumper_anchor";
+
+/**
+ * Add this dom element arg to an element you want to be able to jump to/from with the nextJumpTarget and
+ * prevJumpTarget commands.
+ */
+export const kbJumperAnchor = (el: HTMLElement): DomElementArg => ([
+  dom.cls(kbJumperClass),
+  (el) => {
+    if (!isProgrammaticallyFocusable(el, true) && el.getAttribute("tabindex") === null) {
+      el.setAttribute("tabindex", "-1");
+    }
+  },
+]);
 
 export const cssFocusedPanel = styled("div", `
   &-focused:focus {

--- a/app/client/components/RegionFocusSwitcher.ts
+++ b/app/client/components/RegionFocusSwitcher.ts
@@ -86,7 +86,6 @@ export class RegionFocusSwitcher extends Disposable {
       },
       nextJumpTarget: () => this._jump("next"),
       prevJumpTarget: () => this._jump("prev"),
-      focusSectionHeader: () => this._jump("next"),
       cancel: this._onEscapeKeypress.bind(this),
     }, this, true));
 

--- a/app/client/components/RegionFocusSwitcher.ts
+++ b/app/client/components/RegionFocusSwitcher.ts
@@ -787,7 +787,7 @@ export const kbJumperClass = "kb_jumper_anchor";
  * Add this dom element arg to an element you want to be able to jump to/from with the nextJumpTarget and
  * prevJumpTarget commands.
  */
-export const kbJumperAnchor = (el: HTMLElement): DomElementArg => ([
+export const kbJumperAnchor = (): DomElementArg => ([
   dom.cls(kbJumperClass),
   (el) => {
     if (!isProgrammaticallyFocusable(el, true) && el.getAttribute("tabindex") === null) {

--- a/app/client/components/buildViewSectionDom.ts
+++ b/app/client/components/buildViewSectionDom.ts
@@ -91,6 +91,8 @@ export function buildViewSectionDom(options: {
     if (!use(vs.linkSrcSectionRef)) { return null; }
     return use(use(vs.linkSrcSection).titleDef);
   });
+
+  const regionFocusSwitcher = gristDoc.regionFocusSwitcher;
   return dom("div.view_leaf.viewsection_content.flexvbox.flexauto",
     testId(`viewlayout-section-${sectionRowId}`),
     dom.autoDispose(selectedBySectionTitle),
@@ -101,6 +103,8 @@ export function buildViewSectionDom(options: {
     dom.cls("active_section--no-focus", use => !vs.isDisposed() && use(vs.hasFocus) && !use(vs.hasRegionFocus)),
     dom.cls("active_section--no-indicator", use => !focusable || (!vs.isDisposed() && !use(vs.hasVisibleFocus))),
     dom.maybe<BaseView | null>(use => use(vs.viewInstance), viewInstance => dom("div.viewsection_title.flexhbox",
+      regionFocusSwitcher?.panelAttrs(`section-header-${sectionRowId}`, ""),
+      dom.attr("aria-label", use => t(`{{title}} widget header`, { title: use(vs.titleDef) })),
       cssDragIcon("DragDrop",
         dom.cls("viewsection_drag_indicator"),
         // Makes element grabbable only if grist is not readonly.

--- a/app/client/components/commandList.ts
+++ b/app/client/components/commandList.ts
@@ -53,6 +53,9 @@ export type CommandName =
   "nextRegion" |
   "prevRegion" |
   "creatorPanel" |
+  "focusSectionHeader" |
+  "nextJumpTarget" |
+  "prevJumpTarget" |
   "shiftDown" |
   "shiftUp" |
   "shiftRight" |
@@ -425,6 +428,21 @@ export const groups: CommendGroupDef[] = [{
       name: "creatorPanel",
       keys: ["Ctrl+Alt+o"],
       desc: () => t("Toggle creator panel keyboard focus"),
+      alwaysOn: true,
+    }, {
+      name: "focusSectionHeader",
+      keys: ["Ctrl+i"],
+      desc: () => t("When focused on a widget, move focus between widget and widget header"),
+      alwaysOn: true,
+    }, {
+      name: "nextJumpTarget",
+      keys: ["Ctrl+i"],
+      desc: () => t("When focused on a page panel, focus next landmark"),
+      alwaysOn: true,
+    }, {
+      name: "prevJumpTarget",
+      keys: ["Ctrl+Shift+I"],
+      desc: () => t("When focused on a page panel, focus previous landmark"),
       alwaysOn: true,
     }, {
       name: "viewAsCard",

--- a/app/client/components/commandList.ts
+++ b/app/client/components/commandList.ts
@@ -430,6 +430,8 @@ export const groups: CommendGroupDef[] = [{
       desc: () => t("Toggle creator panel keyboard focus"),
       alwaysOn: true,
     }, {
+      // This only gets its own command so it can be listed as separate keyboard shortcut.
+      // The actual command that triggers things with Ctrl+i is nextJumpTarget.
       name: "focusSectionHeader",
       keys: ["Ctrl+i"],
       desc: () => t("When focused on a widget, move focus between widget and widget header"),

--- a/app/client/lib/focusUtils.ts
+++ b/app/client/lib/focusUtils.ts
@@ -150,7 +150,7 @@ export function focusAdjacentFocusable(container: HTMLElement, delta: 1 | -1, op
   }
 
   let i = focusables.indexOf(active);
-  if (i < 0) {
+  if (i < 0 && fallbackTargetIndex >= 0) {
     targets[fallbackTargetIndex]?.focus();
     return true;
   }

--- a/app/client/lib/focusUtils.ts
+++ b/app/client/lib/focusUtils.ts
@@ -116,26 +116,66 @@ function getFocusableEdges(el: HTMLElement) {
 /**
  * Move focus to the next/previous focusable in `container` (same ordering as Tab / Shift+Tab).
  */
-export function focusAdjacentFocusable(container: HTMLElement, delta: 1 | -1): boolean {
+export function focusAdjacentFocusable(container: HTMLElement, delta: 1 | -1, options: {
+  /** Additional CSS selector string to restrict the list of focusable elements we should try to focus */
+  matching?: string;
+  /** Set to false to include [tabindex="-1"] elements */
+  onlyUserFocusable?: boolean,
+  /** Set to true to try to focus the first element of the container when the last element is reached and vice-versa */
+  loop?: boolean,
+} = {}): boolean {
+  const { matching, onlyUserFocusable = true, loop = false } = options;
+
   const active = getActiveEl();
   if (!(active instanceof HTMLElement) || !container.contains(active)) {
     return false;
   }
-  const ordered = getFocusables(container);
-  const i = ordered.indexOf(active);
+
+  const focusables = onlyUserFocusable ? getUserFocusables(container) : getAllFocusables(container);
+
+  let targets: (HTMLElement | null)[] = focusables;
+  let fallbackTargetIndex = -1;
+  if (matching) {
+    targets = focusables.map((el, index) => {
+      if (!el.matches(matching)) {
+        return null;
+      }
+      if (
+        (delta === 1 && fallbackTargetIndex === -1) || (loop && delta === -1)
+      ) {
+        fallbackTargetIndex = index;
+      }
+      return el;
+    });
+  }
+
+  let i = focusables.indexOf(active);
   if (i < 0) {
-    return false;
+    targets[fallbackTargetIndex]?.focus();
+    return true;
   }
-  const j = i + delta;
-  if (j < 0 || j >= ordered.length) {
-    return false;
+  for (let j = 0; j < targets.length - 1; j++) {
+    i = loop ?
+      (i + delta + targets.length) % targets.length :
+      i + delta;
+    if (i < 0 || i >= targets.length) {
+      break;
+    }
+    if (targets[i]) {
+      targets[i]?.focus();
+      return true;
+    }
   }
-  ordered[j].focus();
-  return true;
+  return false;
 }
 
-function getFocusables(container: HTMLElement): HTMLElement[] {
-  return Array.from(container.querySelectorAll<HTMLElement>(focusableSelectorsString)).filter(isFocusable);
+export function getUserFocusables(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(userFocusableSelectorsString)).filter(isUserFocusable);
+}
+
+export function getAllFocusables(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(allFocusableSelectorsString))
+    .filter(el => isProgrammaticallyFocusable(el, true));
 }
 
 function findFocusableEl(
@@ -144,7 +184,7 @@ function findFocusableEl(
 ): HTMLElement | null {
   // If we’re walking forward, check if this element is focusable, and return it
   // immediately if it is.
-  if (forward && isFocusable(el)) { return el; }
+  if (forward && isUserFocusable(el)) { return el; }
 
   // We should only search the subtree of this element if it can have focusable
   // children.
@@ -195,7 +235,7 @@ function findFocusableEl(
   // If we’re walking backward, we want to check the element’s entire subtree
   // before checking the element itself. If this element is focusable, return
   // it.
-  if (!forward && isFocusable(el)) { return el; }
+  if (!forward && isUserFocusable(el)) { return el; }
 
   return null;
 }
@@ -258,7 +298,7 @@ function getNextSiblingEl(el: HTMLElement, forward: boolean) {
 /**
  * Determine if an element is focusable and has user-visible painted dimensions.
  */
-export const isFocusable = (el: HTMLElement) => {
+export const isUserFocusable = (el: HTMLElement) => {
   // A shadow host that delegates focus will never directly receive focus,
   // even with `tabindex=0`. Consider our <fancy-button> custom element, which
   // delegates focus to its shadow button:
@@ -272,7 +312,15 @@ export const isFocusable = (el: HTMLElement) => {
   // button. Our library should behave the same way.
   if (el.shadowRoot?.delegatesFocus) { return false; }
 
-  return el.matches(focusableSelectorsString) && !isHidden(el);
+  return el.matches(userFocusableSelectorsString) && !isHidden(el);
+};
+
+/**
+ * Determine if an element is programmatically focusable, without checking if it is actually visible.
+ */
+export const isProgrammaticallyFocusable = (el: HTMLElement, includeHidden = false) => {
+  if (el.shadowRoot?.delegatesFocus) { return false; }
+  return el.matches(allFocusableSelectorsString) && (includeHidden || !isHidden(el));
 };
 
 /**
@@ -296,23 +344,27 @@ const notInert = ":not([inert]):not([inert] *)";
 const notNegTabIndex = ':not([tabindex^="-"])';
 const notDisabled = ":not(:disabled)";
 
-const focusableSelectors = [
-  `a[href]${notInert}${notNegTabIndex}`,
-  `area[href]${notInert}${notNegTabIndex}`,
-  `input:not([type="hidden"]):not([type="radio"])${notInert}${notNegTabIndex}${notDisabled}`,
-  `input[type="radio"]${notInert}${notNegTabIndex}${notDisabled}`,
-  `select${notInert}${notNegTabIndex}${notDisabled}`,
-  `textarea${notInert}${notNegTabIndex}${notDisabled}`,
-  `button${notInert}${notNegTabIndex}${notDisabled}`,
-  `details${notInert} > summary:first-of-type${notNegTabIndex}`,
-  // Discard until Firefox supports `:has()`
-  // See: https://github.com/KittyGiraudel/focusable-selectors/issues/12
-  // `details:not(:has(> summary))${notInert}${notNegTabIndex}`,
-  `iframe${notInert}${notNegTabIndex}`,
-  `audio[controls]${notInert}${notNegTabIndex}`,
-  `video[controls]${notInert}${notNegTabIndex}`,
-  `[contenteditable]${notInert}${notNegTabIndex}`,
-  `[tabindex]${notInert}${notNegTabIndex}`,
-];
+const focusableSelectors = (includeNegativeTabIndexes: boolean) => {
+  const tabIndexPart = includeNegativeTabIndexes ? "" : notNegTabIndex;
+  return [
+    `a[href]${notInert}${tabIndexPart}`,
+    `area[href]${notInert}${tabIndexPart}`,
+    `input:not([type="hidden"]):not([type="radio"])${notInert}${tabIndexPart}${notDisabled}`,
+    `input[type="radio"]${notInert}${tabIndexPart}${notDisabled}`,
+    `select${notInert}${tabIndexPart}${notDisabled}`,
+    `textarea${notInert}${tabIndexPart}${notDisabled}`,
+    `button${notInert}${tabIndexPart}${notDisabled}`,
+    `details${notInert} > summary:first-of-type${tabIndexPart}`,
+    // Discard until Firefox supports `:has()`
+    // See: https://github.com/KittyGiraudel/focusable-selectors/issues/12
+    // `details:not(:has(> summary))${notInert}${tabIndexPart}`,
+    `iframe${notInert}${tabIndexPart}`,
+    `audio[controls]${notInert}${tabIndexPart}`,
+    `video[controls]${notInert}${tabIndexPart}`,
+    `[contenteditable]${notInert}${tabIndexPart}`,
+    `[tabindex]${notInert}${tabIndexPart}`,
+  ];
+};
 
-export const focusableSelectorsString = focusableSelectors.join(",");
+export const userFocusableSelectorsString = focusableSelectors(false).join(",");
+export const allFocusableSelectorsString = focusableSelectors(true).join(",");

--- a/app/client/ui/AccountWidget.ts
+++ b/app/client/ui/AccountWidget.ts
@@ -1,3 +1,4 @@
+import { kbJumperAnchor } from "app/client/components/RegionFocusSwitcher";
 import { makeT } from "app/client/lib/localization";
 import { getLoginOrSignupUrl, getLoginUrl, getLogoutUrl, getSignupUrl } from "app/client/lib/urlUtils";
 import { AppModel } from "app/client/models/AppModel";
@@ -61,6 +62,7 @@ export class AccountWidget extends Disposable {
 
   private _buildAccountMenuButton(user: FullUser | null) {
     return cssUserIcon(
+      kbJumperAnchor,
       createUserImage(user, "medium", testId("user-icon")),
       menu(() => this._makeAccountMenu(user), { placement: "bottom-end" }),
     );
@@ -69,6 +71,7 @@ export class AccountWidget extends Disposable {
   private _buildSignInAndSignUpButtons() {
     return [
       cssSigninButton(t("Sign in"),
+        kbJumperAnchor,
         cssSigninButton.cls("-secondary"),
         dom.on("click", () => { this._docPageModel?.clearUnsavedChanges(); }),
         dom.attr("href", (use) => {
@@ -92,6 +95,7 @@ export class AccountWidget extends Disposable {
 
   private _buildUseThisTemplateButton() {
     return cssUseThisTemplateButton(t("Use This Template"),
+      kbJumperAnchor,
       dom.attr("href", (use) => {
         const { doc: srcDocId } = use(urlState().state);
         return getLoginOrSignupUrl({ srcDocId });

--- a/app/client/ui/AddNewButton.ts
+++ b/app/client/ui/AddNewButton.ts
@@ -1,3 +1,4 @@
+import { kbJumperAnchor } from "app/client/components/RegionFocusSwitcher";
 import { makeT } from "app/client/lib/localization";
 import { theme, vars } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
@@ -18,6 +19,7 @@ export function addNewButton(
   ...args: DomElementArg[]
 ) {
   return cssAddNewButton(
+    kbJumperAnchor,
     cssAddNewButton.cls("-open", isOpen),
     cssAddNewButton.cls("-disabled", isDisabled),
     // Setting spacing as flex items allows them to shrink faster when there isn't enough space.

--- a/app/client/ui/DocList.ts
+++ b/app/client/ui/DocList.ts
@@ -1,3 +1,4 @@
+import { kbJumperAnchor } from "app/client/components/RegionFocusSwitcher";
 import { stopEvent } from "app/client/lib/domUtils";
 import { loadUserManager } from "app/client/lib/imports";
 import { makeT } from "app/client/lib/localization";
@@ -163,7 +164,7 @@ export class DocList extends Disposable {
               cssOptionsColumn(),
             ),
             unstyledUl(
-              dom.forEach(docs, (doc) => {
+              dom.forEach(docs, (doc, index) => {
                 return cssDocRow(
                   cssDoc(
                     cssDoc.cls("-no-access", doc.disabledAt !== undefined || !roles.canView(doc.access)),
@@ -182,6 +183,7 @@ export class DocList extends Disposable {
                           urlState().setLinkUrl(docUrl(doc)),
                           stripIconFromName(doc.name, Boolean(doc.options?.appearance?.icon?.emoji)),
                           testId("doc-name"),
+                          index % 10 === 0 || index === docs.length - 1 ? kbJumperAnchor : null,
                         ),
                         cssDocBadges(
                           doc.isPinned ?

--- a/app/client/ui/FilterConfig.ts
+++ b/app/client/ui/FilterConfig.ts
@@ -1,3 +1,4 @@
+import { kbJumperAnchor } from "app/client/components/RegionFocusSwitcher";
 import { makeT } from "app/client/lib/localization";
 import { ViewSectionRec } from "app/client/models/DocModel";
 import { attachColumnFilterMenu } from "app/client/ui/ColumnFilterMenu";
@@ -102,6 +103,7 @@ export class FilterConfig extends Disposable {
           const filters = use(this._section.filters);
           return textButton(
             t("Add column"),
+            kbJumperAnchor,
             addFilterMenu(filters, this._popupControls, {
               menuOptions: {
                 placement: "bottom-end",

--- a/app/client/ui/HomeLeftPane.ts
+++ b/app/client/ui/HomeLeftPane.ts
@@ -1,3 +1,5 @@
+import { fixOutlineOverflow } from "app/client/components/KeyboardFocusHighlighter";
+import { kbJumperAnchor } from "app/client/components/RegionFocusSwitcher";
 import { startHomeAirtableImport } from "app/client/lib/airtable/startHomeAirtableImport";
 import { loadUserManager } from "app/client/lib/imports";
 import { makeT } from "app/client/lib/localization";
@@ -78,6 +80,8 @@ export function createHomeLeftPane(leftPanelOpen: Observable<boolean>, home: Hom
       ),
       dom("nav",
         { "aria-labelledby": "grist-workspaces-heading" },
+        kbJumperAnchor,
+        fixOutlineOverflow,
         dom.forEach(home.workspaces, (ws) => {
           if (ws.isSupportWorkspace) { return null; }
           const info = getWorkspaceInfo(home.app, ws);
@@ -136,6 +140,8 @@ export function createHomeLeftPane(leftPanelOpen: Observable<boolean>, home: Hom
       )),
       cssHomeTools(
         { "aria-labelledby": "grist-resources-heading" },
+        kbJumperAnchor,
+        fixOutlineOverflow,
         cssSectionHeader(
           cssSectionHeaderText(t("Grist Resources"), { id: "grist-resources-heading" }),
         ),

--- a/app/client/ui/OpenAccessibilityModal.ts
+++ b/app/client/ui/OpenAccessibilityModal.ts
@@ -113,13 +113,14 @@ const keyboardSection = () => {
   const nextRegionShortcut = dom("span", getCssKeys(allCommands.nextRegion.humanKeys));
   const prevRegionShortcut = dom("span", getCssKeys(allCommands.prevRegion.humanKeys));
   const creatorPanelShortcut = dom("span", getCssKeys(allCommands.creatorPanel.humanKeys));
+  const focusSectionHeaderShortcut = dom("span", getCssKeys(allCommands.focusSectionHeader.humanKeys));
   const shortcutsModal = dom("span", getCssKeys(allCommands.shortcuts.humanKeys));
   const accessibilityModal = dom("span", getCssKeys(allCommands.accessibility.humanKeys));
   return cssSection(
     cssModalSubheading(t("Keyboard navigation"), { "role": "heading", "aria-level": 2 }),
     dom("p", t("On a document page, keyboard navigation is first locked on the current widget.")),
     dom("p", t("Focus on other parts of the user interface using the following shortcuts:")),
-    dom("ul",
+    cssShortcutList(
       cssShortcutRow(t("{{nextRegionShortcut}} Focus on the next region", { nextRegionShortcut })),
       cssShortcutRow(t("{{prevRegionShortcut}} Focus on the previous region", { prevRegionShortcut })),
       cssShortcutRow(t("{{creatorPanelShortcut}} Focus to and from the creator panel", { creatorPanelShortcut })),
@@ -136,8 +137,12 @@ const keyboardSection = () => {
       dom("li", t("Finally, the right panel – or the creator panel – is only available \
 through its own shortcut and is not included in the next and previous region cycle.")),
     ),
+    dom("p", t("When focus is on a widget, {{focusSectionHeaderShortcut}} toggles focus between the widget and its \
+header.", { focusSectionHeaderShortcut })),
+    dom("p", t("When focus is on a panel, the same shortcut lets you jump between predefined landmarks, making \
+it easier to quickly navigate inside that panel.")),
     cssModalSubheading(t("Other important keyboard shortcuts"), { "role": "heading", "aria-level": 3 }),
-    dom("ul",
+    cssShortcutList(
       cssShortcutRow(t("{{shortcutsModal}} Show the complete list of keyboard shortcuts", { shortcutsModal })),
       cssShortcutRow(t("{{accessibilityModal}} Show the accessibility options (this modal)", { accessibilityModal })),
     ),
@@ -196,6 +201,10 @@ const cssKey = styled("span", `
   padding: 0.2em 0.4em;
   border-radius: 0.2em;
   line-height: 1.3;
+`);
+
+const cssShortcutList = styled("ul", `
+  padding-left: 0;
 `);
 
 const cssShortcutRow = styled("li", `

--- a/app/client/ui/OpenAccessibilityModal.ts
+++ b/app/client/ui/OpenAccessibilityModal.ts
@@ -113,7 +113,7 @@ const keyboardSection = () => {
   const nextRegionShortcut = dom("span", getCssKeys(allCommands.nextRegion.humanKeys));
   const prevRegionShortcut = dom("span", getCssKeys(allCommands.prevRegion.humanKeys));
   const creatorPanelShortcut = dom("span", getCssKeys(allCommands.creatorPanel.humanKeys));
-  const focusSectionHeaderShortcut = dom("span", getCssKeys(allCommands.focusSectionHeader.humanKeys));
+  const nextJumpTargetShortcut = dom("span", getCssKeys(allCommands.nextJumpTarget.humanKeys));
   const shortcutsModal = dom("span", getCssKeys(allCommands.shortcuts.humanKeys));
   const accessibilityModal = dom("span", getCssKeys(allCommands.accessibility.humanKeys));
   return cssSection(
@@ -137,8 +137,8 @@ const keyboardSection = () => {
       dom("li", t("Finally, the right panel – or the creator panel – is only available \
 through its own shortcut and is not included in the next and previous region cycle.")),
     ),
-    dom("p", t("When focus is on a widget, {{focusSectionHeaderShortcut}} toggles focus between the widget and its \
-header.", { focusSectionHeaderShortcut })),
+    dom("p", t("When focus is on a widget, {{nextJumpTargetShortcut}} toggles focus between the widget and its \
+header.", { nextJumpTargetShortcut })),
     dom("p", t("When focus is on a panel, the same shortcut lets you jump between predefined landmarks, making \
 it easier to quickly navigate inside that panel.")),
     cssModalSubheading(t("Other important keyboard shortcuts"), { "role": "heading", "aria-level": 3 }),

--- a/app/client/ui/Pages.ts
+++ b/app/client/ui/Pages.ts
@@ -1,6 +1,8 @@
 import { createGroup } from "app/client/components/commands";
 import { buildDuplicatePageDialog } from "app/client/components/duplicatePage";
 import { GristDoc } from "app/client/components/GristDoc";
+import { fixOutlineOverflow } from "app/client/components/KeyboardFocusHighlighter";
+import { kbJumperAnchor } from "app/client/components/RegionFocusSwitcher";
 import { makeT } from "app/client/lib/localization";
 import { logTelemetryEvent } from "app/client/lib/telemetry";
 import { PageRec } from "app/client/models/DocModel";
@@ -59,6 +61,8 @@ export function buildPagesDom(owner: Disposable, activeDoc: GristDoc, isOpen: Ob
   // dom
   return dom("nav",
     { "aria-label": t("Document pages") },
+    kbJumperAnchor,
+    fixOutlineOverflow,
     dom.create(TreeViewComponent, model, { isOpen, selected, isReadonly: activeDoc.isReadonly }),
   );
 }

--- a/app/client/ui/RightPanel.ts
+++ b/app/client/ui/RightPanel.ts
@@ -20,6 +20,7 @@ import { MappedFieldsConfig } from "app/client/components/Forms/MappedFieldsConf
 import { GristDoc, IExtraTool, TabContent } from "app/client/components/GristDoc";
 import { EmptyFilterState } from "app/client/components/LinkingState";
 import { RefSelect } from "app/client/components/RefSelect";
+import { kbJumperAnchor } from "app/client/components/RegionFocusSwitcher";
 import ViewConfigTab from "app/client/components/ViewConfigTab";
 import { domAsync } from "app/client/lib/domAsync";
 import * as imports from "app/client/lib/imports";
@@ -508,6 +509,7 @@ export class RightPanel extends Disposable {
             return isRawTable && isSummaryTable;
           }),
           { id: "right-widget-title-input" },
+          kbJumperAnchor,
           testId("right-widget-title"),
         )),
 

--- a/app/client/ui/SortConfig.ts
+++ b/app/client/ui/SortConfig.ts
@@ -1,4 +1,5 @@
 import { GristDoc } from "app/client/components/GristDoc";
+import { kbJumperAnchor } from "app/client/components/RegionFocusSwitcher";
 import koArray from "app/client/lib/koArray";
 import * as kf from "app/client/lib/koForm";
 import { makeT } from "app/client/lib/localization";
@@ -240,6 +241,7 @@ export class SortConfig extends Disposable {
         const cols = use(available);
         return textButton(
           t("Add column"),
+          kbJumperAnchor,
           dropdownWithSearch({
             popupOptions: menuOptions,
             options: () => cols.map(col => ({ label: col.label, value: col })),

--- a/app/client/ui/Tools.ts
+++ b/app/client/ui/Tools.ts
@@ -1,5 +1,7 @@
 import { ACLUsersPopup } from "app/client/aclui/ACLUsers";
 import { GristDoc } from "app/client/components/GristDoc";
+import { fixOutlineOverflow } from "app/client/components/KeyboardFocusHighlighter";
+import { kbJumperAnchor } from "app/client/components/RegionFocusSwitcher";
 import { makeT } from "app/client/lib/localization";
 import { urlState } from "app/client/models/gristUrlState";
 import { getUserOrgPrefObs, markAsSeen } from "app/client/models/UserPrefs";
@@ -61,6 +63,8 @@ export function tools(owner: Disposable, gristDoc: GristDoc, leftPanelOpen: Obse
   updateCanViewAccessRules();
   return cssTools(
     { "aria-labelledby": "grist-tools-heading" },
+    kbJumperAnchor,
+    fixOutlineOverflow,
     cssTools.cls("-collapsed", use => !use(leftPanelOpen)),
     cssSectionHeader(cssSectionHeaderText(t("TOOLS"), { id: "grist-tools-heading" })),
     buildOpenAssistantButton(gristDoc, testId("assistant")),

--- a/app/client/ui/ViewSectionMenu.ts
+++ b/app/client/ui/ViewSectionMenu.ts
@@ -13,6 +13,7 @@ import { basicButton, primaryButton } from "app/client/ui2018/buttons";
 import { isNarrowScreenObs, theme, vars } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
 import { menu } from "app/client/ui2018/menus";
+import { unstyledButton } from "app/client/ui2018/unstyled";
 
 import { Computed, dom, IDisposableOwner, makeTestId, styled } from "grainjs";
 import { defaultMenuOptions } from "popweasel";
@@ -227,7 +228,7 @@ function makeCustomOptions(section: ViewSectionRec) {
 
 const clsOldUI = styled("div", ``);
 
-export const cssMenu = styled("div", `
+export const cssMenu = styled(unstyledButton, `
   display: flex;
   cursor: pointer;
   border-radius: 3px;
@@ -302,7 +303,7 @@ export const cssDotsIconWrapper = styled(cssIconWrapper, `
   }
 `);
 
-const cssExpandIconWrapper = styled("div", `
+const cssExpandIconWrapper = styled(unstyledButton, `
   display: flex;
   border-radius: 3px;
   align-items: center;

--- a/app/client/ui/VisibleFieldsConfig.ts
+++ b/app/client/ui/VisibleFieldsConfig.ts
@@ -1,5 +1,7 @@
 import DetailView from "app/client/components/DetailView";
 import { GristDoc } from "app/client/components/GristDoc";
+import { fixOutlineOverflow } from "app/client/components/KeyboardFocusHighlighter";
+import { kbJumperAnchor } from "app/client/components/RegionFocusSwitcher";
 import { KoArray, syncedKoArray } from "app/client/lib/koArray";
 import * as kf from "app/client/lib/koForm";
 import { makeT } from "app/client/lib/localization";
@@ -215,6 +217,8 @@ export class VisibleFieldsConfig extends Disposable {
     });
     return [
       dom("div", { "role": "group", "aria-labelledby": "visible-fields-label" },
+        kbJumperAnchor,
+        fixOutlineOverflow,
         cssHeader(
           cssFieldListHeader(
             dom.text(use => t("Visible {{label}}", { label: use(this._fieldLabel) })),
@@ -255,6 +259,8 @@ export class VisibleFieldsConfig extends Disposable {
         ),
       ),
       dom("div", { "role": "group", "aria-labelledby": "hidden-fields-label" },
+        kbJumperAnchor,
+        fixOutlineOverflow,
         cssHeader(
           cssHeaderButton(
             icon(

--- a/app/client/ui2018/breadcrumbs.ts
+++ b/app/client/ui2018/breadcrumbs.ts
@@ -1,3 +1,4 @@
+import { kbJumperAnchor } from "app/client/components/RegionFocusSwitcher";
 import { makeT } from "app/client/lib/localization";
 import { urlState } from "app/client/models/gristUrlState";
 import { cssHideForNarrowScreen, mediaNotSmall, testId, theme } from "app/client/ui2018/cssVars";
@@ -183,6 +184,7 @@ export function docBreadcrumbs(
       save: options.docNameSave,
       inputArgs: [
         testId("bc-doc"),
+        kbJumperAnchor,
         cssEditableName.cls(""),
         dom.boolAttr("disabled", options.isDocNameReadOnly || false),
       ],

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -2495,7 +2495,7 @@
         "While not mandatory, you can enable screen reader improvements for a better navigation experience:": "While not mandatory, you can enable screen reader improvements for a better navigation experience:",
         "We recommend using Firefox, Chrome or Edge in order to use Grist with a screen reader.": "We recommend using Firefox, Chrome or Edge in order to use Grist with a screen reader.",
         "When focus is on a panel, the same shortcut lets you jump between predefined landmarks, making it easier to quickly navigate inside that panel.": "When focus is on a panel, the same shortcut lets you jump between predefined landmarks, making it easier to quickly navigate inside that panel.",
-        "When focus is on a widget, {{focusSectionHeaderShortcut}} toggles focus between the widget and its header.": "When focus is on a widget, {{focusSectionHeaderShortcut}} toggles focus between the widget and its header."
+        "When focus is on a widget, {{nextJumpTargetShortcut}} toggles focus between the widget and its header.": "When focus is on a widget, {{nextJumpTargetShortcut}} toggles focus between the widget and its header."
     },
     "ProposedChangesPage": {
         "Proposed changes": "Proposed changes",

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -2493,7 +2493,9 @@
         "Screen reader navigation": "Screen reader navigation",
         "Warning: screen reader support is a work-in-progress in Grist and is improving over time. Feedback is greatly appreciated!": "Warning: screen reader support is a work-in-progress in Grist and is improving over time. Feedback is greatly appreciated!",
         "While not mandatory, you can enable screen reader improvements for a better navigation experience:": "While not mandatory, you can enable screen reader improvements for a better navigation experience:",
-        "We recommend using Firefox, Chrome or Edge in order to use Grist with a screen reader.": "We recommend using Firefox, Chrome or Edge in order to use Grist with a screen reader."
+        "We recommend using Firefox, Chrome or Edge in order to use Grist with a screen reader.": "We recommend using Firefox, Chrome or Edge in order to use Grist with a screen reader.",
+        "When focus is on a panel, the same shortcut lets you jump between predefined landmarks, making it easier to quickly navigate inside that panel.": "When focus is on a panel, the same shortcut lets you jump between predefined landmarks, making it easier to quickly navigate inside that panel.",
+        "When focus is on a widget, {{focusSectionHeaderShortcut}} toggles focus between the widget and its header.": "When focus is on a widget, {{focusSectionHeaderShortcut}} toggles focus between the widget and its header."
     },
     "ProposedChangesPage": {
         "Proposed changes": "Proposed changes",

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -1669,7 +1669,8 @@
     "buildViewSectionDom": {
         "No data": "No data",
         "No row selected in {{title}}": "No row selected in {{title}}",
-        "Not all data is shown": "Not all data is shown"
+        "Not all data is shown": "Not all data is shown",
+        "{{title}} widget header": "{{title}} widget header"
     },
     "FloatingEditor": {
         "Collapse Editor": "Collapse Editor"
@@ -2635,7 +2636,10 @@
         "Open the context menu": "Open the context menu",
         "Toggle the screen reader improvements": "Toggle the screen reader improvements",
         "Open the current column menu": "Open the current column menu",
-        "Open the current row menu": "Open the current row menu"
+        "Open the current row menu": "Open the current row menu",
+        "When focused on a page panel, focus next landmark": "When focused on a page panel, focus next landmark",
+        "When focused on a page panel, focus previous landmark": "When focused on a page panel, focus previous landmark",
+        "When focused on a widget, move focus between widget and widget header": "When focused on a widget, move focus between widget and widget header"
     },
     "GridViewMenusDateHelpers": {
         "12-hour format": "12-hour format",

--- a/static/locales/fr.client.json
+++ b/static/locales/fr.client.json
@@ -2489,7 +2489,9 @@
         "Screen reader navigation": "Navigation avec lecteur d'écran",
         "Warning: screen reader support is a work-in-progress in Grist and is improving over time. Feedback is greatly appreciated!": "Attention : le support des lecteurs d'écran est en cours de développement dans Grist et s'améliore régulièrement. N'hésitez pas à nous faire part de vos retours.",
         "While not mandatory, you can enable screen reader improvements for a better navigation experience:": "Même si ce n'est pas obligatoire, vous pouvez activer les améliorations pour lecteurs d'écran pour une meilleure expérience de navigation :",
-        "We recommend using Firefox, Chrome or Edge in order to use Grist with a screen reader.": "Nous recommandons d'utiliser Firefox, Chrome ou Edge pour utiliser Grist avec un lecteur d'écran."
+        "We recommend using Firefox, Chrome or Edge in order to use Grist with a screen reader.": "Nous recommandons d'utiliser Firefox, Chrome ou Edge pour utiliser Grist avec un lecteur d'écran.",
+        "When focus is on a panel, the same shortcut lets you jump between predefined landmarks, making it easier to quickly navigate inside that panel.": "Quand le focus est dans un panneau, le même raccourci vous permet de sauter rapidement entre des repères prédéfinis, rendant la navigation dans le panneau plus facile.",
+        "When focus is on a widget, {{focusSectionHeaderShortcut}} toggles focus between the widget and its header.": "Quand le focus est dans une vue, {{focusSectionHeaderShortcut}} bascule le focus entre la vue et l'en-tête de la vue."
     },
     "ProposedChangesPage": {
         "Proposed changes": "Suggestions de modifications",

--- a/static/locales/fr.client.json
+++ b/static/locales/fr.client.json
@@ -2491,7 +2491,7 @@
         "While not mandatory, you can enable screen reader improvements for a better navigation experience:": "Même si ce n'est pas obligatoire, vous pouvez activer les améliorations pour lecteurs d'écran pour une meilleure expérience de navigation :",
         "We recommend using Firefox, Chrome or Edge in order to use Grist with a screen reader.": "Nous recommandons d'utiliser Firefox, Chrome ou Edge pour utiliser Grist avec un lecteur d'écran.",
         "When focus is on a panel, the same shortcut lets you jump between predefined landmarks, making it easier to quickly navigate inside that panel.": "Quand le focus est dans un panneau, le même raccourci vous permet de sauter rapidement entre des repères prédéfinis, rendant la navigation dans le panneau plus facile.",
-        "When focus is on a widget, {{focusSectionHeaderShortcut}} toggles focus between the widget and its header.": "Quand le focus est dans une vue, {{focusSectionHeaderShortcut}} bascule le focus entre la vue et l'en-tête de la vue."
+        "When focus is on a widget, {{nextJumpTargetShortcut}} toggles focus between the widget and its header.": "Quand le focus est dans une vue, {{nextJumpTargetShortcut}} bascule le focus entre la vue et l'en-tête de la vue."
     },
     "ProposedChangesPage": {
         "Proposed changes": "Suggestions de modifications",

--- a/static/locales/fr.client.json
+++ b/static/locales/fr.client.json
@@ -1608,7 +1608,8 @@
     "buildViewSectionDom": {
         "No data": "Aucune donnée",
         "No row selected in {{title}}": "Aucune ligne sélectionnée dans {{title}}",
-        "Not all data is shown": "Toute la donnée n'est pas visible"
+        "Not all data is shown": "Toute la donnée n'est pas visible",
+        "{{title}} widget header": "En-tête de la vue {{title}}"
     },
     "UserManager": {
         "Allow anyone with the link to open.": "Permettre à toute personne possédant le lien de l'ouvrir.",
@@ -2563,8 +2564,8 @@
         "Find previous occurrence": "Rechercher l’occurrence précédente",
         "Finish editing a cell and save without moving to next record": "Terminer de modifier une cellule et sauvegarder sans se déplacer sur l'enregistrement suivant",
         "Finish editing a cell, saving the value": "Terminer de modifier une cellule, et sauvegarder la valeur",
-        "Focus next page panel or widget": "Placer le focus sur la prochaine page, panneau ou widget",
-        "Focus previous page panel or widget": "Placer le focus sur la page, panneau ou widget précédente",
+        "Focus next page panel or widget": "Placer le focus sur le prochain panneau ou la prochaine vue",
+        "Focus previous page panel or widget": "Placer le focus sur la page précédente ou la vue précédente",
         "Freeze or unfreeze selected columns": "Figer ou défiger les colonnes sélectionnées",
         "Hide the currently selected columns": "Masquer les colonnes sélectionnées",
         "Hide the currently selected fields": "Masquer les champs sélectionnés",
@@ -2621,7 +2622,7 @@
         "Sort the view data by the currently selected field in ascending order": "Trier les données de la vue par le champ sélectionné dans l'ordre croissant",
         "Sort the view data by the currently selected field in descending order": "Trier les données de la vue par le champ sélectionné dans l'ordre décroissant",
         "Start editing the currently-selected cell": "Commencer à modifier la cellule sélectionnée",
-        "Toggle creator panel keyboard focus": "Alterner le focus du panneau de création",
+        "Toggle creator panel keyboard focus": "Basculer le focus entre le panneau de création et la vue courante",
         "Toggle the currently selected checkbox or switch cell": "Basculer les valeurs de la case à coché ou de l'interrupteur sélectionné",
         "Undo last action": "Annuler la dernière action",
         "Use the currently selected row as table headers": "Utiliser la ligne sélectionnée comme entêtes de table",
@@ -2632,7 +2633,10 @@
         "Open the context menu": "Ouvrir le menu contextuel",
         "Toggle the screen reader improvements": "Activer ou désactiver les améliorations pour lecteurs d'écran",
         "Open the current column menu": "Ouvrir le menu de la colonne actuelle",
-        "Open the current row menu": "Ouvrir le menu de la ligne actuelle"
+        "Open the current row menu": "Ouvrir le menu de la ligne actuelle",
+        "When focused on a page panel, focus next landmark": "Quand le focus est dans un panneau, placer le focus sur le prochain repère",
+        "When focused on a page panel, focus previous landmark": "Quand le focus est dans un panneau, placer le focus sur le repère précédent",
+        "When focused on a widget, move focus between widget and widget header": "Quand le focus est dans une vue, basculer le focus entre la vue et l'en-tête de la vue"
     },
     "GridViewMenusDateHelpers": {
         "12-hour format": "format 12-heures",

--- a/test/nbrowser/RegionFocusSwitcher.ts
+++ b/test/nbrowser/RegionFocusSwitcher.ts
@@ -33,17 +33,27 @@ const assertTabToNavigate = async (containerSelector?: string) => {
 };
 
 const cycle = async (dir: "forward" | "backward" = "forward") => {
-  const modKey = await gu.modKey();
   const shortcut = dir === "forward" ?
-    Key.chord(modKey, "o") :
-    Key.chord(modKey, Key.SHIFT, "O");
+    Key.chord(Key.CONTROL, "o") :
+    Key.chord(Key.CONTROL, Key.SHIFT, "O");
 
   await gu.sendKeys(shortcut);
 };
 
 const toggleCreatorPanelFocus = async () => {
-  const modKey = await gu.modKey();
-  await gu.sendKeys(Key.chord(modKey, Key.ALT, "o"));
+  await gu.sendKeys(Key.chord(Key.CONTROL, Key.ALT, "o"));
+};
+
+const jump = async (dir: "next" | "prev" = "next") => {
+  const shortcut = dir === "next" ?
+    Key.chord(Key.CONTROL, "i") :
+    Key.chord(Key.CONTROL, Key.SHIFT, "I");
+  await gu.sendKeys(shortcut);
+};
+
+const assertActiveElementMatches = async (selector: string, expected: boolean = true) => {
+  const activeElement = await driver.switchTo().activeElement();
+  assert.equal(await activeElement.matches(selector), expected);
 };
 
 const panelMatchs = {
@@ -59,6 +69,10 @@ const assertPanelFocus = async (panel: "left" | "top" | "right" | "main", expect
 const assertSectionFocus = async (sectionId: number, expected: boolean = true) => {
   await expectClipboardFocus(expected);
   assert.equal(await gu.getSectionId() === sectionId, expected);
+};
+
+const assertSectionHeaderFocus = async (sectionId: number, expected: boolean = true) => {
+  await assertActiveElementMatches(`[data-grist-region-id="section-header-${sectionId}"]`, expected);
 };
 
 /**
@@ -293,6 +307,69 @@ describe("RegionFocusSwitcher", function() {
     await driver.find(".test-undo").click();
     await assertPanelFocus("top", false);
     await expectClipboardFocus(true, 0);
+  });
+
+  it("should jump between a widget and its header with Ctrl+I", async function() {
+    const session = await gu.session().teamSite.login();
+    await session.tempNewDoc(cleanup);
+
+    const sectionId = await gu.getSectionId();
+
+    await jump();
+    await assertSectionHeaderFocus(sectionId);
+    await assertTabToNavigate(`[data-grist-region-id="section-header-${sectionId}"]`);
+
+    await driver.sendKeys(Key.ESCAPE);
+    await assertSectionHeaderFocus(sectionId);
+
+    await driver.sendKeys(Key.ESCAPE);
+    await assertSectionFocus(sectionId);
+
+    await jump();
+    await assertSectionHeaderFocus(sectionId);
+
+    await jump();
+    await assertSectionFocus(sectionId);
+  });
+
+  it("should jump through panel landmarks with (Shift+)Ctrl+I", async function() {
+    const session = await gu.session().teamSite.login();
+    await session.tempNewDoc(cleanup);
+
+    await cycle();
+    await assertPanelFocus("left");
+
+    // First landmark is the "Add New" button
+    await jump();
+    await assertActiveElementMatches(".test-dp-add-new");
+
+    // Tab one time to move focus inside the document pages list, then jump back to the
+    // previous landmark, it should be the "Document pages" navigation
+    await driver.sendKeys(Key.TAB);
+    await jump("prev");
+    assert.equal(await driver.switchTo().activeElement().getAttribute("aria-label"), "Document pages");
+
+    // Next landmark is the tools list, pressing tab once in it should focus the Access Rules link
+    await jump();
+    await driver.sendKeys(Key.TAB);
+    await assertActiveElementMatches(".test-tools-access-rules a");
+
+    // There is no landmark left: jumping should loop back to the first landmark
+    await jump();
+    await assertActiveElementMatches(".test-dp-add-new");
+
+    // Cycling through regions and coming back should keep the landmark focus
+    await cycle();
+    await assertPanelFocus("top");
+    await cycle();
+    await cycle();
+    await assertActiveElementMatches(".test-dp-add-new");
+
+    await driver.sendKeys(Key.ESCAPE);
+    await assertPanelFocus("left");
+
+    await driver.sendKeys(Key.ESCAPE);
+    await expectClipboardFocus(true);
   });
 
   afterEach(() => gu.checkForErrors());


### PR DESCRIPTION
## Context

There are two somewhat related issues when navigating with keyboard on a Grist page:

- we may have lots of things in one panel, forcing users to press Tab _a lot_
- widget headers, containing widget title and main interactions (filter, sort, fullscreen button) are not reachable with keyboard

I find those are related because they both are about "navigating inside the current region".

While the first issue is cumbersome but not totally blocking, the second is a more concerning issue, as some widget-related actions are available only through this UI.

## Proposed solution

This adds a new keyboard shortcut intended to be used to navigate inside the current region. @dsagal I vaguely remember you thought of something like this when I first came up with the regions idea. So I'm curious of what you'd think of it!

The idea is:

- I still press (Shift+)Ctrl+O to change active region (widget, or panel)
- and then, I can press (Shift+)Ctrl+I to "jump" between interesting landmarks in that region

For panels, that basically behaves the same as Tabbing, just on a whitelist of elements.  
For widgets, that toggles keyboard focus between the widget itself, and the widget header.


## Related issues

## Has this been tested?

~This still needs a bit of work to make sure everything works, and needs updated tests.~ Done

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts


https://github.com/user-attachments/assets/24a51ce3-8b09-4adb-80d7-5b00877a31bb


