### PR TITLE
Update MCP banner CSS

### DIFF
--- a/app/client/components/McpConnectBanner.ts
+++ b/app/client/components/McpConnectBanner.ts
@@ -2,7 +2,6 @@ import { Banner } from "app/client/components/Banner";
 import { makeT } from "app/client/lib/localization";
 import { inlineMarkdown } from "app/client/lib/markdown";
 import { AppModel } from "app/client/models/AppModel";
-import { theme } from "app/client/ui2018/cssVars";
 import { colorIcon } from "app/client/ui2018/icons";
 import { commonUrls } from "app/common/gristUrls";
 
@@ -35,23 +34,14 @@ export class McpConnectBanner extends Disposable {
           ))),
           testId("text"),
         ),
-        style: "info",
+        style: "custom",
+        background: "linear-gradient(to right, #29A3A3, #16A772)",
         showCloseButton: true,
-        bannerCssClass: cssBanner.className,
         onClose: () => this._app.dismissPopup("mcpConnectBanner"),
       });
     });
   }
 }
-
-const cssBanner = styled("div", `
-  & a {
-    color: ${theme.controlFg};
-  }
-  & .test-banner-close {
-    background-color: ${theme.text};
-  }
-`);
 
 const cssMessage = styled("div", `
   display: flex;


### PR DESCRIPTION
## Context

The new CSS matches existing banners for announcements, and fixes an issue with the banner close button being unreadable in dark mode.

## Proposed solution

Change the banner style to custom and use the same linear gradient as other announcement banners/popups in UI.

## Has this been tested?

Manually.

## Screenshots / Screencasts

<img width="2560" height="1440" alt="IMG_2081" src="https://github.com/user-attachments/assets/dae2139d-66e4-430b-b31d-74c46beaeef1" />