### PR TITLE
Recover cleanly when the network comes back after a sleep

### DIFF
--- a/app/client/components/Comm.ts
+++ b/app/client/components/Comm.ts
@@ -396,7 +396,7 @@ export class Comm extends dispose.Disposable implements GristServerAPI, DocListA
     const serverSpeaksForThis = r.sent && r.sentOn === reconnected && !connectMsg.needReload &&
       lastReceivedReqId !== undefined;
 
-    if (serverSpeaksForThis && lastReceivedReqId !== null && reqId <= lastReceivedReqId) {
+    if (serverSpeaksForThis && typeof lastReceivedReqId === "number" && reqId <= lastReceivedReqId) {
       // The server has it, so wait rather than ask again. Safe because a response prepared while
       // the socket was down is replayed as a missed message, and if any were lost the server sets
       // needReload, ruled out above.

--- a/app/client/components/Comm.ts
+++ b/app/client/components/Comm.ts
@@ -383,19 +383,23 @@ export class Comm extends dispose.Disposable implements GristServerAPI, DocListA
     }
   }
 
-  private _resendPendingRequest(reqId: number, r: CommRequestInFlight, msg: CommClientConnect,
+  private _resendPendingRequest(reqId: number, r: CommRequestInFlight, connectMsg: CommClientConnect,
     reconnected: GristWSConnection | null) {
     let error = null;
     const connection = this._connection(r.docId);
 
-    // The server can only speak for a request we did send, on the connection it is resuming.
-    const lastReceivedReqId = (r.sent && r.sentOn === reconnected && !msg.needReload) ?
-      msg.lastReceivedReqId : undefined;
+    // lastReceivedReqId speaks only for requests that went out on the connection being resumed.
+    // Ids come from one counter shared by every connection on the page, and are handed out when a
+    // request is made rather than when it is sent, so one we sent elsewhere, or have not sent at
+    // all, can be numbered below it too.
+    const { lastReceivedReqId } = connectMsg;
+    const serverSpeaksForThis = r.sent && r.sentOn === reconnected && !connectMsg.needReload &&
+      lastReceivedReqId !== undefined;
 
-    if (lastReceivedReqId != null && reqId <= lastReceivedReqId) {
-      // The server has it, so wait rather than ask again. Safe only because the answer cannot go
-      // missing: a response prepared while the socket was down is replayed as a missed message,
-      // and if any were lost the server sets needReload, which we ruled out above.
+    if (serverSpeaksForThis && lastReceivedReqId !== null && reqId <= lastReceivedReqId) {
+      // The server has it, so wait rather than ask again. Safe because a response prepared while
+      // the socket was down is replayed as a missed message, and if any were lost the server sets
+      // needReload, ruled out above.
       log.debug("Comm: req #" + reqId + " " + r.methodName + " survived the reconnect");
       return;
     }
@@ -403,12 +407,13 @@ export class Comm extends dispose.Disposable implements GristServerAPI, DocListA
     if (r.clientId !== null && r.clientId !== connection.clientId) {
       // If we are waiting to send this request for a particular clientId, but clientId changed.
       error = "pending with outdated clientId";
-    } else if (r.sent && lastReceivedReqId === undefined) {
+    } else if (r.sent && !serverSpeaksForThis) {
       // We sent it, and reconnected without learning whether it arrived. The safer choice is to
       // reject it.
       error = "interrupted by reconnect";
     } else {
-      // Never sent, or the server says it never arrived: either way it has had no effect yet.
+      // Never sent, or the server read past it without seeing it: either way it has had no
+      // effect yet.
       r.sent = connection.send(r.requestMsg);
       r.sentOn = r.sent ? connection : null;
     }

--- a/app/client/components/Comm.ts
+++ b/app/client/components/Comm.ts
@@ -26,7 +26,9 @@ import { GristWSConnection } from "app/client/components/GristWSConnection";
 import * as dispose from "app/client/lib/dispose";
 import * as log from "app/client/lib/log";
 import { ApiError } from "app/common/ApiError";
-import { CommRequest, CommResponse, CommResponseBase, CommResponseError, ValidEvent } from "app/common/CommTypes";
+import {
+  CommClientConnect, CommRequest, CommResponse, CommResponseBase, CommResponseError, ValidEvent,
+} from "app/common/CommTypes";
 import { UserAction } from "app/common/DocActions";
 import { DocListAPI, OpenDocOptions, OpenLocalDocResult } from "app/common/DocListAPI";
 import { GristServerAPI } from "app/common/GristServerAPI";
@@ -47,6 +49,8 @@ export interface CommRequestInFlight {
   methodName: string;
   requestMsg: string;
   sent: boolean;
+  // Which connection it went out on; only that one can say what became of it.
+  sentOn: GristWSConnection | null;
 }
 
 function isCommResponseError(msg: CommResponse | CommResponseError): msg is CommResponseError {
@@ -261,6 +265,7 @@ export class Comm extends dispose.Disposable implements GristServerAPI, DocListA
         methodName,
         requestMsg,
         sent,
+        sentOn: sent ? connection : null,
       });
     });
   }
@@ -358,11 +363,12 @@ export class Comm extends dispose.Disposable implements GristServerAPI, DocListA
       }
     } else {
       if (message.type === "clientConnect") {
-        // Reject or re-send any pending requests as appropriate in the order in which they were
-        // added to the pendingRequests map.
+        // Wait for, re-send, or reject any pending requests as appropriate, in the order in which
+        // they were added to the pendingRequests map.
+        const reconnected = this._connections.get(docId) ?? null;
         for (const [id, req] of this.pendingRequests) {
           if (reqMatchesConnection(req.docId, docId)) {
-            this._resendPendingRequest(id, req);
+            this._resendPendingRequest(id, req, message, reconnected);
           }
         }
       }
@@ -377,19 +383,34 @@ export class Comm extends dispose.Disposable implements GristServerAPI, DocListA
     }
   }
 
-  private _resendPendingRequest(reqId: number, r: CommRequestInFlight) {
+  private _resendPendingRequest(reqId: number, r: CommRequestInFlight, msg: CommClientConnect,
+    reconnected: GristWSConnection | null) {
     let error = null;
     const connection = this._connection(r.docId);
-    if (r.sent) {
-      // If we sent a request, and reconnected before getting a response, we don't know what
-      // happened. The safer choice is to reject the request.
-      error = "interrupted by reconnect";
-    } else if (r.clientId !== null && r.clientId !== connection.clientId) {
+
+    // The server can only speak for a request we did send, on the connection it is resuming.
+    const lastReceivedReqId = (r.sent && r.sentOn === reconnected && !msg.needReload) ?
+      msg.lastReceivedReqId : undefined;
+
+    if (lastReceivedReqId != null && reqId <= lastReceivedReqId) {
+      // The server has it, so wait rather than ask again. Safe only because the answer cannot go
+      // missing: a response prepared while the socket was down is replayed as a missed message,
+      // and if any were lost the server sets needReload, which we ruled out above.
+      log.debug("Comm: req #" + reqId + " " + r.methodName + " survived the reconnect");
+      return;
+    }
+
+    if (r.clientId !== null && r.clientId !== connection.clientId) {
       // If we are waiting to send this request for a particular clientId, but clientId changed.
       error = "pending with outdated clientId";
+    } else if (r.sent && lastReceivedReqId === undefined) {
+      // We sent it, and reconnected without learning whether it arrived. The safer choice is to
+      // reject it.
+      error = "interrupted by reconnect";
     } else {
-      // Waiting to send the request, and clientId is fine: go ahead and send it.
+      // Never sent, or the server says it never arrived: either way it has had no effect yet.
       r.sent = connection.send(r.requestMsg);
+      r.sentOn = r.sent ? connection : null;
     }
     if (error) {
       log.warn("Comm: Rejecting req #" + reqId + " " + r.methodName + ": " + error);

--- a/app/client/components/GristWSConnection.ts
+++ b/app/client/components/GristWSConnection.ts
@@ -262,10 +262,16 @@ export class GristWSConnection extends Disposable {
     let needReload = false;
     if ("type" in message && message.type === "clientConnect" && processClientConnect) {
       if (this._established) {
+        // Comm relies on this: a second pass would re-judge requests against a stale
+        // lastReceivedReqId and reject ones it had just re-sent.
         this._log("GristWSConnection skipping duplicate 'clientConnect' message");
         return;
       }
       this._established = true;
+
+      // Reset backoff once established, not merely opened. A server that accepts a socket and
+      // drops it without sending clientConnect would otherwise never see us back off.
+      this._reconnectAttempts = 0;
 
       // Update flag to indicate if the active session changed, and warrants a reload. (The server
       // should be setting needReload too, so this shouldn't be strictly needed.)
@@ -361,7 +367,6 @@ export class GristWSConnection extends Disposable {
       this._log("GristWSConnection: onopen: " + connectMessage);
 
       this.trigger("connectionStatus", connectMessage, "OK");
-      this._reconnectAttempts = 0; // reset reconnection information
       this._scheduleHeartbeat();
     };
 

--- a/app/client/models/DocPageModel.ts
+++ b/app/client/models/DocPageModel.ts
@@ -423,7 +423,7 @@ contact the document owners to attempt a document recovery. [{{error}}]", { erro
   private _onOpenError(err: Error) {
     if (err instanceof CancelledError) {
       // This means that we started loading a new doc before the previous one finished loading.
-      console.log("DocPageModel _openDoc cancelled");
+      console.log("DocPageModel _openDoc cancelled", err.cause ?? "");
       return;
     }
     // Expected errors (e.g. Access Denied) produce a separate error page. For unexpected errors,

--- a/app/common/AsyncFlow.ts
+++ b/app/common/AsyncFlow.ts
@@ -34,7 +34,10 @@ import { Disposable, IDisposable } from "grainjs";
 
 type DisposeListener = ReturnType<Disposable["onDispose"]>;
 
-export class CancelledError extends Error {}
+export class CancelledError extends Error {
+  // Set when a cancelled flow then failed on its way out.
+  constructor(message: string, public readonly cause?: unknown) { super(message); }
+}
 
 export class FlowRunner extends Disposable {
   public resultPromise: Promise<void>;
@@ -45,6 +48,12 @@ export class FlowRunner extends Disposable {
     async function runFlow() {
       try {
         return await func(flow);
+      } catch (err) {
+        // A cancelled flow may fail on its way out. Report that as cancelled, keeping the cause.
+        if (flow.isCancelled && !(err instanceof CancelledError)) {
+          throw new CancelledError("cancelled", err);
+        }
+        throw err;
       } finally {
         flow.dispose();
       }
@@ -70,6 +79,8 @@ export class AsyncFlow extends Disposable {
     this._handles.delete(obj);
     return obj;
   }
+
+  public get isCancelled(): boolean { return this._isCancelled; }
 
   public checkIfCancelled() {
     if (this._isCancelled) {

--- a/app/common/CommTypes.ts
+++ b/app/common/CommTypes.ts
@@ -179,14 +179,14 @@ export interface CommClientConnect extends CommMessageBase {
   // Array of serialized messages missed from the server while disconnected.
   missedMessages?: string[];
 
-  // The last reqId the server read from this client, or null if it read none. Present only when
-  // the server is resuming the session, so absent and null say different things: absent is "not
-  // resuming", null is "resuming, and nothing you sent reached me".
+  // The last reqId the server read from this client, or "none" if it read none. Present only when
+  // the server is resuming the session, so absent and "none" say different things: absent is "not
+  // resuming", "none" is "resuming, and nothing you sent reached me".
   //
   // The client acts on both. Absent, a sent request is rejected, since we cannot tell what became
-  // of it. Null, it cannot have arrived, so it is sent again. Defaulting one to the other would
-  // silently turn rejects into re-sends. See _resendPendingRequest in Comm.ts.
-  lastReceivedReqId?: number | null;
+  // of it. "none", it cannot have arrived, so it is sent again. Defaulting one to the other would
+  // silently turn rejects into re-sends.
+  lastReceivedReqId?: number | "none";
 
   // Which version the server reports for itself.
   serverVersion?: string;

--- a/app/common/CommTypes.ts
+++ b/app/common/CommTypes.ts
@@ -179,6 +179,15 @@ export interface CommClientConnect extends CommMessageBase {
   // Array of serialized messages missed from the server while disconnected.
   missedMessages?: string[];
 
+  // The last reqId the server read from this client, or null if it read none. Set only when the
+  // server is resuming the session: it says which outstanding requests will still be answered,
+  // and which never arrived and so may be sent again.
+  //
+  // Absent and null mean different things, and the client acts on both: absent is "the server did
+  // not say", so a sent request is rejected, while null is "the server read nothing", so it is
+  // safe to send again. Defaulting one to the other would silently turn rejects into re-sends.
+  lastReceivedReqId?: number | null;
+
   // Which version the server reports for itself.
   serverVersion?: string;
 

--- a/app/common/CommTypes.ts
+++ b/app/common/CommTypes.ts
@@ -179,13 +179,13 @@ export interface CommClientConnect extends CommMessageBase {
   // Array of serialized messages missed from the server while disconnected.
   missedMessages?: string[];
 
-  // The last reqId the server read from this client, or null if it read none. Set only when the
-  // server is resuming the session: it says which outstanding requests will still be answered,
-  // and which never arrived and so may be sent again.
+  // The last reqId the server read from this client, or null if it read none. Present only when
+  // the server is resuming the session, so absent and null say different things: absent is "not
+  // resuming", null is "resuming, and nothing you sent reached me".
   //
-  // Absent and null mean different things, and the client acts on both: absent is "the server did
-  // not say", so a sent request is rejected, while null is "the server read nothing", so it is
-  // safe to send again. Defaulting one to the other would silently turn rejects into re-sends.
+  // The client acts on both. Absent, a sent request is rejected, since we cannot tell what became
+  // of it. Null, it cannot have arrived, so it is sent again. Defaulting one to the other would
+  // silently turn rejects into re-sends. See _resendPendingRequest in Comm.ts.
   lastReceivedReqId?: number | null;
 
   // Which version the server reports for itself.

--- a/app/server/lib/Client.ts
+++ b/app/server/lib/Client.ts
@@ -97,6 +97,14 @@ export class Client {
   private _authSession: AuthSession = AuthSession.unauthenticated();
   private _nextSeqId: number = 0;     // Next sequence-ID for messages sent to the client
 
+  // What _nextSeqId was when _missedMessages was last emptied. Anything from here on that we
+  // don't have was sent successfully. Only _clearMissedMessages() should set this.
+  private _firstMissedSeqId: number = 0;
+
+  // Last request-ID read off the socket, or null if none. Requests arrive in order, so this says
+  // which of the client's outstanding requests reached us.
+  private _lastReceivedReqId: number | null = null;
+
   // Identifier for the current GristWSConnection object connected to this client.
   private _counter: string | null = null;
   private _i18Instance?: i18n;
@@ -337,8 +345,13 @@ export class Client {
     }
 
     // We collected any missed messages we need; clear the stored map of them.
-    this._missedMessages.clear();
-    this._missedMessagesTotalLength = 0;
+    this._clearMissedMessages();
+
+    if (newClient) {
+      // A reloaded tab keeps its clientId but numbers its requests afresh from zero, so what we
+      // remember from its previous life would be misleadingly high.
+      this._lastReceivedReqId = null;
+    }
 
     let docsClosed: number | null = null;
     if (!seamlessReconnect) {
@@ -361,6 +374,8 @@ export class Client {
       clientId: this.clientId,
       missedMessages,
       needReload,
+      // Only meaningful when resuming the session; otherwise no earlier request survives.
+      lastReceivedReqId: seamlessReconnect ? this._lastReceivedReqId : undefined,
     };
 
     try {
@@ -388,15 +403,19 @@ export class Client {
     }
   }
 
-  // Get messages in order of their key in the _missedMessages map.
+  // Get messages in order of their key in the _missedMessages map. A null lastSeqId means the
+  // client received no numbered message at all on its last connection, so everything we hold
+  // is news to it.
+  //
+  // Returning undefined for a gap is load-bearing: it forces needReload, and only that stops a
+  // client waiting on requests it had in flight. See _resendPendingRequest in Comm.ts.
   public getMissedMessages(lastSeqId: number | null): string[] | undefined {
+    const firstNeeded = lastSeqId === null ? this._firstMissedSeqId : lastSeqId + 1;
     const result: string[] = [];
-    if (lastSeqId !== null) {
-      for (let i = lastSeqId + 1; i < this._nextSeqId; i++) {
-        const m = this._missedMessages.get(i);
-        if (m === undefined) { return; }
-        result.push(m);
-      }
+    for (let i = firstNeeded; i < this._nextSeqId; i++) {
+      const m = this._missedMessages.get(i);
+      if (m === undefined) { return; }
+      result.push(m);
     }
     return result;
   }
@@ -412,8 +431,7 @@ export class Client {
       clearTimeout(this._destroyTimer);
       this._destroyTimer = null;
     }
-    this._missedMessages.clear();
-    this._missedMessagesTotalLength = 0;
+    this._clearMissedMessages();
     this._comm.removeClient(this);
     this._destroyed = true;
   }
@@ -449,6 +467,9 @@ export class Client {
         docId: request.docId,  // caution: trusting client for docId for this purpose.
       });
       return;
+    }
+    if (typeof request.reqId === "number") {
+      this._lastReceivedReqId = request.reqId;
     }
     let response: CommResponse | CommResponseError;
     const method = this._methods.get(request.method);
@@ -509,6 +530,14 @@ export class Client {
     let fd = 0;
     while (this._docFDs[fd]) { fd++; }
     return fd;
+  }
+
+  // Empty the queue of messages held for a disconnected client. _firstMissedSeqId moves with it,
+  // so getMissedMessages() can tell "never held that" apart from "held it and lost it".
+  private _clearMissedMessages() {
+    this._missedMessages.clear();
+    this._missedMessagesTotalLength = 0;
+    this._firstMissedSeqId = this._nextSeqId;
   }
 
   private _sendToWebsocket(message: string): Promise<void> {

--- a/app/server/lib/Client.ts
+++ b/app/server/lib/Client.ts
@@ -97,9 +97,18 @@ export class Client {
   private _authSession: AuthSession = AuthSession.unauthenticated();
   private _nextSeqId: number = 0;     // Next sequence-ID for messages sent to the client
 
-  // What _nextSeqId was when _missedMessages was last emptied. Anything from here on that we
-  // don't have was sent successfully. Only _clearMissedMessages() should set this.
-  private _firstMissedSeqId: number = 0;
+  // Start of the range of sequence-IDs _missedMessages can account for. Below it, we have nothing
+  // to say. From it on, anything we are not holding was sent. Only _dropMissedMessages() sets it.
+  private _missedMessagesWindowStart: number = 0;
+
+  // Set when we have handed a client messages and let go of them. If it comes back saying it
+  // received nothing, they are gone.
+  private _handoverUnconfirmed: boolean = false;
+
+  // Set when we have told a client to reload, until one turns up that has. The demand goes out
+  // over a connection that has just proved unreliable, and by then we have moved past the
+  // messages we could not account for, so nothing else would be left to say it again.
+  private _reloadPending: boolean = false;
 
   // Last request-ID read off the socket, or null if none. Requests arrive in order, so this says
   // which of the client's outstanding requests reached us.
@@ -344,25 +353,32 @@ export class Client {
       }
     }
 
-    // We collected any missed messages we need; clear the stored map of them.
-    this._clearMissedMessages();
+    // Everything below this is either in the missedMessages we just collected, or went to an
+    // earlier connection. Anything from here on is sent live.
+    const collectedThrough = this._nextSeqId;
 
     if (newClient) {
       // A reloaded tab keeps its clientId but numbers its requests afresh from zero, so what we
-      // remember from its previous life would be misleadingly high.
+      // remember from its previous life would be misleadingly high. Nothing we handed the page
+      // before is in doubt any more either, since this one never asked for it.
       this._lastReceivedReqId = null;
-    }
-
-    let docsClosed: number | null = null;
-    if (!seamlessReconnect) {
-      // The browser client can't recover from missed messages and will need to reopen docs. Close
-      // all docs we kept open. If it's a new Client object, this is a no-op.
-      docsClosed = this.closeAllDocs();
+      this._handoverUnconfirmed = false;
     }
 
     // An existing browser client that can't recover, or that connected to a new Client object,
     // will need to reopen docs. Tell it to reload.
     const needReload = !newClient && !seamlessReconnect;
+
+    this._reloadPending = needReload;
+
+    let docsClosed: number | null = null;
+    if (!seamlessReconnect) {
+      // The browser client can't recover from missed messages and will need to reopen docs, so
+      // what we hold is of no use to it. Close all docs we kept open. If it's a new Client
+      // object, this is a no-op.
+      this._dropMissedMessages(collectedThrough);
+      docsClosed = this.closeAllDocs();
+    }
 
     this._log.debug({ newClient, needReload, docsClosed, missedMessages: missedMessages?.length },
       "sending clientConnect");
@@ -380,6 +396,14 @@ export class Client {
 
     try {
       await this._sendToWebsocket(JSON.stringify(clientConnectMsg));
+
+      // Only let go once the send has gone through. If it throws, the client learned nothing of
+      // what it missed, and can ask again when it next connects.
+      this._dropMissedMessages(collectedThrough);
+      if (missedMessages?.length) {
+        // A successful send is not proof of arrival, so we are owed an account of these.
+        this._handoverUnconfirmed = true;
+      }
 
       if (needReload) {
         // If the client should reload, close the socket without waiting. This connection should
@@ -410,7 +434,10 @@ export class Client {
   // Returning undefined for a gap is load-bearing: it forces needReload, and only that stops a
   // client waiting on requests it had in flight. See _resendPendingRequest in Comm.ts.
   public getMissedMessages(lastSeqId: number | null): string[] | undefined {
-    const firstNeeded = lastSeqId === null ? this._firstMissedSeqId : lastSeqId + 1;
+    // Neither a client we are still waiting to see reload, nor one that cannot account for what
+    // we handed it, has anything to resume. Report a gap for both.
+    if (this._reloadPending || (lastSeqId === null && this._handoverUnconfirmed)) { return; }
+    const firstNeeded = lastSeqId === null ? this._missedMessagesWindowStart : lastSeqId + 1;
     const result: string[] = [];
     for (let i = firstNeeded; i < this._nextSeqId; i++) {
       const m = this._missedMessages.get(i);
@@ -431,7 +458,7 @@ export class Client {
       clearTimeout(this._destroyTimer);
       this._destroyTimer = null;
     }
-    this._clearMissedMessages();
+    this._dropMissedMessages(this._nextSeqId);
     this._comm.removeClient(this);
     this._destroyed = true;
   }
@@ -532,12 +559,16 @@ export class Client {
     return fd;
   }
 
-  // Empty the queue of messages held for a disconnected client. _firstMissedSeqId moves with it,
-  // so getMissedMessages() can tell "never held that" apart from "held it and lost it".
-  private _clearMissedMessages() {
-    this._missedMessages.clear();
-    this._missedMessagesTotalLength = 0;
-    this._firstMissedSeqId = this._nextSeqId;
+  // Let go of messages held for a disconnected client, up to but not including seqId. The window
+  // start moves with them, so getMissedMessages() can tell "never held that" from "held it once".
+  private _dropMissedMessages(seqId: number) {
+    for (const [key, message] of this._missedMessages) {
+      if (key < seqId) {
+        this._missedMessages.delete(key);
+        this._missedMessagesTotalLength -= message.length;
+      }
+    }
+    this._missedMessagesWindowStart = Math.max(this._missedMessagesWindowStart, seqId);
   }
 
   private _sendToWebsocket(message: string): Promise<void> {

--- a/app/server/lib/Client.ts
+++ b/app/server/lib/Client.ts
@@ -102,7 +102,7 @@ export class Client {
   private _missedMessagesWindowStart: number = 0;
 
   // Set when we have handed a client messages and let go of them. If it comes back saying it
-  // received nothing, they are gone.
+  // received nothing, they are gone. Cleared once it comes back able to account for them.
   private _handoverUnconfirmed: boolean = false;
 
   // Set when we have told a client to reload, until one turns up that has. The demand goes out
@@ -349,7 +349,9 @@ export class Client {
       missedMessages = this.getMissedMessages(lastSeqId);
       if (missedMessages) {
         // We have all the needed messages (possibly an empty array); can do a seamless reconnect.
+        // No gap also means the client accounted for what we handed it before, so that is settled.
         seamlessReconnect = true;
+        this._handoverUnconfirmed = false;
       }
     }
 
@@ -391,7 +393,7 @@ export class Client {
       missedMessages,
       needReload,
       // Only meaningful when resuming the session; otherwise no earlier request survives.
-      lastReceivedReqId: seamlessReconnect ? this._lastReceivedReqId : undefined,
+      lastReceivedReqId: seamlessReconnect ? (this._lastReceivedReqId ?? "none") : undefined,
     };
 
     try {
@@ -432,7 +434,7 @@ export class Client {
   // is news to it.
   //
   // Returning undefined for a gap is load-bearing: it forces needReload, and only that stops a
-  // client waiting on requests it had in flight. See _resendPendingRequest in Comm.ts.
+  // client waiting on requests it had in flight.
   public getMissedMessages(lastSeqId: number | null): string[] | undefined {
     // Neither a client we are still waiting to see reload, nor one that cannot account for what
     // we handed it, has anything to resume. Report a gap for both.

--- a/app/server/lib/DocManager.ts
+++ b/app/server/lib/DocManager.ts
@@ -59,6 +59,12 @@ export interface IMemoryLoadEstimator {
   getTotalMemoryUsedMB(): number;
 }
 
+export const Deps = {
+  // Called at the start of every openDoc, and a no-op outside tests. Tests replace it to hold an
+  // open in progress. See TestingHooks.setDocOpenPaused().
+  testBeforeOpenDoc: async () => {},
+};
+
 /**
  * DocManager keeps track of "active" Grist documents, i.e. those loaded
  * in-memory, with clients connected to them.
@@ -334,6 +340,8 @@ export class DocManager extends EventEmitter implements IMemoryLoadEstimator {
     if (typeof options === "string") {
       throw new Error("openDoc call with outdated parameter type");
     }
+
+    await Deps.testBeforeOpenDoc();
 
     const insightLog = insightLogEntry();
     insightLog?.addMeta(client.getLogMeta());

--- a/app/server/lib/ITestingHooks-ti.ts
+++ b/app/server/lib/ITestingHooks-ti.ts
@@ -20,6 +20,8 @@ export const ITestingHooks = t.iface([], {
   "commSetClientPersistence": t.func("number", t.param("ttlMs", "number")),
   "commSetClientJsonMemoryLimits": t.func("ClientJsonMemoryLimits", t.param("limits", "ClientJsonMemoryLimits")),
   "closeDocs": t.func("void"),
+  "setDocOpenPaused": t.func("void", t.param("paused", "boolean")),
+  "getDocOpenCount": t.func("number"),
   "setDocWorkerActivation": t.func("void", t.param("workerId", "string"), t.param("active", t.union(t.lit("active"), t.lit("inactive"), t.lit("crash")))),
   "flushAuthorizerCache": t.func("void"),
   "flushDocs": t.func("void"),

--- a/app/server/lib/ITestingHooks.ts
+++ b/app/server/lib/ITestingHooks.ts
@@ -16,6 +16,8 @@ export interface ITestingHooks {
   commSetClientPersistence(ttlMs: number): Promise<number>;
   commSetClientJsonMemoryLimits(limits: ClientJsonMemoryLimits): Promise<ClientJsonMemoryLimits>;
   closeDocs(): Promise<void>;
+  setDocOpenPaused(paused: boolean): Promise<void>;
+  getDocOpenCount(): Promise<number>;
   setDocWorkerActivation(workerId: string, active: "active" | "inactive" | "crash"): Promise<void>;
   flushAuthorizerCache(): Promise<void>;
   flushDocs(): Promise<void>;

--- a/app/server/lib/TestingHooks.ts
+++ b/app/server/lib/TestingHooks.ts
@@ -4,6 +4,7 @@ import { Deps as CommClientDeps } from "app/server/lib/Client";
 import * as Client from "app/server/lib/Client";
 import { Comm } from "app/server/lib/Comm";
 import { Deps as DiscourseConnectDeps } from "app/server/lib/DiscourseConnect";
+import { Deps as DocManagerDeps } from "app/server/lib/DocManager";
 import { FlexServer } from "app/server/lib/FlexServer";
 import { invalidateAllReloadableSettings, invalidateReloadableSettings } from "app/server/lib/gristSettings";
 import { ClientJsonMemoryLimits, ITestingHooks } from "app/server/lib/ITestingHooks";
@@ -75,6 +76,20 @@ export async function connectTestingHooks(socketPath: string): Promise<TestingHo
     isClosed: () => closed,
   });
 }
+
+// Set while setDocOpenPaused() is holding document opens up. Kept outside the TestingHooks
+// instance, which is created afresh for each connection to the testing socket.
+let docOpenGate: { held: Promise<void>, release: () => void } | null = null;
+
+// Document opens seen since the last setDocOpenPaused(true). Counting continues after unpausing,
+// so a test can let the document finish opening and then ask how many opens it took. Were the
+// count to stop at the moment of unpausing, "no second open arrived" would be a race rather than
+// a fact.
+let docOpensSeen = 0;
+
+// Longest that document opens will be held before the gate lets go by itself, so that a test
+// dying before it unpauses cannot wedge every later document open on this server.
+const maxDocOpenPauseMs = 60000;
 
 export class TestingHooks implements ITestingHooks {
   private _oldEnv: NodeJS.ProcessEnv | null = null;
@@ -190,6 +205,37 @@ export class TestingHooks implements ITestingHooks {
     for (const server of this._workerServers) {
       await server.testCloseDocs();
     }
+  }
+
+  // Hold up any document a client asks to open, until unpaused. Lets a test keep a document open
+  // outstanding while it interferes with the connection, as happens for real on a shaky network.
+  public async setDocOpenPaused(paused: boolean): Promise<void> {
+    log.info("TestingHooks.setDocOpenPaused called with", paused);
+    if (paused) {
+      if (docOpenGate) { return; }
+      let letGo!: () => void;
+      const held = new Promise<void>((resolve) => { letGo = resolve; });
+      const timer = setTimeout(() => {
+        log.warn(`TestingHooks.setDocOpenPaused: releasing after ${maxDocOpenPauseMs}ms; ` +
+          "was a test left paused?");
+        void this.setDocOpenPaused(false);
+      }, maxDocOpenPauseMs);
+      timer.unref();   // Don't keep the server alive just to hold this gate.
+      docOpensSeen = 0;
+      docOpenGate = { held, release: () => { clearTimeout(timer); letGo(); } };
+      DocManagerDeps.testBeforeOpenDoc = async () => {
+        docOpensSeen += 1;
+        await docOpenGate?.held;   // Counts but no longer waits once released.
+      };
+    } else {
+      docOpenGate?.release();
+      docOpenGate = null;
+    }
+  }
+
+  // How many document opens have arrived since setDocOpenPaused(true) was called.
+  public async getDocOpenCount(): Promise<number> {
+    return docOpensSeen;
   }
 
   public async setDocWorkerActivation(workerId: string, active: "active" | "inactive" | "crash"):

--- a/test/nbrowser/SleepWake.ts
+++ b/test/nbrowser/SleepWake.ts
@@ -1,0 +1,132 @@
+/**
+ * When a laptop sleeps, its websocket dies, and after a while the server forgets the client
+ * altogether. On wake the browser reconnects, and the app has to open the document all over
+ * again. Opening a document is not quick, since it may have to be fetched and given a sandbox,
+ * and a network that has just come back is not always steady. These tests check that the user
+ * ends up looking at a working document rather than an error, whichever way that goes.
+ */
+
+import { TestingHooksClient } from "app/server/lib/TestingHooks";
+import * as gu from "test/nbrowser/gristUtils";
+import { server, setupTestSuite } from "test/nbrowser/testUtils";
+
+import { assert, driver } from "mocha-webdriver";
+
+describe("SleepWake", function() {
+  this.timeout(90000);
+  const cleanup = setupTestSuite();
+
+  let hooks: TestingHooksClient;
+
+  before(async function() {
+    hooks = await server.getTestingHooks();
+  });
+
+  afterEach(async function() {
+    await hooks.setDocOpenPaused(false);
+  });
+
+  beforeEach(async function() {
+    const session = await gu.session().teamSite.login();
+    await session.tempDoc(cleanup, "Hello.grist");
+    await gu.waitForDocToLoad();
+    await gu.wipeToasts();
+    // Mark the current DocPageModel. The app replaces it when it reopens the document, which is
+    // how we tell that the wake has been noticed.
+    await driver.executeScript("window.gristDocPageModel.__sleepWakeStamp = true;");
+  });
+
+  // Cut the browser off from the server, as a sleeping laptop is: open websockets are
+  // terminated, and attempts to reconnect are refused.
+  async function networkDown() {
+    await hooks.commShutdown();
+  }
+
+  async function networkUp() {
+    await hooks.commRestart();
+  }
+
+  // Go away for long enough that the server unloads the document we had open, and gives up on
+  // the client it was holding for us. Both happen well within a night's sleep.
+  async function sleep() {
+    await networkDown();
+    await hooks.closeDocs();
+    await hooks.disconnectClients();
+  }
+
+  // Wait until the app has thrown away the document it had open and is busy opening it again.
+  async function waitForReopenToStart() {
+    await driver.wait(async () => driver.executeScript(`
+      const pageModel = window.gristDocPageModel;
+      return Boolean(pageModel && !pageModel.__sleepWakeStamp);
+    `), 30000, "app never started reopening the document");
+  }
+
+  // Wait until the server is holding a document open request. That it arrived at all means the
+  // app has noticed the wake and started over.
+  async function waitForDocOpenInFlight() {
+    await driver.wait(async () => (await hooks.getDocOpenCount()) > 0, 30000,
+      "no document open request arrived");
+  }
+
+  // Check that we are looking at a working document, with nothing broken along the way.
+  async function assertDocIsUsable() {
+    // Settle first, either way, so that giving up is reported as such rather than as a timeout.
+    await driver.wait(async () =>
+      (await driver.findAll(".test-modal-title")).length > 0 ||
+      (await driver.findAll(".viewsection_title")).length > 0,
+    30000, "the app neither opened the document nor said anything about it");
+
+    assert.deepEqual(await driver.findAll(".test-modal-title", e => e.getText()), [],
+      "the app gave up on the document instead of waiting for it");
+    assert.deepEqual(await gu.getAppErrors(), []);
+    await gu.waitForDocToLoad(30000);
+    assert.equal(await gu.getCell({ rowNum: 1, col: 0 }).getText(), "hello");
+  }
+
+  it("recovers when the network comes back cleanly", async function() {
+    await sleep();
+    await networkUp();
+    await waitForReopenToStart();
+    await assertDocIsUsable();
+  });
+
+  it("recovers when the network blips while the document is opening", async function() {
+    await sleep();
+
+    // Hold the open request, so one is certainly outstanding when the network misbehaves. On a
+    // real server, opening a document after a wake takes a while anyway.
+    await hooks.setDocOpenPaused(true);
+    await networkUp();
+    await waitForDocOpenInFlight();
+
+    // Wifi is still settling, and the connection blips. It returns quickly enough that the server
+    // still knows us, so the document we asked for is still on its way.
+    await networkDown();
+    await networkUp();
+
+    await hooks.setDocOpenPaused(false);
+    await assertDocIsUsable();
+
+    // The blip cost nothing: the document was opened once and the answer reached us, rather than
+    // the app starting over. Checked after loading, by which time a second open would have shown.
+    assert.equal(await hooks.getDocOpenCount(), 1, "the document was opened more than once");
+  });
+
+  it("recovers when the network goes away again while the document is opening", async function() {
+    await sleep();
+
+    await hooks.setDocOpenPaused(true);
+    await networkUp();
+    await waitForDocOpenInFlight();
+
+    // This time the second outage is long too, so the server gives up on us again and nobody is
+    // left to answer for the document. The app has to start over, and may do so quietly.
+    await networkDown();
+    await hooks.disconnectClients();
+    await hooks.setDocOpenPaused(false);
+    await networkUp();
+
+    await assertDocIsUsable();
+  });
+});

--- a/test/server/Comm.ts
+++ b/test/server/Comm.ts
@@ -633,6 +633,13 @@ describe("Comm", function() {
         { clientId, newClient: "0", counter: "c1", lastSeqId: String(seqIds[0]) });
       assert.isFalse(msg2.needReload);
       ws2.close();
+      await waitForSocketRelease(clientId);
+
+      // A later blip has nothing to report, since nothing was sent in between. A quiet
+      // connection is not a client failing to account for the handover, which is settled by now.
+      const { ws: ws3, msg: msg3 } = await connectWithParams({ clientId, newClient: "0", counter: "c1" });
+      assert.isFalse(msg3.needReload, "expected a confirmed handover to stop being held against it");
+      ws3.close();
     });
 
     it("should stop demanding a reload once the client has started over", async function() {
@@ -672,7 +679,7 @@ describe("Comm", function() {
       // answers to requests that never reached anyone.
       const { ws: ws3, msg: msg3 } = await connectWithParams({ clientId, newClient: "0", counter: "c2" });
       assert.isFalse(msg3.needReload);
-      assert.isNull(msg3.lastReceivedReqId);
+      assert.equal(msg3.lastReceivedReqId, "none");
       ws3.close();
     });
 
@@ -976,7 +983,7 @@ describe("Comm", function() {
         sent?: boolean,              // did the request go out?
         elsewhere?: boolean,         // did it go out on some other connection?
         needReload?: boolean,        // is the server telling us to start over?
-        lastReceivedReqId?: number | null,   // what the server read, undefined for "did not say"
+        lastReceivedReqId?: number | "none",  // what the server read, undefined for "did not say"
         boundClientId?: string,      // the request is only valid for this clientId
         expected: string,            // RESEND, WAIT, or the error the caller should see
       }[] = [
@@ -993,7 +1000,7 @@ describe("Comm", function() {
 
         // Sent, and the server read on past without seeing it, so it never arrived.
         { name: "sent, server stopped short of it", sent: true, lastReceivedReqId: REQ_ID - 1, expected: RESEND },
-        { name: "sent, server read nothing at all", sent: true, lastReceivedReqId: null, expected: RESEND },
+        { name: "sent, server read nothing at all", sent: true, lastReceivedReqId: "none", expected: RESEND },
 
         // Sent, and nothing the server said covers it.
         { name: "sent, server did not say", sent: true, expected: "interrupted by reconnect" },
@@ -1038,7 +1045,7 @@ describe("Comm", function() {
           cliComm.pendingRequests.set(REQ_ID, request as any);
 
           // A row that leaves lastReceivedReqId out is testing "the server did not say", which is
-          // not the same as a row that sets it to null, so the field is only added when named.
+          // not the same as a row that sets it to "none", so the field is only added when named.
           const connectMsg: CommClientConnect = {
             type: "clientConnect", clientId: "current", needReload: Boolean(c.needReload),
             ...("lastReceivedReqId" in c ? { lastReceivedReqId: c.lastReceivedReqId } : {}),

--- a/test/server/Comm.ts
+++ b/test/server/Comm.ts
@@ -157,15 +157,19 @@ describe("Comm", function() {
     });
   }
 
-  // Connect with explicit query params (e.g. clientId/newClient) to exercise reconnects, and
-  // return the socket together with the server's first message. The message handler is attached
-  // synchronously, before the socket opens: a needReload reconnect gets a single clientConnect
-  // followed immediately by a close, so a handler attached afterwards (as connect()+getMessages()
-  // does) would miss it.
-  async function connectWithParams(query: Record<string, string>, options?: GristClientSocketOptions) {
+  // Open a socket with explicit query params (e.g. clientId/newClient), to exercise reconnects.
+  function openSocket(query: Record<string, string>, options?: GristClientSocketOptions) {
     const port = (server.address() as AddressInfo).port;
     const qs = new URLSearchParams(query).toString();
-    const ws = new GristClientSocket(`ws://localhost:${port}/?${qs}`, options);
+    return new GristClientSocket(`ws://localhost:${port}/?${qs}`, options);
+  }
+
+  // As openSocket, but returns the socket together with the server's first message. The message
+  // handler is attached synchronously, before the socket opens: a needReload reconnect gets a
+  // single clientConnect followed immediately by a close, so a handler attached afterwards (as
+  // connect()+getMessages() does) would miss it.
+  async function connectWithParams(query: Record<string, string>, options?: GristClientSocketOptions) {
+    const ws = openSocket(query, options);
     const msg = await new Promise<CommClientConnect>((resolve, reject) => {
       ws.onmessage = (data: string) => resolve(JSON.parse(data));
       ws.onerror = (err: Error) => reject(err);
@@ -410,70 +414,251 @@ describe("Comm", function() {
       assert.equal(failedSendCount, sendShouldFail ? 1 : 0, "Expected to see a failed send");
     }
 
-    // A server method that takes its time, along with a promise that resolves once the server has
-    // started running it.
-    function makeSlowMethod(delayMs: number) {
+    // A server method the test drives: `started` resolves once the server has begun running it,
+    // and `finish()` lets it return.
+    function makeControlledMethod() {
       let notifyStarted!: () => void;
+      let finish!: () => void;
       const started = new Promise<void>((resolve) => { notifyStarted = resolve; });
+      const finished = new Promise<void>((resolve) => { finish = resolve; });
       const methods = {
-        methodSlow: async function(client: Client, x: any) {
+        methodControlled: async function(client: Client, x: any) {
           notifyStarted();
-          await delay(delayMs);
-          return { x, name: "methodSlow" };
+          await finished;
+          return { x, name: "methodControlled" };
         },
       };
-      return { methods, started };
+      return { methods, started, finish };
+    }
+
+    // How many messages the server is holding for a client that was not there to receive them.
+    function queuedMessageCount(clientId: string) {
+      return (comm!.getClient(clientId) as any)._missedMessages.size;
+    }
+
+    // The client's next clientConnect, which is how it learns a connection is up. Waiting for the
+    // next one rather than for any at all is what tells a reconnect from the connection before it.
+    function nextClientConnect(cliComm: ClientComm & BackboneEvents): Promise<CommClientConnect> {
+      return new Promise(resolve => cliComm.once("clientConnect", resolve));
+    }
+
+    // Let the server lose the next request that reaches it, as a network on its way out does.
+    function swallowNextRequest() {
+      let notifyLost!: () => void;
+      const lost = new Promise<void>((resolve) => { notifyLost = resolve; });
+      const stub: sinon.SinonStub = sandbox.stub(Client.prototype as any, "_onMessage")
+        .callsFake(async function(this: any, ...args: unknown[]): Promise<unknown> {
+          const message = args[0] as string;
+          if (JSON.parse(message).reqId !== undefined) {
+            stub.restore();
+            notifyLost();
+            return;
+          }
+          return stub.wrappedMethod.call(this, message);
+        });
+      return lost;
     }
 
     it("should deliver the response to a request that outlives a reconnect", async function() {
-      // Take longer over the request than the client takes to reconnect (about a second), so that
-      // the server is still working on it when the client comes back.
-      const { methods, started } = makeSlowMethod(3000);
+      const { methods, started, finish } = makeControlledMethod();
       const { cliComm, forwarder } = await startManagedConnection({ ...assortedMethods, ...methods });
 
-      // Start a slow request, and wait until the server has actually begun processing it.
-      const respPromise = cliComm._makeRequest(null, null, "methodSlow", "foo");
+      // Start a request, and wait until the server has actually begun processing it.
+      const respPromise = cliComm._makeRequest(null, null, "methodControlled", "foo");
       await started;
 
-      // The connection drops and comes back while the server is still working. The server still
-      // has our Client object, so it can tell us on reconnect that our request is in hand. There
-      // is nothing to do but wait for the answer.
+      // The connection drops and comes back while the server is still working. The server kept
+      // our Client object, so it can say on reconnect that the request is in hand.
+      const reconnected = nextClientConnect(cliComm);
       await forwarder.disconnectServerSide();
       await forwarder.connect();
+      await reconnected;
 
-      assert.deepEqual(await respPromise, { x: "foo", name: "methodSlow" });
+      // Only now let the server finish, so the answer is worked out after the reconnect.
+      finish();
+      assert.deepEqual(await respPromise, { x: "foo", name: "methodControlled" });
+    });
+
+    it("should reject a request the server cannot vouch for", async function() {
+      const { methods, started, finish } = makeControlledMethod();
+      const { cliComm, forwarder } = await startManagedConnection({ ...assortedMethods, ...methods });
+
+      const respPromise = cliComm._makeRequest(null, null, "methodControlled", "foo");
+      await started;
+
+      // The server forgets us while we are away, so on reconnect it can say nothing about the
+      // request it had in hand. Asking again could repeat work already done, and waiting would
+      // be waiting for nobody, so the request is rejected and the caller told.
+      await forwarder.disconnectServerSide();
+      comm!.destroyAllClients();
+      await forwarder.connect();
+      await assert.isRejected(respPromise, /interrupted by reconnect/);
+      finish();
+    });
+
+    it("should ask again for a request that never reached the server", async function() {
+      const { cliComm, forwarder } = await startManagedConnection(assortedMethods);
+
+      // One request that does arrive, so the server has a request id to report.
+      assert.deepEqual(await cliComm._makeRequest(null, null, "methodSync", "foo", 1),
+        { x: "foo", y: 1, name: "methodSync" });
+
+      // The next one is lost on its way in, as one in flight when the network goes is.
+      const lost = swallowNextRequest();
+      const respPromise = cliComm._makeRequest(null, null, "methodSync", "bar", 2);
+      await lost;
+
+      // On reconnect the server names the earlier request as the last it read, so this one cannot
+      // have arrived and cannot have had any effect. Asking again is safe, and better than
+      // failing a request that provably never landed.
+      await forwarder.disconnectServerSide();
+      await forwarder.connect();
+      assert.deepEqual(await respPromise, { x: "bar", y: 2, name: "methodSync" });
     });
 
     it("should deliver a response prepared while the connection was down", async function() {
-      const { methods, started } = makeSlowMethod(500);
+      const { methods, started, finish } = makeControlledMethod();
       const { cliComm, forwarder } = await startManagedConnection({ ...assortedMethods, ...methods });
+      const { clientId } = await nextClientConnect(cliComm);
 
-      // This is the client's first request, so it has not yet received anything numbered from the
-      // server, and has no place in the message stream to reconnect from.
-      const respPromise = cliComm._makeRequest(null, null, "methodSlow", "foo");
+      // The client's first request, so it has received nothing numbered, and has no place in the
+      // message stream to reconnect from.
+      const respPromise = cliComm._makeRequest(null, null, "methodControlled", "foo");
       await started;
 
-      // Stay away long enough for the server to finish the request and queue up its answer, with
-      // no socket to send it on.
+      // Finish only once the server has noticed the socket is gone, so it has to queue the answer.
       await forwarder.disconnectServerSide();
-      await delay(1500);
-      await forwarder.connect();
+      await waitForSocketRelease(clientId);
+      finish();
+      await waitForCondition(() => (queuedMessageCount(clientId) > 0), 2000);
 
-      assert.deepEqual(await respPromise, { x: "foo", name: "methodSlow" });
+      await forwarder.connect();
+      assert.deepEqual(await respPromise, { x: "foo", name: "methodControlled" });
     });
 
-    it("should not report request ids from before a browser tab started over", async function() {
-      await startComm(assortedMethods);
+    // Leave the server holding an answer the client has never had a chance to receive: it asked a
+    // question and went away. It has received nothing numbered, so it cannot say where to resume.
+    async function queueAnswerForAbsentClient() {
+      const { methods, started, finish } = makeControlledMethod();
+      await startComm({ ...assortedMethods, ...methods });
       cleanup.push(() => stopComm());
 
-      // A tab connects and gets a fair way through its requests.
       const ws1 = await connect();
       const [msg1] = await getMessages(ws1, 1) as CommClientConnect[];
       const clientId = msg1.clientId;
-      ws1.send(JSON.stringify({ reqId: 42, method: "methodSync", args: ["foo", 1] }));
-      await getMessages(ws1, 1);
+      ws1.send(JSON.stringify({ reqId: 0, method: "methodControlled", args: ["foo"] }));
+      await started;
+
       ws1.close();
       await waitForSocketRelease(clientId);
+      finish();
+      await waitForCondition(() => (queuedMessageCount(clientId) > 0), 2000);
+      return clientId;
+    }
+
+    // Connect, ask one question, take the answer, and go away. The answer goes out while the
+    // client is there to receive it, so the server is left holding no copy of it.
+    async function connectAskAndLeave(reqId: number) {
+      await startComm(assortedMethods);
+      cleanup.push(() => stopComm());
+
+      const ws = await connect();
+      const [msg] = await getMessages(ws, 1) as CommClientConnect[];
+      const clientId = msg.clientId;
+      ws.send(JSON.stringify({ reqId, method: "methodSync", args: ["foo", 1] }));
+      await getMessages(ws, 1);
+      ws.close();
+      await waitForSocketRelease(clientId);
+      return clientId;
+    }
+
+    // Connect, wait for the server to lose the clientConnect it sends in reply, and go away again.
+    async function connectAndLoseClientConnect(clientId: string, how: "failSend" | "swallow") {
+      const lost = loseNextClientConnect(how);
+      const ws = openSocket({ clientId, newClient: "0", counter: "c1" });
+      await new Promise<void>((resolve, reject) => { ws.onopen = resolve; ws.onerror = reject; });
+      await lost;
+      ws.close();
+      await waitForSocketRelease(clientId);
+    }
+
+    // Stop the next clientConnect from reaching the client. "failSend" is a socket that dies as
+    // the server answers it; "swallow" is one that takes the message and goes quiet. The
+    // difference matters: only the second leaves the server thinking it delivered something.
+    function loseNextClientConnect(how: "failSend" | "swallow") {
+      let notifyLost!: () => void;
+      const lost = new Promise<void>((resolve) => { notifyLost = resolve; });
+      const stub: sinon.SinonStub = sandbox.stub(Client.prototype as any, "_sendToWebsocket")
+        .callsFake(async function(this: any, ...args: unknown[]): Promise<unknown> {
+          const message = args[0] as string;
+          if (message.includes(`"clientConnect"`)) {
+            stub.restore();
+            notifyLost();
+            if (how === "failSend") { throw new Error("WebSocket is not open"); }
+            return;
+          }
+          return stub.wrappedMethod.call(this, message);
+        });
+      return lost;
+    }
+
+    it("should keep hold of missed messages if clientConnect cannot be sent", async function() {
+      const clientId = await queueAnswerForAbsentClient();
+
+      // The tab reconnects, but the clientConnect carrying the answer never makes it out.
+      await connectAndLoseClientConnect(clientId, "failSend");
+
+      // The client learned nothing, so the server must still hold the answer for it.
+      const { ws, msg } = await connectWithParams({ clientId, newClient: "0", counter: "c1" });
+      assert.isFalse(msg.needReload);
+      assert.deepEqual((msg.missedMessages || []).map(m => JSON.parse(m).data),
+        [{ x: "foo", name: "methodControlled" }]);
+      ws.close();
+    });
+
+    it("should let a client carry on once it has taken its missed messages", async function() {
+      const clientId = await queueAnswerForAbsentClient();
+
+      // The tab reconnects and takes the answer it missed.
+      const { ws: ws1, msg: msg1 } = await connectWithParams({ clientId, newClient: "0", counter: "c1" });
+      assert.isFalse(msg1.needReload);
+      const seqIds = (msg1.missedMessages || []).map(m => JSON.parse(m).seqId);
+      assert.lengthOf(seqIds, 1);
+      ws1.close();
+      await waitForSocketRelease(clientId);
+
+      // The connection blips again, and this time the tab can say where it got to. Having taken
+      // what we handed over, it must not be sent back to the start for it.
+      const { ws: ws2, msg: msg2 } = await connectWithParams(
+        { clientId, newClient: "0", counter: "c1", lastSeqId: String(seqIds[0]) });
+      assert.isFalse(msg2.needReload);
+      ws2.close();
+    });
+
+    it("should stop demanding a reload once the client has started over", async function() {
+      const clientId = await connectAskAndLeave(0);
+      await connectAndLoseClientConnect(clientId, "swallow");
+
+      const { ws: ws1, msg: msg1 } = await connectWithParams({ clientId, newClient: "0", counter: "c1" });
+      assert.isTrue(msg1.needReload, "expected the server to be asking for a reload");
+      ws1.close();
+      await waitForSocketRelease(clientId);
+
+      // The tab reloads, as asked. It keeps its clientId, and the server has nothing more to say.
+      const { ws: ws2, msg: msg2 } = await connectWithParams({ clientId, newClient: "1", counter: "c2" });
+      assert.isFalse(msg2.needReload);
+      ws2.close();
+      await waitForSocketRelease(clientId);
+
+      // A blip after that resumes as normal, rather than sending the tab round again.
+      const { ws: ws3, msg: msg3 } = await connectWithParams({ clientId, newClient: "0", counter: "c2" });
+      assert.isFalse(msg3.needReload);
+      ws3.close();
+    });
+
+    it("should not report request ids from before a browser tab started over", async function() {
+      // A tab connects and gets a fair way through its requests.
+      const clientId = await connectAskAndLeave(42);
 
       // The tab is reloaded. It takes its clientId along, since that lives in sessionStorage, but
       // it is a fresh page numbering its requests from zero again.
@@ -672,6 +857,210 @@ describe("Comm", function() {
       await waitForCondition(() => eventSpy.callCount > 0);
       assert.deepEqual(eventSpy.getCalls().map(call => call.args[0].n), [n - 1]);
     }
+
+    // The seqIds of the messages the server is holding for a client.
+    function queuedSeqIds(clientId: string): number[] {
+      return [...(comm!.getClient(clientId) as any)._missedMessages.keys()].sort((a, b) => a - b);
+    }
+
+    // What the server tells a client that turns up asking to carry on. Each row puts the server
+    // in a state and reconnects with given parameters. Past the stated outcome, every row is held
+    // to two rules that must hold whatever the state, since between them they are what stops a
+    // client waiting on an answer that is never coming.
+    describe("what to tell a client that reconnects", function() {
+      // The server volunteers a request id only when offering to resume. A fresh page is not
+      // resuming, however little it is being asked to do.
+      function assertOfferIsConsistent(resuming: boolean, msg: CommClientConnect) {
+        assert.equal(msg.lastReceivedReqId !== undefined, resuming,
+          resuming ? "a resume should say what it read" : "only a resume may say what it read");
+      }
+
+      // A resume must hand over every message the client has not accounted for, unbroken. A hole
+      // would leave it waiting; a message left behind would leave it a message short.
+      function assertNothingLeftBehind(resuming: boolean, held: number[], lastSeqId: number | undefined,
+        msg: CommClientConnect) {
+        if (!resuming) { return; }
+        const delivered = (msg.missedMessages || []).map(m => JSON.parse(m).seqId);
+        for (let i = 1; i < delivered.length; i++) {
+          assert.equal(delivered[i], delivered[i - 1] + 1, `hole in delivery: ${delivered}`);
+        }
+        if (lastSeqId !== undefined && delivered.length) {
+          assert.equal(delivered[0], lastSeqId + 1, "delivery should carry on where the client left off");
+        }
+        const owed = held.filter(seqId => lastSeqId === undefined || seqId > lastSeqId);
+        assert.deepEqual(delivered, owed, "a resume should hand over exactly what the client is owed");
+      }
+
+      const cases: {
+        state: "holding an answer" | "answered while connected" | "handed over unconfirmed" |
+          "reload demanded but lost",
+        newClient: string,
+        lastSeqId?: number,
+        needReload: boolean,
+        why: string,
+      }[] = [
+        { state: "holding an answer", newClient: "0", needReload: false,
+          why: "the answer is still here to hand over" },
+        { state: "holding an answer", newClient: "0", lastSeqId: 0, needReload: false,
+          why: "the client already has it" },
+        { state: "holding an answer", newClient: "1", needReload: false,
+          why: "a fresh page needs nothing and is told to reload nothing" },
+
+        { state: "answered while connected", newClient: "0", needReload: true,
+          why: "the answer went out live and is gone, and the client cannot account for it" },
+        { state: "answered while connected", newClient: "0", lastSeqId: 0, needReload: false,
+          why: "the client accounts for everything" },
+
+        { state: "handed over unconfirmed", newClient: "0", needReload: true,
+          why: "we let go of messages this client says it never received" },
+        { state: "handed over unconfirmed", newClient: "0", lastSeqId: 0, needReload: false,
+          why: "the client can show it received them after all" },
+
+        { state: "reload demanded but lost", newClient: "0", needReload: true,
+          why: "it never heard the demand, and we have moved past what it missed" },
+        { state: "reload demanded but lost", newClient: "0", lastSeqId: 0, needReload: true,
+          why: "accounting for messages is no help once the demand has gone unheard" },
+        { state: "reload demanded but lost", newClient: "1", needReload: false,
+          why: "the page started over, which is all we were waiting for" },
+      ];
+
+      for (const c of cases) {
+        const params = `newClient=${c.newClient}` + (c.lastSeqId === undefined ? "" : `, lastSeqId=${c.lastSeqId}`);
+        it(`${c.needReload ? "should demand a reload" : "should let it carry on"} ` +
+          `(${c.state}, ${params}): ${c.why}`, async function() {
+          let clientId: string;
+          switch (c.state) {
+            case "holding an answer":
+              clientId = await queueAnswerForAbsentClient();
+              break;
+            case "answered while connected":
+              clientId = await connectAskAndLeave(0);
+              break;
+            case "handed over unconfirmed":
+              clientId = await queueAnswerForAbsentClient();
+              await connectAndLoseClientConnect(clientId, "swallow");
+              break;
+            case "reload demanded but lost":
+              clientId = await connectAskAndLeave(0);
+              await connectAndLoseClientConnect(clientId, "swallow");
+              break;
+          }
+
+          const held = queuedSeqIds(clientId);
+          const query: Record<string, string> = { clientId, newClient: c.newClient, counter: "c1" };
+          if (c.lastSeqId !== undefined) { query.lastSeqId = String(c.lastSeqId); }
+          const { ws, msg } = await connectWithParams(query);
+
+          assert.equal(msg.needReload, c.needReload, c.why);
+          const resuming = c.newClient === "0" && !msg.needReload;
+          assertOfferIsConsistent(resuming, msg);
+          assertNothingLeftBehind(resuming, held, c.lastSeqId, msg);
+          ws.close();
+        });
+      }
+    });
+
+    // What the client does with a request left in flight when a clientConnect arrives. The three
+    // outcomes are: wait for an answer the server says is coming, send it again because it
+    // provably never landed, or reject it because nobody can say what became of it. Rejecting one
+    // that never arrived costs the user an error for nothing; re-sending one that did arrive
+    // could repeat work already done. So each row is worth stating.
+    describe("what to do with a request in flight", function() {
+      const RESEND = "resend", WAIT = "wait";
+
+      // A request numbered 4, so rows can put the server's last-read id either side of it.
+      const REQ_ID = 4;
+
+      const cases: {
+        name: string,
+        sent?: boolean,              // did the request go out?
+        elsewhere?: boolean,         // did it go out on some other connection?
+        needReload?: boolean,        // is the server telling us to start over?
+        lastReceivedReqId?: number | null,   // what the server read, undefined for "did not say"
+        boundClientId?: string,      // the request is only valid for this clientId
+        expected: string,            // RESEND, WAIT, or the error the caller should see
+      }[] = [
+        // Never sent, so it has had no effect and asking is always safe.
+        { name: "never sent, server up to date", lastReceivedReqId: 9, expected: RESEND },
+        { name: "never sent, server silent", expected: RESEND },
+        { name: "never sent, reload demanded", needReload: true, expected: RESEND },
+        { name: "never sent, bound to an older clientId", boundClientId: "stale",
+          expected: "pending with outdated clientId" },
+
+        // Sent, and the server accounts for it: it is in hand, and the answer cannot go astray.
+        { name: "sent, server read past it", sent: true, lastReceivedReqId: REQ_ID + 1, expected: WAIT },
+        { name: "sent, server read exactly it", sent: true, lastReceivedReqId: REQ_ID, expected: WAIT },
+
+        // Sent, and the server read on past without seeing it, so it never arrived.
+        { name: "sent, server stopped short of it", sent: true, lastReceivedReqId: REQ_ID - 1, expected: RESEND },
+        { name: "sent, server read nothing at all", sent: true, lastReceivedReqId: null, expected: RESEND },
+
+        // Sent, and nothing the server said covers it.
+        { name: "sent, server did not say", sent: true, expected: "interrupted by reconnect" },
+        { name: "sent, reload demanded", sent: true, needReload: true, lastReceivedReqId: REQ_ID,
+          expected: "interrupted by reconnect" },
+        { name: "sent on another connection", sent: true, elsewhere: true, lastReceivedReqId: REQ_ID,
+          expected: "interrupted by reconnect" },
+
+        // An outdated clientId only bites a request that is still ours to hold back.
+        { name: "in hand, though bound to an older clientId", sent: true, lastReceivedReqId: REQ_ID,
+          boundClientId: "stale", expected: WAIT },
+        { name: "never arrived, and bound to an older clientId", sent: true, lastReceivedReqId: REQ_ID - 1,
+          boundClientId: "stale", expected: "pending with outdated clientId" },
+      ];
+
+      for (const c of cases) {
+        it(`should ${c.expected === RESEND ? "send again" : c.expected === WAIT ? "wait" : "reject"}: ` +
+          `${c.name}`, function() {
+          stubWorkerConfig();
+          const cliComm = ClientComm.create() as ClientComm & BackboneEvents;
+          cleanup.push(async () => cliComm.dispose());
+
+          // The connection the clientConnect arrived on, and another the request may have used.
+          const send = sinon.stub().returns(true);
+          const dispose = sinon.stub();
+          const reconnected = { clientId: "current", send, dispose } as unknown as GristWSConnection;
+          const other = {
+            clientId: "current", send: sinon.stub().returns(true), dispose,
+          } as unknown as GristWSConnection;
+          (cliComm as any)._connections.set(null, reconnected);
+
+          const reject = sinon.stub();
+          const request = {
+            resolve: sinon.stub(), reject,
+            clientId: c.boundClientId ?? null,
+            docId: null,
+            methodName: "methodSync",
+            requestMsg: "the request",
+            sent: Boolean(c.sent),
+            sentOn: c.sent ? (c.elsewhere ? other : reconnected) : null,
+          };
+          cliComm.pendingRequests.set(REQ_ID, request as any);
+
+          // A row that leaves lastReceivedReqId out is testing "the server did not say", which is
+          // not the same as a row that sets it to null, so the field is only added when named.
+          const connectMsg: CommClientConnect = {
+            type: "clientConnect", clientId: "current", needReload: Boolean(c.needReload),
+            ...("lastReceivedReqId" in c ? { lastReceivedReqId: c.lastReceivedReqId } : {}),
+          } as CommClientConnect;
+          (cliComm as any)._resendPendingRequest(REQ_ID, request, connectMsg, reconnected);
+
+          if (c.expected === RESEND) {
+            assert.deepEqual(send.args, [["the request"]], "expected the request to go out again");
+            assert.equal(reject.callCount, 0, "expected no rejection");
+            assert.isTrue(cliComm.pendingRequests.has(REQ_ID), "expected the request to stay pending");
+          } else if (c.expected === WAIT) {
+            assert.equal(send.callCount, 0, "expected nothing to be sent");
+            assert.equal(reject.callCount, 0, "expected no rejection");
+            assert.isTrue(cliComm.pendingRequests.has(REQ_ID), "expected the request to stay pending");
+          } else {
+            assert.equal(send.callCount, 0, "expected nothing to be sent");
+            assert.match(reject.args[0]?.[0]?.message ?? "", new RegExp(c.expected));
+            assert.isFalse(cliComm.pendingRequests.has(REQ_ID), "expected the request to be dropped");
+          }
+        });
+      }
+    });
   });
 
   describe("websocket auth", function() {

--- a/test/server/Comm.ts
+++ b/test/server/Comm.ts
@@ -157,6 +157,32 @@ describe("Comm", function() {
     });
   }
 
+  // Connect with explicit query params (e.g. clientId/newClient) to exercise reconnects, and
+  // return the socket together with the server's first message. The message handler is attached
+  // synchronously, before the socket opens: a needReload reconnect gets a single clientConnect
+  // followed immediately by a close, so a handler attached afterwards (as connect()+getMessages()
+  // does) would miss it.
+  async function connectWithParams(query: Record<string, string>, options?: GristClientSocketOptions) {
+    const port = (server.address() as AddressInfo).port;
+    const qs = new URLSearchParams(query).toString();
+    const ws = new GristClientSocket(`ws://localhost:${port}/?${qs}`, options);
+    const msg = await new Promise<CommClientConnect>((resolve, reject) => {
+      ws.onmessage = (data: string) => resolve(JSON.parse(data));
+      ws.onerror = (err: Error) => reject(err);
+    });
+    return { ws, msg };
+  }
+
+  // Wait until the server has released clientId's websocket, so it is eligible for reconnect.
+  async function waitForSocketRelease(clientId: string) {
+    const client = comm!.getClient(clientId);
+    for (let i = 0; i < 200 && client.isConnected(); i++) {
+      await delay(10);
+    }
+    // Say so here rather than letting the reconnect that follows fail for reasons of its own.
+    assert.isFalse(client.isConnected(), `Client ${clientId} still held a websocket after 2s`);
+  }
+
   describe("server methods", function() {
     let ws: GristClientSocket;
     beforeEach(async function() {
@@ -271,6 +297,16 @@ describe("Comm", function() {
     const docId = "docId_abc";
     this.timeout(10000);
 
+    // GristWSConnection declines to connect unless the page config names a worker for the doc.
+    function stubWorkerConfig() {
+      (global as any).window = undefined;
+      const partialConfig: Pick<GristLoadConfig, "getWorkerFull" | "assignmentId"> = {
+        getWorkerFull: { [docId]: { selfPrefix: "STUB", docWorkerUrl: null, docWorkerId: null } },
+        assignmentId: docId,
+      };
+      sandbox.stub(global as any, "window").value({ gristConfig: partialConfig });
+    }
+
     // Helper to set up a Comm server, a Comm client, and a forwarder between them that allows
     // simulating disconnects.
     async function startManagedConnection(methods: { [name: string]: ClientMethod }) {
@@ -285,14 +321,7 @@ describe("Comm", function() {
       await forwarder.connect();
       cleanup.push(() => forwarder.disconnect());
 
-      // To create a client-side Comm object, we need to trick GristWSConnection's check for
-      // whether there is a worker to connect to.
-      (global as any).window = undefined;
-      const partialConfig: Pick<GristLoadConfig, "getWorkerFull" | "assignmentId"> = {
-        getWorkerFull: { [docId]: { selfPrefix: "STUB", docWorkerUrl: null, docWorkerId: null } },
-        assignmentId: docId,
-      };
-      sandbox.stub(global as any, "window").value({ gristConfig: partialConfig });
+      stubWorkerConfig();
 
       // We also need to get GristWSConnection to use a custom GristWSSettings object, and to
       // connect to the forwarder's port.
@@ -380,6 +409,117 @@ describe("Comm", function() {
       // Check that we saw the situation we were hoping to test.
       assert.equal(failedSendCount, sendShouldFail ? 1 : 0, "Expected to see a failed send");
     }
+
+    // A server method that takes its time, along with a promise that resolves once the server has
+    // started running it.
+    function makeSlowMethod(delayMs: number) {
+      let notifyStarted!: () => void;
+      const started = new Promise<void>((resolve) => { notifyStarted = resolve; });
+      const methods = {
+        methodSlow: async function(client: Client, x: any) {
+          notifyStarted();
+          await delay(delayMs);
+          return { x, name: "methodSlow" };
+        },
+      };
+      return { methods, started };
+    }
+
+    it("should deliver the response to a request that outlives a reconnect", async function() {
+      // Take longer over the request than the client takes to reconnect (about a second), so that
+      // the server is still working on it when the client comes back.
+      const { methods, started } = makeSlowMethod(3000);
+      const { cliComm, forwarder } = await startManagedConnection({ ...assortedMethods, ...methods });
+
+      // Start a slow request, and wait until the server has actually begun processing it.
+      const respPromise = cliComm._makeRequest(null, null, "methodSlow", "foo");
+      await started;
+
+      // The connection drops and comes back while the server is still working. The server still
+      // has our Client object, so it can tell us on reconnect that our request is in hand. There
+      // is nothing to do but wait for the answer.
+      await forwarder.disconnectServerSide();
+      await forwarder.connect();
+
+      assert.deepEqual(await respPromise, { x: "foo", name: "methodSlow" });
+    });
+
+    it("should deliver a response prepared while the connection was down", async function() {
+      const { methods, started } = makeSlowMethod(500);
+      const { cliComm, forwarder } = await startManagedConnection({ ...assortedMethods, ...methods });
+
+      // This is the client's first request, so it has not yet received anything numbered from the
+      // server, and has no place in the message stream to reconnect from.
+      const respPromise = cliComm._makeRequest(null, null, "methodSlow", "foo");
+      await started;
+
+      // Stay away long enough for the server to finish the request and queue up its answer, with
+      // no socket to send it on.
+      await forwarder.disconnectServerSide();
+      await delay(1500);
+      await forwarder.connect();
+
+      assert.deepEqual(await respPromise, { x: "foo", name: "methodSlow" });
+    });
+
+    it("should not report request ids from before a browser tab started over", async function() {
+      await startComm(assortedMethods);
+      cleanup.push(() => stopComm());
+
+      // A tab connects and gets a fair way through its requests.
+      const ws1 = await connect();
+      const [msg1] = await getMessages(ws1, 1) as CommClientConnect[];
+      const clientId = msg1.clientId;
+      ws1.send(JSON.stringify({ reqId: 42, method: "methodSync", args: ["foo", 1] }));
+      await getMessages(ws1, 1);
+      ws1.close();
+      await waitForSocketRelease(clientId);
+
+      // The tab is reloaded. It takes its clientId along, since that lives in sessionStorage, but
+      // it is a fresh page numbering its requests from zero again.
+      const { ws: ws2, msg: msg2 } = await connectWithParams({ clientId, newClient: "1", counter: "c2" });
+      assert.equal(msg2.clientId, clientId, "expected the Client to be reused");
+      ws2.close();
+      await waitForSocketRelease(clientId);
+
+      // The connection blips and the reloaded tab reconnects. The server must not claim to have
+      // received request #42 of a page that has not got past #0, or the tab would sit waiting for
+      // answers to requests that never reached anyone.
+      const { ws: ws3, msg: msg3 } = await connectWithParams({ clientId, newClient: "0", counter: "c2" });
+      assert.isFalse(msg3.needReload);
+      assert.isNull(msg3.lastReceivedReqId);
+      ws3.close();
+    });
+
+    it("should back off when the server accepts a connection and then drops it", async function() {
+      this.timeout(20000);
+      await startComm(assortedMethods);
+      cleanup.push(() => stopComm());
+
+      // Accept the websocket and then immediately drop it, as the server does when something goes
+      // wrong while setting the connection up, such as a failure to look the user up.
+      sandbox.stub(Comm.prototype as any, "_onWebSocketConnection")
+        .callsFake(async (websocket: any) => { websocket.terminate(); });
+
+      // Count how often the client tries.
+      let attempts = 0;
+      const port = (server.address() as AddressInfo).port;
+      const settings = getWSSettings(`http://localhost:${port}`);
+      const counted: GristWSSettings = {
+        ...settings,
+        makeWebSocket(url: string) { attempts++; return settings.makeWebSocket(url); },
+      };
+
+      stubWorkerConfig();
+      const connection = GristWSConnection.create(null, counted);
+      cleanup.push(async () => connection.dispose());
+      connection.initialize(docId);
+
+      // Left to retry at the shortest interval, the client would get through about one attempt a
+      // second. Backing off, it should manage only a handful in this time.
+      await delay(8000);
+      assert.isAtMost(attempts, 6, `Expected the client to back off, but it tried ${attempts} times`);
+    });
 
     it("should receive all server messages (small) in order when send doesn't fail", async function() {
       await testSendOrdering({ noFailedSend: true, useSmallMsgs: true });
@@ -693,30 +833,6 @@ describe("Comm", function() {
       const client = comm!.getClient(msgs[0].clientId);
       assert.equal(client.authSession.userId, ANONYMOUS_ID);
     });
-
-    // Connect with explicit query params (e.g. clientId/newClient) to exercise reconnects, and
-    // return the socket together with the server's first message. The message handler is attached
-    // synchronously, before the socket opens: a needReload reconnect gets a single clientConnect
-    // followed immediately by a close, so a handler attached afterwards (as connect()+getMessages()
-    // does) would miss it.
-    async function connectWithParams(query: Record<string, string>, options?: GristClientSocketOptions) {
-      const port = (server.address() as AddressInfo).port;
-      const qs = new URLSearchParams(query).toString();
-      const ws = new GristClientSocket(`ws://localhost:${port}/?${qs}`, options);
-      const msg = await new Promise<CommClientConnect>((resolve, reject) => {
-        ws.onmessage = (data: string) => resolve(JSON.parse(data));
-        ws.onerror = (err: Error) => reject(err);
-      });
-      return { ws, msg };
-    }
-
-    // Wait until the server has released clientId's websocket, so it is eligible for reconnect.
-    async function waitForSocketRelease(clientId: string) {
-      const client = comm!.getClient(clientId);
-      for (let i = 0; i < 200 && client.isConnected(); i++) {
-        await delay(10);
-      }
-    }
 
     it("should not let a different identity reuse a clientId on reconnect", async function() {
       const db = makeDbManager({


### PR DESCRIPTION
After a laptop wakes, the websocket is dead and the server has already forgotten the client, so the app has to reopen the document over a network that has not settled. Users saw "Error" and a request to reload.

The main fix: on reconnect the client rejected every in-flight request, because it could not tell whether the request had arrived. The server does know, and now says so, and the client waits for whatever the server already holds. That is safe because a response prepared while the socket was down is replayed as a missed message, and if any were lost the server sets needReload, where the client rejects as before.

Also fixed:

- A response prepared for a client that had received no numbered message was dropped, as there was nowhere to resume from. Missed messages now track the start of the window, not just the last id.

- A reloaded tab keeps its clientId but numbers requests from zero, so the remembered id is cleared for a new client. Otherwise the server claims to hold requests the fresh page never sent.

- A cancelled document open could fail during teardown and surface as a document error. CancelledError now carries the cause, which the caller logs rather than shows.

- Reconnect backoff reset on socket open rather than on a connection being established, so a server that accepted sockets and dropped them was retried once a second indefinitely.
