### PR TITLE
Fixes Airtable count column erroring with Ref column

### DIFF
--- a/app/common/airtable/AirtableSchemaImporter.ts
+++ b/app/common/airtable/AirtableSchemaImporter.ts
@@ -160,7 +160,7 @@ const AirtableFieldMappers: { [type: string]: AirtableFieldMapper } = {
     const fieldOptions = field.options;
     if (fieldOptions?.isValid && fieldOptions.recordLinkFieldId) {
       formula = {
-        formula: "len($[R0])",
+        formula: "len($[R0]) if isinstance($[R0], list) else int(bool($[R0]))",
         replacements: [{ originalTableId: table.id, originalColId: fieldOptions.recordLinkFieldId }],
       };
     }

--- a/test/common/airtable/AirtableSchemaImporter.ts
+++ b/test/common/airtable/AirtableSchemaImporter.ts
@@ -185,7 +185,7 @@ describe("AirtableSchemaImporter", function() {
         type: "Numeric",
         isFormula: true,
         formula: {
-          formula: "len($[R0])",
+          formula: "len($[R0]) if isinstance($[R0], list) else int(bool($[R0]))",
           replacements: [{ originalTableId: firstTableId, originalColId: referencedField.id }],
         },
       });


### PR DESCRIPTION
## Context

The Airtable importer imports Airtable reference columns as either "Ref" or "RefList" columns, depending on whether the Airtable column is limited to 1 entry.

In Airtable, a "Count" column will output the number of referenced records in a reference column, even if limited to 1.

Currently in Grist, an imported "Count" column will error if the column it refers to was imported as a "Ref" and not a "RefList".

## Proposed solution

This adjust the "Count" column formula to handle both Ref and RefList columns. 

## Has this been tested?

- [X] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

