### PR TITLE
Quiet a lint warning on the ServerMode union

### DIFF
--- a/test/server/lib/docapi/helpers.ts
+++ b/test/server/lib/docapi/helpers.ts
@@ -69,6 +69,8 @@ export interface TestContext {
 /** Server configuration mode */
 export const CoreServerMode = StringUnion("merged", "separated", "direct");
 export type CoreServerMode = typeof CoreServerMode.type;
+// ExtraServerModes is `never` in core; other editions widen it.
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 export type ServerMode = CoreServerMode | ExtraServerModes;
 
 // Module-level state for each test run


### PR DESCRIPTION
The ServerMode type is CoreServerMode | ExtraServerModes. In grist-core, ExtraServerModes is just `never`, and a union with `never` collapses to the other side. Extensions can add over server modes, such as "fleet" multi-server mode.
