### PR TITLE
Add workaround for stale deploymentType in help us improve survey

### DIFF
--- a/app/client/ui/EditionSection.ts
+++ b/app/client/ui/EditionSection.ts
@@ -1,4 +1,5 @@
 import { makeT } from "app/client/lib/localization";
+import { sessionStorageObs } from "app/client/lib/localStorageObs";
 import { getHomeUrl } from "app/client/models/AppModel";
 import { Notifier } from "app/client/models/NotifyModel";
 import { retryOnNetworkError } from "app/client/models/ToggleEnterpriseModel";
@@ -34,6 +35,19 @@ const t = makeT("EditionSection");
 const testId = makeTestId("test-edition-");
 
 export type Edition = "enterprise" | "core";
+
+/**
+ * Session storage key holding the {@link Edition} last applied in this session.
+ *
+ * The page's `gristConfig` (including `deploymentType`) is static after the page is
+ * served, so any switch applied by the wizard -- which restarts the server but does not
+ * reload the page -- leaves it stale for the rest of the flow.
+ *
+ * This is a workaround for preserving the selected edition for the help us improve
+ * survey. TODO: Remove this and replace it with something better
+ * (e.g. a page reload upon server restart due to an edition change).
+ */
+export const APPLIED_EDITION_KEY = "grist:setupAppliedEdition";
 
 type Surface = "admin" | "wizard";
 
@@ -76,6 +90,7 @@ export class EditionSection extends Disposable implements ConfigSection {
 
   private _selectedEdition = Observable.create<Edition | null>(this, null);
   private _serverEdition = Observable.create<Edition>(this, "core");
+  private _appliedEdition = this.autoDispose(sessionStorageObs(APPLIED_EDITION_KEY));
   // Pre-confirmed in admin-panel mode so the confirm/edit flow only runs in the wizard.
   private _editionConfirmed = Observable.create<boolean>(this, !!this._options.inAdminPanel);
 
@@ -195,6 +210,7 @@ export class EditionSection extends Disposable implements ConfigSection {
       await this._configAPI.setValue({ edition: selected });
     }
     this._serverEdition.set(selected);
+    this._appliedEdition.set(selected);
   }
 
   public get restartWaitAttempts(): number | undefined {

--- a/app/client/ui/HelpUsImproveSection.ts
+++ b/app/client/ui/HelpUsImproveSection.ts
@@ -1,6 +1,8 @@
 import { makeT } from "app/client/lib/localization";
+import { sessionStorageObs } from "app/client/lib/localStorageObs";
 import { getHomeUrl } from "app/client/models/homeUrl";
 import { showEnterpriseToggle } from "app/client/ui/ActivationPage";
+import { APPLIED_EDITION_KEY, Edition } from "app/client/ui/EditionSection";
 import { textInput } from "app/client/ui/inputs";
 import { cssQuickSetupCard } from "app/client/ui/SettingsLayout";
 import { theme } from "app/client/ui2018/cssVars";
@@ -56,6 +58,7 @@ export class HelpUsImproveSection extends Disposable {
   private _hearAbout = Observable.create<string>(this, "");
   private _userType = Observable.create<string>(this, "");
   private _subscribeEnabled = Observable.create<boolean>(this, false);
+  private _appliedEdition = this.autoDispose(sessionStorageObs(APPLIED_EDITION_KEY));
   // Seeded from initialEmail in the constructor.
   private _email = Observable.create<string>(this, "");
 
@@ -146,6 +149,12 @@ export class HelpUsImproveSection extends Disposable {
     }
 
     const { installationId, deploymentType } = getAdminConfig();
+
+    // An edition switch applied earlier in the wizard restarts the server without
+    // reloading the page, leaving deploymentType in window.gristConfig stale.
+    // TODO: Trigger a page reload upon server restart after an edition change.
+    const appliedEdition = this._appliedEdition.get() as Edition | null;
+
     return {
       installationId,
       loginWithGristClientId: await this._fetchLoginWithGristClientId(),
@@ -153,8 +162,10 @@ export class HelpUsImproveSection extends Disposable {
       role: userType,
       subscribeToUpdates: subscribe,
       email: subscribe ? email : "",
-      deploymentType,
-      build: showEnterpriseToggle() ? "full" : "community",
+      deploymentType: appliedEdition ?? deploymentType,
+      build: appliedEdition ?
+        (appliedEdition === "enterprise" ? "full" : "community") :
+        (showEnterpriseToggle() ? "full" : "community"),
     };
   }
 

--- a/app/client/ui/HelpUsImproveSection.ts
+++ b/app/client/ui/HelpUsImproveSection.ts
@@ -163,9 +163,7 @@ export class HelpUsImproveSection extends Disposable {
       subscribeToUpdates: subscribe,
       email: subscribe ? email : "",
       deploymentType: appliedEdition ?? deploymentType,
-      build: appliedEdition ?
-        (appliedEdition === "enterprise" ? "full" : "community") :
-        (showEnterpriseToggle() ? "full" : "community"),
+      build: (appliedEdition === "enterprise" || showEnterpriseToggle()) ? "full" : "community",
     };
   }
 

--- a/app/client/ui/QuickSetupApplyStep.ts
+++ b/app/client/ui/QuickSetupApplyStep.ts
@@ -8,6 +8,7 @@ import { cssShadowedPrimaryButton } from "app/client/ui/SettingsLayout";
 import { bigBasicButton } from "app/client/ui2018/buttons";
 import { theme } from "app/client/ui2018/cssVars";
 import { loadingSpinner } from "app/client/ui2018/loaders";
+import { ApiError } from "app/common/ApiError";
 import { commonUrls } from "app/common/gristUrls";
 import { not } from "app/common/gutil";
 import { HelpUsImproveResponse, HelpUsImproveSubmission } from "app/common/HelpUsImproveAPI";
@@ -56,6 +57,8 @@ export class QuickSetupApplyStep extends Disposable {
   private _lastResponse = Observable.create<HelpUsImproveResponse | null>(this, null);
   // Cached survey contents to avoid re-fetching any data (e.g. oidc client id)
   private _surveyPayload: HelpUsImproveSubmission | null = null;
+  // Guards against resubmitting when the user retries a Go Live that can't restart.
+  private _surveySent = false;
   private _surveyMessage = Computed.create(this, (use) => {
     const resp = use(this._lastResponse);
     // No structured response (network / unknown error): both parts retry.
@@ -142,18 +145,30 @@ export class QuickSetupApplyStep extends Disposable {
     } catch (e) {
       if (this.isDisposed()) { return; }
       this._error.set(String(e));
-      // Don't submit survey if we failed to restart
+      // Sections are applied before the restart is attempted, so a server that can't
+      // restart itself has still saved everything else. Send the survey anyway, since
+      // the user won't reach the success page that normally sends it.
+      if (e instanceof ApiError && e.details?.code === "RestartUnavailable" && !this._surveySent) {
+        this._surveySent = true;
+        await this._captureSurveyPayload();
+        if (this.isDisposed()) { return; }
+        void this._submitSurvey();
+      }
       return;
     }
     if (this.isDisposed()) { return; }
     // Cache the survey payload while the form is still mounted, then switch
     // to the success page. Retry re-uses this cached payload.
-    if (commonUrls.helpUsImproveSurvey) {
-      this._surveyPayload = await this._improveForm.getSubmissionData();
-    }
+    await this._captureSurveyPayload();
     if (this.isDisposed()) { return; }
+    this._surveySent = true;
     this._restarted.set(true);
     void this._submitSurvey();
+  }
+
+  private async _captureSurveyPayload() {
+    if (!commonUrls.helpUsImproveSurvey) { return; }
+    this._surveyPayload = await this._improveForm.getSubmissionData();
   }
 
   private async _submitSurvey() {

--- a/app/common/ApiError.ts
+++ b/app/common/ApiError.ts
@@ -40,7 +40,8 @@ export type ApiErrorCode =
   | "UserNotConfirmed" |
   "FormNotFound" |
   "FormNotPublished" |
-  "ContextLimitExceeded";
+  "ContextLimitExceeded" |
+  "RestartUnavailable";
 
 /**
  * An error with an http status code.

--- a/app/server/lib/attachEarlyEndpoints.ts
+++ b/app/server/lib/attachEarlyEndpoints.ts
@@ -1,4 +1,4 @@
-import { ApiError } from "app/common/ApiError";
+import { ApiError, ApiErrorDetails } from "app/common/ApiError";
 import {
   ConfigKey,
   ConfigKeyChecker,
@@ -126,6 +126,7 @@ export function attachEarlyEndpoints(options: AttachOptions) {
         return res.status(409).send({
           error:
             "Cannot automatically restart the Grist server to enact changes. Please restart server manually.",
+          details: { code: "RestartUnavailable" } satisfies ApiErrorDetails,
         });
       }
       // We're going down, so we're no longer ready to serve requests.


### PR DESCRIPTION
## Context

The `deploymentType` is not always accurately reflected in the payload to the help us improve survey. Specifically, when switching to the full edition, the page doesn't currently reload, leaving a stale value in `window.gristConfig`.

Additionally, if the RestartShell is unavailable, the survey response fails to POST on the go live step due to being caught by the same error handler that handles the 409 response from the restart endpoint.

## Proposed solution

This adds a temporary workaround that persists the selected edition in a session storage key, and ensures that the survey is still submitted if the go live step failed because restart is unavailable.

## Has this been tested?

Manual and existing tests.