### PR TITLE
Translate temp row ids inside RefList values

### DIFF
--- a/sandbox/grist/column.py
+++ b/sandbox/grist/column.py
@@ -586,6 +586,20 @@ class ReferenceListColumn(BaseReferenceColumn):
   ReferenceListColumn maintains for each row a list of references (row IDs) into another table.
   Accessing them yields RecordSets.
   """
+  def prepare_new_values(self, row_ids, values, ignore_data=False, action_summary=None):
+    # Translate temporary negative row ids to their final ids, as ReferenceColumn does.
+    # Values have been through convert(), so lists here hold only ints; other shapes pass
+    # through.
+    if action_summary:
+      values = [
+        action_summary.translate_new_row_ids(self._target_table.table_id, v)
+        if isinstance(v, list) and any(r < 0 for r in v)
+        else v
+        for v in values
+      ]
+    return super(ReferenceListColumn, self).prepare_new_values(
+        row_ids, values, ignore_data=ignore_data, action_summary=action_summary)
+
   def _clean_up_value(self, value):
     if isinstance(value, str):
       # This is second part of a "hack" we have to do when we rename tables. During

--- a/sandbox/grist/column.py
+++ b/sandbox/grist/column.py
@@ -449,6 +449,16 @@ class BaseReferenceColumn(BaseColumn):
     for r in self._value_iterable(new_value):
       self._relation.add_reference(row_id, r)
 
+  def _reject_unresolved_temp_ids(self, values):
+    # A negative id surviving translation is a temp id the bundle never created, and can never
+    # resolve. (A positive missing id is a supported dangling ref, so we leave those alone.)
+    for value in values:
+      for r in (value if isinstance(value, list) else (value,)):
+        if isinstance(r, int) and r < 0:
+          raise ValueError(
+            "Reference to unknown temporary row id %s in column %s.%s" % (
+              r, self.table_id, self.col_id))
+
   def _clean_up_value(self, value):
     raise NotImplementedError()
 
@@ -570,6 +580,7 @@ class ReferenceColumn(BaseReferenceColumn):
   def prepare_new_values(self, row_ids, values, ignore_data=False, action_summary=None):
     if action_summary and values:
       values = action_summary.translate_new_row_ids(self._target_table.table_id, values)
+      self._reject_unresolved_temp_ids(values)
     return super(ReferenceColumn, self).prepare_new_values(row_ids, values,
         ignore_data=ignore_data, action_summary=action_summary)
 
@@ -597,6 +608,7 @@ class ReferenceListColumn(BaseReferenceColumn):
         else v
         for v in values
       ]
+      self._reject_unresolved_temp_ids(values)
     return super(ReferenceListColumn, self).prepare_new_values(
         row_ids, values, ignore_data=ignore_data, action_summary=action_summary)
 

--- a/sandbox/grist/test_temp_rowids.py
+++ b/sandbox/grist/test_temp_rowids.py
@@ -87,6 +87,117 @@ class TestTempRowIds(test_engine.EngineTestCase):
       ]
     })
 
+  def test_reflist_temp_ids(self):
+    self.load_sample(testsamples.sample_students)
+
+    self.engine.apply_user_actions([useractions.from_repr(
+      ['AddColumn', 'Schools', 'addresses', {'type': 'RefList:Address', 'isFormula': False}])])
+
+    out_actions = self.engine.apply_user_actions([useractions.from_repr(ua) for ua in (
+      ['BulkAddRecord', 'Address', [-1, -2], {'city': ['A', 'B']}],
+
+      # A RefList mixing temp ids and an existing id, and one left unset.
+      ['AddRecord', 'Schools', None, {'name': 'S1', 'addresses': ['L', -1, 11, -2]}],
+      ['AddRecord', 'Schools', None, {'name': 'S2'}],
+
+      # An update whose row id and RefList value both use temp ids.
+      ['AddRecord', 'Schools', -5, {'name': 'S3'}],
+      ['UpdateRecord', 'Schools', -5, {'addresses': ['L', -2]}],
+    )])
+
+    self.assertTableData('Schools', cols="subset", data=[
+      ["id",  "name",       "addresses"],
+      [1,     "Columbia",   None],
+      [2,     "Columbia",   None],
+      [3,     "Yale",       None],
+      [4,     "Yale",       None],
+      [5,     "S1",         [15, 11, 16]],
+      [6,     "S2",         None],
+      [7,     "S3",         [16]],
+    ])
+
+    # The actions above, with rowIds and RefList values translated.
+    self.assertPartialOutActions(out_actions, {
+      "stored": [
+        ['BulkAddRecord', 'Address', [15, 16], {'city': ['A', 'B']}],
+        ['AddRecord', 'Schools', 5, {'addresses': ['L', 15, 11, 16], 'name': 'S1'}],
+        ['AddRecord', 'Schools', 6, {'name': 'S2'}],
+        ['AddRecord', 'Schools', 7, {'name': 'S3'}],
+        ['UpdateRecord', 'Schools', 7, {'addresses': ['L', 16]}],
+      ]
+    })
+
+  def test_reflist_same_action_temp_ids(self):
+    self.load_sample(testsamples.sample_students)
+
+    self.engine.apply_user_actions([useractions.from_repr(
+      ['AddColumn', 'Schools', 'partners', {'type': 'RefList:Schools', 'isFormula': False}])])
+
+    # Mutual references within a single bulk add: no processing order could
+    # satisfy this cycle without temp ids.
+    out_actions = self.engine.apply_user_actions([useractions.from_repr(
+      ['BulkAddRecord', 'Schools', [-1, -2], {
+        'name': ['P1', 'P2'],
+        'partners': [['L', -2], ['L', -1, -2]],
+      }])])
+
+    self.assertTableData('Schools', cols="subset", data=[
+      ["id",  "name",       "partners"],
+      [1,     "Columbia",   None],
+      [2,     "Columbia",   None],
+      [3,     "Yale",       None],
+      [4,     "Yale",       None],
+      [5,     "P1",         [6]],
+      [6,     "P2",         [5, 6]],
+    ])
+
+    self.assertPartialOutActions(out_actions, {
+      "stored": [
+        ['BulkAddRecord', 'Schools', [5, 6], {
+          'name': ['P1', 'P2'],
+          'partners': [['L', 6], ['L', 5, 6]],
+        }],
+      ]
+    })
+
+  def test_reflist_unusual_values(self):
+    self.load_sample(testsamples.sample_students)
+
+    # Unusual values should not break translation. Conversion runs first and turns any list
+    # holding a non-int into alttext, so garbage lands as it would without temp ids.
+    self.engine.apply_user_actions([useractions.from_repr(ua) for ua in (
+      ['AddColumn', 'Schools', 'addresses', {'type': 'RefList:Address', 'isFormula': False}],
+      ['AddRecord', 'Address', -1, {'city': 'A'}],
+      ['BulkAddRecord', 'Schools', [None] * 7, {
+        'name': ['S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7'],
+        'addresses': [
+          'hello',                  # alttext, not a list
+          None,
+          0,
+          ['L'],                    # empty list
+          ['L', 11],                # existing ids only
+          ['L', -99],               # temp id with no mapping
+          ['L', -1.5],              # negative float, not an int
+        ],
+      }],
+      # Odd elements mixed in with a real temp id.
+      ['AddRecord', 'Schools', None, {'name': 'S8', 'addresses': ['L', -1, 'x']}],
+      ['AddRecord', 'Schools', None, {'name': 'S9', 'addresses': ['L', -1, ['L', 11]]}],
+    )])
+
+    self.assertTableData('Schools', cols="subset", rows=lambda r: r.id > 4, data=[
+      ["id",  "name",   "addresses"],
+      [5,     "S1",     "hello"],
+      [6,     "S2",     None],
+      [7,     "S3",     None],
+      [8,     "S4",     None],
+      [9,     "S5",     [11]],
+      [10,    "S6",     [-99]],
+      [11,    "S7",     "[-1.5]"],
+      [12,    "S8",     "[-1, 'x']"],
+      [13,    "S9",     "[-1, [11]]"],
+    ])
+
   def test_update_remove(self):
     self.load_sample(testsamples.sample_students)
 

--- a/sandbox/grist/test_temp_rowids.py
+++ b/sandbox/grist/test_temp_rowids.py
@@ -163,26 +163,27 @@ class TestTempRowIds(test_engine.EngineTestCase):
   def test_reflist_unusual_values(self):
     self.load_sample(testsamples.sample_students)
 
-    # Unusual values should not break translation. Conversion runs first and turns any list
-    # holding a non-int into alttext, so garbage lands as it would without temp ids.
+    # Conversion turns any list holding a non-int into alttext before translation runs, so
+    # garbage lands as garbage without disturbing valid temp ids in the same bundle. (Unresolved
+    # negatives are the exception -- rejected; see tests below.)
     self.engine.apply_user_actions([useractions.from_repr(ua) for ua in (
       ['AddColumn', 'Schools', 'addresses', {'type': 'RefList:Address', 'isFormula': False}],
-      ['AddRecord', 'Address', -1, {'city': 'A'}],
-      ['BulkAddRecord', 'Schools', [None] * 7, {
-        'name': ['S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7'],
+      ['AddRecord', 'Address', -1, {'city': 'A'}],   # temp id -1 maps to Address 15
+      ['BulkAddRecord', 'Schools', [None] * 8, {
+        'name': ['S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7', 'S8'],
         'addresses': [
           'hello',                  # alttext, not a list
           None,
           0,
           ['L'],                    # empty list
           ['L', 11],                # existing ids only
-          ['L', -99],               # temp id with no mapping
-          ['L', -1.5],              # negative float, not an int
+          ['L', -1],                # valid temp id
+          ['L', 11, -1],            # existing id mixed with a valid temp id
+          ['L', -1.5],              # non-int element -> alttext, so not rejected
         ],
       }],
-      # Odd elements mixed in with a real temp id.
-      ['AddRecord', 'Schools', None, {'name': 'S8', 'addresses': ['L', -1, 'x']}],
-      ['AddRecord', 'Schools', None, {'name': 'S9', 'addresses': ['L', -1, ['L', 11]]}],
+      ['AddRecord', 'Schools', None, {'name': 'S9', 'addresses': ['L', -1, 'x']}],
+      ['AddRecord', 'Schools', None, {'name': 'S10', 'addresses': ['L', -1, ['L', 11]]}],
     )])
 
     self.assertTableData('Schools', cols="subset", rows=lambda r: r.id > 4, data=[
@@ -192,11 +193,30 @@ class TestTempRowIds(test_engine.EngineTestCase):
       [7,     "S3",     None],
       [8,     "S4",     None],
       [9,     "S5",     [11]],
-      [10,    "S6",     [-99]],
-      [11,    "S7",     "[-1.5]"],
-      [12,    "S8",     "[-1, 'x']"],
-      [13,    "S9",     "[-1, [11]]"],
+      [10,    "S6",     [15]],          # temp id translated despite garbage in sibling rows
+      [11,    "S7",     [11, 15]],
+      [12,    "S8",     "[-1.5]"],
+      [13,    "S9",     "[-1, 'x']"],
+      [14,    "S10",    "[-1, [11]]"],
     ])
+
+  def test_reflist_rejects_unresolved_temp_id(self):
+    self.load_sample(testsamples.sample_students)
+    self.engine.apply_user_actions([useractions.from_repr(
+      ['AddColumn', 'Schools', 'addresses', {'type': 'RefList:Address', 'isFormula': False}])])
+
+    # An unresolved negative id rejects the whole bundle rather than storing an unusable ref.
+    with self.assertRaisesRegex(ValueError, r"unknown temporary row id -99 in column Schools\.addresses"):
+      self.engine.apply_user_actions([useractions.from_repr(
+        ['AddRecord', 'Schools', None, {'name': 'S1', 'addresses': ['L', -99]}])])
+
+  def test_ref_rejects_unresolved_temp_id(self):
+    self.load_sample(testsamples.sample_students)
+
+    # Same rejection for a single Ref, not just RefList.
+    with self.assertRaisesRegex(ValueError, r"unknown temporary row id -99 in column Schools\.address"):
+      self.engine.apply_user_actions([useractions.from_repr(
+        ['AddRecord', 'Schools', None, {'name': 'S1', 'address': -99}])])
 
   def test_update_remove(self):
     self.load_sample(testsamples.sample_students)


### PR DESCRIPTION
The data engine lets a bundle of user actions use temporary negative row ids: an add may declare e.g. row id -1, later actions in the same bundle may refer to -1, and the engine replaces it everywhere with the real id it assigns. This already worked in Ref values and in row-id positions, but inside RefList values temp ids landed as literal negatives. Add the missing ReferenceListColumn.prepare_new_values override, mirroring ReferenceColumn. Rows that reference each other through RefList columns can now be created in one bundle, even mutual references within a single bulk add.
