### PR TITLE
Grid option to hide row numbers, or show rowIDs in their place

### DIFF
--- a/app/client/components/Forms/FormConfig.ts
+++ b/app/client/components/Forms/FormConfig.ts
@@ -1,5 +1,6 @@
 import { fromKoSave } from "app/client/lib/fromKoSave";
 import { makeT } from "app/client/lib/localization";
+import { obsPropWithSaveOnWrite } from "app/client/lib/obsPropWithSaveOnWrite";
 import { ViewFieldRec } from "app/client/models/DocModel";
 import { fieldWithDefault, SaveableObjObservable } from "app/client/models/modelUtil";
 import { FormFieldOptions, FormOptionsAlignment, FormOptionsSortOrder, FormSelectFormat } from "app/client/ui/FormAPI";
@@ -16,7 +17,7 @@ import { labeledSquareCheckbox } from "app/client/ui2018/checkbox";
 import { theme } from "app/client/ui2018/cssVars";
 import { select } from "app/client/ui2018/menus";
 
-import { Computed, Disposable, dom, fromKo, IDisposableOwner, makeTestId, styled } from "grainjs";
+import { Disposable, dom, fromKo, makeTestId, styled } from "grainjs";
 
 const t = makeT("FormConfig");
 
@@ -133,27 +134,6 @@ export class FormOptionsLimitConfig extends Disposable {
       ),
     ];
   }
-}
-
-/**
- * obsPropWithSaveOnWrite(owner, observable, prop, fallback) creates an observable for
- * observable()[prop], similar to fieldWithDefault(jsonObservable.prop(prop), fallback).
- *
- * It also sets and saves the observable on write, to satisfy the expectations of the checkbox
- * element. It uses `setAndSaveOrRevert` for saving.
- *
- * TODO Move this helper to a common place, e.g. modelUtil once it's converted to typescript.
- */
-function obsPropWithSaveOnWrite<Props extends object, Key extends keyof Props, Val extends Props[Key]>(
-  owner: IDisposableOwner,
-  obs: SaveableObjObservable<Props>,
-  prop: Key,
-  fallback: Val,
-): Computed<NonNullable<Props[Key]> | Val> {
-  return Computed.create(owner, use => use(obs)[prop] ?? fallback)
-    .onWrite((value) => {
-      obs.setAndSaveOrRevert({ ...obs.peek(), [prop]: value }).catch(reportError);
-    });
 }
 
 export class FormFieldRulesConfig extends Disposable {

--- a/app/client/components/GridView.css
+++ b/app/client/components/GridView.css
@@ -93,13 +93,20 @@
   cursor: pointer;
 }
 
-/* Row IDs mode: monospace IDs in grey brackets */
+/* Row IDs mode: monospace IDs in grey decorative brackets */
 .gridview_row_id {
   font-family: var(--grist-theme-font-family-mono, monospace);
   font-size: 0.9em;
 }
-.gridview_row_id_bracket {
+.gridview_row_id::before,
+.gridview_row_id::after {
   color: var(--grist-theme-text-light, #929299);
+}
+.gridview_row_id::before {
+  content: "[";
+}
+.gridview_row_id::after {
+  content: "]";
 }
 
 /* Menu toggle on a row */

--- a/app/client/components/GridView.css
+++ b/app/client/components/GridView.css
@@ -12,6 +12,10 @@
   -moz-user-select: none;
   -webkit-user-select: none;
   --gridview-header-height: 24px;
+  /* Width of the row-number gutter, and of the record's left border beside it. Both are set
+   * from JS on this element (both zero when row numbers are hidden); these are the defaults. */
+  --row-num-width: 52px;
+  --row-num-border: 1px;
 }
 
 .gridview_data_scroll {
@@ -46,7 +50,7 @@
 }
 
 .gridview_corner_spacer { /* spacer in .gridview_data_header */
-  width: 52px; /* matches row_num width */
+  width: var(--row-num-width); /* matches row_num width */
   flex: none;
 }
 
@@ -64,12 +68,18 @@
   display:flex;
 }
 
+/* The record's left border, against the row-number gutter (viewCommon.css sets its style and
+   color); it collapses together with the gutter. */
+.gridview_data_pane .record {
+  border-left-width: var(--row-num-border);
+}
+
 .gridview_data_row_num { /* Row nums, stick to the left side */
   position: -webkit-sticky;
   position: sticky;
   left: 0px;
   overflow: hidden;
-  width: 52px; /* Also should match width for .gridview_header_corner, and the overlay elements */
+  width: var(--row-num-width); /* Also should match width for .gridview_header_corner, and the overlay elements */
   flex: none;
 
   border-bottom: 1px solid var(--grist-theme-table-header-border, lightgray);
@@ -133,7 +143,7 @@
     border-left: 1px solid var(--grist-color-dark-grey);
   }
   .print-widget .gridview_data_header {
-    padding-left: 52px !important;
+    padding-left: var(--row-num-width) !important;
   }
   .print-widget .gridview_data_pane .print-all-rows {
     display: table-row-group;
@@ -157,10 +167,34 @@
 }
 
 .gridview_data_corner_overlay {
-  width: 52px;
+  width: var(--row-num-width);
   height: var(--gridview-header-height);
   z-index: 30;
   cursor: pointer;
+}
+
+/* Labels the gutter in Row IDs mode; styled like a column header. */
+.gridview_corner_label {
+  line-height: var(--gridview-header-height);
+  text-align: center;
+  color: var(--grist-theme-table-header-fg, unset);
+}
+
+/* Corner menu toggle (row-numbers menu), styled like the row-header menu toggles. Uses opacity
+ * rather than visibility so that it can also be revealed by hovering the toggle itself when the
+ * gutter is hidden: the corner is then 0px wide and the toggle sits (via the max() below) over
+ * the left edge of the first column header. */
+.gridview_data_corner_overlay .menu_toggle {
+  position: absolute;
+  top: 2px;
+  left: max(4px, calc(var(--row-num-width) - 18px));
+  opacity: 0;
+}
+
+.gridview_data_corner_overlay:hover .menu_toggle,
+.gridview_data_corner_overlay .menu_toggle:hover,
+.gridview_data_corner_overlay .menu_toggle.weasel-popup-open {
+  opacity: 1;
 }
 
 /* Left most shadow - displayed next to row numbers or when columns are frozen - after last frozen column */
@@ -177,7 +211,7 @@
      - frozen-offset: when frozen columns are wider then the screen, we want them to move left initially,
                       this value is the position where this movement should stop.
    */
-  left: calc(52px + (var(--frozen-width, 0) - min(var(--frozen-scroll-offset, 0), var(--frozen-offset, 0))) * 1px);
+  left: calc(var(--row-num-width) + (var(--frozen-width, 0) - min(var(--frozen-scroll-offset, 0), var(--frozen-offset, 0))) * 1px);
   box-shadow: -6px 0 6px 6px var(--grist-theme-table-scroll-shadow, #444);
   /* shadow should only show to the right of it (10px should be enough) */
   -webkit-clip-path: polygon(0 0, 10px 0, 10px 100%, 0 100%);
@@ -189,7 +223,7 @@
 .scroll_shadow_frozen {
   height: 100%;
   width: 0px;
-  left: 52px;
+  left: var(--row-num-width);
   box-shadow: -8px 0 14px 4px var(--grist-theme-table-scroll-shadow, #444);
   -webkit-clip-path: polygon(0 0, 10px 0, 10px 100%, 0 100%);
   clip-path: polygon(0 0, 28px 0, 24px 100%, 0 100%);
@@ -205,7 +239,7 @@
   /* this value is the same as for the left shadow - but doesn't need to really on the scroll offset
      as this component will be hidden when the scroll starts
    */
-  left: calc(52px + var(--frozen-width, 0) * 1px);
+  left: calc(var(--row-num-width) + var(--frozen-width, 0) * 1px);
   background-color: var(--grist-theme-table-frozen-columns-border, #999999);
   z-index: 30;
   user-select: none;
@@ -226,19 +260,20 @@
 }
 
 .gridview_header_backdrop_left {
-  width: calc(52px + 1px); /* Matches rowid width (+border) */
+  width: calc(var(--row-num-width) + var(--row-num-border)); /* Matches rowid width (+border) */
   height:100%;
   top: 1px; /* go under 1px border on scrollpane */
   z-index: 10;
-  border-right: 1px solid var(--grist-theme-table-header-border, lightgray);
+  border-right: var(--row-num-border) solid var(--grist-theme-table-header-border, lightgray);
 }
 
 .gridview_left_border {
   position: absolute;
+  left: var(--row-num-width);
   width: 0px; /* Matches rowid width (+border) */
   height: 100%;
   z-index: 30;
-  border-right: 1px solid var(--grist-theme-table-body-border, var(--grist-color-dark-grey)) !important;
+  border-right: var(--row-num-border) solid var(--grist-theme-table-body-border, var(--grist-color-dark-grey)) !important;
   user-select: none;
   pointer-events: none
 }
@@ -309,7 +344,7 @@
 /* style header and a data field */
 .record .field.frozen {
   position: sticky;
-  left: calc(52px + 1px + (var(--frozen-position, 0) - var(--frozen-offset, 0)) * 1px); /* 52px (4em) for row number + total width of cells + 1px for border*/
+  left: calc(var(--row-num-width) + var(--row-num-border) + (var(--frozen-position, 0) - var(--frozen-offset, 0)) * 1px); /* row-number gutter + its border + total width of cells */
   z-index: 10;
 }
 /* for data field we need to reuse color from record (add-row and zebra stripes) */

--- a/app/client/components/GridView.css
+++ b/app/client/components/GridView.css
@@ -96,6 +96,7 @@
 /* Row IDs mode: monospace IDs in grey brackets */
 .gridview_row_id {
   font-family: var(--grist-theme-font-family-mono, monospace);
+  font-size: 0.9em;
 }
 .gridview_row_id_bracket {
   color: var(--grist-theme-text-light, #929299);

--- a/app/client/components/GridView.css
+++ b/app/client/components/GridView.css
@@ -93,6 +93,14 @@
   cursor: pointer;
 }
 
+/* Row IDs mode: monospace IDs in grey brackets */
+.gridview_row_id {
+  font-family: var(--grist-theme-font-family-mono, monospace);
+}
+.gridview_row_id_bracket {
+  color: var(--grist-theme-text-light, #929299);
+}
+
 /* Menu toggle on a row */
 .gridview_data_row_num .menu_toggle {
   visibility: hidden;

--- a/app/client/components/GridView.ts
+++ b/app/client/components/GridView.ts
@@ -180,10 +180,10 @@ export default class GridView extends BaseView {
     this._inline = gridOptions?.inline ?? false;
     this._autoWidthHolder = this.autoDispose(new Holder());
 
-    const rowNumbers = viewSectionModel.optionsObj.prop("rowNumbers");
+    const sectionOptions = viewSectionModel.optionsObj;
     this._rowIndexRenderer = gridOptions?.rowIndexRenderer ??
       (row => dom.text((use) => {
-        if (use(rowNumbers) === "rowId") {
+        if (use(sectionOptions).rowNumbers === "rowId") {
           const rowId = use(row.id);
           // The add-row's id observable is left blank (it has no rowId yet); show nothing for it.
           return typeof rowId === "number" ? `[${rowId}]` : "";
@@ -292,7 +292,7 @@ export default class GridView extends BaseView {
     this.numFrozen = this.viewSection.numFrozen;
     // Width of the row-number gutter; collapses to zero when row numbers are hidden.
     this._rowNumWidth = this.autoDispose(ko.pureComputed<number>(() =>
-      rowNumbers() === "hidden" ? 0 : ROW_NUMBER_WIDTH));
+      sectionOptions().rowNumbers === "hidden" ? 0 : ROW_NUMBER_WIDTH));
     // calculate total width of all frozen columns
     this.frozenWidth = this.autoDispose(ko.pureComputed(() => this.colRightOffsets().getSumTo(this.numFrozen())));
     // show frozenLine when have some frozen columns and not scrolled left
@@ -1386,7 +1386,6 @@ export default class GridView extends BaseView {
     const vHorizontalGridlines = v.optionsObj.prop("horizontalGridlines");
     const vVerticalGridlines   = v.optionsObj.prop("verticalGridlines");
     const vZebraStripes        = v.optionsObj.prop("zebraStripes");
-    const vRowNumbers          = v.optionsObj.prop("rowNumbers");
 
     const renameCommands = {
       nextField: () => {
@@ -1421,7 +1420,7 @@ export default class GridView extends BaseView {
         "div.gridview_data_corner_overlay",
         this._cornerRenderer,
         // In Row IDs mode, label the gutter, header-style, to name what the bracketed values are.
-        dom.maybe(use => use(vRowNumbers) === "rowId", () =>
+        dom.maybe(use => use(v.optionsObj).rowNumbers === "rowId", () =>
           dom("div.gridview_corner_label", t("ID"), testId("corner-label"))),
         this._buildCornerMenu(),
       ),

--- a/app/client/components/GridView.ts
+++ b/app/client/components/GridView.ts
@@ -182,11 +182,16 @@ export default class GridView extends BaseView {
 
     const sectionOptions = viewSectionModel.optionsObj;
     this._rowIndexRenderer = gridOptions?.rowIndexRenderer ??
-      (row => dom.text((use) => {
+      (row => dom.domComputed((use) => {
         if (use(sectionOptions).rowNumbers === "rowId") {
           const rowId = use(row.id);
           // The add-row's id observable is left blank (it has no rowId yet); show nothing for it.
-          return typeof rowId === "number" ? `[${rowId}]` : "";
+          if (typeof rowId !== "number") { return null; }
+          return dom("span.gridview_row_id",
+            dom("span.gridview_row_id_bracket", "["),
+            String(rowId),
+            dom("span.gridview_row_id_bracket", "]"),
+          );
         }
         return String(use(row._index)! + 1);
       }));

--- a/app/client/components/GridView.ts
+++ b/app/client/components/GridView.ts
@@ -2218,12 +2218,19 @@ export default class GridView extends BaseView {
    */
   private _buildCornerMenu() {
     if (this.isReadonly || this.gridOptions?.rowMenu === false) { return null; }
-    return menuToggle(null,
-      // Don't let the click through to the corner's select-all handler.
-      dom.on("click", ev => ev.stopPropagation()),
-      menu(() => rowNumbersMenu(this.viewSection), { trigger: ["click"] }),
-      testId("corner-menu-trigger"),
-    );
+    return [
+      // Open the menu on right-click anywhere in the corner, the same way as row headers do.
+      dom.on("contextmenu", (ev) => {
+        ev.preventDefault();
+        ((ev.currentTarget as HTMLElement).querySelector<HTMLElement>(".menu_toggle"))?.click();
+      }),
+      menuToggle(null,
+        // Don't let the click through to the corner's select-all handler.
+        dom.on("click", ev => ev.stopPropagation()),
+        menu(() => rowNumbersMenu(this.viewSection), { trigger: ["click"] }),
+        testId("corner-menu-trigger"),
+      ),
+    ];
   }
 
   protected _getRowContextMenuOptions(): IRowContextMenu {

--- a/app/client/components/GridView.ts
+++ b/app/client/components/GridView.ts
@@ -187,11 +187,7 @@ export default class GridView extends BaseView {
           const rowId = use(row.id);
           // The add-row's id observable is left blank (it has no rowId yet); show nothing for it.
           if (typeof rowId !== "number") { return null; }
-          return dom("span.gridview_row_id",
-            dom("span.gridview_row_id_bracket", "["),
-            String(rowId),
-            dom("span.gridview_row_id_bracket", "]"),
-          );
+          return dom("span.gridview_row_id", String(rowId));
         }
         return String(use(row._index)! + 1);
       }));

--- a/app/client/components/GridView.ts
+++ b/app/client/components/GridView.ts
@@ -40,6 +40,7 @@ import {
   calcFieldsCondition,
   freezeAction,
   IMultiColumnContextMenu,
+  rowNumbersMenu,
 } from "app/client/ui/GridViewMenus";
 import { menuToggle } from "app/client/ui/MenuToggle";
 import { mouseDragMatchElem } from "app/client/ui/mouseDrag";
@@ -169,6 +170,7 @@ export default class GridView extends BaseView {
   private _inline: boolean;
   private _rowIndexRenderer: RowIndexRenderer;
   private _cornerRenderer: CornerRenderer;
+  private _rowNumWidth: ko.Computed<number>;
   private _autoWidthHolder: Holder<Disposable>;
 
   constructor(gristDoc: GristDoc, viewSectionModel: ViewSectionRec, protected gridOptions?: GridViewOptions) {
@@ -178,8 +180,16 @@ export default class GridView extends BaseView {
     this._inline = gridOptions?.inline ?? false;
     this._autoWidthHolder = this.autoDispose(new Holder());
 
+    const rowNumbers = viewSectionModel.optionsObj.prop("rowNumbers");
     this._rowIndexRenderer = gridOptions?.rowIndexRenderer ??
-      (row => dom.text(use => String(use(row._index)! + 1)));
+      (row => dom.text((use) => {
+        if (use(rowNumbers) === "rowId") {
+          const rowId = use(row.id);
+          // The add-row's id observable is left blank (it has no rowId yet); show nothing for it.
+          return typeof rowId === "number" ? `[${rowId}]` : "";
+        }
+        return String(use(row._index)! + 1);
+      }));
     this._cornerRenderer = gridOptions?.cornerRenderer ??
       (() => dom.on("click", () => this.selectAll()));
     this.viewSection = viewSectionModel;
@@ -280,6 +290,9 @@ export default class GridView extends BaseView {
     this.width = ko.observable(0);
     // helper for clarity
     this.numFrozen = this.viewSection.numFrozen;
+    // Width of the row-number gutter; collapses to zero when row numbers are hidden.
+    this._rowNumWidth = this.autoDispose(ko.pureComputed<number>(() =>
+      rowNumbers() === "hidden" ? 0 : ROW_NUMBER_WIDTH));
     // calculate total width of all frozen columns
     this.frozenWidth = this.autoDispose(ko.pureComputed(() => this.colRightOffsets().getSumTo(this.numFrozen())));
     // show frozenLine when have some frozen columns and not scrolled left
@@ -297,14 +310,14 @@ export default class GridView extends BaseView {
       const revealWidth = lastField ? lastField.widthDef() : 0;
       // calculate the offset: start from zero, then move all left to hide frozen columns,
       // then to right to fill whole width, then to left to reveal last column and plus button
-      const initialOffset = -this.frozenWidth() - ROW_NUMBER_WIDTH + this.width() - revealWidth - PLUS_WIDTH;
+      const initialOffset = -this.frozenWidth() - this._rowNumWidth() + this.width() - revealWidth - PLUS_WIDTH;
       // Final check - we actually don't want to have
       // the split (between frozen and normal columns) be moved left too far,
       // it should stop at the middle of the available grid space (whole width - row number width).
       // This can happen when last column is too wide, and we are not able to show it in a full width.
       // To calculate the middle point: hide all frozen columns (by moving them maximum to the left)
       // and then move them to right by half width of the section.
-      const middleOffset = -this.frozenWidth() - ROW_NUMBER_WIDTH + this.width() / 2;
+      const middleOffset = -this.frozenWidth() - this._rowNumWidth() + this.width() / 2;
       // final offset is the bigger number of those two (offsets are negative - so take
       // the number that is closer to 0)
       const offset = Math.floor(Math.max(initialOffset, middleOffset));
@@ -579,7 +592,7 @@ export default class GridView extends BaseView {
           const fields = this.viewSection.viewFields().all();
           const fieldsWidthSum = fields.reduce((sum, field) => sum + field.widthDef.peek(), 0);
 
-          const targetWidth =  Math.min(fieldsWidthSum + ROW_NUMBER_WIDTH + scrollSize.width, maxWidth);
+          const targetWidth =  Math.min(fieldsWidthSum + this._rowNumWidth.peek() + scrollSize.width, maxWidth);
           widthObs.set(targetWidth);
         };
         updateWidth();
@@ -1373,6 +1386,7 @@ export default class GridView extends BaseView {
     const vHorizontalGridlines = v.optionsObj.prop("horizontalGridlines");
     const vVerticalGridlines   = v.optionsObj.prop("verticalGridlines");
     const vZebraStripes        = v.optionsObj.prop("zebraStripes");
+    const vRowNumbers          = v.optionsObj.prop("rowNumbers");
 
     const renameCommands = {
       nextField: () => {
@@ -1396,11 +1410,20 @@ export default class GridView extends BaseView {
       styleCustomVar("--frozen-offset", this.frozenOffset),
       // total width of frozen columns
       styleCustomVar("--frozen-width", this.frozenWidth),
+      // width of the row-number gutter (zero when hidden)
+      styleCustomVar("--row-num-width", use => `${use(this._rowNumWidth)}px`),
+      // the record's left border, delineating it from the gutter (none when the gutter is
+      // hidden, which would otherwise double up with the widget frame's border)
+      styleCustomVar("--row-num-border", use => use(this._rowNumWidth) === 0 ? "0px" : use(v.borderWidthPx)),
       // Corner, bars and shadows
       // Corner and shadows (so it's fixed to the grid viewport)
       this._cornerDom = dom(
         "div.gridview_data_corner_overlay",
         this._cornerRenderer,
+        // In Row IDs mode, label the gutter, header-style, to name what the bracketed values are.
+        dom.maybe(use => use(vRowNumbers) === "rowId", () =>
+          dom("div.gridview_corner_label", t("ID"), testId("corner-label"))),
+        this._buildCornerMenu(),
       ),
       dom("div.scroll_shadow_top", dom.show(this.scrollShadow.top)),
       dom("div.scroll_shadow_left",
@@ -1414,9 +1437,7 @@ export default class GridView extends BaseView {
       // it comes from the first cell in the grid) making a gap between row-number and actual column. So when we scroll
       // the content of the scrolled columns will be visible to the user (as there is blank space there).
       // This line fills the gap. NOTE that we are using number here instead of a boolean.
-      dom("div.gridview_left_border", dom.show(use => Boolean(use(this.numFrozen))),
-        dom.style("left", ROW_NUMBER_WIDTH + "px"),
-      ),
+      dom("div.gridview_left_border", dom.show(use => Boolean(use(this.numFrozen)))),
       // left shadow that will be visible on top of frozen columns
       dom("div.scroll_shadow_frozen", dom.show(this.frozenShadow)),
       // When cursor leaves the GridView, remove hover immediately (without debounce).
@@ -1465,7 +1486,6 @@ export default class GridView extends BaseView {
 
               dom("div.column_names.record",
                 dom.style("minWidth", "100%"),
-                dom.style("borderLeftWidth", v.borderWidthPx),
                 kd.foreach(v.viewFields(), (field: ViewFieldRec) => {
                   const canRename = ko.pureComputed(() => !field.column().disableEditData());
                   const isEditingLabel = koUtil.withKoUtils(ko.pureComputed({
@@ -1667,7 +1687,6 @@ export default class GridView extends BaseView {
 
         // rowid dom
         dom("div.gridview_data_row_num",
-          dom.style("width", ROW_NUMBER_WIDTH + "px"),
           dom("div.gridview_data_row_info",
             dom.cls("linked_dst", (use) => {
               const myRowId = use(row.id);
@@ -1709,7 +1728,6 @@ export default class GridView extends BaseView {
         ),
         dom("div.record",
           dom.cls("record-add", row._isAddRow),
-          dom.style("borderLeftWidth", v.borderWidthPx),
           dom.style("borderBottomWidth", v.borderWidthPx),
           dom.cls("font-bold", fontBold),
           dom.cls("font-underline", fontUnderline),
@@ -2030,7 +2048,7 @@ export default class GridView extends BaseView {
     const colStart = this.cellSelector.colLower();
     const colEnd = this.cellSelector.colUpper();
     const shadowWidth = this.colRightOffsets.peek().getCumulativeValueRange(colStart, colEnd + 1);
-    const shadowLeft = (ROW_NUMBER_WIDTH + this.colRightOffsets.peek().getSumTo(colStart) - this.scrollLeft());
+    const shadowLeft = (this._rowNumWidth.peek() + this.colRightOffsets.peek().getSumTo(colStart) - this.scrollLeft());
 
     this.colLine.style.left = shadowLeft + "px";
     this.colShadow.style.left = shadowLeft + "px";
@@ -2081,7 +2099,7 @@ export default class GridView extends BaseView {
       dropIndex = Math.min(dropIndex, this.cellSelector.colLower());
     }
 
-    let linePos = ROW_NUMBER_WIDTH + this.colRightOffsets.peek().getSumTo(dropIndex);
+    let linePos = this._rowNumWidth.peek() + this.colRightOffsets.peek().getSumTo(dropIndex);
     // If there are frozen columns and dropIndex (column index) is inside the frozen set.
     const frozenCount = this.numFrozen();
     const inFrozen = frozenCount > 0 && dropIndex < frozenCount;
@@ -2192,6 +2210,21 @@ export default class GridView extends BaseView {
   protected rowContextMenu() {
     const options = this._getRowContextMenuOptions();
     return this.customRowMenu(RowContextMenu(options), options);
+  }
+
+  /**
+   * Menu toggle in the top-left corner of the grid, for choosing what the row-number gutter
+   * shows. When the gutter is hidden it sits over the left edge of the first column header
+   * (see its positioning in GridView.css); it is revealed on hover.
+   */
+  private _buildCornerMenu() {
+    if (this.isReadonly || this.gridOptions?.rowMenu === false) { return null; }
+    return menuToggle(null,
+      // Don't let the click through to the corner's select-all handler.
+      dom.on("click", ev => ev.stopPropagation()),
+      menu(() => rowNumbersMenu(this.viewSection), { trigger: ["click"] }),
+      testId("corner-menu-trigger"),
+    );
   }
 
   protected _getRowContextMenuOptions(): IRowContextMenu {

--- a/app/client/lib/obsPropWithSaveOnWrite.ts
+++ b/app/client/lib/obsPropWithSaveOnWrite.ts
@@ -1,0 +1,27 @@
+import { reportError } from "app/client/models/errors";
+import { SaveableObjObservable } from "app/client/models/modelUtil";
+
+import { Computed, IDisposableOwner } from "grainjs";
+
+/**
+ * obsPropWithSaveOnWrite(owner, observable, prop, fallback) creates an observable for
+ * observable()[prop], similar to fieldWithDefault(jsonObservable.prop(prop), fallback), but
+ * without involving jsonObservable's per-property knockout machinery.
+ *
+ * On write, it sets and saves the full object with the one property updated, using
+ * `setAndSaveOrRevert`. Writing a value equal to the one currently shown is a no-op, so that
+ * e.g. re-selecting the current option of a select() doesn't produce an empty user action.
+ */
+export function obsPropWithSaveOnWrite<Props extends object, Key extends keyof Props, Val extends Props[Key]>(
+  owner: IDisposableOwner,
+  obs: SaveableObjObservable<Props>,
+  prop: Key,
+  fallback: Val,
+): Computed<NonNullable<Props[Key]> | Val> {
+  return Computed.create(owner, use => use(obs)[prop] ?? fallback)
+    .onWrite((value) => {
+      if (value !== (obs.peek()[prop] ?? fallback)) {
+        obs.setAndSaveOrRevert({ ...obs.peek(), [prop]: value }).catch(reportError);
+      }
+    });
+}

--- a/app/client/models/entities/ViewSectionRec.ts
+++ b/app/client/models/entities/ViewSectionRec.ts
@@ -82,11 +82,16 @@ export interface ChartOptions {
   aggregate?: boolean;
 }
 
+// What the row-number gutter of a grid shows: position numbers (default), bracketed row IDs,
+// or nothing (gutter collapsed).
+export type RowNumbersMode = "number" | "rowId" | "hidden";
+
 export interface ViewSectionOptions extends ChartOptions {
   // Options for GridView.
   verticalGridlines?: boolean;
   horizontalGridlines?: boolean;
   zebraStripes?: boolean;
+  rowNumbers?: RowNumbersMode;
   numFrozen?: number;
   rowHeight?: number;           // Optional limit on height of rows, in lines.
   rowHeightUniform?: boolean;   // Whether rowHeight should make rows uniform height, by expanding shorter rows.
@@ -472,6 +477,7 @@ export function createViewSectionRec(this: ViewSectionRec, docModel: DocModel): 
     verticalGridlines: true,
     horizontalGridlines: true,
     zebraStripes: false,
+    rowNumbers: "number",
     customView: "",
     numFrozen: 0,
   };

--- a/app/client/ui/GridOptions.ts
+++ b/app/client/ui/GridOptions.ts
@@ -1,13 +1,15 @@
 import { makeT } from "app/client/lib/localization";
 import { obsPropWithSaveOnWrite } from "app/client/lib/obsPropWithSaveOnWrite";
 import { ViewSectionRec } from "app/client/models/DocModel";
-import { rowNumbersModeOptions } from "app/client/ui/GridViewMenus";
+import { RowNumbersMode } from "app/client/models/entities/ViewSectionRec";
+import { rowNumbersMenu } from "app/client/ui/GridViewMenus";
 import { cssGroupLabel, cssRow } from "app/client/ui/RightPanelStyles";
 import { labeledSquareCheckbox } from "app/client/ui2018/checkbox";
-import { testId } from "app/client/ui2018/cssVars";
-import { select } from "app/client/ui2018/menus";
+import { testId, theme } from "app/client/ui2018/cssVars";
+import { icon } from "app/client/ui2018/icons";
+import { menu } from "app/client/ui2018/menus";
 
-import { Disposable, dom, styled } from "grainjs";
+import { Computed, Disposable, dom, Observable, styled } from "grainjs";
 
 const t = makeT("GridOptions");
 
@@ -21,6 +23,19 @@ export class GridOptions extends Disposable {
 
   public buildDom() {
     const options = this._section.optionsObj;
+    const rowNumbers = obsPropWithSaveOnWrite(this, options, "rowNumbers", "number" as RowNumbersMode);
+
+    // What the gutter shows when visible. Remembered while hidden, so that re-checking "Show"
+    // restores the last mode rather than always resetting to numbers.
+    const shownMode = Observable.create<RowNumbersMode>(this,
+      rowNumbers.get() === "hidden" ? "number" : rowNumbers.get());
+    this.autoDispose(rowNumbers.addListener((mode) => {
+      if (mode !== "hidden") { shownMode.set(mode); }
+    }));
+
+    const showRowNumbers = Computed.create(this, use => use(rowNumbers) !== "hidden")
+      .onWrite(show => rowNumbers.set(show ? shownMode.get() : "hidden"));
+
     return dom("div",
       { "role": "group", "aria-labelledby": "grid-options-label" },
       cssGroupLabel(t("Grid Options"), { id: "grid-options-label" }),
@@ -50,10 +65,12 @@ export class GridOptions extends Disposable {
         ),
 
         cssRow(
-          cssSelectLabel(t("Row numbers"), { id: "row-numbers-label" }),
-          dom.update(
-            select(obsPropWithSaveOnWrite(this, options, "rowNumbers", "number"), rowNumbersModeOptions()),
-            { "aria-labelledby": "row-numbers-label" },
+          labeledSquareCheckbox(showRowNumbers, t("Show"), testId("row-numbers-show")),
+          cssModeLink(
+            dom.text(use => use(shownMode) === "rowId" ? t("row IDs") : t("row numbers")),
+            icon("Dropdown"),
+            menu(() => rowNumbersMenu(this._section, { includeHidden: false })),
+            testId("row-numbers-mode"),
           ),
           testId("row-numbers"),
         ),
@@ -64,7 +81,12 @@ export class GridOptions extends Disposable {
   }
 }
 
-const cssSelectLabel = styled("span", `
-  flex: 1 0 auto;
-  margin-right: 16px;
+// Link-like trigger for the row-numbers mode menu, continuing the checkbox's label.
+const cssModeLink = styled("div", `
+  display: flex;
+  align-items: center;
+  margin-left: 4px;
+  color: ${theme.controlFg};
+  --icon-color: ${theme.controlFg};
+  cursor: pointer;
 `);

--- a/app/client/ui/GridOptions.ts
+++ b/app/client/ui/GridOptions.ts
@@ -1,11 +1,13 @@
 import { makeT } from "app/client/lib/localization";
 import { ViewSectionRec } from "app/client/models/DocModel";
 import { KoSaveableObservable, setSaveValue } from "app/client/models/modelUtil";
+import { rowNumbersModeOptions } from "app/client/ui/GridViewMenus";
 import { cssGroupLabel, cssRow } from "app/client/ui/RightPanelStyles";
 import { labeledSquareCheckbox } from "app/client/ui2018/checkbox";
 import { testId } from "app/client/ui2018/cssVars";
+import { select } from "app/client/ui2018/menus";
 
-import { Computed, Disposable, dom, IDisposableOwner } from "grainjs";
+import { Computed, Disposable, dom, IDisposableOwner, styled } from "grainjs";
 
 const t = makeT("GridOptions");
 
@@ -47,19 +49,35 @@ export class GridOptions extends Disposable {
           testId("zebra-stripe-button"),
         ),
 
+        cssRow(
+          cssSelectLabel(t("Row numbers"), { id: "row-numbers-label" }),
+          dom.update(
+            select(setSaveValueFromKo(this, section.optionsObj.prop("rowNumbers")), rowNumbersModeOptions()),
+            { "aria-labelledby": "row-numbers-label" },
+          ),
+          testId("row-numbers"),
+        ),
+
         testId("grid-options"),
       ]),
     );
   }
 }
 
-// Returns a grainjs observable that reflects the value of obs a knockout saveable observable. The
-// returned observable will set and save obs to the given value when written. If the obs.save() call
-// fails, then it gets reset to its previous value.
-function setSaveValueFromKo(owner: IDisposableOwner, obs: KoSaveableObservable<boolean | undefined>) {
-  const ret = Computed.create(null, use => use(obs) ?? false);
+// Returns a grainjs observable that reflects the value of obs a knockout saveable observable.
+// The returned observable will set and save obs to the given value when written; the save is
+// skipped if the value is unchanged, and if the obs.save() call fails, then obs gets reset to
+// its previous value. The value is never actually undefined: all grid options get defaults
+// merged in by ViewSectionRec's defaultOptions.
+function setSaveValueFromKo<T>(owner: IDisposableOwner, obs: KoSaveableObservable<T | undefined>) {
+  const ret = Computed.create(owner, use => use(obs)!);
   ret.onWrite(async (val) => {
     await setSaveValue(obs, val);
   });
   return ret;
 }
+
+const cssSelectLabel = styled("span", `
+  flex: 1 0 auto;
+  margin-right: 16px;
+`);

--- a/app/client/ui/GridOptions.ts
+++ b/app/client/ui/GridOptions.ts
@@ -1,13 +1,13 @@
 import { makeT } from "app/client/lib/localization";
+import { obsPropWithSaveOnWrite } from "app/client/lib/obsPropWithSaveOnWrite";
 import { ViewSectionRec } from "app/client/models/DocModel";
-import { KoSaveableObservable, setSaveValue } from "app/client/models/modelUtil";
 import { rowNumbersModeOptions } from "app/client/ui/GridViewMenus";
 import { cssGroupLabel, cssRow } from "app/client/ui/RightPanelStyles";
 import { labeledSquareCheckbox } from "app/client/ui2018/checkbox";
 import { testId } from "app/client/ui2018/cssVars";
 import { select } from "app/client/ui2018/menus";
 
-import { Computed, Disposable, dom, IDisposableOwner, styled } from "grainjs";
+import { Disposable, dom, styled } from "grainjs";
 
 const t = makeT("GridOptions");
 
@@ -20,14 +20,14 @@ export class GridOptions extends Disposable {
   }
 
   public buildDom() {
-    const section = this._section;
+    const options = this._section.optionsObj;
     return dom("div",
       { "role": "group", "aria-labelledby": "grid-options-label" },
       cssGroupLabel(t("Grid Options"), { id: "grid-options-label" }),
       dom("div", [
         cssRow(
           labeledSquareCheckbox(
-            setSaveValueFromKo(this, section.optionsObj.prop("verticalGridlines")),
+            obsPropWithSaveOnWrite(this, options, "verticalGridlines", true),
             t("Vertical gridlines"),
           ),
           testId("v-grid-button"),
@@ -35,7 +35,7 @@ export class GridOptions extends Disposable {
 
         cssRow(
           labeledSquareCheckbox(
-            setSaveValueFromKo(this, section.optionsObj.prop("horizontalGridlines")),
+            obsPropWithSaveOnWrite(this, options, "horizontalGridlines", true),
             t("Horizontal gridlines"),
           ),
           testId("h-grid-button"),
@@ -43,7 +43,7 @@ export class GridOptions extends Disposable {
 
         cssRow(
           labeledSquareCheckbox(
-            setSaveValueFromKo(this, section.optionsObj.prop("zebraStripes")),
+            obsPropWithSaveOnWrite(this, options, "zebraStripes", false),
             t("Zebra stripes"),
           ),
           testId("zebra-stripe-button"),
@@ -52,7 +52,7 @@ export class GridOptions extends Disposable {
         cssRow(
           cssSelectLabel(t("Row numbers"), { id: "row-numbers-label" }),
           dom.update(
-            select(setSaveValueFromKo(this, section.optionsObj.prop("rowNumbers")), rowNumbersModeOptions()),
+            select(obsPropWithSaveOnWrite(this, options, "rowNumbers", "number"), rowNumbersModeOptions()),
             { "aria-labelledby": "row-numbers-label" },
           ),
           testId("row-numbers"),
@@ -62,19 +62,6 @@ export class GridOptions extends Disposable {
       ]),
     );
   }
-}
-
-// Returns a grainjs observable that reflects the value of obs a knockout saveable observable.
-// The returned observable will set and save obs to the given value when written; the save is
-// skipped if the value is unchanged, and if the obs.save() call fails, then obs gets reset to
-// its previous value. The value is never actually undefined: all grid options get defaults
-// merged in by ViewSectionRec's defaultOptions.
-function setSaveValueFromKo<T>(owner: IDisposableOwner, obs: KoSaveableObservable<T | undefined>) {
-  const ret = Computed.create(owner, use => use(obs)!);
-  ret.onWrite(async (val) => {
-    await setSaveValue(obs, val);
-  });
-  return ret;
 }
 
 const cssSelectLabel = styled("span", `

--- a/app/client/ui/GridViewMenus.ts
+++ b/app/client/ui/GridViewMenus.ts
@@ -6,7 +6,7 @@ import { makeT } from "app/client/lib/localization";
 import { ColumnRec } from "app/client/models/entities/ColumnRec";
 import { ViewFieldRec } from "app/client/models/entities/ViewFieldRec";
 import { RowNumbersMode, ViewSectionRec } from "app/client/models/entities/ViewSectionRec";
-import { setSaveValue } from "app/client/models/modelUtil";
+import { reportError } from "app/client/models/errors";
 import { buildDateHelpersMenuItems } from "app/client/ui/GridViewMenusDateHelpers";
 import { withInfoTooltip } from "app/client/ui/tooltips";
 import { isNarrowScreen, testId, theme, vars } from "app/client/ui2018/cssVars";
@@ -1068,11 +1068,16 @@ export function rowNumbersModeOptions(): IOptionFull<RowNumbersMode>[] {
  * The active mode is marked with a green tick.
  */
 export function rowNumbersMenu(viewSection: ViewSectionRec): DomElementArg[] {
-  const prop = viewSection.optionsObj.prop("rowNumbers");
+  const options = viewSection.optionsObj;
+  const setMode = (rowNumbers: RowNumbersMode) => {
+    if (options.peek().rowNumbers !== rowNumbers) {
+      options.setAndSaveOrRevert({ ...options.peek(), rowNumbers }).catch(reportError);
+    }
+  };
   return [
     menuSubHeader(t("Row numbers")),
-    ...rowNumbersModeOptions().map(({ value, label }) => menuItem(() => setSaveValue(prop, value),
-      cssTickSlot(prop.peek() === value ? icon("Tick", testId("row-numbers-selected")) : null),
+    ...rowNumbersModeOptions().map(({ value, label }) => menuItem(() => setMode(value),
+      cssTickSlot(options.peek().rowNumbers === value ? icon("Tick", testId("row-numbers-selected")) : null),
       label,
     )),
   ];

--- a/app/client/ui/GridViewMenus.ts
+++ b/app/client/ui/GridViewMenus.ts
@@ -1078,7 +1078,7 @@ export function rowNumbersMenu(viewSection: ViewSectionRec): DomElementArg[] {
     menuSubHeader(t("Row numbers")),
     ...rowNumbersModeOptions().map(({ value, label }) => menuItem(() => setMode(value),
       cssTickSlot(options.peek().rowNumbers === value ? icon("Tick", testId("row-numbers-selected")) : null),
-      label,
+      value === "rowId" ? withInfoTooltip(label, "rowIds", { variant: "hover" }) : label,
     )),
   ];
 }

--- a/app/client/ui/GridViewMenus.ts
+++ b/app/client/ui/GridViewMenus.ts
@@ -5,12 +5,15 @@ import { GristDoc } from "app/client/components/GristDoc";
 import { makeT } from "app/client/lib/localization";
 import { ColumnRec } from "app/client/models/entities/ColumnRec";
 import { ViewFieldRec } from "app/client/models/entities/ViewFieldRec";
+import { RowNumbersMode, ViewSectionRec } from "app/client/models/entities/ViewSectionRec";
+import { setSaveValue } from "app/client/models/modelUtil";
 import { buildDateHelpersMenuItems } from "app/client/ui/GridViewMenusDateHelpers";
 import { withInfoTooltip } from "app/client/ui/tooltips";
 import { isNarrowScreen, testId, theme, vars } from "app/client/ui2018/cssVars";
 import { IconName } from "app/client/ui2018/IconList";
 import { icon } from "app/client/ui2018/icons";
 import {
+  IOptionFull,
   menuCssClass,
   menuDivider,
   menuIcon,
@@ -1045,5 +1048,44 @@ const cssListFun = styled("div", `
   text-align: center;
   .${weasel.cssMenuItem.className}-sel & {
     color: ${theme.choiceTokenFg};
+  }
+`);
+
+/**
+ * The choices of what the row-number gutter shows, shared by the widget-panel select and the
+ * grid's corner menu.
+ */
+export function rowNumbersModeOptions(): IOptionFull<RowNumbersMode>[] {
+  return [
+    { value: "number", label: t("Numbers") },
+    { value: "rowId", label: t("Row IDs") },
+    { value: "hidden", label: t("Hidden") },
+  ];
+}
+
+/**
+ * Menu to choose what the row-number gutter shows, opened from the grid's top-left corner.
+ * The active mode is marked with a green tick.
+ */
+export function rowNumbersMenu(viewSection: ViewSectionRec): DomElementArg[] {
+  const prop = viewSection.optionsObj.prop("rowNumbers");
+  return [
+    menuSubHeader(t("Row numbers")),
+    ...rowNumbersModeOptions().map(({ value, label }) => menuItem(() => setSaveValue(prop, value),
+      cssTickSlot(prop.peek() === value ? icon("Tick", testId("row-numbers-selected")) : null),
+      label,
+    )),
+  ];
+}
+
+// A menuIcon-sized slot for the tick marking the active mode, rendered (empty) on every item so
+// that the labels align. The tick turns white while its item is selected, to stay visible.
+const cssTickSlot = styled("div", `
+  flex: none;
+  width: 16px;
+  margin-right: 8px;
+  --icon-color: ${theme.controlFg};
+  .${weasel.cssMenuItem.className}-sel & {
+    --icon-color: ${theme.menuItemSelectedFg};
   }
 `);

--- a/app/client/ui/GridViewMenus.ts
+++ b/app/client/ui/GridViewMenus.ts
@@ -1052,22 +1052,16 @@ const cssListFun = styled("div", `
 `);
 
 /**
- * The choices of what the row-number gutter shows, shared by the widget-panel select and the
- * grid's corner menu.
+ * Menu to choose what the row-number gutter shows, opened from the grid's top-left corner and
+ * from the widget panel's "Show [row numbers]" link (which omits the Hidden mode — the panel's
+ * checkbox covers hiding). The active mode is marked with a green tick.
  */
-export function rowNumbersModeOptions(): IOptionFull<RowNumbersMode>[] {
-  return [
+export function rowNumbersMenu(viewSection: ViewSectionRec, { includeHidden = true } = {}): DomElementArg[] {
+  const modes: IOptionFull<RowNumbersMode>[] = [
     { value: "number", label: t("Numbers") },
     { value: "rowId", label: t("Row IDs") },
-    { value: "hidden", label: t("Hidden") },
+    ...(includeHidden ? [{ value: "hidden" as const, label: t("Hidden") }] : []),
   ];
-}
-
-/**
- * Menu to choose what the row-number gutter shows, opened from the grid's top-left corner.
- * The active mode is marked with a green tick.
- */
-export function rowNumbersMenu(viewSection: ViewSectionRec): DomElementArg[] {
   const options = viewSection.optionsObj;
   const setMode = (rowNumbers: RowNumbersMode) => {
     if (options.peek().rowNumbers !== rowNumbers) {
@@ -1076,7 +1070,7 @@ export function rowNumbersMenu(viewSection: ViewSectionRec): DomElementArg[] {
   };
   return [
     menuSubHeader(t("Row numbers")),
-    ...rowNumbersModeOptions().map(({ value, label }) => menuItem(() => setMode(value),
+    ...modes.map(({ value, label }) => menuItem(() => setMode(value),
       cssTickSlot(options.peek().rowNumbers === value ? icon("Tick", testId("row-numbers-selected")) : null),
       value === "rowId" ? withInfoTooltip(label, "rowIds", { variant: "hover" }) : label,
     )),

--- a/app/client/ui/GristTooltips.ts
+++ b/app/client/ui/GristTooltips.ts
@@ -253,7 +253,7 @@ and be careful when clicking embedded links. Report malicious forms to [{{mail}}
     ...args,
   ),
   rowIds: (...args: DomElementArg[]) => cssTooltipContent(
-    dom("div", t("Row IDs are stable numeric identifiers, used by reference columns to identify records.")),
+    dom("div", t("Row IDs are stable and unique numeric identifiers, used by reference columns to identify records.")),
     dom("div",
       cssLink({ href: commonUrls.helpUnderstandingReferenceColumns, target: "_blank" }, t("Learn more.")),
     ),

--- a/app/client/ui/GristTooltips.ts
+++ b/app/client/ui/GristTooltips.ts
@@ -57,6 +57,7 @@ export type Tooltip =
   "formFraming" |
   "formUrlValues" |
   "rowHeight" |
+  "rowIds" |
   "suggestions"
   ;
 
@@ -249,6 +250,13 @@ and be careful when clicking embedded links. Report malicious forms to [{{mail}}
   ),
   rowHeight: (...args: DomElementArg[]) => cssTooltipContent(
     t("Set the maximum number of lines for multi-line text."),
+    ...args,
+  ),
+  rowIds: (...args: DomElementArg[]) => cssTooltipContent(
+    dom("div", t("Row IDs are stable numeric identifiers, used by reference columns to identify records.")),
+    dom("div",
+      cssLink({ href: commonUrls.helpUnderstandingReferenceColumns, target: "_blank" }, t("Learn more.")),
+    ),
     ...args,
   ),
   suggestions: () => cssTooltipContent(

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -565,6 +565,7 @@
     "GridOptions": {
         "Grid Options": "Grid Options",
         "Horizontal gridlines": "Horizontal gridlines",
+        "Row numbers": "Row numbers",
         "Vertical gridlines": "Vertical gridlines",
         "Zebra stripes": "Zebra stripes"
     },
@@ -637,7 +638,11 @@
         "Choice List": "Choice List",
         "Reference": "Reference",
         "Reference List": "Reference List",
-        "Attachment": "Attachment"
+        "Attachment": "Attachment",
+        "Row numbers": "Row numbers",
+        "Numbers": "Numbers",
+        "Row IDs": "Row IDs",
+        "Hidden": "Hidden"
     },
     "GristDoc": {
         "Added new linked section to view {{viewName}}": "Added new linked section to view {{viewName}}",
@@ -1551,6 +1556,7 @@
     },
     "GridView": {
         "Click to insert": "Click to insert",
+        "ID": "ID",
         "row {{rowNum}} {{colName}}": "row {{rowNum}} {{colName}}",
         "row {{rowNum}} {{colName}} (new row)": "row {{rowNum}} {{colName}} (new row)"
     },

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -565,9 +565,11 @@
     "GridOptions": {
         "Grid Options": "Grid Options",
         "Horizontal gridlines": "Horizontal gridlines",
-        "Row numbers": "Row numbers",
+        "Show": "Show",
         "Vertical gridlines": "Vertical gridlines",
-        "Zebra stripes": "Zebra stripes"
+        "Zebra stripes": "Zebra stripes",
+        "row IDs": "row IDs",
+        "row numbers": "row numbers"
     },
     "GridViewMenus": {
         "Add column": "Add column",
@@ -1453,7 +1455,7 @@
         "When checked, this field’s default value can be prefilled from the URL using query parameters.": "When checked, this field’s default value can be prefilled from the URL using query parameters.",
         "With suggestions, users make changes in a personal copy without modifying the original document, then submit these suggestions to be reviewed by the document owner prior to integration.": "With suggestions, users make changes in a personal copy without modifying the original document, then submit these suggestions to be reviewed by the document owner prior to integration.",
         "Unpin to hide the button while keeping the filter.": "Unpin to hide the button while keeping the filter.",
-        "Row IDs are stable numeric identifiers, used by reference columns to identify records.": "Row IDs are stable numeric identifiers, used by reference columns to identify records."
+        "Row IDs are stable and unique numeric identifiers, used by reference columns to identify records.": "Row IDs are stable and unique numeric identifiers, used by reference columns to identify records."
     },
     "DescriptionConfig": {
         "DESCRIPTION": "DESCRIPTION",

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -1452,7 +1452,8 @@
         "You can add comments to cells, reply to comment threads, and @-mention collaborators.": "You can add comments to cells, reply to comment threads, and @-mention collaborators.",
         "When checked, this field’s default value can be prefilled from the URL using query parameters.": "When checked, this field’s default value can be prefilled from the URL using query parameters.",
         "With suggestions, users make changes in a personal copy without modifying the original document, then submit these suggestions to be reviewed by the document owner prior to integration.": "With suggestions, users make changes in a personal copy without modifying the original document, then submit these suggestions to be reviewed by the document owner prior to integration.",
-        "Unpin to hide the button while keeping the filter.": "Unpin to hide the button while keeping the filter."
+        "Unpin to hide the button while keeping the filter.": "Unpin to hide the button while keeping the filter.",
+        "Row IDs are stable numeric identifiers, used by reference columns to identify records.": "Row IDs are stable numeric identifiers, used by reference columns to identify records."
     },
     "DescriptionConfig": {
         "DESCRIPTION": "DESCRIPTION",

--- a/test/nbrowser/RowNumbers.ts
+++ b/test/nbrowser/RowNumbers.ts
@@ -45,22 +45,24 @@ describe("RowNumbers", function() {
     assert.isFalse(await driver.find(".active_section .test-corner-label").isPresent());
   });
 
-  it("shows bracketed row IDs in Row IDs mode, blank for the add-row", async function() {
+  it("shows row IDs in Row IDs mode, blank for the add-row", async function() {
     await setRowNumbers("Row IDs");
-    assert.deepEqual(await gutterTexts(), ["[1]", "[2]", "[3]", ""]);
+    // The brackets around the ID are decorative (CSS ::before/::after), invisible to getText().
+    assert.deepEqual(await gutterTexts(), ["1", "2", "3", ""]);
+    assert.isTrue(await driver.find(".active_section .gridview_data_row_num .gridview_row_id").isPresent());
     // The corner labels the gutter in this mode.
     assert.equal(await driver.find(".active_section .test-corner-label").getText(), "ID");
   });
 
   it("keeps row IDs attached to their rows", async function() {
     await gu.sendActions([["RemoveRecord", "Table1", 2]]);
-    assert.deepEqual(await gutterTexts(), ["[1]", "[3]", ""]);
+    assert.deepEqual(await gutterTexts(), ["1", "3", ""]);
     await gu.sendActions([["AddRecord", "Table1", null, { A: "dates" }]]);
-    assert.deepEqual(await gutterTexts(), ["[1]", "[3]", "[4]", ""]);
+    assert.deepEqual(await gutterTexts(), ["1", "3", "4", ""]);
 
     // Sort descending: numbers would renumber, but row IDs travel with their rows.
     await gu.openColumnMenu("A", "sort-dsc");
-    assert.deepEqual(await gutterTexts(), ["[4]", "[3]", "[1]", ""]);
+    assert.deepEqual(await gutterTexts(), ["4", "3", "1", ""]);
   });
 
   it("keeps row selection and row menu working in Row IDs mode", async function() {
@@ -168,6 +170,6 @@ describe("RowNumbers", function() {
 
     await driver.find(".test-row-numbers-show").click();
     await gu.waitForServer();
-    assert.deepEqual(await gutterTexts(), ["[1]", "[3]", "[4]", ""]);
+    assert.deepEqual(await gutterTexts(), ["1", "3", "4", ""]);
   });
 });

--- a/test/nbrowser/RowNumbers.ts
+++ b/test/nbrowser/RowNumbers.ts
@@ -134,4 +134,17 @@ describe("RowNumbers", function() {
     assert.equal(await menu.find(".test-row-numbers-selected").findClosest("li").getText(), "Numbers");
     await driver.sendKeys(Key.ESCAPE);
   });
+
+  it("opens the corner menu on right-click", async function() {
+    await gu.rightClick(driver.find(".active_section .gridview_data_corner_overlay"));
+    const menu = await gu.findOpenMenu(1000);
+    assert.equal(await menu.find(".test-row-numbers-selected").findClosest("li").getText(), "Numbers");
+
+    // The "Row IDs" item explains itself with an info tooltip.
+    await menu.findContent("li", "Row IDs").find(".test-info-tooltip").mouseMove();
+    const popup = await driver.findWait(".test-info-tooltip-popup", 1000);
+    assert.match(await popup.getText(), /Row IDs are stable numeric identifiers/);
+    assert.match(await popup.find("a").getAttribute("href"), /col-refs\/#understanding-reference-columns/);
+    await driver.sendKeys(Key.ESCAPE);
+  });
 });

--- a/test/nbrowser/RowNumbers.ts
+++ b/test/nbrowser/RowNumbers.ts
@@ -15,9 +15,19 @@ describe("RowNumbers", function() {
     return (await driver.find(".active_section .gridview_data_row_num").getRect()).width;
   }
 
-  async function setRowNumbers(label: string) {
+  // The panel control is a "Show" checkbox plus a link naming the shown mode ("row numbers" or
+  // "row IDs") that opens a menu to switch.
+  async function setRowNumbers(label: "Numbers" | "Row IDs" | "Hidden") {
     await gu.openWidgetPanel();
-    await gu.setSelectValue(".test-row-numbers", label);
+    if (label === "Hidden") {
+      if (await driver.find(".test-row-numbers-show").matches(":checked")) {
+        await driver.find(".test-row-numbers-show").click();
+      }
+    } else {
+      await driver.find(".test-row-numbers-mode").click();
+      await (await gu.findOpenMenu(1000)).findContent("li", label).click();
+    }
+    await gu.waitForServer();
   }
 
   before(async function() {
@@ -143,8 +153,21 @@ describe("RowNumbers", function() {
     // The "Row IDs" item explains itself with an info tooltip.
     await menu.findContent("li", "Row IDs").find(".test-info-tooltip").mouseMove();
     const popup = await driver.findWait(".test-info-tooltip-popup", 1000);
-    assert.match(await popup.getText(), /Row IDs are stable numeric identifiers/);
+    assert.match(await popup.getText(), /Row IDs are stable and unique numeric identifiers/);
     assert.match(await popup.find("a").getAttribute("href"), /col-refs\/#understanding-reference-columns/);
     await driver.sendKeys(Key.ESCAPE);
+  });
+
+  it("restores the last shown mode when re-checking Show", async function() {
+    await setRowNumbers("Row IDs");
+    await driver.find(".test-row-numbers-show").click();
+    await gu.waitForServer();
+    assert.equal(await gutterWidth(), 0);
+    // The mode link still names the remembered mode while hidden.
+    assert.equal(await driver.find(".test-row-numbers-mode").getText(), "row IDs");
+
+    await driver.find(".test-row-numbers-show").click();
+    await gu.waitForServer();
+    assert.deepEqual(await gutterTexts(), ["[1]", "[3]", "[4]", ""]);
   });
 });

--- a/test/nbrowser/RowNumbers.ts
+++ b/test/nbrowser/RowNumbers.ts
@@ -1,0 +1,137 @@
+import * as gu from "test/nbrowser/gristUtils";
+import { setupTestSuite } from "test/nbrowser/testUtils";
+
+import { assert, driver, Key } from "mocha-webdriver";
+
+describe("RowNumbers", function() {
+  this.timeout("60s");
+  const cleanup = setupTestSuite();
+
+  async function gutterTexts(): Promise<string[]> {
+    return await driver.findAll(".active_section .gridview_data_row_num", e => e.getText());
+  }
+
+  async function gutterWidth(): Promise<number> {
+    return (await driver.find(".active_section .gridview_data_row_num").getRect()).width;
+  }
+
+  async function setRowNumbers(label: string) {
+    await gu.openWidgetPanel();
+    await gu.setSelectValue(".test-row-numbers", label);
+  }
+
+  before(async function() {
+    const session = await gu.session().login();
+    await session.tempNewDoc(cleanup, "RowNumbers");
+    await gu.sendActions([
+      ["AddRecord", "Table1", null, { A: "apples" }],
+      ["AddRecord", "Table1", null, { A: "bananas" }],
+      ["AddRecord", "Table1", null, { A: "cherries" }],
+    ]);
+  });
+
+  it("shows row numbers by default", async function() {
+    assert.deepEqual(await gutterTexts(), ["1", "2", "3", "4"]);
+    assert.isFalse(await driver.find(".active_section .test-corner-label").isPresent());
+  });
+
+  it("shows bracketed row IDs in Row IDs mode, blank for the add-row", async function() {
+    await setRowNumbers("Row IDs");
+    assert.deepEqual(await gutterTexts(), ["[1]", "[2]", "[3]", ""]);
+    // The corner labels the gutter in this mode.
+    assert.equal(await driver.find(".active_section .test-corner-label").getText(), "ID");
+  });
+
+  it("keeps row IDs attached to their rows", async function() {
+    await gu.sendActions([["RemoveRecord", "Table1", 2]]);
+    assert.deepEqual(await gutterTexts(), ["[1]", "[3]", ""]);
+    await gu.sendActions([["AddRecord", "Table1", null, { A: "dates" }]]);
+    assert.deepEqual(await gutterTexts(), ["[1]", "[3]", "[4]", ""]);
+
+    // Sort descending: numbers would renumber, but row IDs travel with their rows.
+    await gu.openColumnMenu("A", "sort-dsc");
+    assert.deepEqual(await gutterTexts(), ["[4]", "[3]", "[1]", ""]);
+  });
+
+  it("keeps row selection and row menu working in Row IDs mode", async function() {
+    const firstGutter = driver.find(".active_section .gridview_data_row_num");
+    await firstGutter.click();
+    assert.include(await firstGutter.getAttribute("class"), "selected");
+    await firstGutter.mouseMove();
+    await firstGutter.find(".test-row-menu-trigger").click();
+    assert.isTrue(await gu.findOpenMenu(1000).isDisplayed());
+    await driver.sendKeys(Key.ESCAPE);
+  });
+
+  it("collapses the gutter in Hidden mode", async function() {
+    await setRowNumbers("Hidden");
+    assert.equal(await gutterWidth(), 0);
+    assert.equal(
+      (await driver.find(".active_section .gridview_data_corner_overlay").getRect()).width, 0);
+    assert.isFalse(await driver.find(".active_section .test-corner-label").isPresent());
+
+    // The record's left border is dropped too, so the grid's left edge shows a single border.
+    assert.equal(
+      await driver.find(".active_section .gridview_row .record").getCssValue("border-left-width"), "0px");
+
+    // Row operations remain available via the cell context menu.
+    const cell = driver.find(".active_section .gridview_row .record .field");
+    await driver.withActions(a => a.contextClick(cell));
+    const menu = await gu.findOpenMenu(1000);
+    assert.isTrue(await menu.findContent("li", /Delete row/).isPresent());
+    await driver.sendKeys(Key.ESCAPE);
+  });
+
+  it("keeps frozen columns flush with the left edge when hidden", async function() {
+    // Clear the whole-row selection left by an earlier test: with the last column selected,
+    // the column menu switches to its multi-column variant, which offers no freeze item.
+    await driver.find(".active_section .gridview_row .record .field").click();
+    await gu.openColumnMenu("A", "Freeze this column");
+    await gu.waitForServer();
+    const paneX = (await driver.find(".active_section .gridview_data_pane").getRect()).x;
+    const frozenX = (await driver.find(".active_section .record .field.frozen").getRect()).x;
+    assert.isAtMost(frozenX - paneX, 2);  // 1px record border; no 52px gutter offset
+  });
+
+  it("persists the mode across reload", async function() {
+    await driver.navigate().refresh();
+    await gu.waitForDocToLoad();
+    assert.equal(await gutterWidth(), 0);
+  });
+
+  it("restores the previous mode on undo", async function() {
+    await setRowNumbers("Numbers");
+    assert.equal(await gutterWidth(), 52);
+    assert.equal(await driver.find(".active_section .gridview_data_row_num").getText(), "1");
+    assert.equal(
+      await driver.find(".active_section .gridview_row .record").getCssValue("border-left-width"), "1px");
+    await gu.undo();
+    assert.equal(await gutterWidth(), 0);
+  });
+
+  it("switches modes via the corner menu, even while hidden", async function() {
+    // The gutter is currently hidden; the corner toggle sits over the first column header's
+    // left edge, and is revealed by hovering it.
+    const trigger = driver.find(".active_section .gridview_data_corner_overlay .test-corner-menu-trigger");
+    await driver.find(".active_section .gridview_row .record .field").mouseMove();
+    assert.equal(await trigger.getCssValue("opacity"), "0");
+    await trigger.mouseMove();
+    assert.equal(await trigger.getCssValue("opacity"), "1");
+    await trigger.click();
+
+    // The menu marks the active mode with a check.
+    let menu = await gu.findOpenMenu(1000);
+    assert.equal(await menu.find(".test-row-numbers-selected").findClosest("li").getText(), "Hidden");
+    await menu.findContent("li", "Numbers").click();
+    await gu.waitForServer();
+    assert.equal(await gutterWidth(), 52);
+    assert.deepEqual(await gutterTexts(), ["1", "2", "3", "4"]);
+
+    // The check follows the active mode.
+    await trigger.mouseMove();
+    await trigger.click();
+    menu = await gu.findOpenMenu(1000);
+    assert.equal(await menu.find(".test-row-numbers-selected").findClosest("li").getText(), "Numbers");
+    await driver.sendKeys(Key.ESCAPE);
+  });
+});


### PR DESCRIPTION
## Context

It has been requested multiple times to allow hiding row numbers (#220, #1927).  Also, since rowIDs are used in references, it is sometimes very useful to show rowIDs (possible today by adding a formula column with `$id` formula, but not at all discoverable).

## Proposed solution

This PR adds a new "Row numbers" setting on grid widgets to choose what the row-header gutter shows:

- Numbers (default): 1-based position in the current sort, as before.
- Row IDs: the record's rowId, bracketed like "[15]" to match how
  references render row IDs; the corner shows an "ID" header label.
- Hidden: the gutter collapses entirely.

The setting is offered in the widget panel's Grid Options and from a new
menu in the grid's top-left corner, revealed on hover like the row-header
menu toggles, with a green tick on the active mode. When the gutter is
hidden, the toggle sits over the left edge of the first column header.

The gutter's width and border are driven by --row-num-width and
--row-num-border CSS variables on the grid pane, so frozen columns,
scroll shadows, and print layout follow along.

Note: implementation also moves FormConfig's `obsPropWithSaveOnWrite` to a shared module (addressing a TODO there), in order to reuse it for the new option, and switches a few other old-style options to it.

## Related issues

#220 (Missing option to hide the row id column)
#1927 (Hide line numbers in tables)

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<img width="959" height="280" alt="Screenshot 2026-07-04 at 21 00 50" src="https://github.com/user-attachments/assets/9b1b57fb-245c-4d7f-a365-14168526f0ec" />

