### PR TITLE
Preserve "View as" for attachment previews and doc exports

### DIFF
--- a/app/client/components/GristDoc.ts
+++ b/app/client/components/GristDoc.ts
@@ -1146,22 +1146,22 @@ export class GristDocImpl extends DisposableWithEvents implements GristDoc {
 
   public getCsvLink() {
     const params = this._getDocApiDownloadParams();
-    return this.docPageModel.appModel.api.getDocAPI(this.docId()).getDownloadCsvUrl(params);
+    return this._downloadDocApi().getDownloadCsvUrl(params);
   }
 
   public getTsvLink() {
     const params = this._getDocApiDownloadParams();
-    return this.docPageModel.appModel.api.getDocAPI(this.docId()).getDownloadTsvUrl(params);
+    return this._downloadDocApi().getDownloadTsvUrl(params);
   }
 
   public getDsvLink() {
     const params = this._getDocApiDownloadParams();
-    return this.docPageModel.appModel.api.getDocAPI(this.docId()).getDownloadDsvUrl(params);
+    return this._downloadDocApi().getDownloadDsvUrl(params);
   }
 
   public getXlsxActiveViewLink() {
     const params = this._getDocApiDownloadParams();
-    return this.docPageModel.appModel.api.getDocAPI(this.docId()).getDownloadXlsxUrl(params);
+    return this._downloadDocApi().getDownloadXlsxUrl(params);
   }
 
   /**
@@ -1938,6 +1938,11 @@ Please check webhooks settings, remove invalid webhooks, and clean the queue."))
     }
   }
 
+  // A DocAPI for building download links, View-as-aware so exports respect ACLs.
+  private _downloadDocApi() {
+    return this.docPageModel.appModel.api.getDocAPI(this.docId(), { propagateViewAs: true });
+  }
+
   private _getDocApiDownloadParams() {
     const activeSection = this.viewModel.activeSection();
     const filters = activeSection.activeFilters.get().map(filterInfo => ({
@@ -1945,7 +1950,6 @@ Please check webhooks settings, remove invalid webhooks, and clean the queue."))
       filter: filterInfo.filter(),
     }));
     const linkingFilter: FilterColValues = activeSection.linkingFilter();
-    const userOverride = this.docPageModel.userOverride.get();
 
     return {
       viewSection: this.viewModel.activeSectionId(),
@@ -1953,7 +1957,6 @@ Please check webhooks settings, remove invalid webhooks, and clean the queue."))
       activeSortSpec: JSON.stringify(activeSection.activeSortSpec()),
       filters: JSON.stringify(filters),
       linkingFilter: JSON.stringify(linkingFilter),
-      ...(userOverride ? { aclAsUser_: userOverride.user?.email } : {}),
     };
   }
 

--- a/app/client/ui/ShareMenu.ts
+++ b/app/client/ui/ShareMenu.ts
@@ -359,7 +359,10 @@ function menuExports(doc: Document, pageModel: DocPageModel) {
         menuItemLink(
           onClick,
           hooks.maybeModifyLinkAttrs({
-            href: pageModel.appModel.api.getDocAPI(doc.id).getDownloadXlsxUrl(),
+            // View-as-aware so a whole-doc export respects ACLs, like the CSV/TSV/DSV links above.
+            href: pageModel.appModel.api
+              .getDocAPI(doc.id, { propagateViewAs: true })
+              .getDownloadXlsxUrl(),
             target: "_blank", download: "",
           }), t("Microsoft Excel (.xlsx)"), testId("tb-share-option")),
       ],

--- a/app/client/widgets/AttachmentsEditor.ts
+++ b/app/client/widgets/AttachmentsEditor.ts
@@ -79,8 +79,11 @@ export class AttachmentsEditor extends NewBaseEditor {
     const initRowIndex: number | undefined = (options.editValue && parseInt(options.editValue, 0) - 1) || 0;
 
     this._attachmentsTable = docData.getMetaTable("_grist_Attachments");
-    this._docApi = options.gristDoc.docApi;
     this._docComm = docData.docComm;
+    // View-as-aware so preview/download URLs respect ACLs. Harmless on the upload path: /uploads
+    // is access-agnostic, and the real gating is on the WebSocket calls that follow.
+    this._docApi = options.gristDoc.appModel.api.getDocAPI(options.gristDoc.docId(),
+      { propagateViewAs: true });
 
     this._rowIds = obsArray(Array.isArray(cellValue) ? cellValue.slice(1) as number[] : []);
     this._attachments = computedArray(this._rowIds, (val: number): Attachment => {

--- a/app/client/widgets/AttachmentsWidget.ts
+++ b/app/client/widgets/AttachmentsWidget.ts
@@ -158,7 +158,7 @@ export class AttachmentsWidget extends NewAbstractWidget {
     );
   }
 
-  // Returns the attachment download url.
+  // Returns the attachment download url, View-as-aware so previews respect ACLs.
   private _getUrl(attId: number, cell: SingleCell): string {
     return this._docApi.getAttachmentDownloadUrl(attId, {
       cell,
@@ -277,9 +277,12 @@ export class AttachmentsWidget extends NewAbstractWidget {
 
   // TODO - This is a very clumsy way of accessing this API, as it doesn't respect any custom options set.
   //        Widgets should be able to access a GristDoc for DocComm and DocApi access, but that needs its own refactor.
+  // View-as-aware so preview URLs respect ACLs. Harmless on the upload path: /uploads is
+  // access-agnostic, and the real gating is on the WebSocket calls that follow.
   private get _docApi() {
     const docComm = this._getDocComm();
-    return new DocAPIImpl(docUrl(docComm.docWorkerUrl), docComm.docId);
+    return new DocAPIImpl(docUrl(docComm.docWorkerUrl), docComm.docId,
+      { propagateViewAs: true });
   }
 }
 

--- a/app/common/BaseAPI.ts
+++ b/app/common/BaseAPI.ts
@@ -7,6 +7,10 @@ export interface IOptions {
   headers?: Record<string, string>;
   fetch?: typeof fetch;
   extraParameters?: Map<string, string>;  // if set, add query parameters to requests.
+  // If set, add the page's "View as" (aclAsUser) params to requests, so URLs this API builds
+  // resolve as the impersonated user, not the owner. Browser-only, and only needed for URLs the
+  // browser fetches directly (downloads, <img> src).
+  propagateViewAs?: boolean;
 }
 
 export interface UploadProgressCallbacks {
@@ -78,6 +82,16 @@ export class BaseAPI {
       }
     }
     this._extraParameters = options.extraParameters;
+    // Like the boot-key fallback above, read "View as" params straight off the page URL.
+    if (options.propagateViewAs && typeof window !== "undefined") {
+      const sp = new URLSearchParams(window.location?.search);
+      // Prefer the id form, as "View as" links do.
+      const key = sp.has("aclAsUserId_") ? "aclAsUserId_" : sp.has("aclAsUser_") ? "aclAsUser_" : undefined;
+      if (key) {
+        this._extraParameters = new Map(this._extraParameters);
+        this._extraParameters.set(key, sp.get(key)!);
+      }
+    }
   }
 
   // Make a modified request, exposed for test convenience.
@@ -151,6 +165,12 @@ export class BaseAPI {
   /** Like `requestJson`, but bypasses the pending-request counter. See `requestUncounted`. */
   protected async requestJsonUncounted(input: string, init: RequestInit = {}): Promise<any> {
     return (await this._doRequest(input, init)).json();
+  }
+
+  // The extra query params (e.g. "View as" aclAsUser_) also sent with every request, exposed so
+  // URL builders for browser-fetched resources (downloads, <img> src) can include them too.
+  protected get extraParameters(): Record<string, string> {
+    return this._extraParameters ? Object.fromEntries(this._extraParameters) : {};
   }
 
   private async _doRequest(input: string, init: RequestInit): Promise<Response> {

--- a/app/common/UserAPI.ts
+++ b/app/common/UserAPI.ts
@@ -470,7 +470,7 @@ export interface UserAPI {
   getWorkerFull(key: string): Promise<PublicDocWorkerUrlInfo>;
   getWorkerAPI(key: string): Promise<DocWorkerAPI>;
   getBillingAPI(): BillingAPI;
-  getDocAPI(docId: string): DocAPI;
+  getDocAPI(docId: string, options?: IOptions): DocAPI;
   fetchApiKey(): Promise<string>;
   createApiKey(): Promise<string>;
   deleteApiKey(): Promise<void>;
@@ -1043,8 +1043,8 @@ export class UserAPIImpl extends BaseAPI implements UserAPI {
     return new BillingAPIImpl(this._homeUrl, this._options);
   }
 
-  public getDocAPI(docId: string): DocAPI {
-    return new DocAPIImpl(this._url, docId, this._options);
+  public getDocAPI(docId: string, options: IOptions = {}): DocAPI {
+    return new DocAPIImpl(this._url, docId, { ...this._options, ...options });
   }
 
   public async fetchApiKey(): Promise<string> {
@@ -1394,29 +1394,33 @@ export class DocAPIImpl extends BaseAPI implements DocAPI {
   }
 
   public getDownloadUrl({ template, removeHistory}: { template: boolean, removeHistory: boolean }): string {
-    return this._url + `/download?template=${template}&nohistory=${removeHistory}`;
+    return this._url + "/download?" + encodeQueryParams({
+      ...this.extraParameters,
+      template: String(template),
+      nohistory: String(removeHistory),
+    });
   }
 
-  public getDownloadXlsxUrl(params: DownloadDocParams) {
-    return this._url + "/download/xlsx?" + encodeQueryParams({ ...params });
+  public getDownloadXlsxUrl(params?: DownloadDocParams) {
+    return this._url + "/download/xlsx?" + encodeQueryParams({ ...this.extraParameters, ...params });
   }
 
   public getDownloadCsvUrl(params: DownloadDocParams) {
     // We spread `params` to work around TypeScript being overly cautious.
-    return this._url + "/download/csv?" + encodeQueryParams({ ...params });
+    return this._url + "/download/csv?" + encodeQueryParams({ ...this.extraParameters, ...params });
   }
 
   public getDownloadTsvUrl(params: DownloadDocParams) {
-    return this._url + "/download/tsv?" + encodeQueryParams({ ...params });
+    return this._url + "/download/tsv?" + encodeQueryParams({ ...this.extraParameters, ...params });
   }
 
   public getDownloadDsvUrl(params: DownloadDocParams) {
-    return this._url + "/download/dsv?" + encodeQueryParams({ ...params });
+    return this._url + "/download/dsv?" + encodeQueryParams({ ...this.extraParameters, ...params });
   }
 
   public getDownloadTableSchemaUrl(params: DownloadDocParams) {
     // We spread `params` to work around TypeScript being overly cautious.
-    return this._url + "/download/table-schema?" + encodeQueryParams({ ...params });
+    return this._url + "/download/table-schema?" + encodeQueryParams({ ...this.extraParameters, ...params });
   }
 
   public async download(
@@ -1428,13 +1432,15 @@ export class DocAPIImpl extends BaseAPI implements DocAPI {
   }
 
   public getDownloadAttachmentsArchiveUrl(params: AttachmentsArchiveParams): string {
-    return this._url + "/attachments/archive?" + encodeQueryParams({ ...params });
+    return this._url + "/attachments/archive?" + encodeQueryParams({ ...this.extraParameters, ...params });
   }
 
   public getAttachmentDownloadUrl(attId: number, params: AttachmentDownloadParams = {}): string {
-    // encodeQueryParams stringifies `undefined` as the literal "null" — strip unset keys first,
-    // otherwise `?inline=null` would be truthy on the server and force inline mode unintentionally.
+    // encodeQueryParams stringifies `undefined` as the literal "null", so strip unset keys first;
+    // otherwise `?inline=null` reads as truthy on the server and forces inline mode.
+    // extraParameters (e.g. "View as") come first so previews respect ACLs, not just the owner.
     const query = omitBy({
+      ...this.extraParameters,
       ...params.cell,
       name: params.name,
       inline: params.inline ? 1 : undefined,

--- a/test/client/models/gristUrlState.ts
+++ b/test/client/models/gristUrlState.ts
@@ -1,6 +1,6 @@
 import { HistWindow, UrlState } from "app/client/lib/UrlState";
 import { UrlStateImpl } from "app/client/models/gristUrlState";
-import { IGristUrlState } from "app/common/gristUrls";
+import { IGristUrlState, userOverrideParams } from "app/common/gristUrls";
 
 import { assert } from "chai";
 import { dom } from "grainjs";
@@ -373,5 +373,17 @@ describe("gristUrlState", function() {
     "https://bar.example.com/doc/DOC/p/44?foo_=X&bar_=B");
     await state.pushUrl(prevState => omit(prevState, "params"));
     assert.equal(mockWindow.location.href, "https://bar.example.com/doc/DOC/p/5");
+  });
+
+  it("should need a page load when entering or leaving View as", function() {
+    // Code that reads the "View as" parameters off the page URL once (e.g. BaseAPI's
+    // propagateViewAs option) relies on this: there is no way to change who we are viewing as
+    // without discarding all client state.
+    const plain: IGristUrlState = { doc: "DOC", docPage: 5 };
+    const viewingAs = userOverrideParams("someone@example.com")(plain);
+    assert.isTrue(prod.needPageLoad(plain, viewingAs));
+    assert.isTrue(prod.needPageLoad(viewingAs, userOverrideParams(null)(viewingAs)));
+    // Moving around the document while viewing as someone is just a page switch, though.
+    assert.isFalse(prod.needPageLoad(viewingAs, { ...viewingAs, docPage: 6 }));
   });
 });

--- a/test/common/UserAPI.ts
+++ b/test/common/UserAPI.ts
@@ -1,0 +1,121 @@
+import { DocAPIImpl, UserAPIImpl } from "app/common/UserAPI";
+
+import { assert } from "chai";
+
+describe("UserAPI", function() {
+  // A dummy fetch so that BaseAPI's constructor doesn't reach for window.fetch in node.
+  const noopFetch = (() => Promise.reject(new Error("not used"))) as unknown as typeof fetch;
+
+  function makeDocApi(extraParameters?: Map<string, string>) {
+    return new DocAPIImpl("https://worker.example.com", "docId", { fetch: noopFetch, extraParameters });
+  }
+
+  describe("getAttachmentDownloadUrl", function() {
+    it("omits View as parameters when none are configured", function() {
+      const url = makeDocApi().getAttachmentDownloadUrl(7);
+      assert.equal(url, "https://worker.example.com/api/docs/docId/attachments/7/download");
+    });
+
+    it("passes along the aclAsUser_ extra parameter (View as by email)", function() {
+      const url = makeDocApi(new Map([["aclAsUser_", "someone@example.com"]]))
+        .getAttachmentDownloadUrl(7, { name: "pic.png" });
+      const params = new URL(url).searchParams;
+      assert.equal(params.get("aclAsUser_"), "someone@example.com");
+      assert.equal(params.get("name"), "pic.png");
+    });
+
+    it("passes along the aclAsUserId_ extra parameter (View as by id)", function() {
+      const url = makeDocApi(new Map([["aclAsUserId_", "42"]])).getAttachmentDownloadUrl(7);
+      assert.equal(new URL(url).searchParams.get("aclAsUserId_"), "42");
+    });
+
+    it("keeps extra parameters alongside cell and inline params", function() {
+      const url = makeDocApi(new Map([["aclAsUser_", "someone@example.com"]]))
+        .getAttachmentDownloadUrl(7, {
+          cell: { rowId: 3, colId: "A", tableId: "Table1" },
+          inline: true,
+        });
+      const params = new URL(url).searchParams;
+      assert.equal(params.get("aclAsUser_"), "someone@example.com");
+      assert.equal(params.get("rowId"), "3");
+      assert.equal(params.get("colId"), "A");
+      assert.equal(params.get("tableId"), "Table1");
+      assert.equal(params.get("inline"), "1");
+    });
+  });
+
+  describe("download URLs", function() {
+    it("include extraParameters (e.g. View as) when configured", function() {
+      const docApi = makeDocApi(new Map([["aclAsUser_", "someone@example.com"]]));
+      const urls = [
+        docApi.getDownloadXlsxUrl(),
+        docApi.getDownloadCsvUrl({ tableId: "T" }),
+        docApi.getDownloadUrl({ template: false, removeHistory: false }),
+        docApi.getDownloadAttachmentsArchiveUrl({ format: "tar" }),
+      ];
+      for (const url of urls) {
+        assert.equal(new URL(url).searchParams.get("aclAsUser_"), "someone@example.com", url);
+      }
+    });
+
+    it("omit them when none are configured", function() {
+      assert.isNull(new URL(makeDocApi().getDownloadXlsxUrl()).searchParams.get("aclAsUser_"));
+    });
+  });
+
+  describe("getDocAPI", function() {
+    it("threads options (extraParameters) into the returned DocAPI's URLs", function() {
+      const api = new UserAPIImpl("https://home.example.com", { fetch: noopFetch });
+      const url = api
+        .getDocAPI("docId", { extraParameters: new Map([["aclAsUser_", "someone@example.com"]]) })
+        .getDownloadXlsxUrl();
+      assert.equal(new URL(url).searchParams.get("aclAsUser_"), "someone@example.com");
+    });
+
+    it("does not let an absent option clobber the base API's extraParameters", function() {
+      const base = new UserAPIImpl("https://home.example.com",
+        { fetch: noopFetch, extraParameters: new Map([["showRemoved", "1"]]) });
+      const url = base.getDocAPI("docId").getDownloadXlsxUrl();
+      assert.equal(new URL(url).searchParams.get("showRemoved"), "1");
+    });
+  });
+
+  describe("propagateViewAs", function() {
+    // Stub a browser-like window with the given query string for the duration of `fn`.
+    function withWindowSearch(search: string, fn: () => void) {
+      const saved = (global as any).window;
+      (global as any).window = { location: { pathname: "/doc", search } };
+      try {
+        fn();
+      } finally {
+        if (saved === undefined) { delete (global as any).window; } else { (global as any).window = saved; }
+      }
+    }
+
+    it("picks up aclAsUser_ from the page URL", function() {
+      withWindowSearch("?aclAsUser_=someone@example.com", function() {
+        const url = new DocAPIImpl("https://worker.example.com", "docId",
+          { fetch: noopFetch, propagateViewAs: true }).getDownloadXlsxUrl();
+        assert.equal(new URL(url).searchParams.get("aclAsUser_"), "someone@example.com");
+      });
+    });
+
+    it("prefers aclAsUserId_ over aclAsUser_", function() {
+      withWindowSearch("?aclAsUser_=someone@example.com&aclAsUserId_=42", function() {
+        const params = new URL(new DocAPIImpl("https://worker.example.com", "docId",
+          { fetch: noopFetch, propagateViewAs: true }).getDownloadXlsxUrl()).searchParams;
+        assert.equal(params.get("aclAsUserId_"), "42");
+        assert.isNull(params.get("aclAsUser_"));
+      });
+    });
+
+    it("adds nothing when the page URL is not in View as mode", function() {
+      withWindowSearch("?foo=bar", function() {
+        const params = new URL(new DocAPIImpl("https://worker.example.com", "docId",
+          { fetch: noopFetch, propagateViewAs: true }).getDownloadXlsxUrl()).searchParams;
+        assert.isNull(params.get("aclAsUser_"));
+        assert.isNull(params.get("aclAsUserId_"));
+      });
+    });
+  });
+});

--- a/test/nbrowser/GranularAccess.ts
+++ b/test/nbrowser/GranularAccess.ts
@@ -1728,6 +1728,50 @@ describe("GranularAccess", function() {
     const editorUrl = await driver.findWait(".test-pw-download", 5000).getAttribute("href");
     await checkAttachment(editorUrl, "uploads/gplaypattern.png");
     await driver.sendKeys(Key.ESCAPE);
+
+    // View as a restricted user: previews must carry aclAsUser_ and resolve with that user's access.
+    await mainSession.login();
+    await mainSession.loadDoc(`/doc/${doc.id}?aclAsUser_=${encodeURIComponent(otherSession.email)}`);
+    await gu.getPageItem(/Data1/).click();
+    await gu.waitForServer();
+
+    // Row 2 (B="notclear") is hidden from non-owners, so only rows 1 and 3 are visible.
+    assert.deepEqual(await gu.getVisibleGridCells("A", [1, 2, 3]),
+      ["near", "in a motor car", ""]);
+
+    // The preview <img> for a visible attachment includes the aclAsUser_ param.
+    await gu.getCell("Pics", 2).click();
+    const viewAsUrl = (await readAttachments())[0].src!;
+    assert.equal(new URL(viewAsUrl).searchParams.get("aclAsUser_"), otherSession.email);
+
+    // The attachment editor's download link is View-as-aware too (built via a separate DocAPI).
+    await gu.waitAppFocus();
+    await driver.sendKeys(Key.ENTER);
+    const editorViewAsUrl = await driver.findWait(".test-pw-download", 5000).getAttribute("href");
+    assert.equal(new URL(editorViewAsUrl).searchParams.get("aclAsUser_"), otherSession.email);
+    await driver.sendKeys(Key.ESCAPE);
+
+    // The hidden row's attachment (grist.png, attId 3) is readable by the owner, but denied once
+    // viewing as the restricted user.
+    const ownerHeaders = { Authorization: `Bearer ${mainSession.getApiKey()}` };
+    const hiddenAttUrl = mutateAttachmentUrl(viewAsUrl, {
+      attId: 3,
+      remove: ["rowId", "colId", "tableId", "name", "aclAsUser_"],
+    });
+    assert.equal(
+      (await axios.get(hiddenAttUrl, { headers: ownerHeaders, validateStatus: () => true })).status,
+      200,
+    );
+    const hiddenAttUrlAsUser = mutateAttachmentUrl(hiddenAttUrl, {
+      set: { aclAsUser_: otherSession.email },
+    });
+    const deniedStatus = (await axios.get(hiddenAttUrlAsUser,
+      { headers: ownerHeaders, validateStatus: () => true })).status;
+    assert.isAtLeast(deniedStatus, 400);
+    assert.notEqual(deniedStatus, 200);
+
+    await driver.find(".test-view-as-banner .test-revert").click();
+    await gu.waitForDocToLoad();
   });
 
   describe("shares", function() {

--- a/test/nbrowser/GranularAccess.ts
+++ b/test/nbrowser/GranularAccess.ts
@@ -1770,8 +1770,12 @@ describe("GranularAccess", function() {
     assert.isAtLeast(deniedStatus, 400);
     assert.notEqual(deniedStatus, 200);
 
+    // Leaving "View as" reloads the page, so nothing keeps building URLs for the user we were
+    // pretending to be.
     await driver.find(".test-view-as-banner .test-revert").click();
     await gu.waitForDocToLoad();
+    await gu.getCell("Pics", 2).click();
+    assert.isNull(new URL((await readAttachments())[0].src!).searchParams.get("aclAsUser_"));
   });
 
   describe("shares", function() {


### PR DESCRIPTION
Attachment previews (widget/editor) and the share menu's whole-doc XLSX export fetch DocApi URLs that build a fresh docSession from the request URL. They dropped the aclAsUser_ link parameter, so they resolved as the owner instead of the impersonated user.

Expose BaseAPI extraParameters to the URL builders, and build these URLs through a View-as-aware DocAPI.

Uploads need no special-casing: the /uploads route is not doc-access controlled, and the real gating happens on the socket calls that follow (addAttachments, UpdateRecord), which already carry the View-as context. So the widget/editor just use one View-as-aware DocAPI throughout; the param is inert on the upload path. MakeCopyMenu's full-doc downloads pass no such context, so copies stay unfiltered.
