### PR TITLE
Show access-rule memos only when they explain the denial

### DIFF
--- a/app/client/models/NotifyModel.ts
+++ b/app/client/models/NotifyModel.ts
@@ -2,6 +2,7 @@ import { makeT } from "app/client/lib/localization";
 import * as log from "app/client/lib/log";
 import { ConnectState, ConnectStateManager } from "app/client/models/ConnectState";
 import { isNarrowScreenObs, testId } from "app/client/ui2018/cssVars";
+import { Memo } from "app/common/ACLPermissions";
 import { delay } from "app/common/delay";
 import { isLongerThan } from "app/common/gutil";
 import { InactivityTimer } from "app/common/InactivityTimer";
@@ -72,7 +73,7 @@ export interface INotifyOptions {
   badgeCounter?: boolean;
   level: NotificationLevel;
 
-  memos?: string[];  // A list of relevant notes.
+  memos?: Memo[];  // Relevant notes attached to a denial, tagged as "reason" or "remedy".
 
   // cssToastAction class from NotifyUI will be applied automatically to action elements.
   actions?: NotifyAction[];

--- a/app/client/ui/NotifyUI.ts
+++ b/app/client/ui/NotifyUI.ts
@@ -10,6 +10,7 @@ import { isNarrowScreenObs, theme, vars } from "app/client/ui2018/cssVars";
 import { IconName } from "app/client/ui2018/IconList";
 import { icon } from "app/client/ui2018/icons";
 import { menuCssClass } from "app/client/ui2018/menus";
+import { Memo, MemoKind } from "app/common/ACLPermissions";
 import { commonUrls, isFeatureEnabled } from "app/common/gristUrls";
 
 import { dom, makeTestId, styled } from "grainjs";
@@ -85,6 +86,34 @@ function notificationIcon(item: Notification) {
   return iconName ? icon(iconName, dom.cls(cssToastIcon.className)) : null;
 }
 
+// Render denial memos. The kind is carried by the icon (a lock for what blocks you, a lightbulb for
+// how you could gain access) rather than a heading, so the distinction survives without on-screen
+// prose; the icon's title is the accessible fallback. Reasons are shown before remedies.
+const memoKindIcon: Record<MemoKind, IconName> = { reason: "Lock", remedy: "Idea" };
+const memoKindTitle: Record<MemoKind, () => string> = {
+  reason: () => t("What's blocking you"),
+  remedy: () => t("How you could gain access"),
+};
+function buildMemos(memos: Memo[]) {
+  const kinds: MemoKind[] = ["reason", "remedy"];
+  return cssToastMemos(
+    kinds.map((kind) => {
+      const items = memos.filter(m => m.kind === kind);
+      if (!items.length) { return null; }
+      // The icon carries the kind visually; give it a label and role so screen readers announce it.
+      const label = memoKindTitle[kind]();
+      return cssToastMemoGroup(
+        testId(`toast-memo-group-${kind}`),
+        items.map(memo => cssToastMemo(
+          cssToastMemoIcon(memoKindIcon[kind],
+            dom.attr("role", "img"), dom.attr("aria-label", label), dom.attr("title", label)),
+          dom("div", memo.text, testId("toast-memo")),
+        )),
+      );
+    }),
+  );
+}
+
 function buildNotificationDom(item: Notification, options: IBeaconOpenOptions) {
   const iconElement = notificationIcon(item);
   const hasLeftIcon = Boolean(!item.options.title && iconElement);
@@ -102,12 +131,7 @@ function buildNotificationDom(item: Notification, options: IBeaconOpenOptions) {
       item.options.actions.length ? cssToastActions(
         item.options.actions.map(action => buildAction(action, item, options)),
       ) : null,
-      item.options.memos.length ? cssToastMemos(
-        item.options.memos.map(memo => cssToastMemo(
-          cssToastMemoIcon("Memo"),
-          dom("div", memo, testId("toast-memo")),
-        )),
-      ) : null,
+      item.options.memos.length ? buildMemos(item.options.memos) : null,
     ),
     dom.maybe(item.options.canUserClose, () =>
       cssToastClose(testId("toast-close"),
@@ -409,6 +433,13 @@ const cssToastMemos = styled("div", `
   margin-top: 8px;
   display: flex;
   flex-direction: column;
+  row-gap: 8px;
+`);
+
+const cssToastMemoGroup = styled("div", `
+  display: flex;
+  flex-direction: column;
+  row-gap: 8px;
 `);
 
 const cssToastMemo = styled("div", `

--- a/app/common/ACLPermissions.ts
+++ b/app/common/ACLPermissions.ts
@@ -42,6 +42,14 @@ export type TablePermissionSet = PermissionSet<TablePermissionValue>;
 // One of the strings 'read', 'update', etc.
 export type PermissionKey = keyof PermissionSet;
 
+// A memo attached to a denial. A "reason" explains what is blocking you; a "remedy" points at a
+// rule that could have granted access (but didn't apply). See extractMemos in PermissionInfo.
+export type MemoKind = "reason" | "remedy";
+export interface Memo {
+  kind: MemoKind;
+  text: string;
+}
+
 const PERMISSION_BITS: { [letter: string]: PermissionKey } = {
   R: "read",
   C: "create",
@@ -127,7 +135,7 @@ export function makePartialPermissions(pset: PartialPermissionSet): PartialPermi
  *
  * Note that this logic satisfies associative property: (a + b) + c == a + (b + c).
  */
-function combinePartialPermission(a: PartialPermissionValue, b: PartialPermissionValue): PartialPermissionValue {
+export function combinePartialPermission(a: PartialPermissionValue, b: PartialPermissionValue): PartialPermissionValue {
   if (!a) { return b; }
   if (!b) { return a; }
   // If the first is uncertain, the second may keep it unchanged, or make certain, or finalize as mixed.

--- a/app/common/ApiError.ts
+++ b/app/common/ApiError.ts
@@ -1,3 +1,5 @@
+import { Memo } from "app/common/ACLPermissions";
+
 /**
  * A tip for fixing an error.
  */
@@ -33,7 +35,7 @@ export interface ApiErrorDetails {
   // If set, contains suggestions for fixing a problem.
   tips?: ApiTip[];
 
-  memos?: string[];
+  memos?: Memo[];
 }
 
 export type ApiErrorCode =

--- a/app/common/ErrorWithCode.ts
+++ b/app/common/ErrorWithCode.ts
@@ -1,9 +1,10 @@
+import { Memo } from "app/common/ACLPermissions";
 import { OpenDocMode } from "app/common/DocListAPI";
 
 interface ErrorDetails {
   status?: number;
   accessMode?: OpenDocMode;
-  memos?: string[];
+  memos?: Memo[];
 }
 
 /**

--- a/app/server/lib/GranularAccess.ts
+++ b/app/server/lib/GranularAccess.ts
@@ -50,7 +50,7 @@ import { DocClients } from "app/server/lib/DocClients";
 import { OptDocSession } from "app/server/lib/DocSession";
 import { DocStorage, REMOVE_UNUSED_ATTACHMENTS_DELAY } from "app/server/lib/DocStorage";
 import log from "app/server/lib/log";
-import { IPermissionInfo, MixedPermissionSetWithContext,
+import { IPermissionInfo, mergeMemoSets, MixedPermissionSetWithContext,
   PermissionInfo, PermissionSetWithContext } from "app/server/lib/PermissionInfo";
 import { TablePermissionSetWithContext } from "app/server/lib/PermissionInfo";
 import { integerParam } from "app/server/lib/requestUtils";
@@ -79,6 +79,11 @@ function isAclTable(tableId: string): boolean {
 }
 
 const ADD_OR_UPDATE_RECORD_ACTIONS = ["AddOrUpdateRecord", "BulkAddOrUpdateRecord"];
+
+// Actions whose update can be denied per-column, and whose written columns sit at index 3.
+const COLUMN_GRANULAR_UPDATE_ACTIONS = [
+  "UpdateRecord", "BulkUpdateRecord", "AddOrUpdateRecord", "BulkAddOrUpdateRecord",
+];
 
 function isAddOrUpdateRecordAction([actionName]: UserAction): boolean {
   return ADD_OR_UPDATE_RECORD_ACTIONS.includes(String(actionName));
@@ -1451,7 +1456,8 @@ export class GranularAccess implements GranularAccessForBundle {
       }
       const tableAccess = await this.getTableAccess(docSession, tableId);
       const accessCheck = await this._getAccessForActionType(docSession, a, "fatal");
-      accessCheck.get(tableAccess);  // will throw if access denied.
+      const permInfo = await this._getAccess(docSession);
+      accessCheck.get(this._focusUpdateMemos(a, tableAccess, permInfo, tableId));  // throws if denied
       return true;
     } else {
       // Any other action might change schema, so continuing could lead
@@ -1518,8 +1524,9 @@ export class GranularAccess implements GranularAccessForBundle {
         throw new Error(`${actionName} cannot yet be used on metadata tables`);
       }
       const tableAccess = await this.getTableAccess(docSession, tableId);
+      const permInfo = await this._getAccess(docSession);
       accessChecks.fatal.read.throwIfNotFullyAllowed(tableAccess);
-      accessChecks.fatal.update.throwIfDenied(tableAccess);
+      accessChecks.fatal.update.throwIfDenied(this._focusUpdateMemos(a, tableAccess, permInfo, tableId));
       accessChecks.fatal.create.throwIfDenied(tableAccess);
     });
   }
@@ -1655,6 +1662,29 @@ export class GranularAccess implements GranularAccessForBundle {
     if (docActions.some(docAction => isSchemaAction(docAction))) {
       await this.update();
     }
+  }
+
+  /**
+   * A table-wide update denial aggregates memos across all columns, so it can surface a memo about
+   * a column the user didn't touch. Return the same verdict and rule type, but with memos scoped to
+   * the columns this update actually touches. No-op for non-update actions or updates with no colIds.
+   *
+   * Update is the only case that needs this: it is the only column-granular data-write permission
+   * (AVAILABLE_BITS_COLUMNS is read/update), so create/delete denials are uniform across columns and
+   * their aggregate memo is already focused. Applies to plain updates and to the update side of an
+   * upsert; both keep the written columns at index 3.
+   */
+  private _focusUpdateMemos(a: DocAction | UserAction, ps: TablePermissionSetWithContext,
+    permInfo: IPermissionInfo, tableId: string): TablePermissionSetWithContext {
+    if (!COLUMN_GRANULAR_UPDATE_ACTIONS.includes(String(a[0]))) { return ps; }
+    const colIds = getColIdsFromDocAction(a as DataAction);
+    // No columns to focus on (e.g. an empty update): fall back to the table-level memos.
+    if (!colIds || colIds.length === 0) { return ps; }
+    return {
+      perms: ps.perms,
+      ruleType: ps.ruleType,
+      getMemos: () => mergeMemoSets(colIds.map(colId => permInfo.getColumnAccess(tableId, colId).getMemos())),
+    };
   }
 
   /**
@@ -1956,7 +1986,8 @@ export class GranularAccess implements GranularAccessForBundle {
       const rowPermInfo = new PermissionInfo(ruler.ruleCollection, input);
       // getTableAccess() evaluates all column rules for THIS record. So it's really rowAccess.
       const rowAccess = rowPermInfo.getTableAccess(tableId);
-      const access = accessCheck.get(rowAccess);
+      // Scope any denial memos to the columns this update touches, as for the table-level checks.
+      const access = accessCheck.get(this._focusUpdateMemos(action, rowAccess, rowPermInfo, tableId));
       if (access === "deny") {
         toRemove.push(idx);
       } else if (access !== "allow" && colValues) {
@@ -2540,7 +2571,7 @@ export class GranularAccess implements GranularAccessForBundle {
     const tableId = getTableId(action);
     const permInfo = await this._getStepAccess(cursor);
     const tableAccess = permInfo.getTableAccess(tableId);
-    const access = accessCheck.get(tableAccess);
+    const access = accessCheck.get(this._focusUpdateMemos(action, tableAccess, permInfo, tableId));
     if (access === "allow") { return; }
     if (access === "mixed") {
       // Deal with row-level access for the mixed condition.

--- a/app/server/lib/PermissionInfo.ts
+++ b/app/server/lib/PermissionInfo.ts
@@ -1,7 +1,7 @@
-import { ALL_PERMISSION_PROPS, emptyPermissionSet,
-  makePartialPermissions, mergePartialPermissions, mergePermissions,
-  MixedPermissionSet, PartialPermissionSet, PermissionSet, TablePermissionSet,
-  toMixed } from "app/common/ACLPermissions";
+import { ALL_PERMISSION_PROPS, combinePartialPermission, emptyPermissionSet,
+  makePartialPermissions, Memo, mergePartialPermissions, mergePermissions,
+  MixedPermissionSet, PartialPermissionSet, PartialPermissionValue,
+  PermissionSet, TablePermissionSet, toMixed } from "app/common/ACLPermissions";
 import { ACLRuleCollection } from "app/common/ACLRuleCollection";
 import { RuleSet } from "app/common/GranularAccessClause";
 import { getSetMapValue } from "app/common/gutil";
@@ -26,19 +26,24 @@ export type TablePermissionSetWithContext = PermissionSetWithContextOf<TablePerm
 export type PermissionSetWithContext = PermissionSetWithContextOf<PermissionSet<string>>;
 
 // Accumulator for memos of relevant rules.
-export type MemoSet = PermissionSet<string[]>;
+export type MemoSet = PermissionSet<Memo[]>;
 
-// Merge MemoSets by collecting all memos with de-duplication.
+// Merge MemoSets by collecting all memos, de-duplicating on kind and text.
 export function mergeMemoSets(psets: MemoSet[]): MemoSet {
   const result: Partial<MemoSet> = {};
   for (const prop of ALL_PERMISSION_PROPS) {
-    const merged = new Set<string>();
+    const seen = new Set<string>();
+    const merged: Memo[] = [];
     for (const p of psets) {
       for (const memo of p[prop]) {
-        merged.add(memo);
+        const key = `${memo.kind} ${memo.text}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          merged.push(memo);
+        }
       }
     }
-    result[prop] = [...merged];
+    result[prop] = merged;
   }
   return result as MemoSet;
 }
@@ -123,7 +128,19 @@ abstract class RuleInfo<MixedT extends TableT, TableT> {
 export class MemoInfo extends RuleInfo<MemoSet, MemoSet> {
   protected _processRule(ruleSet: RuleSet, defaultAccess?: () => MemoSet): MemoSet {
     const pset = extractMemos(ruleSet, this._input);
-    return defaultAccess ? mergeMemoSets([pset, defaultAccess()]) : pset;
+    if (!defaultAccess) { return pset; }
+    // Once this rule set settles a bit (see combinePartialPermission), a lower-precedence default no
+    // longer affects the outcome. Its "remedy" is then shadowed and misleading, so drop it. But its
+    // "reason" still names a rule that also blocks you, so keep it; a bit can have several barriers.
+    const perms = evaluateRule(ruleSet, this._input);
+    const defaultMemos = defaultAccess();
+    const relevantDefaults = emptyMemoSet();
+    for (const prop of ALL_PERMISSION_PROPS) {
+      relevantDefaults[prop] = isCertainPermission(perms[prop]) ?
+        defaultMemos[prop].filter(memo => memo.kind === "reason") :
+        defaultMemos[prop];
+    }
+    return mergeMemoSets([pset, relevantDefaults]);
   }
 
   protected _mergeTableAccess(access: MemoSet[]): MemoSet {
@@ -218,6 +235,11 @@ export class PermissionInfo extends RuleInfo<MixedPermissionSet, TablePermission
   }
 }
 
+// A partial permission is "certain" when merging in a lower-precedence value can't change it.
+function isCertainPermission(perm: PartialPermissionValue): boolean {
+  return perm === "allow" || perm === "deny" || perm === "mixed";
+}
+
 /**
  * Evaluate a RuleSet on a given input (user and optionally record). If a record is needed but not
  * included, the result may include permission values like 'allowSome', 'denySome', or 'mixed' (for
@@ -283,31 +305,39 @@ function evaluateRule(ruleSet: RuleSet, input: PredicateFormulaInput): PartialPe
 }
 
 /**
- * If a rule has a memo, and passes, add that memo for all permissions it denies.
- * If a rule has a memo, and fails, add that memo for all permissions it allows.
+ * Collect the memos relevant to a denial, tagged by kind:
+ * - "reason": a rule that passes and denies. All are kept (co-equal denies each block independently).
+ * - "remedy": a rule that fails but would allow. Dropped once an earlier rule in body/precedence
+ *   order certainly denies the bit, since satisfying a shadowed rule wouldn't change the outcome.
  */
 function extractMemos(ruleSet: RuleSet, input: PredicateFormulaInput): MemoSet {
   const pset = emptyMemoSet();
+  const acc: PartialPermissionSet = emptyPermissionSet();
   for (const rule of ruleSet.body) {
     try {
       const passing = rule.matchFunc!(input);
       for (const prop of ALL_PERMISSION_PROPS) {
         const p = rule.permissions[prop];
-        const memos: string[] = pset[prop];
         if (rule.memo) {
           if (passing && p === "deny") {
-            memos.push(rule.memo);
-          } else if (!passing && p === "allow") {
-            memos.push(rule.memo);
+            pset[prop].push({ kind: "reason", text: rule.memo });
+          } else if (!passing && p === "allow" && !isCertainPermission(acc[prop])) {
+            pset[prop].push({ kind: "remedy", text: rule.memo });
           }
         }
+        // Only a matched rule contributes to the resolved permission for this bit.
+        if (passing) { acc[prop] = combinePartialPermission(acc[prop], p); }
       }
     } catch (e) {
+      // Match unknown (rec absent), so leave `acc` unadvanced -- keep later remedies rather than
+      // suppress on a shadow we can't confirm. On the row path (where memos show) rec is present.
       if (e.code !== "NEED_ROW_DATA") {
         // If a rule is failing unexpectedly, give some information via memos.
-        // TODO: Could give a more structured result.
         for (const prop of ALL_PERMISSION_PROPS) {
-          pset[prop].push(`Rule [${rule.aclFormula}] for ${ruleSet.tableId} has an error: ${e.message}`);
+          pset[prop].push({
+            kind: "reason",
+            text: `Rule [${rule.aclFormula}] for ${ruleSet.tableId} has an error: ${e.message}`,
+          });
         }
       }
     }

--- a/test/nbrowser/AccessRulesSchemaEdit.ts
+++ b/test/nbrowser/AccessRulesSchemaEdit.ts
@@ -181,7 +181,7 @@ describe("AccessRulesSchemaEdit", function() {
     let error = await editorApi.applyUserActions(docId, [["RenameTable", "Table1", "Renamed3"]])
       .then(() => null).catch(err => err);
     assert.match(error?.message, /Blocked by table structure access rules/);
-    assert.deepInclude(error?.details, { memos: ["Memo MIXED"] });
+    assert.deepInclude(error?.details, { memos: [{ kind: "reason", text: "Memo MIXED" }] });
 
     // Change the memos on both copies of the rule.
     await enterRulePart(findDefaultRuleSet("*"), 1, null, {}, "Memo DDD");
@@ -200,7 +200,7 @@ describe("AccessRulesSchemaEdit", function() {
     error = await editorApi.applyUserActions(docId, [["RenameTable", "Table1", "Renamed3"]])
       .then(() => null).catch(err => err);
     assert.match(error?.message, /Blocked by table structure access rules/);
-    assert.deepInclude(error?.details, { memos: ["Memo SSS"] });
+    assert.deepInclude(error?.details, { memos: [{ kind: "reason", text: "Memo SSS" }] });
 
     // Check what the rules are on the default resource.
     const mainDocApi = api.getDocAPI(docId);

--- a/test/nbrowser/GranularAccess.ts
+++ b/test/nbrowser/GranularAccess.ts
@@ -15,6 +15,49 @@ describe("GranularAccess", function() {
   this.timeout(40000);
   const cleanup = setupTestSuite();
 
+  it("groups denial memos by kind", async function() {
+    const owner = await gu.session().teamSite.login();
+    const api = owner.createHomeApi();
+    const doc = await owner.tempNewDoc(cleanup, "MemoKinds", { load: false });
+
+    // A rule that would grant an owner update access (a "remedy" for the editor), plus a
+    // record-dependent deny (the "reason"). The reason is record-dependent so the client can't
+    // pre-block the edit -- it is attempted and denied server-side, producing the memo toast.
+    await api.applyUserActions(doc, [
+      // A real data row, so editing cell (0, 1) is an update rather than adding a new record.
+      ["AddRecord", "Table1", null, { A: "hi" }],
+      ["AddRecord", "_grist_ACLResources", -1, { tableId: "Table1", colIds: "*" }],
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -1, aclFormula: "user.Access == OWNER", permissionsText: "+U", memo: "Owners can edit",
+      }],
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -1, aclFormula: 'newRec.A != ""', permissionsText: "-U", memo: "Editing is locked",
+      }],
+    ]);
+    await api.updateDocPermissions(doc, {
+      users: { [gu.translateUser("user2").email]: "editors" },
+    });
+
+    // As the editor, try to edit a cell. The denial toast should group the two memo kinds.
+    const editorSession = await gu.session().teamSite.user("user2").login();
+    await editorSession.loadDoc(`/doc/${doc}`);
+    await gu.getCell(0, 1).click();
+    await gu.waitAppFocus();
+    await gu.sendKeys("nope", Key.ENTER);
+    await gu.waitForServer();
+
+    // Assert the grouping structurally (which memo is in which kind's group), not any UI copy.
+    const toast = await driver.findWait(".test-notifier-toast-wrapper", 2000);
+    const memosInGroup = (kind: string) => toast.findAll(
+      `.test-notifier-toast-memo-group-${kind} .test-notifier-toast-memo`, el => el.getText());
+    assert.deepEqual(await memosInGroup("reason"), ["Editing is locked"]);
+    assert.deepEqual(await memosInGroup("remedy"), ["Owners can edit"]);
+    // The kind icon carries an accessible label for screen readers (copy not pinned).
+    const iconLabel = await toast.find('.test-notifier-toast-memo-group-reason [role="img"]')
+      .getAttribute("aria-label");
+    assert.isNotEmpty(iconLabel);
+  });
+
   it("restores formula data column after rejection", async function() {
     // Create a document owned by default user.
     const mainSession = await gu.session().teamSite.login();
@@ -910,10 +953,14 @@ describe("GranularAccess", function() {
       await gu.waitForServer();
       const message = await driver.findWait(".test-notifier-toast-wrapper", 2000).getText();
 
-      // The last character in each regexp is the "x" to close the toast.
+      // A memo shows only if it explains this denial: the rule that blocks you (reason), or a
+      // would-allow rule not overruled by a higher-precedence denial (remedy). Column: rule3 blocks
+      // and overrules the table/doc remedies, so only rule3 shows. Table: rule2b blocks create, its
+      // sibling remedy rule2 survives, the doc remedy rule1 is shadowed. Reasons list before remedies.
+      // The trailing character is the "x" to close the toast.
       const expectedRegex = (blockedBy === "column") ?
-        /^Blocked by column update access rules\nrule3\nrule2\nrule1\n.$/ :
-        /^Blocked by table create access rules\nrule2\nrule2b\nrule1\n.$/;
+        /^Blocked by column update access rules\nrule3\n.$/ :
+        /^Blocked by table create access rules\nrule2b\nrule2\n.$/;
 
       assert.match(message, expectedRegex);
       await gu.wipeToasts();

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -1,3 +1,4 @@
+import { Memo } from "app/common/ACLPermissions";
 import { LocalActionBundle, SandboxActionBundle } from "app/common/ActionBundle";
 import { PermissionDataWithExtraUsers } from "app/common/ActiveDocAPI";
 import { delay } from "app/common/delay";
@@ -952,6 +953,173 @@ describe("GranularAccess", function() {
     await assertDeniedFor(owner.applyUserActions(docId, [
       ["ModifyColumn", "Table2", "A", { formula: "a formula" }],
     ]), ["rule_s"]);
+  });
+
+  it("does not show memos from shadowed lower-precedence rules", async function() {
+    // A column rule that denies shouldn't drag along a shadowed table-default rule's memo.
+    await freshDoc();
+    await owner.applyUserActions(docId, [
+      ["AddTable", "Table1", [{ id: "A" }]],
+      ["AddRecord", "Table1", null, { A: "test1" }],
+      ["AddRecord", "_grist_ACLResources", -1, { tableId: "Table1", colIds: "A" }],  // column
+      ["AddRecord", "_grist_ACLResources", -2, { tableId: "Table1", colIds: "*" }],  // table default
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -1, aclFormula: "user.Access == EDITOR", permissionsText: "-U", memo: "col_deny",
+      }],
+      ["AddRecord", "_grist_ACLRules", null, {
+        // Would grant update, but doesn't apply to the editor: its memo must stay suppressed.
+        resource: -2, aclFormula: "user.Access == OWNER", permissionsText: "+U", memo: "table_allow",
+      }],
+    ]);
+    await assertDeniedWithMemos(editor.getDocAPI(docId).updateRows("Table1", { id: [1], A: ["x"] }),
+      [{ kind: "reason", text: "col_deny" }]);
+  });
+
+  it("keeps a shadowed lower-precedence deny memo", async function() {
+    // The counterpart to the test above. A column rule blocks the edit but has no memo, and a
+    // broader table rule also denies, with one. That broader rule is a real barrier (a reason), not
+    // a false-hope remedy, so its memo is kept even though the column rule settles access first.
+    await freshDoc();
+    await owner.applyUserActions(docId, [
+      ["AddTable", "Table1", [{ id: "A" }]],
+      ["AddRecord", "Table1", null, { A: "test1" }],
+      ["AddRecord", "_grist_ACLResources", -1, { tableId: "Table1", colIds: "A" }],  // column
+      ["AddRecord", "_grist_ACLResources", -2, { tableId: "Table1", colIds: "*" }],  // table default
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -1, aclFormula: "user.Access == EDITOR", permissionsText: "-U",  // no memo
+      }],
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -2, aclFormula: "", permissionsText: "-U", memo: "This table is locked",
+      }],
+    ]);
+    await assertDeniedWithMemos(editor.getDocAPI(docId).updateRows("Table1", { id: [1], A: ["x"] }),
+      [{ kind: "reason", text: "This table is locked" }]);
+  });
+
+  it("tags a would-allow rule as a remedy", async function() {
+    // A rule that would grant access but doesn't apply to the user is a "remedy" hint, shown
+    // alongside the "reason" from the rule that actually blocks.
+    await freshDoc();
+    await owner.applyUserActions(docId, [
+      ["AddTable", "Table1", [{ id: "A" }]],
+      ["AddRecord", "Table1", null, { A: "test1" }],
+      ["AddRecord", "_grist_ACLResources", -1, { tableId: "Table1", colIds: "*" }],
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -1, aclFormula: "user.Access == OWNER", permissionsText: "+U", memo: "owners_only",
+      }],
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -1, aclFormula: "", permissionsText: "-U", memo: "no_edit",
+      }],
+    ]);
+    await assertDeniedWithMemos(editor.getDocAPI(docId).updateRows("Table1", { id: [1], A: ["x"] }),
+      [{ kind: "remedy", text: "owners_only" }, { kind: "reason", text: "no_edit" }]);
+  });
+
+  it("drops a remedy shadowed by an earlier deny in the same rule set", async function() {
+    // The would-allow rule comes after a rule that already denies, so satisfying it couldn't change
+    // the outcome. Its memo is dropped, leaving only the reason.
+    await freshDoc();
+    await owner.applyUserActions(docId, [
+      ["AddTable", "Table1", [{ id: "A" }]],
+      ["AddRecord", "Table1", null, { A: "test1" }],
+      ["AddRecord", "_grist_ACLResources", -1, { tableId: "Table1", colIds: "*" }],
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -1, aclFormula: "True", permissionsText: "-U", memo: "locked",
+      }],
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -1, aclFormula: "user.Access == OWNER", permissionsText: "+U", memo: "owners_only",
+      }],
+    ]);
+    await assertDeniedWithMemos(editor.getDocAPI(docId).updateRows("Table1", { id: [1], A: ["x"] }),
+      [{ kind: "reason", text: "locked" }]);
+  });
+
+  it("does not show shadowed memos for row-dependent denials", async function() {
+    // As above, but a row-dependent deny, reported via the row-level per-column censoring path.
+    await freshDoc();
+    await owner.applyUserActions(docId, [
+      ["AddTable", "Table1", [{ id: "A" }]],
+      ["AddRecord", "Table1", null, { A: "x" }],
+      ["AddRecord", "_grist_ACLResources", -1, { tableId: "Table1", colIds: "A" }],  // column
+      ["AddRecord", "_grist_ACLResources", -2, { tableId: "Table1", colIds: "*" }],  // table default
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -1, aclFormula: 'rec.A == "x"', permissionsText: "-U", memo: "col_deny",
+      }],
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -2, aclFormula: "user.Access == OWNER", permissionsText: "+U", memo: "table_allow",
+      }],
+    ]);
+    await assertDeniedWithMemos(editor.getDocAPI(docId).updateRows("Table1", { id: [1], A: ["y"] }),
+      [{ kind: "reason", text: "col_deny" }]);
+  });
+
+  it("scopes memos to the touched column when a table-wide update is denied", async function() {
+    // Every column denies update (column A's rule + doc default), so the denial is reported at the
+    // table level. The editor edits column A, so the memo should be column A's reason -- not the
+    // table-default rule's remedy, which only pertains to other columns.
+    await freshDoc();
+    await owner.applyUserActions(docId, [
+      ["AddTable", "Table1", [{ id: "A" }, { id: "B" }]],
+      ["AddRecord", "Table1", null, { A: "x", B: "y" }],
+      ["AddRecord", "_grist_ACLResources", -1, { tableId: "Table1", colIds: "A" }],  // column A
+      ["AddRecord", "_grist_ACLResources", -2, { tableId: "Table1", colIds: "*" }],  // table default
+      ["AddRecord", "_grist_ACLResources", -3, { tableId: "*", colIds: "*" }],       // doc default
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -1, aclFormula: "", permissionsText: "-U", memo: "col_deny",
+      }],
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -2, aclFormula: "user.Access == OWNER", permissionsText: "+U", memo: "table_allow",
+      }],
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -3, aclFormula: "", permissionsText: "-U",
+      }],
+    ]);
+    await assertDeniedWithMemos(editor.getDocAPI(docId).updateRows("Table1", { id: [1], A: ["z"] }),
+      [{ kind: "reason", text: "col_deny" }]);
+  });
+
+  it("scopes memos to the touched column for a row-dependent denial", async function() {
+    // A row-dependent deny routes through the per-row path. Every column of this row denies update
+    // (column B's rule plus the row-wide rule), so it throws at the row level. The editor edits
+    // column A, so only the rule that governs column A should be named, not column B's.
+    await freshDoc();
+    await owner.applyUserActions(docId, [
+      ["AddTable", "Table1", [{ id: "A" }, { id: "B" }]],
+      ["AddRecord", "Table1", null, { A: "lock", B: "y" }],
+      ["AddRecord", "_grist_ACLResources", -1, { tableId: "Table1", colIds: "B" }],  // column B
+      ["AddRecord", "_grist_ACLResources", -2, { tableId: "Table1", colIds: "*" }],  // table default
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -1, aclFormula: "True", permissionsText: "-U", memo: "B-memo",
+      }],
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -2, aclFormula: 'rec.A == "lock"', permissionsText: "-U", memo: "row-memo",
+      }],
+    ]);
+    await assertDeniedWithMemos(editor.getDocAPI(docId).updateRows("Table1", { id: [1], A: ["z"] }),
+      [{ kind: "reason", text: "row-memo" }]);
+  });
+
+  it("scopes memos to the touched column for an upsert", async function() {
+    // An upsert (AddOrUpdateRecord) that updates column B should name only the rule governing B,
+    // not column A's, even though update is denied table-wide.
+    await freshDoc();
+    await owner.applyUserActions(docId, [
+      ["AddTable", "Table1", [{ id: "A" }, { id: "B" }]],
+      ["AddRecord", "Table1", null, { A: "x", B: "y" }],
+      ["AddRecord", "_grist_ACLResources", -1, { tableId: "Table1", colIds: "A" }],  // column A
+      ["AddRecord", "_grist_ACLResources", -2, { tableId: "Table1", colIds: "*" }],  // table default
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -1, aclFormula: "True", permissionsText: "-U", memo: "A-memo",
+      }],
+      ["AddRecord", "_grist_ACLRules", null, {
+        resource: -2, aclFormula: "True", permissionsText: "-U", memo: "T-memo",
+      }],
+    ]);
+    await assertDeniedWithMemos(
+      editor.applyUserActions(docId, [
+        ["BulkAddOrUpdateRecord", "Table1", { A: ["x"] }, { B: ["new"] }, {}],
+      ]),
+      [{ kind: "reason", text: "T-memo" }]);
   });
 
   it("respects table wildcard", async function() {
@@ -4598,6 +4766,18 @@ function assertUnchanged(check: () => PromiseLike<any>) {
 }
 
 async function assertDeniedFor(check: Promise<any>, memos: string[], test = /access rules/) {
+  try {
+    await check;
+    throw new Error("not denied");
+  } catch (e) {
+    assert.match(e?.details?.userError, test);
+    // Memos are now {kind, text}; compare on text so existing expectations keep working.
+    assert.deepEqual((e?.details?.memos ?? []).map((m: any) => m.text), memos);
+  }
+}
+
+// Like assertDeniedFor, but asserts the full tagged memos ({kind, text}).
+async function assertDeniedWithMemos(check: Promise<any>, memos: Memo[], test = /access rules/) {
   try {
     await check;
     throw new Error("not denied");


### PR DESCRIPTION
A memo is a note attached to an access rule, surfaced when a rule blocks you so the denial is explained. The bug: a memo could surface that had no bearing on your denial.

Example. A column rule denies an edit with the memo "This column is locked," while a lower-precedence table rule would grant it to owners, memo "Only owners can edit here." A non-owner editor is correctly blocked, but saw both memos. The column rule overruled the table rule, so the second had no part in this denial. Whether it still points at a real way in is the harder question, taken up below.

The principle: a memo shows only if it explains the denial, either as a reason (the rule that blocked you) or a remedy (a rule that would have granted access). Two changes follow.

1. Memos respect rule precedence, the same column-over-table-over-doc ordering Grist already applies to permissions. A remedy shows only while no higher-precedence rule has settled the permission; once one denies, lower remedies drop. A reason from a lower level stays, since one action can trip several blocks at once: a column rule and the table default may both deny, and each is a true part of the answer.

2. When a table-wide edit is denied, memos come from the columns actually written, not every column. Same principle, applied across columns rather than across rule levels.

Neither change alters access itself, only the explanation.

Path not taken. The exact test for a remedy is counterfactual: would satisfying its condition actually grant access, given the other rules in play? Answering that means re-evaluating every rule under a hypothetical user or row, and there is no general answer: conditions are arbitrary formulas, and one can be met many ways (a single named user, or anyone in a group), each with a different result. So a remedy overruled by a higher-precedence denial cannot be cheaply verified: it may be a real way in, or a false hope that grants at its own level yet never clears the block above. Rather than advertise access we cannot confirm, precedence drops it. The cost is that a genuine remedy is sometimes dropped with the false ones.

Each memo now carries its kind, reason or remedy, and the toast marks them with a lock or a lightbulb.
