### PR TITLE
Freshen and fix formatting for some comments used in generated documentation

### DIFF
--- a/app/plugin/FileParserAPI.ts
+++ b/app/plugin/FileParserAPI.ts
@@ -41,7 +41,7 @@ export interface FileSource {
   path: string;
 
   /**
-   * The platform-specific flavor of the path stored in the {path} property.
+   * The platform-specific flavor of the path stored in the {@link path} property.
    * Certain sandboxed environments may have a different path convention to the local OS.
    * E.g. Pyodide (WASM Python in Node/Deno) uses POSIX paths, even on a Windows host OS.
    * This enables the path above to be interpreted correctly / converted.

--- a/app/plugin/GristAPI.ts
+++ b/app/plugin/GristAPI.ts
@@ -141,15 +141,19 @@ export interface GristDocAPI {
 
 /**
  * CellFormatType determines how each cell value is represented.
- * - "normal" -- the usual encoding used in Grist, which depends on the column type (e.g. a Date
- *   is secondsSinceEpoch, and a Ref is an integer (rowId).
- * - "typed" -- represents each value in the same format as in the "normal" format for "Any"
- *   columns, e.g. a Date is ["d", secondsSinceEpoch] and RefList is ["r", TableId, [rodIds, ...]].
- *   Exceptions are also returned as ["E", TypeName...] values, even for /records endpoints.
  *
- * When omitted, REST API uses "normal" format, while Custom Widget API uses an in-between format
- * for backward compatibility: it represents most values as "typed", but RefList and Attachments
- * as "normal".
+ * - `"normal"` -- the compact format usual for Grist, whose interpretation depends on the column
+ *   type, e.g. a Date is a number (seconds since epoch), and a Ref is a number (rowId).
+ * - `"typed"` -- a self-describing typed form, the same as the "normal" format for `Any` columns,
+ *   e.g. a Date is `["d", secondsSinceEpoch]` and a RefList is `["r", tableId, [rowIds, ...]]`.
+ *   Formula errors are also returned inline, as `["E", ...]` values.
+ *
+ * When omitted, the REST API uses the "normal" format, while the Custom Widget API uses an
+ * in-between format for backward compatibility: it represents most values as "typed", but
+ * RefList and Attachments as "normal".
+ *
+ * See [Grist data format](https://github.com/gristlabs/grist-core/blob/main/documentation/grist-data-format.md)
+ * for details.
  */
 export type CellFormatType = "normal" | "typed";
 

--- a/sandbox/grist/functions/date.py
+++ b/sandbox/grist/functions/date.py
@@ -659,7 +659,7 @@ def YEARFRAC(start_date, end_date, basis=0):
   likely the best choice.
 
   See <https://en.wikipedia.org/wiki/360-day_calendar> for explanation of
-  the US 30/360 and European 30/360 methods. See <http://www.dwheeler.com/yearfrac/> for analysis of
+  the US 30/360 and European 30/360 methods. See <https://web.archive.org/web/20210118174252/https://dwheeler.com/yearfrac/> for analysis of
   Excel's particular implementation.
 
   Basis `-1` is similar to `1`, but differs from Excel when dates span both leap and non-leap years.


### PR DESCRIPTION
## Context

These comments are used in documentation published at https://support.getgrist.com (via https://github.com/gristlabs/grist-help repo). The change fixes formatting, improves clarity, and in case of a broken link, updates it to what `grist-help` already uses.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->