### PR TITLE
ci: pin superfly/flyctl-actions/setup-flyctl to a full commit SHA

### DIFF
--- a/.github/workflows/fly-cleanup.yml
+++ b/.github/workflows/fly-cleanup.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository_owner == 'gristlabs'
     steps:
       - uses: actions/checkout@v3
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
         with:
           version: 0.2.72
       - run: node buildtools/fly-deploy.js clean

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
         with:
           version: 0.2.72
       - name: Download artifacts

--- a/.github/workflows/fly-destroy.yml
+++ b/.github/workflows/fly-destroy.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
         with:
           version: 0.2.72
       - name: Destroy fly.io app


### PR DESCRIPTION
### What
Pin `superfly/flyctl-actions/setup-flyctl@master` → `ed8efb3…` in `fly-deploy.yml`, `fly-cleanup.yml`,
and `fly-destroy.yml` (tag kept in a comment).

### Why
All three jobs have the `FLY_API_TOKEN` deploy credential in scope while this third-party action runs,
and it's referenced by the moving `@master` ref. If that action's `master` were moved (compromise or an
accidental change), the new code would run with the Fly.io deploy token — the class of issue behind the
2025 `tj-actions/changed-files` incident. Pinning to a SHA removes that.

### Scope / safety
Behaviour unchanged (SHA = current tip of master). Signed-off. Per GitHub's [pin-to-SHA guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflows, the FLY_API_TOKEN exposure, and the pinned SHA myself.</sub>
