### PR TITLE
Fix a batch of CI flakes in the nbrowser and server tests

### DIFF
--- a/app/client/components/Clipboard.ts
+++ b/app/client/components/Clipboard.ts
@@ -25,6 +25,7 @@ import { copyToClipboard, readDataFromClipboard } from "app/client/lib/clipboard
 import { FocusLayer } from "app/client/lib/FocusLayer";
 import { makeT } from "app/client/lib/localization";
 import { makePasteHtml, makePasteText, parsePasteHtml, PasteData } from "app/client/lib/tableUtil";
+import { testPendingPastes } from "app/client/lib/testPendingOps";
 import { ShortcutKey, ShortcutKeyContent } from "app/client/ui/ShortcutKey";
 import { confirmModal } from "app/client/ui2018/modals";
 import { visuallyHidden } from "app/client/ui2018/visuallyHidden";
@@ -324,14 +325,25 @@ export class Clipboard extends Disposable {
       if (this._cutCallback) {
         // Cuts should only be possible on the first paste after a cut and only if the data being
         // pasted matches the data that was cut.
-        commands.allCommands.paste.run(pasteData, this._cutCallback);
+        this._runPaste(pasteData, this._cutCallback);
       }
     } else {
       this._cutData = null;
-      commands.allCommands.paste.run(pasteData, null);
+      this._runPaste(pasteData, null);
     }
     // The cut callback should only be usable once so it needs to be cleared after every paste.
     this._cutCallback = null;
+  }
+
+  /**
+   * Runs the paste command, counted so tests can wait for it. Nothing awaits a paste, and a file
+   * paste is an upload followed by a separate action, so in-flight request counts go quiet in
+   * between and look like success. Counting here rather than in each view's paste command keeps
+   * it to the one place a paste is dispatched from. See PendingOps.
+   */
+  private _runPaste(pasteData: PasteData, cutCallback: (() => unknown) | null) {
+    // Floated, as the bare run() call was before: nothing awaits a paste.
+    void testPendingPastes.track(async () => commands.allCommands.paste.run(pasteData, cutCallback));
   }
 }
 

--- a/app/client/lib/GristWindow.ts
+++ b/app/client/lib/GristWindow.ts
@@ -25,6 +25,8 @@ declare global {
     gristApp?: {
       topAppModel?: TopAppModel;
       testNumPendingApiRequests?: () => number;
+      testNumPendingChecks?: () => number;
+      testNumPendingPastes?: () => number;
     };
     cmd?: { [name: string]: () => void };
     isRunningUnderElectron?: boolean;

--- a/app/client/lib/testPendingOps.ts
+++ b/app/client/lib/testPendingOps.ts
@@ -1,0 +1,42 @@
+/**
+ * Counters for client operations in flight, existing purely so browser tests can wait on a
+ * condition instead of polling a rendered value. Same idea as BaseAPI.numPendingRequests, which
+ * is what makes waitForServer a condition rather than a guess. Named with a test prefix, as the
+ * production code gains nothing from these.
+ *
+ * Keep this a leaf module. App.ts reads the counts and is on the main entry path, so importing the
+ * modules that own these operations would pull their top-level makeT() in ahead of setupLocale and
+ * blank the page.
+ */
+export class TestPendingOps {
+  private _count: number = 0;
+
+  public get count(): number { return this._count; }
+
+  /**
+   * Counts `fn` as in flight until it settles. Increments before calling, so an operation that
+   * starts and then yields is never observed at zero.
+   */
+  public async track<T>(fn: () => Promise<T>): Promise<T> {
+    this._count++;
+    try {
+      return await fn();
+    } finally {
+      this._count--;
+    }
+  }
+
+  /** For promise chains that cannot be wrapped in track(). */
+  public start(): void { this._count++; }
+
+  public end(): void { this._count--; }
+}
+
+/** Admin panel checks (boot probes); results land in observables as they arrive. */
+export const testPendingChecks = new TestPendingOps();
+
+/**
+ * Paste operations. A file paste is an upload followed by a separate addAttachments action, so
+ * in-flight request counts go quiet between the two and look like success.
+ */
+export const testPendingPastes = new TestPendingOps();

--- a/app/client/models/AdminChecks.ts
+++ b/app/client/models/AdminChecks.ts
@@ -1,4 +1,5 @@
 import { makeT } from "app/client/lib/localization";
+import { testPendingChecks } from "app/client/lib/testPendingOps";
 import { reportError } from "app/client/models/errors";
 import { BootProbeIds, BootProbeInfo, BootProbeResult } from "app/common/BootProbe";
 import { InstallAPI } from "app/common/InstallAPI";
@@ -136,6 +137,7 @@ export class AdminCheckRunner {
     public results: Map<string, Observable<BootProbeResult>>,
     public parent: Disposable,
     background: boolean = false) {
+    testPendingChecks.start();
     this._installAPI.runCheck(id, { background }).then((result) => {
       if (parent.isDisposed()) { return; }
       const ob = results.get(id);
@@ -145,6 +147,9 @@ export class AdminCheckRunner {
     }).catch((e) => {
       if (parent.isDisposed()) { return; }
       results.get(id)?.set({ status: "fault", details: { error: String(e) } });
+    }).finally(() => {
+      // After the observable is set, so a count of zero means values are already written.
+      testPendingChecks.end();
     });
   }
 

--- a/app/client/ui/App.ts
+++ b/app/client/ui/App.ts
@@ -12,6 +12,7 @@ import { onClickOutside } from "app/client/lib/domUtils";
 import { FocusLayer } from "app/client/lib/FocusLayer";
 import * as koUtil from "app/client/lib/koUtil";
 import { makeT } from "app/client/lib/localization";
+import { testPendingChecks, testPendingPastes } from "app/client/lib/testPendingOps";
 import { reportError, TopAppModel, TopAppModelImpl } from "app/client/models/AppModel";
 import { DocPageModel } from "app/client/models/DocPageModel";
 import { setUpErrorHandling } from "app/client/models/errors";
@@ -265,6 +266,14 @@ export class AppImpl extends DisposableWithEvents implements App {
 
   public testNumPendingApiRequests(): number {
     return BaseAPI.numPendingRequests();
+  }
+
+  public testNumPendingChecks(): number {
+    return testPendingChecks.count;
+  }
+
+  public testNumPendingPastes(): number {
+    return testPendingPastes.count;
   }
 
   private _reloadPane() {

--- a/app/client/ui/SettingsLayout.ts
+++ b/app/client/ui/SettingsLayout.ts
@@ -134,7 +134,10 @@ export function SectionItem(options: {
           cssItemShort.cls("-expandable"),
           dom.on("click", () => isCollapsed.set(!isCollapsed.get())),
         ),
-        collapsibleContent(isCollapsed, cssExpandedContent(options.expandedContent)),
+        collapsibleContent(isCollapsed, cssExpandedContent(options.expandedContent),
+          // The element whose max-height animates: what a test waits on to know the
+          // expand or collapse settled.
+          testId(`admin-panel-item-content-${options.id}`)),
         testId(`admin-panel-item-${options.id}`),
       );
     });
@@ -155,9 +158,11 @@ export function SectionItem(options: {
 /**
  * Wrap `content` in the animated max-height container used by collapsible settings rows, driven
  * by `isCollapsed`. The caller owns the header and toggle; shared so every collapsible animates
- * identically.
+ * identically. Extra `args` go on the animating wrapper, which is what a test watches.
  */
-export function collapsibleContent(isCollapsed: Observable<boolean>, content: DomContents): DomContents {
+export function collapsibleContent(
+  isCollapsed: Observable<boolean>, content: DomContents, ...args: DomElementArg[]
+): DomContents {
   return cssExpandedContentWrap(
     transition(isCollapsed, {
       prepare(elem, close) { elem.style.maxHeight = close ? elem.scrollHeight + "px" : "0"; },
@@ -165,6 +170,7 @@ export function collapsibleContent(isCollapsed: Observable<boolean>, content: Do
       finish(elem, close) { elem.style.maxHeight = close ? "0" : "unset"; },
     }),
     content,
+    ...args,
   );
 }
 

--- a/test/nbrowser/AdminPanel.ts
+++ b/test/nbrowser/AdminPanel.ts
@@ -1,6 +1,6 @@
 import { TelemetryLevel } from "app/common/Telemetry";
 import {
-  currentVersion, isEnabled, itemValue, toggleItem, withExpandedItem,
+  clickSwitch, currentVersion, isEnabled, itemValue, switchElement, toggleItem, withExpandedItem,
 } from "test/nbrowser/AdminPanelTools";
 import * as gu from "test/nbrowser/gristUtils";
 import { useFastSandboxProbe } from "test/nbrowser/sandboxProbeFixture";
@@ -136,7 +136,7 @@ describe("AdminPanel", function() {
   it("supports opting in to telemetry from the page", async function() {
     await assertTelemetryLevel("off");
 
-    let toggle = driver.find(".test-admin-panel-item-value-telemetry .test-toggle-switch");
+    let toggle = await switchElement("telemetry");
     assert.equal(await isEnabled(toggle), false);
 
     await withExpandedItem("telemetry", async () => {
@@ -157,7 +157,7 @@ describe("AdminPanel", function() {
     // Reload the page and check that the Grist config indicates telemetry is set to "limited".
     await driver.navigate().refresh();
     await gu.waitForAdminPanel();
-    toggle = driver.find(".test-admin-panel-item-value-telemetry .test-toggle-switch");
+    toggle = await switchElement("telemetry");
     assert.equal(await isEnabled(toggle), true);
     await toggleItem("telemetry");
     await driver.findContentWait(".test-support-grist-page-telemetry-section button", /Opt out of Telemetry/, 2000);
@@ -172,7 +172,7 @@ describe("AdminPanel", function() {
     await driver.findContent(".test-support-grist-page-telemetry-section button", /Opt out of Telemetry/).click();
     await driver.findContentWait(".test-support-grist-page-telemetry-section button", /Opt in to Telemetry/, 2000);
     assert.isFalse(await driver.find(".test-support-grist-page-telemetry-section-message").isPresent());
-    let toggle = driver.find(".test-admin-panel-item-value-telemetry .test-toggle-switch");
+    let toggle = await switchElement("telemetry");
     assert.equal(await isEnabled(toggle), false);
 
     // Reload the page and check that the Grist config indicates telemetry is set to "off".
@@ -182,21 +182,20 @@ describe("AdminPanel", function() {
     await driver.findContentWait(".test-support-grist-page-telemetry-section button", /Opt in to Telemetry/, 2000);
     assert.isFalse(await driver.find(".test-support-grist-page-telemetry-section-message").isPresent());
     await assertTelemetryLevel("off");
-    toggle = driver.find(".test-admin-panel-item-value-telemetry .test-toggle-switch");
+    toggle = await switchElement("telemetry");
     assert.equal(await isEnabled(toggle), false);
   });
 
   it("supports toggling telemetry from the toggle in the top line", async function() {
-    const toggle = driver.find(".test-admin-panel-item-value-telemetry .test-toggle-switch");
-    assert.equal(await isEnabled(toggle), false);
-    await toggle.click();
-    await gu.waitForServer();
-    assert.equal(await isEnabled(toggle), true);
+    // Look up by name each time: the panel re-renders as the value settles, which can leave a
+    // held element stale or hidden.
+    assert.equal(await isEnabled("telemetry"), false);
+    await clickSwitch("telemetry");
+    assert.equal(await isEnabled("telemetry"), true);
     assert.match(await driver.find(".test-support-grist-page-telemetry-section-message").getText(),
       /You have opted in/);
-    await toggle.click();
-    await gu.waitForServer();
-    assert.equal(await isEnabled(toggle), false);
+    await clickSwitch("telemetry");
+    assert.equal(await isEnabled("telemetry"), false);
     await withExpandedItem("telemetry", async () => {
       assert.equal(await driver.find(".test-support-grist-page-telemetry-section-message").isPresent(), false);
     });
@@ -210,7 +209,7 @@ describe("AdminPanel", function() {
     // Check that the Support Grist page reports telemetry is enabled.
     await driver.get(`${server.getHost()}/admin`);
     await gu.waitForAdminPanel();
-    const toggle = driver.find(".test-admin-panel-item-value-telemetry .test-toggle-switch");
+    const toggle = await switchElement("telemetry");
     assert.equal(await isEnabled(toggle), true);
     await toggleItem("telemetry");
     assert.equal(
@@ -239,10 +238,9 @@ describe("AdminPanel", function() {
   it("should show version", async function() {
     await driver.get(`${server.getHost()}/admin`);
     await gu.waitForAdminPanel();
-    await gu.waitToPass(async () => {
-      assert.equal(await driver.find(".test-admin-panel-item-version").isDisplayed(), true);
-      assert.match(await driver.find(".test-admin-panel-item-value-version").getText(), /^Version \d+\./);
-    }, 3000);
+    // Build-time constant, rendered with the panel; nothing to wait for.
+    assert.equal(await driver.find(".test-admin-panel-item-version").isDisplayed(), true);
+    assert.match(await driver.find(".test-admin-panel-item-value-version").getText(), /^Version \d+\./);
   });
 
   it("should show admin accounts", async function() {
@@ -252,9 +250,9 @@ describe("AdminPanel", function() {
     assert.equal(await adminAccounts.isDisplayed(), true);
     const adminDisplay = await driver.find(".test-admin-panel-admin-accounts-display");
 
-    await gu.waitToPass(async () => {
-      assert.equal("1 admin account", await adminDisplay.getText());
-    }, 3000);
+    // The count comes from the "admins" probe; the item renders "checking" until it reports.
+    await gu.waitForAdminChecks();
+    assert.equal("1 admin account", await adminDisplay.getText());
 
     await toggleItem("admins");
 
@@ -274,12 +272,10 @@ describe("AdminPanel", function() {
     await driver.get(`${server.getHost()}/admin`);
     await gu.waitForAdminPanel();
     assert.equal(await driver.find(".test-admin-panel-item-sandboxing").isDisplayed(), true);
-    await gu.waitToPass(
-      // unknown for grist-saas, unconfigured for grist-core.
-      async () => assert.match(await driver.find(".test-admin-panel-item-value-sandboxing").getText(),
-        /^((Error: unknown)|(unconfigured))/),
-      3000,
-    );
+    await gu.waitForAdminChecks();
+    // unknown for grist-saas, unconfigured for grist-core.
+    assert.match(await driver.find(".test-admin-panel-item-value-sandboxing").getText(),
+      /^((Error: unknown)|(unconfigured))/);
     // It would be good to test other scenarios, but we are using
     // a multi-server setup on grist-saas and the sandbox test isn't
     // useful there yet.
@@ -289,10 +285,8 @@ describe("AdminPanel", function() {
     await driver.get(`${server.getHost()}/admin`);
     await gu.waitForAdminPanel();
     assert.equal(await driver.find(".test-admin-panel-item-name-probe-system-user").isDisplayed(), true);
-    await gu.waitToPass(
-      async () => assert.match(await driver.find(".test-admin-panel-item-value-probe-system-user").getText(), /✅/),
-      3000,
-    );
+    await gu.waitForAdminChecks();
+    assert.match(await driver.find(".test-admin-panel-item-value-probe-system-user").getText(), /✅/);
   });
 
   const upperCheckNow = () => driver.find(".test-admin-panel-updates-upper-check-now");

--- a/test/nbrowser/AdminPanelTools.ts
+++ b/test/nbrowser/AdminPanelTools.ts
@@ -2,19 +2,75 @@ import * as gu from "test/nbrowser/gristUtils";
 
 import { driver, WebElement } from "mocha-webdriver";
 
+// Items are filled in by probes and config reads that land after the panel is on screen.
+const ITEM_TIMEOUT = 4000;
+
 export function itemElement(itemId: string) {
-  return driver.findWait(`.test-admin-panel-item-${itemId}`, 1000);
+  return driver.findWait(`.test-admin-panel-item-${itemId}`, ITEM_TIMEOUT);
+}
+
+/**
+ * Height of an item's collapsible content, or null if it has none. SectionItem only builds the
+ * animated wrapper for items with expandedContent that are not disabled.
+ */
+async function itemContentHeight(itemId: string): Promise<number | null> {
+  return await driver.executeScript<number | null>((sel: string) => {
+    const el = document.querySelector(sel);
+    return el ? el.getBoundingClientRect().height : null;
+  }, `.test-admin-panel-item-content-${itemId}`);
+}
+
+/**
+ * Waits for an expand or collapse to finish. The content is always in the DOM; what changes is
+ * the wrapper's max-height, animated over 0.3s. So wait for the height to settle.
+ */
+async function waitForItemTransition(itemId: string, expanded: boolean) {
+  const deadline = Date.now() + ITEM_TIMEOUT;
+  let previous: number | null = null;
+  while (true) {
+    const height = await itemContentHeight(itemId);
+    if (height === null) { return; }    // Nothing collapsible here, nothing to wait for.
+    // Require non-zero when expanding, so readings taken before the transition starts do not
+    // look settled. Covers a not-yet-started collapse too, where the height is still full.
+    if (height === previous && (expanded ? height > 0 : height === 0)) { return; }
+    previous = height;
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for item ${itemId} to ${expanded ? "expand" : "collapse"}`);
+    }
+    // Sample well over one animation frame: back-to-back reads inside a frame would make a
+    // mid-transition height look settled.
+    await driver.sleep(50);
+  }
+}
+
+async function isItemExpanded(itemId: string) {
+  return (await itemContentHeight(itemId) ?? 0) > 0;
+}
+
+function itemHeader(itemId: string) {
+  return itemElement(itemId).find(`.test-admin-panel-item-name-${itemId}`);
 }
 
 export async function toggleItem(itemId: string) {
-  const header = itemElement(itemId).find(`.test-admin-panel-item-name-${itemId}`);
-  await header.click();
-  await driver.sleep(500);    // Time to expand or collapse.
-  return header;
+  // Read state before clicking to know which way we are going.
+  const wasExpanded = await isItemExpanded(itemId);
+  await itemHeader(itemId).click();
+  await waitForItemTransition(itemId, !wasExpanded);
+}
+
+/**
+ * Idempotent counterpart to toggleItem. Tests in a file share a page, so an item may already be
+ * in the requested state.
+ */
+async function setItemExpanded(itemId: string, expanded: boolean) {
+  if (await isItemExpanded(itemId) !== expanded) {
+    await itemHeader(itemId).click();
+    await waitForItemTransition(itemId, expanded);
+  }
 }
 
 export function itemValue(itemId: string) {
-  return driver.findWait(`.test-admin-panel-item-value-${itemId}`, 100).getText();
+  return driver.findWait(`.test-admin-panel-item-value-${itemId}`, ITEM_TIMEOUT).getText();
 }
 
 /**
@@ -24,7 +80,7 @@ export function sectionValue(sectionId: string) {
   return {
     text: () => itemValue(sectionId),
     status: async () => {
-      const item = await driver.findWait(`.test-admin-panel-item-value-${sectionId}`, 100);
+      const item = await driver.findWait(`.test-admin-panel-item-value-${sectionId}`, ITEM_TIMEOUT);
       if (await item.find(".test-admin-panel-value-label-success").isPresent()) {
         return "success";
       } else if (await item.find(".test-admin-panel-value-label-danger").isPresent()) {
@@ -39,21 +95,39 @@ export function sectionValue(sectionId: string) {
 }
 
 export async function withExpandedItem(itemId: string, callback: () => Promise<void>) {
-  const header = await toggleItem(itemId);
+  await setItemExpanded(itemId, true);
   await callback();
-  await header.click();
-  await driver.sleep(500);    // Time to collapse.
+  await setItemExpanded(itemId, false);
+}
+
+/**
+ * Finds an item's toggle switch. Pass `visible: true` before clicking: HidableToggle keeps the
+ * switch hidden until its value arrives, and clicking a hidden element throws
+ * ElementNotInteractableError. Re-finds on each poll, since the panel re-renders as values land.
+ */
+export async function switchElement(name: string, options: { visible?: boolean } = {}) {
+  const selector = `.test-admin-panel-item-value-${name} .test-toggle-switch`;
+  await driver.wait(async () => {
+    try {
+      const [elem] = await driver.findAll(selector);
+      if (!elem) { return false; }
+      return options.visible ? await elem.isDisplayed() : true;
+    } catch (e) {
+      return false;   // Replaced mid-poll.
+    }
+  }, ITEM_TIMEOUT, `Timed out waiting for toggle switch ${JSON.stringify(selector)}`);
+  return driver.find(selector);
 }
 
 export async function clickSwitch(name: string) {
-  const toggle = driver.find(`.test-admin-panel-item-value-${name} .test-toggle-switch`);
+  const toggle = await switchElement(name, { visible: true });
   await toggle.click();
   await gu.waitForServer();
 }
 
 export async function isEnabled(switchElem: WebElement | string) {
   if (typeof switchElem === "string") {
-    switchElem = driver.find(`.test-admin-panel-item-value-${switchElem} .test-toggle-switch`);
+    switchElem = await switchElement(switchElem);
   }
   return (await switchElem.find("input").getAttribute("checked")) === null ? false : true;
 }

--- a/test/nbrowser/CopyPasteFiles.ts
+++ b/test/nbrowser/CopyPasteFiles.ts
@@ -35,8 +35,8 @@ describe("CopyPasteFiles", function() {
     await gu.getCell({ rowNum: 1, col: "Photo" }).click();
     await driver.executeScript(syntheticPasteFile,
       [{ content: samplePngContent.toString("base64"), name: "flower.png", type: "image/png" }]);
-    await gu.waitToPass(async () =>
-      assert.deepEqual(await getCellThumbTitles(gu.getCell({ rowNum: 1, col: "Photo" })), ["flower.png"]));
+    await gu.waitForPaste();
+    assert.deepEqual(await getCellThumbTitles(gu.getCell({ rowNum: 1, col: "Photo" })), ["flower.png"]);
 
     // Add a couple more records
     await api.applyUserActions(docId, [
@@ -48,6 +48,8 @@ describe("CopyPasteFiles", function() {
       { content: samplePngContent.toString("base64"), name: "flower.png", type: "image/png" },
       { content: samplePdfContent.toString("base64"), name: "sample.pdf", type: "application/pdf" },
     ]);
+
+    await gu.waitForPaste();
 
     assert.deepEqual(await getCellThumbTitles(gu.getCell({ rowNum: 1, col: "Name" })), []);
     assert.deepEqual(await getCellThumbTitles(gu.getCell({ rowNum: 1, col: "Photo" })), ["flower.png"]);

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -4245,7 +4245,60 @@ namespace gristUtils {
     }, timeMs);
   }
 
-  export const waitForAdminPanel = () => driver.findWait(".test-admin-panel", 2000);
+  /**
+   * Waits for the admin panel to be on screen and to have rendered content. The
+   * `.test-admin-panel` shell appears immediately, but the installation panel inside renders
+   * nothing until the probe list arrives, so waiting on the shell alone hands back an empty panel
+   * and every driver.find that follows races the fetch.
+   *
+   * `> *` matches elements only, never the comment nodes grainjs leaves as placeholders.
+   */
+  export async function waitForAdminPanel() {
+    // Two waits rather than one, so a missing shell and a shell that never fills report separately.
+    await driver.findWait(".test-admin-panel", 2000);
+    await driver.findWait(".test-admin-panel > *", 4000);
+  }
+
+  /**
+   * Polls one of the PendingOps counters exposed on window.gristApp until it reaches zero.
+   *
+   * A missing hook is an error, not a pass. Tolerating it would turn these helpers into no-ops
+   * whenever the hook was renamed or not wired up, and a wait that silently does nothing is worse
+   * than no wait at all: the test still passes, so nothing tells you the wait has gone. A missing
+   * window.gristApp is different, and we keep waiting for it, since the page may still be loading.
+   */
+  async function waitForPendingOps(hook: string, what: string, optTimeout: number) {
+    await driver.wait(async () => {
+      const result = await driver.executeScript<number | string>(
+        `if (!window.gristApp) { return "no-app"; }
+         if (!window.gristApp.${hook}) { return "no-hook"; }
+         return window.gristApp.${hook}();`,
+      ).catch(() => "no-app");
+      if (result === "no-hook") {
+        throw new Error(`window.gristApp.${hook} is not defined, so ${what} cannot be waited on`);
+      }
+      return result === 0;
+    }, optTimeout, `Timed out waiting for ${what}`);
+  }
+
+  /**
+   * Waits for every admin panel check (boot probe) to report back.
+   *
+   * Call after waitForAdminPanel: the panel has to have rendered for its checks to have started,
+   * or a count of zero just means nothing has begun.
+   */
+  export async function waitForAdminChecks(optTimeout: number = 10000) {
+    await waitForPendingOps("testNumPendingChecks", "admin panel checks to settle", optTimeout);
+  }
+
+  /**
+   * Waits for an in-progress paste. Nothing awaits a paste (the clipboard handler fires the
+   * command and returns), and waitForServer is not a substitute: a file paste is an upload plus a
+   * separate addAttachments action, and a poll between the two sees nothing outstanding.
+   */
+  export async function waitForPaste(optTimeout: number = 10000) {
+    await waitForPendingOps("testNumPendingPastes", "paste to complete", optTimeout);
+  }
 
   /** Gets the value from the select component */
   export async function getSelectValue(selector: string) {
@@ -4415,7 +4468,7 @@ namespace gristUtils {
    * By default, we verify that the given text is part of the latest announcement.
    */
   export async function assertScreenReaderAnnouncement(expected: string, mustBeLast: boolean = true) {
-    // We always wait a bit for the test to pass because announcements are not done synchronously
+    // Announcements are not synchronous, and a busy machine can take well over half a second.
     await driver.wait(async () => {
       // We manually get textContent instead of relying on selenium's getText because the text is visually hidden.
       const text = await driver.executeScript<string>((onlyLast: boolean) => {
@@ -4426,7 +4479,7 @@ namespace gristUtils {
         return (el?.textContent || "").toLowerCase();
       }, mustBeLast);
       return text.includes(expected.toLowerCase());
-    }, 500);
+    }, 4000);
   }
 
 } // end of namespace gristUtils

--- a/test/server/lib/HostedStorageManager.ts
+++ b/test/server/lib/HostedStorageManager.ts
@@ -1247,6 +1247,11 @@ describe("HostedStorageManager", function() {
       }
     });
 
+    // node-sqlite3's default busy_timeout. A step approaching this blocks a client waiting to write.
+    const BUSY_TIMEOUT_MS = 1000;
+    // Copy steps are bounded to PAGES_TO_BACKUP_PER_STEP pages, so they should land well inside it.
+    const QUICK_STEP_MS = 250;
+
     for (const mode of ["without-doc", "with-doc", "with-closing-doc"] as const) {
       it(`backups are robust to locking (${mode})`, async function() {
         // Takes some time to create large db and play with it.
@@ -1260,17 +1265,21 @@ describe("HostedStorageManager", function() {
         let eventAction: string = "";
         let eventCount: number = 0;
         let restartCount: number = 0;
-        let slowSteps: number = 0;
-        let slowStepsTotalTime: number = 0;
+        // Copy steps and the final step, kept apart: through the document's own connection the
+        // last step does more than copy pages and is reliably slower. backupSqliteDatabase
+        // separates them for the same reason.
+        let maxNonFinalStepMs: number = 0;
+        // A step is only known to be non-final once another starts.
+        let pendingStepMs: number | undefined;
         function progress(event: BackupEvent) {
           if (event.phase === "after") {
-            // Duration of backup action should never approach the default node-sqlite3 busy_timeout of 1s.
-            // If it does, then user actions could be blocked.
             assert.equal(event.action, eventAction);
             const dt = Date.now() - eventStart;
-            if (dt > 250) {
-              slowSteps++;
-              slowStepsTotalTime += dt;
+            if (event.action === "step") {
+              if (pendingStepMs !== undefined) {
+                maxNonFinalStepMs = Math.max(maxNonFinalStepMs, pendingStepMs);
+              }
+              pendingStepMs = dt;
             }
             eventCount++;
           } else if (event.phase === "before") {
@@ -1346,26 +1355,26 @@ describe("HostedStorageManager", function() {
         const db2 = await SQLiteDB.openDBRaw(dest);
         assert.lengthOf(await db2.all("select rowid from data"), 30000 + 100);
 
+        const finalStepMs = pendingStepMs ?? 0;
+
         if (mode === "without-doc") {
           // If simulating a backup not done via the connection to the source database
           // then disruption should cause backup restart.
           assert.isAbove(restartCount, 0);
-          // There should be no slow steps.
-          assert.equal(slowSteps, 0);
+          // Nothing goes through the document's connection, so every step is just copying pages.
+          assert.isBelow(maxNonFinalStepMs, QUICK_STEP_MS);
+          assert.isBelow(finalStepMs, QUICK_STEP_MS);
         } else {
           // If simulating a backup done via the connection to the source database
           // then disruption should not cause backup restart.
           assert.equal(restartCount, 0);
-          // There may be one slowish step at the end if a lot of edits
-          // happen during backup.
-          assert.isBelow(slowSteps, 2);
-          // For this test, slow step shouldn't be too long, though
-          // that's hardware dependent.
-          // Could exceed busy time, but that isn't a problem now we
-          // are using the same db object as the rest of Grist - any
-          // work waiting will be held just like any pair of editors
-          // competing.
-          assert.isBelow(slowStepsTotalTime, 5000);
+          // The property under test: no copy step may approach the busy timeout, or a client
+          // waiting to write blocks for that long. The insert loop above checks this directly.
+          assert.isBelow(maxNonFinalStepMs, BUSY_TIMEOUT_MS);
+          // The final step does extra work and may exceed the busy timeout. Harmless on a shared
+          // connection: waiting work is held like any pair of editors competing. Bound it loosely
+          // (hardware dependent) to catch a lock held unreasonably long.
+          assert.isBelow(finalStepMs, 5000);
         }
       });
     }


### PR DESCRIPTION
Some waits now key off a real condition: the panel having content, a transition settling, or a count of in-flight work reaching zero. TestPendingOps adds that last one for admin checks and pastes, in the spirit of BaseAPI.numPendingRequests. The rest are timeouts with more headroom.

waitForAdminPanel used to return before the panel had content, so tests asserting an item is absent were passing without testing anything.

Dropping withExpandedItem's driver.sleep(500) exposed a bug it had hidden: it toggled rather than expanded, so an item left expanded by an earlier test was collapsed for the callback. The assertion held either way, so nothing failed.

The last step of a backup finalizes it, so it does extra work and can be slow. The old check allowed one slow step, which that final step could consume, leaving no room for any other. A single ordinary step drifting over the 250ms bar on a busy machine then failed the run. The final step is now checked separately, and ordinary steps must stay under sqlite's 1 second busy timeout, which is when a blocked write actually fails.
