### PR TITLE
Fixes Ref column values imported from not resolving correctly

### DIFF
--- a/app/client/lib/airtable/startDocAirtableImport.ts
+++ b/app/client/lib/airtable/startDocAirtableImport.ts
@@ -22,6 +22,7 @@ export async function startDocAirtableImport(gristDoc: GristDoc) {
             id: use(c.colId),
             ref: use(c.id),
             label: use(c.label),
+            type: use(c.type),
             isFormula: use(c.isFormula),
           })),
         })),

--- a/app/common/DocSchemaImport.ts
+++ b/app/common/DocSchemaImport.ts
@@ -289,8 +289,8 @@ export function tablesToSchema(tables: TableMetadata[]): ExistingDocSchema {
   const tableSchemas: ExistingTableSchema[] = [];
   for (const { id: tableId, fields: { tableRef }, columns = [] } of tables) {
     const tableSchema: ExistingTableSchema = { id: tableId, ref: tableRef, columns: [] };
-    for (const { id: colId, fields: { colRef, label, isFormula } } of columns) {
-      tableSchema.columns.push({ id: colId, ref: colRef, label, isFormula });
+    for (const { id: colId, fields: { colRef, label, isFormula, type } } of columns) {
+      tableSchema.columns.push({ id: colId, ref: colRef, label, isFormula, type });
     }
     tableSchemas.push(tableSchema);
   }

--- a/app/common/DocSchemaImportTypes-ti.ts
+++ b/app/common/DocSchemaImportTypes-ti.ts
@@ -17,6 +17,7 @@ export const ExistingTableSchema = t.iface([], {
 
 export const ExistingColumnSchema = t.iface([], {
   "id": "string",
+  "type": "string",
   "ref": "number",
   "label": t.opt("string"),
   "isFormula": "boolean",

--- a/app/common/DocSchemaImportTypes.ts
+++ b/app/common/DocSchemaImportTypes.ts
@@ -16,6 +16,7 @@ export interface ExistingTableSchema {
 
 export interface ExistingColumnSchema {
   id: string;
+  type: string;
   ref: number;
   // Label is required for column matching to work correctly.
   label?: string;

--- a/app/common/airtable/AirtableDataImporter.ts
+++ b/app/common/airtable/AirtableDataImporter.ts
@@ -16,6 +16,7 @@ import {
   RefValuesByColumnId,
   TableReferenceTracker,
 } from "app/common/airtable/AirtableReferenceTracker";
+import { isRefListType } from "app/common/gristTypes";
 import { AddOrUpdateRecord } from "app/plugin/DocApiTypes";
 import { CellValue, GristObjCode } from "app/plugin/GristData";
 import { convertToBulkColValues } from "app/plugin/TableOperationsImpl";
@@ -54,6 +55,7 @@ export async function importDataFromAirtableBase(
       .map(mapping => ({
         id: mapping.gristColumn.id,
         tableId: resolveLinkedTableId(schemaCrosswalk, mapping.airtableField),
+        isList: isRefListType(mapping.gristColumn.type),
       }));
 
     let tableReferenceTracker: TableReferenceTracker | undefined;

--- a/app/common/airtable/AirtableReferenceTracker.ts
+++ b/app/common/airtable/AirtableReferenceTracker.ts
@@ -15,6 +15,7 @@ interface UnresolvedRefsForRecord {
 interface RefColumn {
   tableId?: string;
   id: string;
+  isList: boolean;
 }
 
 export class ReferenceTracker {
@@ -33,8 +34,9 @@ export class ReferenceTracker {
   }
 
   public resolveCellValue(column: RefColumn, originalRecordIds: string[] | undefined): CellValue {
+    const { isList } = column;
     if (!originalRecordIds) {
-      return [GristObjCode.List];
+      return isList ? [GristObjCode.List] : null;
     }
 
     // If there's an Airtable ID column, the sandbox can perform the lookup for us.
@@ -42,13 +44,17 @@ export class ReferenceTracker {
       column.tableId && this.getTable(column.tableId)?.airtableIdColumnId;
 
     if (otherTableAirtableIdColumnId) {
-      return [GristObjCode.LookUp, originalRecordIds, { column: otherTableAirtableIdColumnId }];
+      return [
+        GristObjCode.LookUp,
+        isList ? originalRecordIds : originalRecordIds[0],
+        { column: otherTableAirtableIdColumnId },
+      ];
     }
 
     const internallyKnownRowIds =
       originalRecordIds.map(originalRecordId => this.lookupRowIdForRecord(originalRecordId)).filter(isNonNullish);
 
-    return [GristObjCode.List, ...internallyKnownRowIds];
+    return isList ? [GristObjCode.List, ...internallyKnownRowIds] : internallyKnownRowIds[0];
   }
 
   public addTable(gristTableId: string, columnIdsToUpdate: RefColumn[], options: { airtableIdColumnId?: string } = {}) {

--- a/app/common/airtable/AirtableReferenceTracker.ts
+++ b/app/common/airtable/AirtableReferenceTracker.ts
@@ -35,8 +35,8 @@ export class ReferenceTracker {
 
   public resolveCellValue(column: RefColumn, originalRecordIds: string[] | undefined): CellValue {
     const { isList } = column;
-    if (!originalRecordIds) {
-      return isList ? [GristObjCode.List] : null;
+    if (!originalRecordIds || originalRecordIds.length === 0) {
+      return null;
     }
 
     // If there's an Airtable ID column, the sandbox can perform the lookup for us.
@@ -53,6 +53,10 @@ export class ReferenceTracker {
 
     const internallyKnownRowIds =
       originalRecordIds.map(originalRecordId => this.lookupRowIdForRecord(originalRecordId)).filter(isNonNullish);
+
+    if (internallyKnownRowIds.length === 0) {
+      return null;
+    }
 
     return isList ? [GristObjCode.List, ...internallyKnownRowIds] : internallyKnownRowIds[0];
   }

--- a/app/common/airtable/AirtableReferenceTracker.ts
+++ b/app/common/airtable/AirtableReferenceTracker.ts
@@ -35,7 +35,7 @@ export class ReferenceTracker {
 
   public resolveCellValue(column: RefColumn, originalRecordIds: string[] | undefined): CellValue {
     const { isList } = column;
-    if (!originalRecordIds || originalRecordIds.length === 0) {
+    if (!originalRecordIds?.length) {
       return null;
     }
 

--- a/test/common/DocSchemaImport.ts
+++ b/test/common/DocSchemaImport.ts
@@ -118,6 +118,7 @@ describe("DocSchemaImport", function() {
             {
               id: "A-1",
               ref: 1,
+              type: "Text",
               isFormula: false,
             },
           ],
@@ -207,6 +208,7 @@ describe("DocSchemaImport", function() {
           columns: [{
             id: "ExistingCol1",
             ref: 1,
+            type: "Text",
             // Needs to match the label on the source column for matching to work.
             label: "Col Alpha",
             isFormula: false,
@@ -279,6 +281,7 @@ describe("DocSchemaImport", function() {
           columns: [{
             id: "ExistingCol1",
             ref: 1,
+            type: "Text",
             // Label doesn't match the column schema's label - column shouldn't match.
             label: "",
             isFormula: false,

--- a/test/common/airtable/AirtableDataImporter.ts
+++ b/test/common/airtable/AirtableDataImporter.ts
@@ -24,55 +24,55 @@ describe("AirtableDataImporter", function() {
   const basicCrosswalkFields = [
     {
       airtableField: { id: "fld0", name: "Name", type: "singleLineText" as const, options: {} },
-      gristColumn: { id: "Name", ref: 100, label: "Name", isFormula: false },
+      gristColumn: { id: "Name", ref: 100, label: "Name", type: "Text", isFormula: false },
     },
     {
       airtableField: { id: "fld1", name: "Count", type: "number" as const, options: {} },
-      gristColumn: { id: "Count", ref: 101, label: "Count", isFormula: true },
+      gristColumn: { id: "Count", ref: 101, label: "Count", type: "Numeric", isFormula: true },
     },
     {
       airtableField: { id: "fld2", name: "Formula", type: "formula" as const, options: {} },
-      gristColumn: { id: "Formula", ref: 102, label: "Formula", isFormula: true },
+      gristColumn: { id: "Formula", ref: 102, label: "Formula", type: "Any", isFormula: true },
     },
     {
       airtableField: { id: "fld3", name: "Links", type: "multipleRecordLinks" as const, options: {} },
-      gristColumn: { id: "Links", ref: 103, label: "Links", isFormula: false },
+      gristColumn: { id: "Links", ref: 103, label: "Links", type: "RefList:Main", isFormula: false },
     },
     {
       airtableField: { id: "fld4", name: "AiField", type: "aiText" as const, options: {} },
-      gristColumn: { id: "AiField", ref: 104, label: "AiField", isFormula: false },
+      gristColumn: { id: "AiField", ref: 104, label: "AiField", type: "Text", isFormula: false },
     },
     {
       airtableField: { id: "fld5", name: "CreatedBy", type: "createdBy" as const, options: {} },
-      gristColumn: { id: "CreatedBy", ref: 105, label: "CreatedBy", isFormula: false },
+      gristColumn: { id: "CreatedBy", ref: 105, label: "CreatedBy", type: "Text", isFormula: false },
     },
     {
       airtableField: { id: "fld6", name: "ModifiedBy", type: "lastModifiedBy" as const, options: {} },
-      gristColumn: { id: "ModifiedBy", ref: 106, label: "ModifiedBy", isFormula: false },
+      gristColumn: { id: "ModifiedBy", ref: 106, label: "ModifiedBy", type: "Text", isFormula: false },
     },
     {
       airtableField: { id: "fld7", name: "Collaborators", type: "multipleCollaborators" as const, options: {} },
-      gristColumn: { id: "Collaborators", ref: 107, label: "Collaborators", isFormula: false },
+      gristColumn: { id: "Collaborators", ref: 107, label: "Collaborators", type: "Text", isFormula: false },
     },
     {
       airtableField: { id: "fld8", name: "SingleCollaborator", type: "singleCollaborator" as const, options: {} },
-      gristColumn: { id: "SingleCollaborator", ref: 108, label: "SingleCollaborator", isFormula: false },
+      gristColumn: { id: "SingleCollaborator", ref: 108, label: "SingleCollaborator", type: "Text", isFormula: false },
     },
     {
       airtableField: { id: "fld9", name: "MultipleSelects", type: "multipleSelects" as const, options: {} },
-      gristColumn: { id: "MultipleSelects", ref: 109, label: "MultipleSelects", isFormula: false },
+      gristColumn: { id: "MultipleSelects", ref: 109, label: "MultipleSelects", type: "ChoiceList", isFormula: false },
     },
     {
       airtableField: { id: "fld10", name: "Rollup", type: "rollup" as const, options: {} },
-      gristColumn: { id: "Rollup", ref: 110, label: "Rollup", isFormula: true },
+      gristColumn: { id: "Rollup", ref: 110, label: "Rollup", type: "Any", isFormula: true },
     },
     {
       airtableField: { id: "fld11", name: "Lookup", type: "lookup" as const, options: {} },
-      gristColumn: { id: "Lookup", ref: 111, label: "Lookup", isFormula: true },
+      gristColumn: { id: "Lookup", ref: 111, label: "Lookup", type: "Any", isFormula: true },
     },
     {
       airtableField: { id: "fld12", name: "Attachments", type: "multipleAttachments" as const, options: {} },
-      gristColumn: { id: "Attachments", ref: 112, label: "Attachments", isFormula: false },
+      gristColumn: { id: "Attachments", ref: 112, label: "Attachments", type: "Attachments", isFormula: false },
     },
   ];
 
@@ -87,7 +87,9 @@ describe("AirtableDataImporter", function() {
       fields.set(fieldPair.airtableField.name, fieldPair);
     }
 
-    const airtableIdColumn = { id: AirtableIdColumnId, ref: 111, label: AirtableIdColumnLabel, isFormula: false };
+    const airtableIdColumn = {
+      id: AirtableIdColumnId, ref: 111, label: AirtableIdColumnLabel, type: "Text", isFormula: false,
+    };
     gristColumns.push(airtableIdColumn);
 
     return {
@@ -215,8 +217,8 @@ describe("AirtableDataImporter", function() {
       tracker.addTable("foods", [], { airtableIdColumnId: undefined });
 
       const tableTracker = tracker.addTable("country", [
-        { id: "cities", tableId: "cities" },
-        { id: "local_foods", tableId: "foods" },
+        { id: "cities", tableId: "cities", isList: true },
+        { id: "local_foods", tableId: "foods", isList: true },
       ]);
 
       tableTracker.addUnresolvedRecord({
@@ -254,14 +256,63 @@ describe("AirtableDataImporter", function() {
       });
     });
 
+    it("resolves references via sandbox lookup if an Airtable id column exists", async () => {
+      const tracker = new ReferenceTracker();
+
+      // The target table has an Airtable Id column, so resolution is delegated to the sandbox
+      // via GristObjCode.LookUp regardless of whether the row ids are known locally.
+      tracker.addTable("people", [], { airtableIdColumnId: "Airtable_Id" });
+
+      const tableTracker = tracker.addTable("employees", [
+        // Ref column: single reference, `isList: false`.
+        { id: "manager", tableId: "people", isList: false },
+        // RefList column: multiple references, `isList: true`.
+        { id: "reports", tableId: "people", isList: true },
+      ]);
+
+      tableTracker.addUnresolvedRecord({
+        gristRecordId: 1,
+        refsByColumnId: {
+          manager: ["airtable-manager"],
+          reports: ["airtable-report-1", "airtable-report-2"],
+        },
+      });
+
+      // No manager, no reports - covers the "undefined refs" branch for each isList value.
+      tableTracker.addUnresolvedRecord({
+        gristRecordId: 2,
+        refsByColumnId: {},
+      });
+
+      await tableTracker.bulkUpdateRowsWithUnresolvedReferences(updateRowsMock);
+
+      const call = updateRowsMock.getCall(0);
+      const updates = call.args[1];
+      assert.deepEqual(updates, {
+        id: [1, 2],
+        manager: [
+          // Ref columns result in a single record id sent to the sandbox, not a list.
+          [GristObjCode.LookUp, "airtable-manager", { column: "Airtable_Id" }],
+          // No references to resolve results in null.
+          null,
+        ],
+        reports: [
+          // RefList columns result in a list of record ids sent to the sandbox.
+          [GristObjCode.LookUp, ["airtable-report-1", "airtable-report-2"], { column: "Airtable_Id" }],
+          // No references to resolve results in an empty list.
+          [GristObjCode.List],
+        ],
+      });
+    });
+
     it("skips unresolvable references without error", async () => {
       const tracker = new ReferenceTracker();
 
       tracker.addRecordIdMapping("airtable-rec-1", 10);
 
       const tableTracker = tracker.addTable("users", [
-        { id: "friends", tableId: "people" },
-        { id: "email", tableId: "emails" },
+        { id: "friends", tableId: "people", isList: true },
+        { id: "email", tableId: "emails", isList: true },
       ]);
 
       // Reference to an unmapped record
@@ -287,7 +338,7 @@ describe("AirtableDataImporter", function() {
 
       tracker.addRecordIdMapping("airtable-rec-1", 10);
       const tableTracker = tracker.addTable("users", [{
-        id: "col1", tableId: "users",
+        id: "col1", tableId: "users", isList: true,
       }]);
 
       // Add more than default batch size (100) records
@@ -316,7 +367,7 @@ describe("AirtableDataImporter", function() {
       const tracker = new ReferenceTracker();
 
       tracker.addRecordIdMapping("airtable-rec-1", 10);
-      const tableTracker = tracker.addTable("users", [{ id: "col1", tableId: "users" }]);
+      const tableTracker = tracker.addTable("users", [{ id: "col1", tableId: "users", isList: true }]);
 
       // Add 25 records
       for (let i = 0; i < 25; i++) {
@@ -337,7 +388,7 @@ describe("AirtableDataImporter", function() {
 
     it("does not update if there are no unresolved records", async () => {
       const tracker = new ReferenceTracker();
-      const tableTracker = tracker.addTable("users", [{ id: "friends", tableId: "users" }]);
+      const tableTracker = tracker.addTable("users", [{ id: "friends", tableId: "users", isList: true }]);
 
       const updateRowsMock = sinon.stub().resolves([]);
 

--- a/test/common/airtable/AirtableDataImporter.ts
+++ b/test/common/airtable/AirtableDataImporter.ts
@@ -251,7 +251,7 @@ describe("AirtableDataImporter", function() {
         ],
         local_foods: [
           [GristObjCode.List, 101, 102],
-          [GristObjCode.List],
+          null,
         ],
       });
     });
@@ -299,8 +299,8 @@ describe("AirtableDataImporter", function() {
         reports: [
           // RefList columns result in a list of record ids sent to the sandbox.
           [GristObjCode.LookUp, ["airtable-report-1", "airtable-report-2"], { column: "Airtable_Id" }],
-          // No references to resolve results in an empty list.
-          [GristObjCode.List],
+          // No references to resolve results in null.
+          null,
         ],
       });
     });
@@ -585,7 +585,7 @@ describe("AirtableDataImporter", function() {
       const updateCall = updateRowsMock.getCall(0);
       const updates = updateCall.args[1];
       // Row IDs are created incrementally starting at 1 - so the two referenced rows have 2 and 3.
-      assert.deepEqual(updates.Links, [[GristObjCode.List, 3, 2], [GristObjCode.List], [GristObjCode.List]]);
+      assert.deepEqual(updates.Links, [[GristObjCode.List, 3, 2], null, null]);
     });
 
     it("handles multiple pages of records", async () => {

--- a/test/nbrowser/AirtableImport.ts
+++ b/test/nbrowser/AirtableImport.ts
@@ -345,6 +345,7 @@ describe("AirtableImport", function() {
         assert.deepEqual(await driver.findAll(".test-import-airtable-table-name", el => el.getText()), [
           "Products",
           "Suppliers",
+          "Brand",
           "Orders",
         ]);
       });
@@ -355,8 +356,9 @@ describe("AirtableImport", function() {
           "New table",
           "New table",
           "New table",
+          "New table",
         ]);
-        assert.equal(await driver.find(".test-import-airtable-import").getText(), "Import 3 tables");
+        assert.equal(await driver.find(".test-import-airtable-import").getText(), "Import 4 tables");
 
         // Import Products (tbl79ux7qppckp8hr) as a new table.
         await driver.find(".test-import-airtable-table-tbl79ux7qppckp8hr-destination").click();
@@ -370,8 +372,9 @@ describe("AirtableImport", function() {
           "New table",
           "New table",
           "New table",
+          "New table",
         ]);
-        assert.equal(await driver.find(".test-import-airtable-import").getText(), "Import 3 tables");
+        assert.equal(await driver.find(".test-import-airtable-import").getText(), "Import 4 tables");
 
         // Import Suppliers (tblbyte2tg72cbhhf) as a new table without data.
         await driver.find(".test-import-airtable-table-tblbyte2tg72cbhhf-destination").click();
@@ -385,8 +388,9 @@ describe("AirtableImport", function() {
           "New table",
           "Structure only",
           "New table",
+          "New table",
         ]);
-        assert.equal(await driver.find(".test-import-airtable-import").getText(), "Import 3 tables");
+        assert.equal(await driver.find(".test-import-airtable-import").getText(), "Import 4 tables");
 
         // Skip importing Orders (tblfyhS37Hst5Hvsf).
         await driver.find(".test-import-airtable-table-tblfyhS37Hst5Hvsf-destination").click();
@@ -399,9 +403,10 @@ describe("AirtableImport", function() {
         assert.deepEqual(await driver.findAll(".test-import-airtable-destination-label", el => el.getText()), [
           "New table",
           "Structure only",
+          "New table",
           "Skip",
         ]);
-        assert.equal(await driver.find(".test-import-airtable-import").getText(), "Import 2 tables");
+        assert.equal(await driver.find(".test-import-airtable-import").getText(), "Import 3 tables");
       });
 
       it("should import Airtable base to a new Grist document", async function() {
@@ -410,18 +415,19 @@ describe("AirtableImport", function() {
         await gu.waitForDocToLoad();
 
         assert.equal(await driver.find(".test-bc-doc").value(), "Product planning");
-        assert.deepEqual(await gu.getPageNames(), ["Products", "Suppliers"]);
+        assert.deepEqual(await gu.getPageNames(), ["Products", "Suppliers", "Brand"]);
         assert.deepEqual(await gu.getColumnNames(), [
           "Airtable Id",
           "Name",
           "Price",
           "Category",
           "Suppliers",
+          "Brand",
         ]);
-        assert.deepEqual(await gu.getVisibleGridCells({ rowNums: [1, 2, 3], cols: [0, 1, 2, 3, 4] }), [
-          "reccaegwskzka7wi1", "Widget X", "99.99", "Electronics", "",
-          "recigwb4bc7vq2fhd", "Gadget Y", "149.99", "Electronics", "",
-          "", "", "", "", "",
+        assert.deepEqual(await gu.getVisibleGridCells({ rowNums: [1, 2, 3], cols: [0, 1, 2, 3, 4, 5] }), [
+          "reccaegwskzka7wi1", "Widget X", "99.99", "Electronics", "", "Brand[1]",
+          "recigwb4bc7vq2fhd", "Gadget Y", "149.99", "Electronics", "", "Brand[2]",
+          "", "", "", "", "", "",
         ]);
 
         await gu.getPageItem("Suppliers").click();
@@ -463,6 +469,7 @@ describe("AirtableImport", function() {
           "New table",
           "New table: structure only",
           "Skip",
+          "Brand",
           "Products",
           "Suppliers",
         ]);
@@ -471,8 +478,9 @@ describe("AirtableImport", function() {
           "Products",
           "New table",
           "New table",
+          "New table",
         ]);
-        assert.equal(await driver.find(".test-import-airtable-import").getText(), "Import 3 tables");
+        assert.equal(await driver.find(".test-import-airtable-import").getText(), "Import 4 tables");
 
         // Import Suppliers (tblbyte2tg72cbhhf) as a new table without data.
         await driver.find(".test-import-airtable-table-tblbyte2tg72cbhhf-destination").click();
@@ -480,6 +488,7 @@ describe("AirtableImport", function() {
           "New table",
           "New table: structure only",
           "Skip",
+          "Brand",
           "Products",
           "Suppliers",
         ]);
@@ -488,24 +497,45 @@ describe("AirtableImport", function() {
           "Products",
           "Suppliers",
           "New table",
+          "New table",
         ]);
-        assert.equal(await driver.find(".test-import-airtable-import").getText(), "Import 3 tables");
+        assert.equal(await driver.find(".test-import-airtable-import").getText(), "Import 4 tables");
+
+        // Import Brand (tblbra7dxq31mnstp) to the existing Brand table.
+        await driver.find(".test-import-airtable-table-tblbra7dxq31mnstp-destination").click();
+        assert.deepEqual(await gu.findOpenMenuAllItems("li", el => el.getText()), [
+          "New table",
+          "New table: structure only",
+          "Skip",
+          "Brand",
+          "Products",
+          "Suppliers",
+        ]);
+        await gu.findOpenMenuItem("li", "Brand").click();
+        assert.deepEqual(await driver.findAll(".test-import-airtable-destination-label", el => el.getText()), [
+          "Products",
+          "Suppliers",
+          "Brand",
+          "New table",
+        ]);
+        assert.equal(await driver.find(".test-import-airtable-import").getText(), "Import 4 tables");
 
         await driver.find(".test-import-airtable-import").click();
         await waitForModalToClose();
 
-        assert.deepEqual(await gu.getPageNames(), ["Products", "Suppliers", "Orders"]);
+        assert.deepEqual(await gu.getPageNames(), ["Products", "Suppliers", "Brand", "Orders"]);
         assert.deepEqual(await gu.getColumnNames(), [
           "Airtable Id",
           "Name",
           "Price",
           "Category",
           "Suppliers",
+          "Brand",
         ]);
-        assert.deepEqual(await gu.getVisibleGridCells({ rowNums: [1, 2, 3], cols: [0, 1, 2, 3, 4] }), [
-          "reccaegwskzka7wi1", "Widget X", "99.99", "Electronics", "Suppliers[1]",
-          "recigwb4bc7vq2fhd", "Gadget Y", "149.99", "Electronics", "Suppliers[2]",
-          "", "", "", "", "",
+        assert.deepEqual(await gu.getVisibleGridCells({ rowNums: [1, 2, 3], cols: [0, 1, 2, 3, 4, 5] }), [
+          "reccaegwskzka7wi1", "Widget X", "99.99", "Electronics", "Suppliers[1]", "Brand[1]",
+          "recigwb4bc7vq2fhd", "Gadget Y", "149.99", "Electronics", "Suppliers[2]", "Brand[2]",
+          "", "", "", "", "", "",
         ]);
 
         await gu.getPageItem("Suppliers").click();
@@ -575,7 +605,7 @@ describe("AirtableImport", function() {
         await driver.findWait(".test-import-airtable-import", 2000).click();
         await waitForModalToClose();
 
-        assert.deepEqual(await gu.getPageNames(), ["Table1", "Products", "Suppliers", "Orders"]);
+        assert.deepEqual(await gu.getPageNames(), ["Table1", "Products", "Suppliers", "Brand", "Orders"]);
 
         await gu.getPageItem("Products").click();
         assert.deepEqual(await gu.getColumnNames(), [
@@ -584,11 +614,12 @@ describe("AirtableImport", function() {
           "Price",
           "Category",
           "Suppliers",
+          "Brand",
         ]);
-        assert.deepEqual(await gu.getVisibleGridCells({ rowNums: [1, 2, 3], cols: [0, 1, 2, 3, 4] }), [
-          "reccaegwskzka7wi1", "Widget X", "99.99", "Electronics", "Suppliers[1]",
-          "recigwb4bc7vq2fhd", "Gadget Y", "149.99", "Electronics", "Suppliers[2]",
-          "", "", "", "", "",
+        assert.deepEqual(await gu.getVisibleGridCells({ rowNums: [1, 2, 3], cols: [0, 1, 2, 3, 4, 5] }), [
+          "reccaegwskzka7wi1", "Widget X", "99.99", "Electronics", "Suppliers[1]", "Brand[1]",
+          "recigwb4bc7vq2fhd", "Gadget Y", "149.99", "Electronics", "Suppliers[2]", "Brand[2]",
+          "", "", "", "", "", "",
         ]);
 
         await gu.getPageItem("Suppliers").click();
@@ -685,6 +716,15 @@ const airtableBaseSchemaFixture = {
             linkedTableId: "tblbyte2tg72cbhhf",
           },
         },
+        {
+          id: "fldpb9mpc01qrstuv",
+          name: "Brand",
+          type: "multipleRecordLinks",
+          options: {
+            linkedTableId: "tblbra7dxq31mnstp",
+            prefersSingleRecordLink: true,
+          },
+        },
       ],
     }, {
       id: "tblbyte2tg72cbhhf",
@@ -705,6 +745,17 @@ const airtableBaseSchemaFixture = {
           id: "fldo0m0ozf0k5aatm",
           name: "Phone",
           type: "phoneNumber",
+        },
+      ],
+    }, {
+      id: "tblbra7dxq31mnstp",
+      name: "Brand",
+      primaryFieldId: "fldbn8zk4l2qwrxyc",
+      fields: [
+        {
+          id: "fldbn8zk4l2qwrxyc",
+          name: "Name",
+          type: "singleLineText",
         },
       ],
     }, {
@@ -750,6 +801,7 @@ const airtableListRecordsFixture = {
         Price: 99.99,
         Category: "Electronics",
         Suppliers: ["recoa4mwyeytxu3fb"],
+        Brand: ["recb1uvwxyz012345"],
       },
       createdTime: "2023-01-01T00:00:00.000Z",
     }, {
@@ -759,6 +811,7 @@ const airtableListRecordsFixture = {
         Price: 149.99,
         Category: "Electronics",
         Suppliers: ["recw7cwwskv1q5jck"],
+        Brand: ["recb2fghijkl67890"],
       },
       createdTime: "2023-01-02T00:00:00.000Z",
     }],
@@ -783,7 +836,21 @@ const airtableListRecordsFixture = {
       createdTime: "2023-01-02T00:00:00.000Z",
     }],
   },
-
+  tblbra7dxq31mnstp: {
+    records: [{
+      id: "recb1uvwxyz012345",
+      fields: {
+        Name: "Acme Corp",
+      },
+      createdTime: "2023-01-01T00:00:00.000Z",
+    }, {
+      id: "recb2fghijkl67890",
+      fields: {
+        Name: "Globex",
+      },
+      createdTime: "2023-01-02T00:00:00.000Z",
+    }],
+  },
   tblfyhS37Hst5Hvsf: {
     records: [{
       id: "recjngmiw6qy39v53",


### PR DESCRIPTION
## Context

When Grist imports an Airtable reference column, it can pass the Airtable record ids to the sandbox to get looked up in the target table.

If the Airtable reference column only allows a single reference, we import it as a Ref column instead of a RefList. However, when the "lookup records by id" value was sent to the sandbox for a Ref column, it was still an array. The sandbox wouldn't perform a lookup, and just leave the Airtable record is in the cell as alt text.

## Proposed solution

This passes the column type to the reference resolver, and allows the reference resolver to decide to send either a single record id to lookup or an array of them.

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
