### PR TITLE
Apply a suggestion cleanly when there are references

### DIFF
--- a/app/client/ui/ProposedChangesPage.ts
+++ b/app/client/ui/ProposedChangesPage.ts
@@ -5,6 +5,9 @@ import { ApiData, VirtualDoc, VirtualSection } from "app/client/components/Virtu
 import { makeT } from "app/client/lib/localization";
 import { getTimeFromNow } from "app/client/lib/timeUtils";
 import { ColumnRec } from "app/client/models/DocModel";
+// Without this, `reportError` silently resolves to the DOM global of the
+// same name, which raises an error event and shows the user nothing.
+import { reportError, UserError } from "app/client/models/errors";
 import { urlState } from "app/client/models/gristUrlState";
 import { docListHeader } from "app/client/ui/DocMenuCss";
 import { buildOriginalUrlId } from "app/client/ui/ShareMenu";
@@ -215,11 +218,14 @@ and is subject to change and withdrawal.`,
                     dom.on("click", async () => {
                       const outcome = await this.gristDoc.docComm.applyProposal(proposal.shortId);
                       this._updateProposal(proposal, outcome.proposal);
-                      // For the moment, send debug information to console
-                      for (const change of outcome.log.changes) {
-                        if (change.fail) {
-                          reportError(new Error(change.msg));
-                        }
+                      // Nothing was applied, so say why and leave Accept in
+                      // place to try again.
+                      const failure = outcome.log.changes.find(c => c.kind === "error");
+                      if (failure) {
+                        reportError(new UserError(
+                          t("Could not apply this suggestion: {{detail}}", { detail: failure.msg }),
+                          { key: "proposal-apply-failed" },
+                        ));
                       }
                     }),
                     testId("apply"),

--- a/app/common/ActionSummary.ts
+++ b/app/common/ActionSummary.ts
@@ -51,6 +51,18 @@ import toPairs from "lodash/toPairs";
  *   - columnDeltas: a dictionary of changes within a column.
  *   - updateRows, removeRows, addRows: lists of affected rows.
  *
+ * A rowId is a slot, not a row: the engine may free one and later reuse it for an
+ * unrelated row.  The lists a rowId appears in say what occupied that slot before the
+ * period and what occupies it after:
+ *   - addRows only: empty before, a new row after.
+ *   - removeRows only: a row before, empty after.
+ *   - both: one row before, a different row after.  The first was removed and its
+ *     freed rowId reused for the second.  Two distinct rows share the slot; this is
+ *     not one row that was added and then removed again.
+ *   - updateRows only: the same row before and after, with changed contents.
+ *   - no list: the summary says nothing here.  Either the same row sat there
+ *     untouched, or the slot was empty at both ends.  Neither is a net change.
+ *
  * The columnRenames/columnDeltas pair work just like tableRenames/tableDeltas, just
  * on the scope of columns within a table rather than tables within a document.
  *
@@ -86,6 +98,10 @@ export interface ActionSummary {
  * A collection of changes related to rows and columns of a single table.
  */
 export interface TableDelta {
+  /**
+   * Read these three lists together, not separately.  A rowId in both `removeRows`
+   * and `addRows` is recycled: two different rows sharing one slot.
+   */
   updateRows: number[];  /** rowIds of rows that exist before+after and were changed during */
   removeRows: number[];  /** rowIds of rows that existed before but were removed during */
   addRows: number[];     /** rowIds of rows that were added during, and exist after */

--- a/app/common/ActiveDocAPI.ts
+++ b/app/common/ActiveDocAPI.ts
@@ -559,14 +559,42 @@ export interface ApplyProposalResult {
   log: PatchLog;
 }
 
+// HTTP envelope for POST /proposals/:proposalId/apply; the direct
+// `ActiveDocAPI.applyProposal` returns the unwrapped `ApplyProposalResult`.
+export interface ApplyProposalResponse {
+  proposalId: number;
+  changes: ApplyProposalResult;
+}
+
 export interface PatchLog {
   changes: PatchItem[];
   applied: boolean;
 }
 
-export interface PatchItem {
+// One entry per engine action the patch built, or a single "error" entry if
+// it built none. A partial failure has no representation here: a patch
+// either builds its whole bundle or reports the one error that stopped it.
+export type PatchItem = PatchRowsItem | PatchCellsItem | PatchErrorItem;
+
+export interface PatchRowsItem {
+  kind: "add" | "remove";
+  tableId: string;
+  rowCount: number;
+}
+
+// Cells written to existing rows, or to rows added earlier in the same
+// bundle whose references had to wait for their targets to land.
+export interface PatchCellsItem {
+  kind: "update";
+  tableId: string;
+  cellCount: number;
+}
+
+// Why the patch applied nothing: the string form of whatever was thrown,
+// whether one of Patch's own guards refusing or the engine rejecting.
+export interface PatchErrorItem {
+  kind: "error";
   msg: string;
-  fail?: boolean;
 }
 
 export interface GetActionSummariesResult {

--- a/app/common/UserAPI.ts
+++ b/app/common/UserAPI.ts
@@ -1,4 +1,4 @@
-import { ApplyUAResult, ForkResult, FormulaTimingInfo,
+import { ApplyProposalResponse, ApplyUAResult, ForkResult, FormulaTimingInfo,
   PermissionDataWithExtraUsers, QueryFilters, TimingStatus } from "app/common/ActiveDocAPI";
 import { AssistanceRequest, AssistanceResponse } from "app/common/Assistance";
 import { BaseAPI, IOptions, UploadProgressCallbacks } from "app/common/BaseAPI";
@@ -727,7 +727,7 @@ export interface DocAPI {
   getProposals(options?: {
     outgoing?: boolean
   }): Promise<{ proposals: Proposal[] }>;
-  applyProposal(proposalId: number): Promise<Proposal>;
+  applyProposal(proposalId: number): Promise<ApplyProposalResponse>;
 
   applyUserActions(actions: UserAction[]): Promise<ApplyUAResult>;
 }
@@ -1558,7 +1558,7 @@ export class DocAPIImpl extends BaseAPI implements DocAPI {
     });
   }
 
-  public async applyProposal(proposalId: number) {
+  public async applyProposal(proposalId: number): Promise<ApplyProposalResponse> {
     return this.requestJson(`${this._url}/proposals/${proposalId}/apply`, {
       method: "POST",
     });

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -993,9 +993,12 @@ export class ActiveDoc extends EventEmitter {
   }
 
   /**
-   * Apply a proposal to the document. The proposal is applied as a set of linked action groups
-   * for ease of undo, meaning each action group has a linkId refering to the previous one, and
-   * a otherId set to the first (or root) action group.
+   * Apply a proposal to the document. The proposal lands as a single action bundle, so it
+   * either applies in full or leaves the document untouched, and undoing it is one step.
+   *
+   * Note that the engine write and the proposal's status change are two separate writes with
+   * no transaction spanning them: a crash in between leaves the document patched and the
+   * proposal still open, and accepting it again would duplicate any rows it added.
    */
   public async applyProposal(docSession: OptDocSession, proposalId: number, options?: {
     dismiss?: boolean,

--- a/app/server/lib/Patch.ts
+++ b/app/server/lib/Patch.ts
@@ -1,33 +1,53 @@
 /**
- *
  * An implementation of daff (tabular diff tool) to apply changes.
  * Incomplete and naive.
  *
+ * A patch lands as a single applyUserActions call, so a proposal either
+ * applies fully or not at all. Rows it adds carry negative temporary ids
+ * that the engine replaces with real ones as the bundle applies.
+ *
+ * The rule that shapes everything below: temp ids resolve as rows land, so
+ * a reference may only name a row added earlier in the same bundle. A
+ * forward reference is rejected, taking the whole bundle with it.
  */
 
 import { TableDelta } from "app/common/ActionSummary";
 import { PatchItem, PatchLog } from "app/common/ActiveDocAPI";
-import { UserAction } from "app/common/DocActions";
+import { BulkColValues, CellValue, getColValues, UserAction } from "app/common/DocActions";
 import { DocStateComparisonDetails } from "app/common/DocState";
 import { isHiddenCol } from "app/common/gristTypes";
+import { getSetMapValue } from "app/common/gutil";
 import { MetaRowRecord, MetaTableData } from "app/common/TableData";
+import { CellDelta } from "app/common/TabularDiff";
 import { ActiveDoc } from "app/server/lib/ActiveDoc";
 import { OptDocSession } from "app/server/lib/DocSession";
+import { IsAddedRow, RefInfo, refInfoFromType, translateRefValue } from "app/server/lib/RefTranslator";
+
+import groupBy from "lodash/groupBy";
+
+// Cells to write to one row, before grouping into a BulkUpdateRecord.
+interface RowCells {
+  rowId: number;
+  cells: Record<string, CellValue>;
+}
+
+// One row an Add contributes, with the columns the source actually touched.
+interface RowAdd {
+  sourceRowId: number;
+  tempRowId: number;
+  cols: string[];
+}
 
 export class Patch {
-  private _otherId: number | undefined;
-  private _linkId: number | undefined;
   private _columnsByTableIdAndColId: Record<string, Record<string, MetaRowRecord<"_grist_Tables_column">>> = {};
+  private _refInfoByTableAndCol = new Map<string, Map<string, RefInfo>>();
   private _columns: MetaTableData<"_grist_Tables_column">;
   private _tables: MetaTableData<"_grist_Tables">;
 
   public constructor(private _activeDoc: ActiveDoc, private _docSession: OptDocSession) {
-    // Prepare information about columns for easy access. Perhaps this is overkill
-    // since most proposals will be small?
     const columns = this._activeDoc.docData?.getMetaTable("_grist_Tables_column");
     const tables = this._activeDoc.docData?.getMetaTable("_grist_Tables");
     if (!columns || !tables) {
-      // Should never happen.
       throw new Error("Attempt to patch before document is initialized");
     }
     this._columns = columns;
@@ -35,164 +55,166 @@ export class Patch {
   }
 
   /**
-   * Apply the given comparison as a patch. Return a list of notes.
-   * The returned list is currently haphazard, for debugging purposes only.
+   * Apply the given comparison as a patch. Returns a note per engine action
+   * built, or a single error note if nothing was built and nothing applied.
    */
   public async applyChanges(details: DocStateComparisonDetails): Promise<PatchLog> {
     const changes: PatchItem[] = [];
     try {
       const summary = details.leftChanges;
 
-      // Throw an error if there are structural changes. We'll be able
-      // to handle those! But not yet.
       if (summary.tableRenames.length > 0) {
         throw new Error("table-level changes cannot be handled yet");
       }
-      for (const [, delta] of Object.entries(summary.tableDeltas)) {
+
+      // Ignore metadata for now. Filtered before the guards below, so they
+      // cannot refuse a patch over a table nothing here would touch.
+      const userTables: [string, TableDelta][] = Object.entries(summary.tableDeltas)
+        .filter(([tableId]) => !tableId.startsWith("_grist_"));
+
+      for (const [tableId, delta] of userTables) {
         if (delta.columnRenames.length > 0) {
           throw new Error("column-level changes cannot be handled yet");
         }
+        // A summary truncated under a row cap reads its dropped cells as
+        // "?", which would apply as nulls over real data. Callers must
+        // summarize with maximumInlineRows: null.
+        if (delta.mayBeIncomplete) {
+          throw new Error(`summary for table ${tableId} may be incomplete; refusing to apply`);
+        }
       }
 
-      for (const [tableId, delta] of Object.entries(summary.tableDeltas)) {
-        // Ignore metadata for now.
-        if (tableId.startsWith("_grist_")) { continue; }
-        if (delta.removeRows.length > 0) {
-          changes.push(...await this._removeRows(tableId, delta));
-        }
-        if (delta.addRows.length > 0) {
-          changes.push(...await this._addRows(tableId, delta));
-        }
-        if (delta.updateRows.length > 0) {
-          changes.push(...await this._updateRows(tableId, delta));
-        }
+      const actions = this._buildActions(userTables);
+      // Describe before writing, so an action we cannot account for is
+      // caught while the document is still untouched.
+      const described = actions.map(describeAction);
+
+      if (actions.length > 0) {
+        // The one and only write.
+        await this._activeDoc.applyUserActions(this._docSession, actions);
       }
+      changes.push(...described);
     } catch (e) {
-      changes.push({
-        msg: String(e),
-        fail: true,
-      });
+      changes.push({ kind: "error", msg: String(e) });
     }
-    const applied = changes.some(change => !change.fail);
+    // An empty patch counts as applied. Calling it unapplied would leave
+    // the proposal open with nothing left to accept.
+    const applied = !changes.some(change => change.kind === "error");
     return { changes, applied };
   }
 
-  private async _updateRows(tableId: string, delta: TableDelta): Promise<PatchItem[]> {
-    const changes: PatchItem[] = [];
-    const addedRows = new Set(delta.addRows);
-    // Rows marked as added and updated, we handle with just adding.
-    const rows = delta.updateRows.filter(r => !addedRows.has(r));
-    const columnDeltas = delta.columnDeltas;
-    for (const row of rows) {
-      for (const [colId, columnDelta] of Object.entries(columnDeltas)) {
-        const cellDelta = columnDelta[row];
-        if (!cellDelta) {
-          changes.push({
-            msg: "there is a row that does not exist anymore",
-          });
-          continue;
-        }
-        const pre = cellDelta[0]?.[0];
-        const post = cellDelta[1]?.[0];
-        changes.push(await this._changeCell(delta, tableId, row, colId, pre, post));
-      }
+  /**
+   * Build the whole bundle without touching the document. One part of this
+   * order is load-bearing: every Add must precede anything carrying a temp
+   * id, meaning the Updates, whose Refs may name added rows, and the Ref
+   * cells held back from the Adds. Removes lead only for readability.
+   */
+  private _buildActions(userTables: [string, TableDelta][]): UserAction[] {
+    // Source row ids this patch adds, per table. Local to the call, so
+    // nothing about one patch is visible to the next.
+    const addedRows = new Map<string, Set<number>>();
+    for (const [tableId, delta] of userTables) {
+      addedRows.set(tableId, new Set(delta.addRows));
     }
-    return changes;
+    const isAddedRow: IsAddedRow = (tableId, sourceRowId) =>
+      Boolean(addedRows.get(tableId)?.has(sourceRowId));
+
+    const actions: UserAction[] = [];
+    const heldBack: { tableId: string, rows: RowCells[] }[] = [];
+    for (const [tableId, delta] of userTables) {
+      actions.push(...removeActions(tableId, delta));
+    }
+    for (const [tableId, delta] of userTables) {
+      const added = this._addActions(tableId, delta, isAddedRow);
+      actions.push(...added.actions);
+      if (added.heldBack.length > 0) { heldBack.push({ tableId, rows: added.heldBack }); }
+    }
+    for (const [tableId, delta] of userTables) {
+      actions.push(...this._updateActions(tableId, delta, isAddedRow));
+    }
+    // The Ref cells held out of the Adds. Temp ids appear here in both the
+    // row-id position and the values, all resolved by the time the engine
+    // reaches these actions.
+    for (const { tableId, rows } of heldBack) {
+      actions.push(...bulkUpdates(tableId, rows));
+    }
+    return actions;
   }
 
-  private async _addRows(tableId: string, delta: TableDelta): Promise<PatchItem[]> {
-    const changes: PatchItem[] = [];
+  /**
+   * Build the Adds for one table, along with the Ref cells held out of them:
+   * those name rows this patch adds, so they cannot go inline, and are set by
+   * a later update instead. Holding them uniformly frees the patch from
+   * ordering tables to suit its references, and resolves cycles both ways.
+   */
+  private _addActions(
+    tableId: string, delta: TableDelta, isAddedRow: IsAddedRow,
+  ): { actions: UserAction[], heldBack: RowCells[] } {
     const rows = delta.addRows;
+    if (rows.length === 0) { return { actions: [], heldBack: [] }; }
     const columnDeltas = delta.columnDeltas;
-    for (const row of rows) {
-      const rec: Record<string, any> = {};
-      for (const [colId, columnDelta] of Object.entries(columnDeltas)) {
-        const cellDelta = columnDelta[row];
-        if (!cellDelta) {
-          changes.push({
-            msg: "there is a row that does not exist anymore",
-          });
-          continue;
+    const colIds = Object.keys(columnDeltas).filter(colId => !this._shouldSkip(tableId, colId));
+
+    const additions: RowAdd[] = rows.map(row => ({
+      sourceRowId: row,
+      // Negating the source id keeps temp ids distinct within the table,
+      // which is all the engine asks of them.
+      tempRowId: -row,
+      cols: colIds.filter(colId => columnDeltas[colId][row]),
+    }));
+
+    const actions: UserAction[] = [];
+    const heldBack: RowCells[] = [];
+    for (const group of groupByColumnSet(additions, ra => ra.cols)) {
+      const groupCols = group[0].cols;
+      const colValues: Record<string, CellValue[]> = {};
+      for (const colId of groupCols) { colValues[colId] = []; }
+      for (const ra of group) {
+        const cells: Record<string, CellValue> = {};
+        for (const colId of groupCols) {
+          const value = extractValue(columnDeltas[colId][ra.sourceRowId][1]);
+          const translated = translateRefValue(this._getRefInfo(tableId, colId), value, isAddedRow);
+          if (!translated) {
+            colValues[colId].push(value);
+          } else {
+            cells[colId] = translated.value;
+            colValues[colId].push(null);
+          }
         }
-        rec[colId] = cellDelta[1]?.[0];
+        if (Object.keys(cells).length > 0) { heldBack.push({ rowId: ra.tempRowId, cells }); }
       }
-      changes.push(await this._doAdd(delta, tableId, row, rec));
+      actions.push(["BulkAddRecord", tableId, group.map(ra => ra.tempRowId), colValues]);
     }
-    return changes;
+    return { actions, heldBack };
   }
 
-  private async _removeRows(tableId: string, delta: TableDelta): Promise<PatchItem[]> {
-    const changes: PatchItem[] = [];
-    const rows = delta.removeRows;
-    const columnDeltas = delta.columnDeltas;
+  private _updateActions(tableId: string, delta: TableDelta, isAddedRow: IsAddedRow): UserAction[] {
+    // Rows also being added got their final values in the add pass; rows
+    // also being removed are gone by this point and updating them would
+    // throw. Summaries do list rows in two buckets at once, so filter here
+    // rather than trusting them not to.
+    const excludedRows = new Set([...delta.addRows, ...delta.removeRows]);
+    const rows = delta.updateRows.filter(r => !excludedRows.has(r));
+    if (rows.length === 0) { return []; }
+    const colEntries = Object.entries(delta.columnDeltas).filter(
+      ([colId, _]) => !this._shouldSkip(tableId, colId));
+
+    const rowChanges: RowCells[] = [];
     for (const row of rows) {
-      const rec: Record<string, any> = {};
-      for (const [colId, columnDelta] of Object.entries(columnDeltas)) {
+      const cells: Record<string, CellValue> = {};
+      for (const [colId, columnDelta] of colEntries) {
         const cellDelta = columnDelta[row];
-        if (!cellDelta) {
-          changes.push({
-            msg: "there is a row that does not exist anymore",
-          });
-          continue;
-        }
-        rec[colId] = cellDelta[0]?.[0];
+        if (!cellDelta) { continue; }
+        const value = extractValue(cellDelta[1]);
+        // Every Add is already in the bundle, so temp ids here resolve and
+        // need no deferral.
+        const translated = translateRefValue(this._getRefInfo(tableId, colId), value, isAddedRow);
+        cells[colId] = translated ? translated.value : value;
       }
-      changes.push(await this._doRemove(delta, tableId, row, rec));
+      if (Object.keys(cells).length > 0) { rowChanges.push({ rowId: row, cells }); }
     }
-    return changes;
-  }
 
-  private async _applyUserActions(actions: UserAction[]) {
-    const result = await this._activeDoc.applyUserActions(
-      this._docSession, actions, {
-        otherId: this._otherId,
-        linkId: this._linkId,
-      },
-    );
-    if (!this._otherId) {
-      this._otherId = result.actionNum;
-    }
-    this._linkId = result.actionNum;
-  }
-
-  private async _doAdd(delta: TableDelta, tableId: string,
-    rowId: number, rec: Record<string, any>): Promise<PatchItem> {
-    for (const colId of Object.keys(rec)) {
-      if (this._shouldSkip(tableId, colId)) {
-        delete rec[colId];
-      }
-    }
-    await this._applyUserActions([
-      ["AddRecord", tableId, null, rec],
-    ]);
-    return {
-      msg: "added a record",
-    };
-  }
-
-  private async _doRemove(delta: TableDelta, tableId: string, rowId: number,
-    rec: Record<string, any>): Promise<PatchItem> {
-    await this._applyUserActions([
-      ["RemoveRecord", tableId, rowId],
-    ]);
-    return {
-      msg: "removed a record",
-    };
-  }
-
-  private async _changeCell(delta: TableDelta, tableId: string, rowId: number, colId: string,
-    pre: any, post: any): Promise<PatchItem> {
-    if (this._shouldSkip(tableId, colId)) {
-      return {
-        msg: "skipped a cell",
-      };
-    }
-    await this._applyUserActions([
-      ["UpdateRecord", tableId, rowId, { [colId]: post }],
-    ]);
-    return {
-      msg: "updated a cell",
-    };
+    return bulkUpdates(tableId, rowChanges);
   }
 
   /**
@@ -229,5 +251,59 @@ export class Patch {
     const columns = this._columns.getRecords().filter(rec => rec.parentId === table.id);
     this._columnsByTableIdAndColId[tableId] = Object.fromEntries(columns.map(rec => [String(rec.colId), rec]));
     return this._columnsByTableIdAndColId[tableId];
+  }
+
+  private _getRefInfo(tableId: string, colId: string): RefInfo {
+    const inner = getSetMapValue(this._refInfoByTableAndCol, tableId, () => new Map<string, RefInfo>());
+    const cached = inner.get(colId);
+    if (cached) { return cached; }
+    const col = this._getTableColumn(tableId, colId);
+    const result = refInfoFromType(String(col.type ?? ""));
+    inner.set(colId, result);
+    return result;
+  }
+}
+
+function removeActions(tableId: string, delta: TableDelta): UserAction[] {
+  const rows = delta.removeRows;
+  return rows.length === 0 ? [] : [["BulkRemoveRecord", tableId, rows]];
+}
+
+/** Write the given rows, one BulkUpdateRecord per distinct column set. */
+function bulkUpdates(tableId: string, rowChanges: RowCells[]): UserAction[] {
+  return groupByColumnSet(rowChanges, rc => Object.keys(rc.cells)).map(
+    group => ["BulkUpdateRecord", tableId, group.map(g => g.rowId),
+      getColValues(group.map(g => g.cells))] as UserAction);
+}
+
+/**
+ * Bucket items by the set of columns they write, one bucket per BulkAdd or
+ * BulkUpdate. Mixing rows with different touched-column sets would force
+ * null into columns the source left at their defaults.
+ */
+function groupByColumnSet<T>(items: T[], colsOf: (t: T) => string[]): T[][] {
+  // ColIds can't contain NUL, so the joined sorted-cols string is unique.
+  return Object.values(groupBy(items, item => colsOf(item).slice().sort().join("\0")));
+}
+
+// A CellDelta side is `[value]`, `"?"` (unknown), or `null` (cell didn't
+// exist). The latter two collapse to null.
+function extractValue(side: CellDelta[0]): CellValue {
+  return Array.isArray(side) ? side[0] : null;
+}
+
+/**
+ * Describe one action for the patch log. Deriving the log from the actions,
+ * rather than accumulating it alongside them, keeps the two from drifting.
+ */
+function describeAction(action: UserAction): PatchItem {
+  const [name, tableId, rowIds, colValues] =
+    action as [string, string, number[], BulkColValues];
+  switch (name) {
+    case "BulkAddRecord": return { kind: "add", tableId, rowCount: rowIds.length };
+    case "BulkRemoveRecord": return { kind: "remove", tableId, rowCount: rowIds.length };
+    case "BulkUpdateRecord":
+      return { kind: "update", tableId, cellCount: rowIds.length * Object.keys(colValues).length };
+    default: throw new Error(`patch built an action it cannot describe: ${name}`);
   }
 }

--- a/app/server/lib/Patch.ts
+++ b/app/server/lib/Patch.ts
@@ -82,6 +82,14 @@ export class Patch {
         if (delta.mayBeIncomplete) {
           throw new Error(`summary for table ${tableId} may be incomplete; refusing to apply`);
         }
+        // A rowId in both lists means recycled, but until summary
+        // concatenation is sound (grist-core#2385) it can also mean a row
+        // added and removed again. The two need opposite treatment, and
+        // guessing wrong deletes a trunk row, so refuse both.
+        const removed = new Set(delta.removeRows);
+        if (delta.addRows.some(rowId => removed.has(rowId))) {
+          throw new Error(`summary for table ${tableId} reuses row ids; refusing to apply`);
+        }
       }
 
       const actions = this._buildActions(userTables);

--- a/app/server/lib/RefTranslator.ts
+++ b/app/server/lib/RefTranslator.ts
@@ -1,0 +1,73 @@
+/**
+ * Translating Ref/RefList values across docs whose row id spaces have
+ * diverged. A cross-doc Ref carries a source-side id that the target's
+ * engine will reassign, so without rewriting it lands on the wrong row.
+ *
+ * Rows the diff adds become negative temporary ids for the engine to
+ * resolve. Rows it does not add are taken to be shared with the common
+ * ancestor, so their ids mean the same thing on both sides and pass
+ * through untouched.
+ */
+
+import { CellValue } from "app/common/DocActions";
+import { extractInfoFromColType, isList } from "app/common/gristTypes";
+import { GristObjCode } from "app/plugin/GristData";
+
+export type RefInfo =
+  | { kind: "none" } |
+  { kind: "ref"; refTableId: string } |
+  { kind: "refList"; refTableId: string };
+
+const NON_REF: RefInfo = { kind: "none" };
+
+export function refInfoFromType(colType: string): RefInfo {
+  // Attachments point into _grist_Attachments, which Patch never adds to,
+  // so their ids must pass through.
+  if (colType === "Attachments") { return NON_REF; }
+  const info = extractInfoFromColType(colType);
+  if (info.type === "Ref") { return { kind: "ref", refTableId: info.tableId }; }
+  if (info.type === "RefList") { return { kind: "refList", refTableId: info.tableId }; }
+  return NON_REF;
+}
+
+/**
+ * Whether `sourceRowId` in `tableId` is a row the diff is adding.
+ */
+export type IsAddedRow = (tableId: string, sourceRowId: number) => boolean;
+
+/**
+ * Rewrite a cell value so refs to added rows become temp ids. Undefined
+ * means no rewriting was needed, which also says the value is safe inline
+ * in an Add: carrying no temp ids, it cannot name a row yet to land. The
+ * result is wrapped because `CellValue` includes null, which would
+ * otherwise be indistinguishable from "nothing to do".
+ *
+ * Known gap: an id this same diff removes, or a transient that only ever
+ * existed on the source, is not an added row, so it passes through and
+ * lands dangling (or on whatever row later reuses the id). Detecting those
+ * needs information this function is not given; revisit if it bites.
+ */
+export function translateRefValue(
+  refInfo: RefInfo, sourceValue: CellValue, isAddedRow: IsAddedRow,
+): { value: CellValue } | undefined {
+  if (refInfo.kind === "none") { return undefined; }
+  if (refInfo.kind === "ref") {
+    if (typeof sourceValue !== "number" || sourceValue === 0) { return undefined; }
+    return isAddedRow(refInfo.refTableId, sourceValue) ? { value: -sourceValue } : undefined;
+  }
+  if (!isList(sourceValue)) { return undefined; }
+  const items = sourceValue.slice(1);
+  // Stay undefined unless something actually changes, so a RefList naming
+  // only shared rows can still go inline in an Add.
+  let translated: CellValue[] | null = null;
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (typeof item === "number" && item !== 0 && isAddedRow(refInfo.refTableId, item)) {
+      if (translated === null) { translated = items.slice(0, i); }
+      translated.push(-item);
+    } else if (translated !== null) {
+      translated.push(item);
+    }
+  }
+  return translated === null ? undefined : { value: [GristObjCode.List, ...translated] };
+}

--- a/sandbox/grist/column.py
+++ b/sandbox/grist/column.py
@@ -450,13 +450,15 @@ class BaseReferenceColumn(BaseColumn):
       self._relation.add_reference(row_id, r)
 
   def _reject_unresolved_temp_ids(self, values):
-    # A negative id surviving translation is a temp id the bundle never created, and can never
-    # resolve. (A positive missing id is a supported dangling ref, so we leave those alone.)
+    # A negative id surviving translation names a row the bundle has not added yet. Temp ids
+    # resolve as rows land, so a reference can only point backwards. (A positive missing id is
+    # a supported dangling ref, so we leave those alone.)
     for value in values:
       for r in (value if isinstance(value, list) else (value,)):
         if isinstance(r, int) and r < 0:
           raise ValueError(
-            "Reference to unknown temporary row id %s in column %s.%s" % (
+            "Reference to temporary row id %s in column %s.%s before it was added; add that row "
+            "earlier in the bundle, or set this reference in a later action" % (
               r, self.table_id, self.col_id))
 
   def _clean_up_value(self, value):

--- a/sandbox/grist/test_temp_rowids.py
+++ b/sandbox/grist/test_temp_rowids.py
@@ -206,7 +206,7 @@ class TestTempRowIds(test_engine.EngineTestCase):
       ['AddColumn', 'Schools', 'addresses', {'type': 'RefList:Address', 'isFormula': False}])])
 
     # An unresolved negative id rejects the whole bundle rather than storing an unusable ref.
-    with self.assertRaisesRegex(ValueError, r"unknown temporary row id -99 in column Schools\.addresses"):
+    with self.assertRaisesRegex(ValueError, r"temporary row id -99 in column Schools\.addresses"):
       self.engine.apply_user_actions([useractions.from_repr(
         ['AddRecord', 'Schools', None, {'name': 'S1', 'addresses': ['L', -99]}])])
 
@@ -214,9 +214,51 @@ class TestTempRowIds(test_engine.EngineTestCase):
     self.load_sample(testsamples.sample_students)
 
     # Same rejection for a single Ref, not just RefList.
-    with self.assertRaisesRegex(ValueError, r"unknown temporary row id -99 in column Schools\.address"):
+    with self.assertRaisesRegex(ValueError, r"temporary row id -99 in column Schools\.address"):
       self.engine.apply_user_actions([useractions.from_repr(
         ['AddRecord', 'Schools', None, {'name': 'S1', 'address': -99}])])
+
+  def test_refs_must_point_backwards(self):
+    self.load_sample(testsamples.sample_students)
+
+    # Temp ids resolve as rows land, so a reference to a row the bundle adds later cannot be
+    # translated. This is a rejection, not a stored negative id, and the message says so.
+    with self.assertRaisesRegex(ValueError, r"before it was added"):
+      self.engine.apply_user_actions([useractions.from_repr(ua) for ua in (
+        ['AddRecord', 'Schools', -1, {'name': 'S1', 'address': -1}],
+        ['AddRecord', 'Address', -1, {'city': 'C1'}],
+      )])
+
+    # The same bundle with the adds the other way round is fine.
+    out_actions = self.engine.apply_user_actions([useractions.from_repr(ua) for ua in (
+      ['AddRecord', 'Address', -1, {'city': 'C1'}],
+      ['AddRecord', 'Schools', -1, {'name': 'S1', 'address': -1}],
+    )])
+    self.assertPartialOutActions(out_actions, {
+      "stored": [
+        ['AddRecord', 'Address', 15, {'city': 'C1'}],
+        ['AddRecord', 'Schools', 5, {'name': 'S1', 'address': 15}],
+      ],
+    })
+
+    # A caller that cannot order its adds, because the references form a cycle, sets the
+    # reference in a later action instead. Everything still lands in the one bundle.
+    self.engine.apply_user_actions([useractions.from_repr(
+      ['AddColumn', 'Address', 'school', {'type': 'Ref:Schools', 'isFormula': False}])])
+    out_actions = self.engine.apply_user_actions([useractions.from_repr(ua) for ua in (
+      ['AddRecord', 'Schools', -2, {'name': 'S2'}],
+      ['AddRecord', 'Address', -2, {'city': 'C2'}],
+      ['BulkUpdateRecord', 'Schools', [-2], {'address': [-2]}],
+      ['BulkUpdateRecord', 'Address', [-2], {'school': [-2]}],
+    )])
+    self.assertPartialOutActions(out_actions, {
+      "stored": [
+        ['AddRecord', 'Schools', 6, {'name': 'S2'}],
+        ['AddRecord', 'Address', 16, {'city': 'C2'}],
+        ['UpdateRecord', 'Schools', 6, {'address': 16}],
+        ['UpdateRecord', 'Address', 16, {'school': 6}],
+      ],
+    })
 
   def test_update_remove(self):
     self.load_sample(testsamples.sample_students)

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -2518,7 +2518,8 @@
         "Your suggestions": "Your suggestions",
         "experiment": "experiment",
         "original document": "original document",
-        "Undo dismissal": "Undo dismissal"
+        "Undo dismissal": "Undo dismissal",
+        "Could not apply this suggestion: {{detail}}": "Could not apply this suggestion: {{detail}}"
     },
     "commandList": {
         "Show accessibility options": "Show accessibility options",

--- a/test/nbrowser/ProposedChangesPage.ts
+++ b/test/nbrowser/ProposedChangesPage.ts
@@ -801,6 +801,113 @@ describe("ProposedChangesPage", function() {
     await returnToTrunk(url);
   });
 
+  // The sibling tests above accept while the trunk stands still, so both
+  // documents hand out the same row ids and an untranslated reference is
+  // right by luck. Moving the trunk on first removes that luck, so checks
+  // here go through the referenced name rather than an id.
+  it("creates a new Reference when the trunk has moved on", async function() {
+    const { api, doc } = await makeLifeDoc();
+    const url = await driver.getCurrentUrl();
+
+    await api.applyUserActions(doc.id, [
+      ["AddTable", "Habitat", [{ id: "Name", type: "Text" }]],
+      ["AddRecord", "Habitat", 1, { Name: "Ocean" }],
+      ["AddRecord", "Habitat", 2, { Name: "Forest" }],
+    ]);
+    await api.applyUserActions(doc.id, [
+      ["AddVisibleColumn", "Life", "Habitat", { type: "Ref:Habitat" }],
+      ["UpdateRecord", "Life", 1, { Habitat: 1 }], // Fish -> Ocean
+      ["UpdateRecord", "Life", 2, { Habitat: 2 }], // Primate -> Forest
+    ]);
+    await setReferenceDisplayColumn(api, doc.id, "Life", "Habitat", "Name");
+
+    await workOnCopy(url);
+    await gu.openPage("Habitat");
+    await gu.openPage("Life");
+
+    // Point Fish at a brand new habitat, which takes fork row id 3.
+    await gu.getCell("Habitat", 1).click();
+    await gu.waitAppFocus();
+    await driver.sendKeys("Mountain");
+    await driver.find(".test-ref-editor-new-item").click();
+    await gu.waitForServer();
+
+    await proposeChange();
+    await driver.findContentWait("span", /original document/, 2000).click();
+    await driver.findWait(".test-proposals-header", 2000);
+
+    // The trunk takes row id 3 for its own habitat before accepting, so
+    // Mountain has to land somewhere else.
+    await api.applyUserActions(doc.id, [
+      ["AddRecord", "Habitat", null, { Name: "Desert" }],
+    ]);
+    await driver.findWait(".test-actionlog-tabular-diffs .field_clip", 2000);
+
+    await driver.find(".test-proposals-patch")
+      .find(".test-proposals-apply").click();
+    await gu.waitForServer();
+    assert.match(
+      await driver.findContent(".test-proposals-header", /#1/).getText(),
+      /Accepted/,
+    );
+
+    const habitats = await api.getDocAPI(doc.id).getRows("Habitat");
+    assert.includeMembers(habitats.Name, ["Desert", "Mountain"]);
+    const nameOf = new Map(habitats.id.map((id, i) => [id, habitats.Name[i]]));
+    const life = await api.getDocAPI(doc.id).getRows("Life");
+    assert.deepEqual(life.Habitat.map(id => nameOf.get(Number(id))),
+      ["Mountain", "Forest"]);
+
+    await returnToTrunk(url);
+  });
+
+  it("leaves the trunk alone when a proposal no longer applies", async function() {
+    const { api, doc } = await makeLifeDoc();
+    const url = await driver.getCurrentUrl();
+
+    await workOnCopy(url);
+    // Add a row and edit another. The add is the one to watch: nothing is
+    // wrong with it, and it must still not land.
+    await gu.getCell("B", 3).click();
+    await gu.waitAppFocus();
+    await gu.enterCell("Newt");
+    await gu.getCell("B", 1).click();
+    await gu.waitAppFocus();
+    await gu.enterCell("Bird");
+
+    await proposeChange();
+    await driver.findContentWait("span", /original document/, 2000).click();
+    await driver.findWait(".test-proposals-header", 2000);
+
+    // Delete the row the proposal edits, so the engine rejects that part.
+    await api.applyUserActions(doc.id, [["RemoveRecord", "Life", 1]]);
+    await driver.findWait(".test-actionlog-tabular-diffs .field_clip", 2000);
+
+    await driver.find(".test-proposals-patch")
+      .find(".test-proposals-apply").click();
+    await gu.waitForServer();
+
+    // The user is told why, and the proposal stays open with Accept still
+    // there to try again.
+    assert.match(
+      await driver.findContentWait(".test-notifier-toast-message",
+        /Could not apply this suggestion/, 2000).getText(),
+      /non-existent record/,
+    );
+    await gu.wipeToasts();
+    assert.notMatch(
+      await driver.findContent(".test-proposals-header", /#1/).getText(),
+      /Accepted/,
+    );
+    assert.lengthOf(await driver.find(".test-proposals-patch")
+      .findAll(".test-proposals-apply"), 1);
+
+    // The trunk is exactly as the deletion left it. Newt did not land.
+    assert.deepEqual((await api.getDocAPI(doc.id).getRows("Life")).B, ["Primate"]);
+
+    await returnToTrunk(url);
+  });
+
   it("can make changes on a doc with conditional formatting", async function() {
     const { doc, api } = await makeLifeDoc();
     // const url = await driver.getCurrentUrl();

--- a/test/server/lib/Proposals.ts
+++ b/test/server/lib/Proposals.ts
@@ -797,13 +797,15 @@ describe("Proposals", function() {
       ]);
     });
 
-    // Skipped until #2385 lands. The spec composes an add-then-remove to no
-    // entry; the summarizer instead lists the row in both addRows and
-    // removeRows, which means recycled, and Patch applies the recycle.
-    // Passes with #2385 merged in (checked 2026-07-26).
-    it.skip("does not delete the wrong trunk row on an add-then-remove transient", async function() {
-      // Carol takes fork row id 4, which on the trunk is Frank, so the
-      // recycle deletes Frank and restores the Carol the fork deleted.
+    // The fork's add-then-remove nets to nothing, but summary concatenation
+    // reports the rowId in both addRows and removeRows, which is how a
+    // recycled id is reported too. Patch cannot tell the two apart, and
+    // guesses wrong at the cost of a trunk row, so it refuses both until
+    // https://github.com/gristlabs/grist-core/pull/2385 makes the summary
+    // sound. Then this becomes a genuine recycle to support.
+    it("does not delete the wrong trunk row on an add-then-remove transient", async function() {
+      // Carol takes fork row id 4, which on the trunk is Frank. Applying
+      // the reported recycle would delete Frank and restore Carol.
       const { trunk, fork } = await setupForkWithAdvance({
         trunkSeed: [
           ["AddTable", "Customers", [
@@ -824,7 +826,15 @@ describe("Proposals", function() {
         ["RemoveRecord", "Customers", 4],
       ]);
       const proposal = await fork.makeProposal();
-      await trunk.applyProposal(proposal.shortId);
+      const result = await trunk.applyProposal(proposal.shortId);
+      // Refused, and visibly so: the proposal stays open rather than
+      // reporting success over a document it quietly damaged.
+      assert.isFalse(result.changes.log.applied);
+      assert.lengthOf(result.changes.log.changes, 1);
+      const [item] = result.changes.log.changes;
+      assert.equal(item.kind, "error");
+      assert.match(item.kind === "error" ? item.msg : "", /reuses row ids/);
+      assert.isUndefined(result.changes.proposal.status.status);
       const rows = await trunk.sql(
         "select name from Customers order by id",
       );

--- a/test/server/lib/Proposals.ts
+++ b/test/server/lib/Proposals.ts
@@ -1,9 +1,23 @@
+import { PatchItem } from "app/common/ActiveDocAPI";
+import { CellValue, UserAction } from "app/common/DocActions";
+import { DocStateComparisonDetails } from "app/common/DocState";
+import { isList } from "app/common/gristTypes";
 import { DocAPI, UserAPI } from "app/common/UserAPI";
+import { makeExceptionalDocSession } from "app/server/lib/DocSession";
+import { Patch } from "app/server/lib/Patch";
 import { TestServer } from "test/gen-server/apiUtils";
 import { createTmpDir } from "test/server/docTools";
 import * as testUtils from "test/server/testUtils";
 
 import { assert } from "chai";
+
+// The two success shapes of PatchItem, flattened for assertions: `count`
+// is rows for "add"/"remove" and cells for "update".
+interface ActionRecord {
+  kind: PatchItem["kind"];
+  tableId: string;
+  count: number;
+}
 
 describe("Proposals", function() {
   this.timeout(40000);
@@ -159,5 +173,874 @@ describe("Proposals", function() {
       { fields: { A: "yy", E: 20, F: "quote yy unquote" } },
       { fields: { A: "zz", E: 0,  F: "quote zz unquote" } },
     ]);
+  });
+
+  describe("with Refs in added rows", function() {
+    // `trunkAdvance` runs after the fork so source/target row id spaces
+    // diverge, useful for exposing row id translation bugs.
+    async function setupForkWithAdvance(opts: {
+      trunkSeed: UserAction[],
+      trunkAdvance?: UserAction[],
+    }): Promise<{ trunk: DocAPI, fork: DocAPI }> {
+      const docId = await owner.newDoc({ name: "doc" }, wsId);
+      const trunk = owner.getDocAPI(docId);
+      if (opts.trunkSeed.length > 0) {
+        await trunk.applyUserActions(opts.trunkSeed);
+      }
+      const forkResult = await trunk.fork();
+      const fork = owner.getDocAPI(forkResult.urlId);
+      if (opts.trunkAdvance && opts.trunkAdvance.length > 0) {
+        await trunk.applyUserActions(opts.trunkAdvance);
+      }
+      return { trunk, fork };
+    }
+
+    // Fork-side row ids mean nothing on the trunk, so these read references
+    // back as the labels they point at rather than as ids.
+    async function labelsById(api: DocAPI, tableId: string, colId: string) {
+      const rows = await api.getRows(tableId);
+      return new Map(rows.id.map((id, i) => [id, String(rows[colId][i])]));
+    }
+
+    function listedLabels(cell: CellValue, labels: Map<number, string>): string[] {
+      if (!isList(cell)) { throw new Error(`expected a list, got ${JSON.stringify(cell)}`); }
+      return cell.slice(1).map(id => labels.get(Number(id)) ?? `unknown row ${String(id)}`);
+    }
+
+    // One PatchItem per engine action in the patch's single bundle.
+    async function applyAndGetActions(trunk: DocAPI, shortId: number): Promise<ActionRecord[]> {
+      const result = await trunk.applyProposal(shortId);
+      assert.isTrue(result.changes.log.applied,
+        `patch not fully applied: ${JSON.stringify(result.changes.log.changes)}`);
+      return result.changes.log.changes.map((c) => {
+        if (c.kind === "error") { throw new Error(`unexpected error item: ${c.msg}`); }
+        return {
+          kind: c.kind,
+          tableId: c.tableId,
+          count: c.kind === "update" ? c.cellCount : c.rowCount,
+        };
+      });
+    }
+
+    it("translates a Ref to a row added in the same proposal", async function() {
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Customers", [
+            { id: "name", type: "Text", isFormula: false },
+          ]],
+          ["AddTable", "Orders", [
+            { id: "qty", type: "Numeric", isFormula: false },
+            { id: "customer", type: "Ref:Customers", isFormula: false },
+          ]],
+          ["AddRecord", "Customers", null, { name: "Alice" }],
+        ],
+        trunkAdvance: [
+          ["AddRecord", "Customers", null, { name: "Bob" }],
+          ["AddRecord", "Customers", null, { name: "Dave" }],
+        ],
+      });
+      const rA = await fork.applyUserActions([
+        ["AddRecord", "Customers", null, { name: "Carol" }],
+      ]);
+      const carolForkId: number = rA.retValues[0];
+      await fork.applyUserActions([
+        ["AddRecord", "Orders", null, { qty: 3, customer: carolForkId }],
+      ]);
+      const proposal = await fork.makeProposal();
+      const actions = await applyAndGetActions(trunk, proposal.shortId);
+      // The Ref points at a row this proposal adds, so it is held back
+      // from the Add and set by an update later in the same bundle.
+      assert.sameDeepMembers(actions, [
+        { kind: "add", tableId: "Customers", count: 1 },
+        { kind: "add", tableId: "Orders", count: 1 },
+        { kind: "update", tableId: "Orders", count: 1 },
+      ]);
+      const result = await trunk.sql(
+        "select c.name as cn, o.qty " +
+        "from Orders o join Customers c on c.id = o.customer",
+      );
+      assert.deepEqual(result.records, [{ fields: { cn: "Carol", qty: 3 } }]);
+    });
+
+    it("translates a self-Ref to a row added in the same proposal", async function() {
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Comments", [
+            { id: "body", type: "Text", isFormula: false },
+            { id: "parent_id", type: "Ref:Comments", isFormula: false },
+          ]],
+          ["AddRecord", "Comments", null, { body: "ancestor" }],
+        ],
+        trunkAdvance: [
+          ["AddRecord", "Comments", null, { body: "trunk-only-A" }],
+          ["AddRecord", "Comments", null, { body: "trunk-only-B" }],
+        ],
+      });
+      const rA = await fork.applyUserActions([
+        ["AddRecord", "Comments", null, { body: "Hello?" }],
+      ]);
+      const parentForkId: number = rA.retValues[0];
+      await fork.applyUserActions([
+        ["AddRecord", "Comments", null, { body: "Yes", parent_id: parentForkId }],
+      ]);
+      const proposal = await fork.makeProposal();
+      const actions = await applyAndGetActions(trunk, proposal.shortId);
+      // Two Adds (parent and reply land in separate column-set groups),
+      // then the reply's self-Ref is set once both temp ids are known.
+      assert.sameDeepMembers(actions, [
+        { kind: "add", tableId: "Comments", count: 1 },
+        { kind: "add", tableId: "Comments", count: 1 },
+        { kind: "update", tableId: "Comments", count: 1 },
+      ]);
+      const result = await trunk.sql(
+        "select c.body as child, p.body as parent " +
+        "from Comments c left join Comments p on c.parent_id = p.id " +
+        "where c.body = 'Yes'",
+      );
+      assert.deepEqual(result.records, [{ fields: { child: "Yes", parent: "Hello?" } }]);
+    });
+
+    it("translates a self-Ref where the reply was drafted first", async function() {
+      // Add the reply row before the parent row, so source row ids put the
+      // dependency in reverse order. Exercises within-table deferral.
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Comments", [
+            { id: "body", type: "Text", isFormula: false },
+            { id: "parent_id", type: "Ref:Comments", isFormula: false },
+          ]],
+          ["AddRecord", "Comments", null, { body: "ancestor" }],
+        ],
+        trunkAdvance: [
+          ["AddRecord", "Comments", null, { body: "trunk-only" }],
+        ],
+      });
+      // Reply first, with a placeholder parent_id of 0.
+      const rA = await fork.applyUserActions([
+        ["AddRecord", "Comments", null, { body: "Yes" }],
+      ]);
+      const replyForkId: number = rA.retValues[0];
+      const rB = await fork.applyUserActions([
+        ["AddRecord", "Comments", null, { body: "Hello?" }],
+      ]);
+      const parentForkId: number = rB.retValues[0];
+      // Update the reply's parent_id to point at the parent.
+      await fork.applyUserActions([
+        ["UpdateRecord", "Comments", replyForkId, { parent_id: parentForkId }],
+      ]);
+      const proposal = await fork.makeProposal();
+      const actions = await applyAndGetActions(trunk, proposal.shortId);
+      // Both rows add first, then the reply's parent_id is set.
+      assert.sameDeepMembers(actions, [
+        { kind: "add", tableId: "Comments", count: 1 },
+        { kind: "add", tableId: "Comments", count: 1 },
+        { kind: "update", tableId: "Comments", count: 1 },
+      ]);
+      const result = await trunk.sql(
+        "select c.body as child, p.body as parent " +
+        "from Comments c left join Comments p on c.parent_id = p.id " +
+        "where c.body = 'Yes'",
+      );
+      assert.deepEqual(result.records, [{ fields: { child: "Yes", parent: "Hello?" } }]);
+    });
+
+    it("translates a RefList referencing new rows", async function() {
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Tags", [
+            { id: "name", type: "Text", isFormula: false },
+          ]],
+          ["AddTable", "Articles", [
+            { id: "title", type: "Text", isFormula: false },
+            { id: "tags", type: "RefList:Tags", isFormula: false },
+          ]],
+          ["AddRecord", "Tags", null, { name: "existing" }],
+        ],
+        trunkAdvance: [
+          ["AddRecord", "Tags", null, { name: "trunk-only" }],
+          ["AddRecord", "Tags", null, { name: "trunk-only-2" }],
+        ],
+      });
+      const rA = await fork.applyUserActions([
+        ["AddRecord", "Tags", null, { name: "urgent" }],
+        ["AddRecord", "Tags", null, { name: "draft" }],
+      ]);
+      const tagAId: number = rA.retValues[0];
+      const tagBId: number = rA.retValues[1];
+      await fork.applyUserActions([
+        ["AddRecord", "Articles", null, { title: "X", tags: ["L", tagAId, tagBId] }],
+      ]);
+      const proposal = await fork.makeProposal();
+      const actions = await applyAndGetActions(trunk, proposal.shortId);
+      // The RefList names rows this proposal adds, so the whole cell is
+      // held back and set after both tables' Adds.
+      assert.sameDeepMembers(actions, [
+        { kind: "add", tableId: "Tags", count: 2 },
+        { kind: "add", tableId: "Articles", count: 1 },
+        { kind: "update", tableId: "Articles", count: 1 },
+      ]);
+      const articles = await trunk.getRows("Articles");
+      assert.lengthOf(articles.id, 1);
+      assert.sameMembers(
+        listedLabels(articles.tags[0], await labelsById(trunk, "Tags", "name")),
+        ["draft", "urgent"]);
+    });
+
+    it("translates a three-table chain of Refs", async function() {
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Companies", [
+            { id: "name", type: "Text", isFormula: false },
+          ]],
+          ["AddTable", "Contacts", [
+            { id: "name", type: "Text", isFormula: false },
+            { id: "company", type: "Ref:Companies", isFormula: false },
+          ]],
+          ["AddTable", "Deals", [
+            { id: "label", type: "Text", isFormula: false },
+            { id: "company", type: "Ref:Companies", isFormula: false },
+            { id: "contact", type: "Ref:Contacts", isFormula: false },
+          ]],
+          ["AddRecord", "Companies", null, { name: "OldCo" }],
+        ],
+        trunkAdvance: [
+          ["AddRecord", "Companies", null, { name: "trunk-only" }],
+        ],
+      });
+      const rA = await fork.applyUserActions([
+        ["AddRecord", "Companies", null, { name: "Acme" }],
+      ]);
+      const acmeId: number = rA.retValues[0];
+      const rB = await fork.applyUserActions([
+        ["AddRecord", "Contacts", null, { name: "Alice", company: acmeId }],
+      ]);
+      const aliceId: number = rB.retValues[0];
+      await fork.applyUserActions([
+        ["AddRecord", "Deals", null,
+          { label: "BigOne", company: acmeId, contact: aliceId }],
+      ]);
+      const proposal = await fork.makeProposal();
+      const actions = await applyAndGetActions(trunk, proposal.shortId);
+      // There is no table ordering left to lock: every Add lands before
+      // any Ref cell is set, so the chain resolves whatever order the
+      // summary happens to list the tables in. What matters is the phase
+      // order, so assert that separately from the contents.
+      assert.deepEqual(actions.map(a => a.kind), ["add", "add", "add", "update", "update"]);
+      assert.sameDeepMembers(actions, [
+        { kind: "add", tableId: "Companies", count: 1 },
+        { kind: "add", tableId: "Contacts", count: 1 },
+        { kind: "add", tableId: "Deals", count: 1 },
+        { kind: "update", tableId: "Deals", count: 2 },
+        { kind: "update", tableId: "Contacts", count: 1 },
+      ]);
+      const result = await trunk.sql(
+        "select d.label, comp.name as cn, cont.name as ctn " +
+        "from Deals d " +
+        "join Companies comp on comp.id = d.company " +
+        "join Contacts cont on cont.id = d.contact",
+      );
+      assert.deepEqual(result.records, [
+        { fields: { label: "BigOne", cn: "Acme", ctn: "Alice" } },
+      ]);
+    });
+
+    it("translates a two-table cycle in both directions", async function() {
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          // Tables created without cycle-causing Refs first; the
+          // primary_contact column on Companies has to be added after
+          // Contacts exists, since you can't reference a table that
+          // doesn't exist yet.
+          ["AddTable", "Companies", [
+            { id: "name", type: "Text", isFormula: false },
+          ]],
+          ["AddTable", "Contacts", [
+            { id: "name", type: "Text", isFormula: false },
+            { id: "company", type: "Ref:Companies", isFormula: false },
+          ]],
+          ["AddColumn", "Companies", "primary_contact",
+            { type: "Ref:Contacts", isFormula: false }],
+          ["AddRecord", "Companies", null, { name: "OldCo" }],
+        ],
+        trunkAdvance: [
+          ["AddRecord", "Companies", null, { name: "trunk-only" }],
+        ],
+      });
+      // Add a Company and a Contact, then set the back edge.
+      const rA = await fork.applyUserActions([
+        ["AddRecord", "Companies", null, { name: "Acme" }],
+      ]);
+      const acmeId: number = rA.retValues[0];
+      const rB = await fork.applyUserActions([
+        ["AddRecord", "Contacts", null, { name: "Alice", company: acmeId }],
+      ]);
+      const aliceId: number = rB.retValues[0];
+      await fork.applyUserActions([
+        ["UpdateRecord", "Companies", acmeId, { primary_contact: aliceId }],
+      ]);
+      const proposal = await fork.makeProposal();
+      const actions = await applyAndGetActions(trunk, proposal.shortId);
+      // Neither side of the cycle is privileged: both Refs are held back
+      // from their Adds and set once both rows have landed, so both
+      // directions come out right rather than one being nulled.
+      assert.deepEqual(actions.map(a => a.kind), ["add", "add", "update", "update"]);
+      assert.sameDeepMembers(actions, [
+        { kind: "add", tableId: "Companies", count: 1 },
+        { kind: "add", tableId: "Contacts", count: 1 },
+        { kind: "update", tableId: "Companies", count: 1 },
+        { kind: "update", tableId: "Contacts", count: 1 },
+      ]);
+      const result = await trunk.sql(
+        "select comp.name as cn, cont.name as ctn " +
+        "from Companies comp " +
+        "left join Contacts cont on cont.id = comp.primary_contact " +
+        "where comp.name = 'Acme'",
+      );
+      assert.deepEqual(result.records, [{ fields: { cn: "Acme", ctn: "Alice" } }]);
+      const result2 = await trunk.sql(
+        "select cont.name as ctn, comp.name as cn " +
+        "from Contacts cont " +
+        "join Companies comp on comp.id = cont.company " +
+        "where cont.name = 'Alice'",
+      );
+      assert.deepEqual(result2.records, [{ fields: { ctn: "Alice", cn: "Acme" } }]);
+    });
+
+    it("does not translate Refs into untouched tables", async function() {
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Customers", [
+            { id: "name", type: "Text", isFormula: false },
+          ]],
+          ["AddTable", "Orders", [
+            { id: "qty", type: "Numeric", isFormula: false },
+            { id: "customer", type: "Ref:Customers", isFormula: false },
+          ]],
+          ["AddRecord", "Customers", null, { name: "Alice" }],
+          ["AddRecord", "Customers", null, { name: "Bob" }],
+          ["AddRecord", "Customers", null, { name: "Eve" }],
+        ],
+        trunkAdvance: [
+          ["AddRecord", "Customers", null, { name: "Frank" }],
+        ],
+      });
+      await fork.applyUserActions([
+        ["AddRecord", "Orders", null, { qty: 7, customer: 2 }],
+      ]);
+      const proposal = await fork.makeProposal();
+      const actions = await applyAndGetActions(trunk, proposal.shortId);
+      assert.sameDeepMembers(actions, [{ kind: "add", tableId: "Orders", count: 1 }]);
+      const result = await trunk.sql(
+        "select c.name as cn, o.qty from Orders o join Customers c on c.id = o.customer",
+      );
+      assert.deepEqual(result.records, [{ fields: { cn: "Bob", qty: 7 } }]);
+    });
+
+    it("translates Ref values on the update path", async function() {
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Customers", [
+            { id: "name", type: "Text", isFormula: false },
+          ]],
+          ["AddTable", "Orders", [
+            { id: "qty", type: "Numeric", isFormula: false },
+            { id: "customer", type: "Ref:Customers", isFormula: false },
+          ]],
+          ["AddRecord", "Customers", null, { name: "Alice" }],
+          ["AddRecord", "Orders", null, { qty: 1, customer: 1 }],
+        ],
+        trunkAdvance: [
+          ["AddRecord", "Customers", null, { name: "Bob" }],
+          ["AddRecord", "Customers", null, { name: "Dave" }],
+        ],
+      });
+      const rA = await fork.applyUserActions([
+        ["AddRecord", "Customers", null, { name: "Carol" }],
+      ]);
+      const carolForkId: number = rA.retValues[0];
+      await fork.applyUserActions([
+        ["UpdateRecord", "Orders", 1, { customer: carolForkId }],
+      ]);
+      const proposal = await fork.makeProposal();
+      const actions = await applyAndGetActions(trunk, proposal.shortId);
+      // 1 BulkAdd for the new Customer + 1 BulkUpdate for the existing
+      // Order (one row, one cell).
+      assert.sameDeepMembers(actions, [
+        { kind: "add", tableId: "Customers", count: 1 },
+        { kind: "update", tableId: "Orders", count: 1 },
+      ]);
+      const result = await trunk.sql(
+        "select c.name as cn from Orders o " +
+        "join Customers c on c.id = o.customer where o.id = 1",
+      );
+      assert.deepEqual(result.records, [{ fields: { cn: "Carol" } }]);
+    });
+
+    it("translates a self-RefList (cycle + RefList combined)", async function() {
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Articles", [
+            { id: "title", type: "Text", isFormula: false },
+            { id: "related", type: "RefList:Articles", isFormula: false },
+          ]],
+          ["AddRecord", "Articles", null, { title: "ancestor" }],
+        ],
+        trunkAdvance: [
+          ["AddRecord", "Articles", null, { title: "trunk-only" }],
+        ],
+      });
+      // Add A, B, C. A's related = [B, C].
+      const rA = await fork.applyUserActions([
+        ["AddRecord", "Articles", null, { title: "B" }],
+      ]);
+      const bId: number = rA.retValues[0];
+      const rB = await fork.applyUserActions([
+        ["AddRecord", "Articles", null, { title: "C" }],
+      ]);
+      const cId: number = rB.retValues[0];
+      await fork.applyUserActions([
+        ["AddRecord", "Articles", null, { title: "A", related: ["L", bId, cId] }],
+      ]);
+      const proposal = await fork.makeProposal();
+      const actions = await applyAndGetActions(trunk, proposal.shortId);
+      // B and C add in one group, A in another (different column set);
+      // A's self-RefList is set afterwards.
+      assert.sameDeepMembers(actions, [
+        { kind: "add", tableId: "Articles", count: 2 },
+        { kind: "add", tableId: "Articles", count: 1 },
+        { kind: "update", tableId: "Articles", count: 1 },
+      ]);
+      // Fork-side row ids are meaningless on the trunk; look up by title.
+      const articles = await trunk.getRows("Articles");
+      const aIdx = articles.title.indexOf("A");
+      assert.notEqual(aIdx, -1);
+      assert.sameMembers(
+        listedLabels(articles.related[aIdx], await labelsById(trunk, "Articles", "title")),
+        ["B", "C"]);
+    });
+
+    it("translates a RefList mixing existing and new rows", async function() {
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Tags", [
+            { id: "name", type: "Text", isFormula: false },
+          ]],
+          ["AddTable", "Articles", [
+            { id: "title", type: "Text", isFormula: false },
+            { id: "tags", type: "RefList:Tags", isFormula: false },
+          ]],
+          ["AddRecord", "Tags", null, { name: "shared-tag" }],
+        ],
+        trunkAdvance: [
+          ["AddRecord", "Tags", null, { name: "trunk-only" }],
+          ["AddRecord", "Tags", null, { name: "trunk-only-2" }],
+        ],
+      });
+      // Add a new tag, and an Article whose tags include both the shared
+      // existing tag (id 1, unchanged on both sides) and the new tag.
+      const rA = await fork.applyUserActions([
+        ["AddRecord", "Tags", null, { name: "new-tag" }],
+      ]);
+      const newTagId: number = rA.retValues[0];
+      await fork.applyUserActions([
+        ["AddRecord", "Articles", null, { title: "X", tags: ["L", 1, newTagId] }],
+      ]);
+      const proposal = await fork.makeProposal();
+      const actions = await applyAndGetActions(trunk, proposal.shortId);
+      // The list mixes an existing tag with a new one. One new id is
+      // enough to hold the whole cell back to the update.
+      assert.sameDeepMembers(actions, [
+        { kind: "add", tableId: "Tags", count: 1 },
+        { kind: "add", tableId: "Articles", count: 1 },
+        { kind: "update", tableId: "Articles", count: 1 },
+      ]);
+      const articles = await trunk.getRows("Articles");
+      assert.lengthOf(articles.id, 1);
+      assert.sameMembers(
+        listedLabels(articles.tags[0], await labelsById(trunk, "Tags", "name")),
+        ["new-tag", "shared-tag"]);
+    });
+
+    it("holds back a whole RefList when some of its rows are new", async function() {
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Articles", [
+            { id: "title", type: "Text", isFormula: false },
+            { id: "related", type: "RefList:Articles", isFormula: false },
+          ]],
+          ["AddRecord", "Articles", null, { title: "ancestor" }],
+        ],
+        trunkAdvance: [
+          ["AddRecord", "Articles", null, { title: "trunk-only" }],
+        ],
+      });
+      // A is added first (lowest fork row id) and later updated to point
+      // at B, C, and the shared ancestor row. A's column set {title,
+      // related} differs from B and C's {title}, so they add in separate
+      // groups. The whole list is held back and rebuilt in the update,
+      // preserving the passthrough ancestor id and the list order.
+      const rA = await fork.applyUserActions([
+        ["AddRecord", "Articles", null, { title: "A" }],
+      ]);
+      const aId: number = rA.retValues[0];
+      const rB = await fork.applyUserActions([
+        ["AddRecord", "Articles", null, { title: "B" }],
+        ["AddRecord", "Articles", null, { title: "C" }],
+      ]);
+      const [bId, cId]: number[] = rB.retValues;
+      await fork.applyUserActions([
+        ["UpdateRecord", "Articles", aId, { related: ["L", bId, cId, 1] }],
+      ]);
+      const proposal = await fork.makeProposal();
+      const actions = await applyAndGetActions(trunk, proposal.shortId);
+      assert.sameDeepMembers(actions, [
+        { kind: "add", tableId: "Articles", count: 1 },
+        { kind: "add", tableId: "Articles", count: 2 },
+        { kind: "update", tableId: "Articles", count: 1 },
+      ]);
+      const articles = await trunk.getRows("Articles");
+      const aIdx = articles.title.indexOf("A");
+      assert.notEqual(aIdx, -1);
+      // deepEqual, not sameMembers: list order is preserved, and the shared
+      // ancestor id passes through untranslated in its original position.
+      assert.deepEqual(
+        listedLabels(articles.related[aIdx], await labelsById(trunk, "Articles", "title")),
+        ["B", "C", "ancestor"]);
+    });
+
+    it("handles add + update + remove in one proposal", async function() {
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Customers", [
+            { id: "name", type: "Text", isFormula: false },
+          ]],
+          ["AddTable", "Orders", [
+            { id: "qty", type: "Numeric", isFormula: false },
+            { id: "customer", type: "Ref:Customers", isFormula: false },
+          ]],
+          ["AddRecord", "Customers", null, { name: "Alice" }],
+          ["AddRecord", "Customers", null, { name: "ToRemove" }],
+          ["AddRecord", "Orders", null, { qty: 1, customer: 1 }],
+        ],
+        trunkAdvance: [
+          ["AddRecord", "Customers", null, { name: "trunk-only" }],
+        ],
+      });
+      // On the fork: add Carol, add a new Order pointing at her, point
+      // existing Order at Carol, remove ToRemove.
+      const rA = await fork.applyUserActions([
+        ["AddRecord", "Customers", null, { name: "Carol" }],
+      ]);
+      const carolForkId: number = rA.retValues[0];
+      await fork.applyUserActions([
+        ["AddRecord", "Orders", null, { qty: 5, customer: carolForkId }],
+        ["UpdateRecord", "Orders", 1, { customer: carolForkId }],
+        ["RemoveRecord", "Customers", 2],
+      ]);
+      const proposal = await fork.makeProposal();
+      const actions = await applyAndGetActions(trunk, proposal.shortId);
+      // Phase order matters: removes, then adds, then updates. The two
+      // updates are the existing Order's new customer and the added
+      // Order's held-back Ref cell.
+      assert.deepEqual(actions.map(a => a.kind), ["remove", "add", "add", "update", "update"]);
+      assert.sameDeepMembers(actions, [
+        { kind: "remove", tableId: "Customers", count: 1 },
+        { kind: "add", tableId: "Customers", count: 1 },
+        { kind: "add", tableId: "Orders", count: 1 },
+        { kind: "update", tableId: "Orders", count: 1 },
+        { kind: "update", tableId: "Orders", count: 1 },
+      ]);
+      const ordersResult = await trunk.sql(
+        "select c.name as cn from Orders o " +
+        "join Customers c on c.id = o.customer " +
+        "order by o.id",
+      );
+      assert.deepEqual(ordersResult.records, [
+        { fields: { cn: "Carol" } },
+        { fields: { cn: "Carol" } },
+      ]);
+      const removed = await trunk.sql(
+        "select name from Customers where name = 'ToRemove'",
+      );
+      assert.deepEqual(removed.records, []);
+    });
+
+    it("skips updates of rows that are also being removed", async function() {
+      // Regression: the remove pass deletes the row; without Patch
+      // filtering removed rows out of updateRows, the update pass would
+      // throw on the missing row.
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Customers", [
+            { id: "name", type: "Text", isFormula: false },
+          ]],
+          ["AddRecord", "Customers", null, { name: "Alice" }],
+          ["AddRecord", "Customers", null, { name: "ToRemove" }],
+        ],
+        trunkAdvance: [],
+      });
+      // Update + remove in one bundle.
+      await fork.applyUserActions([
+        ["UpdateRecord", "Customers", 2, { name: "renamed-then-removed" }],
+        ["RemoveRecord", "Customers", 2],
+      ]);
+      const proposal = await fork.makeProposal();
+      const actions = await applyAndGetActions(trunk, proposal.shortId);
+      assert.sameDeepMembers(actions, [
+        { kind: "remove", tableId: "Customers", count: 1 },
+      ]);
+      const rows = await trunk.sql(
+        "select name from Customers order by id",
+      );
+      assert.deepEqual(rows.records, [
+        { fields: { name: "Alice" } },
+      ]);
+    });
+
+    // Skipped until #2385 lands. The spec composes an add-then-remove to no
+    // entry; the summarizer instead lists the row in both addRows and
+    // removeRows, which means recycled, and Patch applies the recycle.
+    // Passes with #2385 merged in (checked 2026-07-26).
+    it.skip("does not delete the wrong trunk row on an add-then-remove transient", async function() {
+      // Carol takes fork row id 4, which on the trunk is Frank, so the
+      // recycle deletes Frank and restores the Carol the fork deleted.
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Customers", [
+            { id: "name", type: "Text", isFormula: false },
+          ]],
+          ["AddRecord", "Customers", null, { name: "Alice" }],
+          ["AddRecord", "Customers", null, { name: "Bob" }],
+          ["AddRecord", "Customers", null, { name: "Eve" }],
+        ],
+        trunkAdvance: [
+          ["AddRecord", "Customers", null, { name: "Frank" }],
+        ],
+      });
+      // Carol gets fork row id 4 (no Frank on the fork). Add-then-remove
+      // in one applyUserActions: net no-op on the fork.
+      await fork.applyUserActions([
+        ["AddRecord", "Customers", null, { name: "Carol" }],
+        ["RemoveRecord", "Customers", 4],
+      ]);
+      const proposal = await fork.makeProposal();
+      await trunk.applyProposal(proposal.shortId);
+      const rows = await trunk.sql(
+        "select name from Customers order by id",
+      );
+      assert.deepEqual(rows.records, [
+        { fields: { name: "Alice" } },
+        { fields: { name: "Bob" } },
+        { fields: { name: "Eve" } },
+        { fields: { name: "Frank" } },
+      ]);
+    });
+
+    it("adds rows with different column sets without nulling defaults", async function() {
+      // Regression: without column-set grouping, untouched cells were
+      // written as literal null instead of the column default (0 for
+      // Numeric, "" for Text).
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Customers", [
+            { id: "name", type: "Text", isFormula: false },
+            { id: "age", type: "Numeric", isFormula: false },
+            { id: "notes", type: "Text", isFormula: false },
+          ]],
+        ],
+        trunkAdvance: [
+          ["AddRecord", "Customers", null, { name: "trunk-only" }],
+        ],
+      });
+      await fork.applyUserActions([
+        ["AddRecord", "Customers", null, { name: "Alice" }],
+        ["AddRecord", "Customers", null, { name: "Bob", age: 30 }],
+        ["AddRecord", "Customers", null, { name: "Carol", notes: "hello" }],
+      ]);
+      const proposal = await fork.makeProposal();
+      await applyAndGetActions(trunk, proposal.shortId);
+      const rows = await trunk.sql(
+        "select name, age, notes from Customers " +
+        "where name in ('Alice', 'Bob', 'Carol') order by name",
+      );
+      assert.deepEqual(rows.records, [
+        { fields: { name: "Alice", age: 0, notes: "" } },
+        { fields: { name: "Bob",   age: 30, notes: "" } },
+        { fields: { name: "Carol", age: 0, notes: "hello" } },
+      ]);
+    });
+
+    it("groups updates by changed-column-set", async function() {
+      // Regression: disjoint changed columns must go in separate BulkUpdates
+      // so the BulkUpdate doesn't null out cells the source didn't clear.
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Orders", [
+            { id: "qty", type: "Numeric", isFormula: false },
+            { id: "label", type: "Text", isFormula: false },
+          ]],
+          ["AddRecord", "Orders", null, { qty: 1, label: "first" }],
+          ["AddRecord", "Orders", null, { qty: 2, label: "second" }],
+        ],
+        trunkAdvance: [],
+      });
+      await fork.applyUserActions([
+        ["UpdateRecord", "Orders", 1, { qty: 100 }],
+        ["UpdateRecord", "Orders", 2, { label: "edited" }],
+      ]);
+      const proposal = await fork.makeProposal();
+      const actions = await applyAndGetActions(trunk, proposal.shortId);
+      assert.sameDeepMembers(actions, [
+        { kind: "update", tableId: "Orders", count: 1 },
+        { kind: "update", tableId: "Orders", count: 1 },
+      ]);
+      const rows = await trunk.sql(
+        "select id, qty, label from Orders order by id",
+      );
+      assert.deepEqual(rows.records, [
+        { fields: { id: 1, qty: 100, label: "first" } },
+        { fields: { id: 2, qty: 2, label: "edited" } },
+      ]);
+    });
+
+    it("sets held-back columns separately when they differ across rows", async function() {
+      // Regression: two rows sharing a column set but deferring different
+      // columns. A single BulkUpdate would null out each row's
+      // inline-translated cell (here, the "ancestor" references).
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Comments", [
+            { id: "body", type: "Text", isFormula: false },
+            { id: "parent_id", type: "Ref:Comments", isFormula: false },
+            { id: "quoted_id", type: "Ref:Comments", isFormula: false },
+          ]],
+          ["AddRecord", "Comments", null, { body: "ancestor" }],
+        ],
+        trunkAdvance: [
+          ["AddRecord", "Comments", null, { body: "trunk-only" }],
+        ],
+      });
+      // A.parent_id=B and B.quoted_id=A; both also reference "ancestor"
+      // (row 1) on the OTHER column inline. A.parent_id is set via
+      // UpdateRecord since B doesn't exist at AddRecord time.
+      const rA = await fork.applyUserActions([
+        ["AddRecord", "Comments", null, { body: "A", quoted_id: 1 }],
+      ]);
+      const aId: number = rA.retValues[0];
+      const rB = await fork.applyUserActions([
+        ["AddRecord", "Comments", null, { body: "B", parent_id: 1, quoted_id: aId }],
+      ]);
+      const bId: number = rB.retValues[0];
+      await fork.applyUserActions([
+        ["UpdateRecord", "Comments", aId, { parent_id: bId }],
+      ]);
+      const proposal = await fork.makeProposal();
+      const actions = await applyAndGetActions(trunk, proposal.shortId);
+      // 1 BulkAdd + 2 updates (disjoint held-back column sets).
+      assert.sameDeepMembers(actions, [
+        { kind: "add", tableId: "Comments", count: 2 },
+        { kind: "update", tableId: "Comments", count: 1 },
+        { kind: "update", tableId: "Comments", count: 1 },
+      ]);
+      const rows = await trunk.sql(
+        "select c.body, p.body as parent, q.body as quoted " +
+        "from Comments c " +
+        "left join Comments p on p.id = c.parent_id " +
+        "left join Comments q on q.id = c.quoted_id " +
+        "where c.body in ('A', 'B') " +
+        "order by c.body",
+      );
+      assert.deepEqual(rows.records, [
+        { fields: { body: "A", parent: "B", quoted: "ancestor" } },
+        { fields: { body: "B", parent: "ancestor", quoted: "A" } },
+      ]);
+    });
+
+    it("refuses to apply a summary marked mayBeIncomplete", async function() {
+      // Truncated summaries read dropped cells as "?", which Patch would
+      // apply as nulls over real data. The guard fails fast instead; no
+      // engine access happens, so a stub ActiveDoc is enough.
+      const fakeDoc: any = { docData: { getMetaTable: () => ({}) } };
+      const patch = new Patch(fakeDoc, makeExceptionalDocSession("system"));
+      const details: DocStateComparisonDetails = {
+        leftChanges: {
+          tableRenames: [],
+          tableDeltas: {
+            T: {
+              updateRows: [1], removeRows: [], addRows: [], columnRenames: [],
+              columnDeltas: { A: { 1: [["x"], "?"] } },
+              mayBeIncomplete: true,
+            },
+          },
+        },
+        rightChanges: { tableRenames: [], tableDeltas: {} },
+      };
+      const log = await patch.applyChanges(details);
+      assert.isFalse(log.applied);
+      assert.lengthOf(log.changes, 1);
+      const [item] = log.changes;
+      assert.equal(item.kind, "error");
+      assert.match(item.kind === "error" ? item.msg : "", /may be incomplete/);
+    });
+
+    it("counts a patch with nothing to do as applied", async function() {
+      // A proposal can resolve to no actions at all. Reporting that as
+      // unapplied would leave it open forever, offering an Accept button
+      // with nothing behind it.
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Customers", [
+            { id: "name", type: "Text", isFormula: false },
+            { id: "shouty", type: "Text", isFormula: true, formula: "$name.upper()" },
+          ]],
+          ["AddRecord", "Customers", null, { name: "Alice" }],
+        ],
+      });
+      // Touch only the formula column, which Patch skips.
+      await fork.applyUserActions([
+        ["ModifyColumn", "Customers", "shouty", { formula: "$name.lower()" }],
+      ]);
+      const proposal = await fork.makeProposal();
+      const result = await trunk.applyProposal(proposal.shortId);
+      assert.isTrue(result.changes.log.applied);
+      assert.deepEqual(result.changes.log.changes, []);
+      // And the proposal is closed out, rather than left open.
+      assert.equal(result.changes.proposal.status.status, "applied");
+    });
+
+    it("leaves the document untouched when the engine rejects the bundle", async function() {
+      const { trunk, fork } = await setupForkWithAdvance({
+        trunkSeed: [
+          ["AddTable", "Customers", [
+            { id: "name", type: "Text", isFormula: false },
+            { id: "score", type: "Numeric", isFormula: false },
+          ]],
+          ["AddRecord", "Customers", null, { name: "Alice", score: 1 }],
+          ["AddRecord", "Customers", null, { name: "Zoe", score: 9 }],
+        ],
+      });
+      // Two adds and an update, in that order within the bundle.
+      await fork.applyUserActions([
+        ["AddRecord", "Customers", null, { name: "Bob", score: 2 }],
+        ["AddRecord", "Customers", null, { name: "Carol", score: 3 }],
+        ["UpdateRecord", "Customers", 1, { name: "Alice II" }],
+      ]);
+      const proposal = await fork.makeProposal();
+      // Delete the row the update targets, so the engine rejects that
+      // action after the adds in the same bundle have already been
+      // processed. No guard in Patch catches this one.
+      await trunk.applyUserActions([["RemoveRecord", "Customers", 1]]);
+      const before = await trunk.sql("select id, score from Customers order by id");
+
+      const result = await trunk.applyProposal(proposal.shortId);
+      assert.isFalse(result.changes.log.applied);
+      assert.deepEqual(result.changes.log.changes.map(c => c.kind), ["error"]);
+
+      // The adds were in the same bundle as the failing update, so none
+      // of them landed: no half-applied wreckage to clean up.
+      const after = await trunk.sql("select id, score from Customers order by id");
+      assert.deepEqual(after.records, before.records);
+      assert.lengthOf(after.records, 1);
+    });
   });
 });


### PR DESCRIPTION
Accepting a proposal used to write the diff out a piece at a time, one engine call per row or cell. A failure partway left the earlier writes in place and marked the proposal applied anyway, so Accept vanished with the job half done. Separately, a reference to a row the proposal itself added carried a row id from the other document, and landed on an unrelated row.

Patch now plans every action first and sends them in one call, giving added rows negative temporary ids for the engine to resolve. Those resolve as rows land, so a reference may only name a row added earlier; rather than order the tables to suit, which is impossible for a cycle, we hold such references out of their add and set them by a later update.

Also: refuse truncated summaries, whose dropped cells would land as nulls; skip updates to rows the proposal also removes; count a proposal applied only when all of it applied; give the patch log a small polish; correct an engine message that called an unresolved temporary id unresolvable when the row simply had not been added yet; and import `reportError` on the proposals page, where it had been resolving to the DOM global of the same name, so apply failures showed the user nothing at all.
