### PR TITLE
i18n: Miscellaneous fix of untranslated strings

### DIFF
--- a/app/client/aclui/AccessRules.ts
+++ b/app/client/aclui/AccessRules.ts
@@ -686,7 +686,7 @@ tables, columns, or rows — useful for sensitive data or role-based permissions
       { helpAccessRules: commonUrls.helpAccessRules }),
       ),
       cssIntroButton(
-        bigPrimaryButton("Enable Access Rules",
+        bigPrimaryButton(t("Enable Access Rules"),
           dom.on("click", () => this._confirmEnableAccessRules()),
           testId("enable-access-rules"),
         ),

--- a/app/client/components/FormRenderer.ts
+++ b/app/client/components/FormRenderer.ts
@@ -196,8 +196,8 @@ class SubmitRenderer extends FormRenderer {
               return event.preventDefault();
             }
             return confirmModal(
-              "Are you sure you want to reset your form?",
-              "Reset",
+              t("Are you sure you want to reset your form?"),
+              t("Reset"),
               () => this.parent?.reset(),
             );
           }),

--- a/app/client/ui2018/ColorSelect.ts
+++ b/app/client/ui2018/ColorSelect.ts
@@ -41,6 +41,15 @@ export class ColorOption {
   }
 }
 
+export const COLOR_OPTION_NONE_TEXTS = {
+  none() {
+    return t("none");
+  },
+  default() {
+    return t("default");
+  },
+};
+
 /**
  * colorSelect allows to select color for both fill and text cell color. It allows for fast
  * selection thanks to two color palette, `lighter` and `darker`, and also to pick custom color with
@@ -220,11 +229,11 @@ export function buildColorPicker(
         fontStrikethroughModel,
       }),
       dom.create(PickerComponent, textColorModel, {
-        title: "text",
+        title: t("text"),
         ...textColor,
       }),
       dom.create(PickerComponent, fillColorModel, {
-        title: "fill",
+        title: t("fill"),
         ...fillColor,
       }),
     ),

--- a/app/client/widgets/CellStyle.ts
+++ b/app/client/widgets/CellStyle.ts
@@ -3,7 +3,7 @@ import { GristDoc } from "app/client/components/GristDoc";
 import { makeT } from "app/client/lib/localization";
 import { ViewFieldRec } from "app/client/models/entities/ViewFieldRec";
 import { textButton } from "app/client/ui2018/buttons";
-import { ColorOption, colorSelect } from "app/client/ui2018/ColorSelect";
+import { COLOR_OPTION_NONE_TEXTS, ColorOption, colorSelect } from "app/client/ui2018/ColorSelect";
 import { testId, theme, vars } from "app/client/ui2018/cssVars";
 import { ConditionalStyle } from "app/client/widgets/ConditionalStyle";
 
@@ -55,12 +55,12 @@ export class CellStyle extends Disposable {
                     color: headerTextColor,
                     defaultColor: theme.tableHeaderFg.toString(),
                     allowsNone: true,
-                    noneText: "default",
+                    noneText: COLOR_OPTION_NONE_TEXTS.default(),
                   }),
                   fillColor: new ColorOption({
                     color: headerFillColor,
                     allowsNone: true,
-                    noneText: "none",
+                    noneText: COLOR_OPTION_NONE_TEXTS.none(),
                   }),
                   fontBold: headerFontBold,
                   fontItalic: headerFontItalic,
@@ -111,12 +111,12 @@ export class CellStyle extends Disposable {
                 color: textColor,
                 defaultColor: this._defaultTextColor,
                 allowsNone: true,
-                noneText: "default",
+                noneText: COLOR_OPTION_NONE_TEXTS.default(),
               }),
               fillColor: new ColorOption({
                 color: fillColor,
                 allowsNone: true,
-                noneText: "none",
+                noneText: COLOR_OPTION_NONE_TEXTS.none(),
               }),
               fontBold: fontBold,
               fontItalic: fontItalic,

--- a/app/client/widgets/ChoiceListEntry.ts
+++ b/app/client/widgets/ChoiceListEntry.ts
@@ -2,7 +2,7 @@ import { makeT } from "app/client/lib/localization";
 import { IToken, TokenField } from "app/client/lib/TokenField";
 import { cssBlockedCursor } from "app/client/ui/RightPanelStyles";
 import { basicButton, primaryButton } from "app/client/ui2018/buttons";
-import { colorButton, ColorOption } from "app/client/ui2018/ColorSelect";
+import { COLOR_OPTION_NONE_TEXTS, colorButton, ColorOption } from "app/client/ui2018/ColorSelect";
 import { testId, theme } from "app/client/ui2018/cssVars";
 import { editableLabel } from "app/client/ui2018/editableLabel";
 import { icon } from "app/client/ui2018/icons";
@@ -357,8 +357,12 @@ export class ChoiceListEntry extends Disposable {
         {
           styleOptions: {
             textColor: new ColorOption({ color: textColorObs, defaultColor: "#000000" }),
-            fillColor: new ColorOption(
-              { color: fillColorObs, allowsNone: true, noneText: "none", defaultColor: "#FFFFFF" }),
+            fillColor: new ColorOption({
+              color: fillColorObs,
+              allowsNone: true,
+              noneText: COLOR_OPTION_NONE_TEXTS.none(),
+              defaultColor: "#FFFFFF",
+            }),
             fontBold: fontBoldObs,
             fontItalic: fontItalicObs,
             fontUnderline: fontUnderlineObs,

--- a/app/client/widgets/ConditionalStyle.ts
+++ b/app/client/widgets/ConditionalStyle.ts
@@ -8,7 +8,7 @@ import { buildHighlightedCode } from "app/client/ui/CodeHighlight";
 import { cssFieldFormula } from "app/client/ui/RightPanelStyles";
 import { withInfoTooltip } from "app/client/ui/tooltips";
 import { textButton } from "app/client/ui2018/buttons";
-import { ColorOption, colorSelect } from "app/client/ui2018/ColorSelect";
+import { COLOR_OPTION_NONE_TEXTS, ColorOption, colorSelect } from "app/client/ui2018/ColorSelect";
 import { theme, vars } from "app/client/ui2018/cssVars";
 import { cssDragger } from "app/client/ui2018/draggableList";
 import { icon } from "app/client/ui2018/icons";
@@ -161,8 +161,16 @@ export class ConditionalStyle extends Disposable {
           ),
           colorSelect(
             {
-              textColor: new ColorOption({ color: textColor, allowsNone: true, noneText: "default" }),
-              fillColor: new ColorOption({ color: fillColor, allowsNone: true, noneText: "none" }),
+              textColor: new ColorOption({
+                color: textColor,
+                allowsNone: true,
+                noneText: COLOR_OPTION_NONE_TEXTS.default(),
+              }),
+              fillColor: new ColorOption({
+                color: fillColor,
+                allowsNone: true,
+                noneText: COLOR_OPTION_NONE_TEXTS.none(),
+              }),
               fontBold,
               fontItalic,
               fontUnderline,


### PR DESCRIPTION
## Context

Some strings remain untranslatable in the UI.

## Proposed solution
Localize these strings:
1. `Enable Access Rules`
<img width="1916" height="785" alt="Enable Access Rules" src="https://github.com/user-attachments/assets/1c2350c9-2b67-4f50-9b55-007d0774c268" />

2. The warning popup before reseting a form:
<img width="429" height="200" alt="The warning popup before reseting a form" src="https://github.com/user-attachments/assets/f33edb92-cf2b-439a-a0fc-81e3b9ef532a" />

3. The popup to select the text and the background colors, where `fill`, `text`, `default` and `none` were not translated:

<img width="268" height="449" alt="image" src="https://github.com/user-attachments/assets/53b48fee-8f19-4b15-85f6-caebdad3d053" />


## Related issues

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->