### PR TITLE
Disable line-clamping trick in Markdown cells

### DIFF
--- a/app/client/components/viewCommon.css
+++ b/app/client/components/viewCommon.css
@@ -142,6 +142,15 @@
   white-space: pre-wrap;
 }
 
+/**
+ * Markdown cells render block-level content with lines that aren't a uniform
+ * height, making them incompatible with the -webkit-box/-webkit-line-clamp
+ * approach above.
+ */
+.row_height_set .field_clip.markdown {
+  display: block;
+}
+
 .row_height_uniform .field_clip {
   min-height: calc(3px + var(--row-height-lines) * 18px);
 }

--- a/app/client/widgets/MarkdownTextBox.ts
+++ b/app/client/widgets/MarkdownTextBox.ts
@@ -19,7 +19,7 @@ export class MarkdownTextBox extends NTextBox {
     const valueObs = row.cells[this.field.colId()];
 
     return dom(
-      "div.field_clip",
+      "div.field_clip.markdown",
       cssMarkdown(
         cssMarkdown.cls("-text-wrap", this.wrapping),
         dom.style("text-align", this.alignment),


### PR DESCRIPTION
Markdown cells don't render lines with uniform heights, making them incompatible with the line-clamping height calculation trick used to show an overflow ellipsis in rows that have a max height.

## Context

Row heights, wrapping, and Markdown-rendered cells together can sometimes appear broken. In particular, list items whose lines are long enough to wrap overlap the lines of list items below them.

This appears to be a problem with the height calculation for max row height being based on a fixed line height (18px), which is not always the case for content rendered as Markdown. It's not always easy to reproduce, and sometimes only manifests at specific max row heights and/or column widths, so the exact reason isn't completely clear.

## Proposed solution

Avoid the -webkit-box line-clamping trick in Markdown cells.

## Has this been tested?

Manually.
