### PR TITLE
Show when a max row height cuts off a Markdown cell

### DIFF
--- a/app/client/components/Printing.ts
+++ b/app/client/components/Printing.ts
@@ -1,5 +1,6 @@
 import BaseView from "app/client/components/BaseView";
 import { CustomView } from "app/client/components/CustomView";
+import { markOverflowingMarkdownCells } from "app/client/lib/markdownOverflow";
 import { DataRowModel } from "app/client/models/DataRowModel";
 import DataTableModel from "app/client/models/DataTableModel";
 import { ViewSectionRec } from "app/client/models/DocModel";
@@ -72,7 +73,8 @@ export async function printViewSection(layout: any, viewSection: ViewSectionRec)
 
     // If .print-all-rows element is present (created for scrolly-based views), use it as the
     // start element for the loop below, to ensure it's rendered flexbox-free.
-    const keyElem = sectionElem.querySelector(".print-all-rows") || sectionElem;
+    const allRowsElem = sectionElem.querySelector<HTMLElement>(".print-all-rows");
+    const keyElem = allRowsElem || sectionElem;
 
     // Go through all parents of the element to be printed. For @media print, we override their
     // layout in a heavy-handed way, forcing them all to be non-flexbox and sized to content,
@@ -81,6 +83,21 @@ export async function printViewSection(layout: any, viewSection: ViewSectionRec)
     while (elem) {
       elem.classList.toggle("print-parent", onOff);
       elem = elem.parentElement;
+    }
+
+    // Mark the Markdown cells that a max row height is cutting off. The rows rendered above for
+    // printing are copies (see renderAllRows), which the ResizeObserver that normally does this
+    // never gets to see. They are hidden while "@media print" isn't in effect, and it isn't yet
+    // at this point, so reveal them for as long as it takes to measure. We are inside the
+    // beforeprint handler, so this is synchronous and nothing gets painted in between.
+    if (onOff && allRowsElem) {
+      const prevDisplay = allRowsElem.style.display;
+      allRowsElem.style.display = "block";
+      try {
+        markOverflowingMarkdownCells(allRowsElem);
+      } finally {
+        allRowsElem.style.display = prevDisplay;
+      }
     }
   }
 

--- a/app/client/components/viewCommon.css
+++ b/app/client/components/viewCommon.css
@@ -149,6 +149,46 @@
  */
 .row_height_set .field_clip.markdown {
   display: block;
+  position: relative;
+}
+
+/**
+ * The "overflowing" class, set in markdownOverflow.ts, marks a Markdown cell
+ * that a max row height is cutting off.
+ *
+ * The fade is what makes the ellipsis legible: it can't be given the cell's
+ * background, which may be a conditional style, a diff color, or nothing at
+ * all, so instead it dims whatever text it lands on. Drawing it in the cell's
+ * own text color keeps it working over any of those backgrounds. It is a
+ * ::before so that the ellipsis, being a ::after, paints on top of it.
+ *
+ * The mask is anchored in px, not a percentage, so that the cue keeps the same
+ * size next to the ellipsis instead of stretching with the column.
+ */
+.row_height_set .field_clip.markdown.overflowing::before {
+  content: '';
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 8px;
+  background: linear-gradient(to top, var(--grist-actual-cell-color, currentColor), transparent);
+  -webkit-mask-image: linear-gradient(to right, transparent calc(100% - 40px), rgb(0, 0, 0) 100%);
+  mask-image: linear-gradient(to right, transparent calc(100% - 40px), rgb(0, 0, 0) 100%);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.row_height_set .field_clip.markdown.overflowing::after {
+  content: '…';
+  position: absolute;
+  right: 3px;
+  bottom: 0;
+  /* Matches .field_clip's line-height, so it lands on a normal line's baseline. */
+  line-height: 18px;
+  color: var(--grist-actual-cell-color, currentColor);
+  pointer-events: none;
+  /* Safari needs the prefix here, or the ellipsis ends up in copied text. */
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .row_height_uniform .field_clip {

--- a/app/client/lib/markdownOverflow.ts
+++ b/app/client/lib/markdownOverflow.ts
@@ -1,0 +1,63 @@
+import { dom } from "grainjs";
+
+/**
+ * Most cells get an overflow ellipsis from the -webkit-line-clamp trick in viewCommon.css, but
+ * Markdown cells opt out of it: their lines aren't of a uniform height, which makes the clamp
+ * misplace them. So when a max row height is set, a Markdown cell is cut off with nothing to say
+ * that there's more to it. Measure them instead, and set an "overflowing" class that
+ * viewCommon.css turns into a visible cue.
+ */
+
+// Rounding in the height calculations can hide a fraction of a pixel in cells that aren't really
+// cut off, so require more than that before showing the cue.
+const OVERFLOW_TOLERANCE_PX = 1;
+
+/** Measures every cell before setting any class, so a batch costs one layout rather than one each. */
+function updateOverflow(clips: HTMLElement[]) {
+  const measured = clips.map(clip => ({
+    clip,
+    isOverflowing: clip.scrollHeight - clip.clientHeight > OVERFLOW_TOLERANCE_PX,
+  }));
+  for (const { clip, isOverflowing } of measured) {
+    clip.classList.toggle("overflowing", isOverflowing);
+  }
+}
+
+/**
+ * Marks the Markdown cells under `root` that are being cut off. Needed for printing, where rows are
+ * built detached and serialized to HTML (see renderAllRows), so the cells that get printed are
+ * copies that the observer below never saw.
+ */
+export function markOverflowingMarkdownCells(root: Element) {
+  updateOverflow(Array.from(root.querySelectorAll<HTMLElement>(".field_clip.markdown")));
+}
+
+/**
+ * The measurement can't happen while building the dom, since the height isn't known until the
+ * Markdown has been laid out; nor in renderCellMarkdown's onMarkedResolved callback, which only
+ * fires while the Markdown extensions are still loading. Hence a ResizeObserver.
+ */
+let _overflowObserver: ResizeObserver | undefined;
+
+function getOverflowObserver(): ResizeObserver {
+  return _overflowObserver ||= new ResizeObserver((entries) => {
+    const clips = new Set<HTMLElement>();
+    for (const entry of entries) {
+      // Entries are cells and the content wrappers within them; either way, measure the cell.
+      const clip = (entry.target as HTMLElement).closest<HTMLElement>(".field_clip");
+      if (clip) { clips.add(clip); }
+    }
+    updateOverflow(Array.from(clips));
+  });
+}
+
+/**
+ * Keeps the "overflowing" class on a Markdown cell up to date for as long as the element lives.
+ * Applied both to the cell, whose size changes when the max row height does, and to the content
+ * wrapper inside it, whose size changes when the value or the column width does.
+ */
+export function watchForOverflow(elem: HTMLElement) {
+  const observer = getOverflowObserver();
+  observer.observe(elem);
+  dom.onDisposeElem(elem, () => observer.unobserve(elem));
+}

--- a/app/client/widgets/MarkdownTextBox.ts
+++ b/app/client/widgets/MarkdownTextBox.ts
@@ -1,3 +1,4 @@
+import { watchForOverflow } from "app/client/lib/markdownOverflow";
 import { DataRowModel } from "app/client/models/DataRowModel";
 import { ViewFieldRec } from "app/client/models/entities/ViewFieldRec";
 import { renderCellMarkdown } from "app/client/ui/MarkdownCellRenderer";
@@ -20,7 +21,9 @@ export class MarkdownTextBox extends NTextBox {
 
     return dom(
       "div.field_clip.markdown",
+      watchForOverflow,
       cssMarkdown(
+        watchForOverflow,
         cssMarkdown.cls("-text-wrap", this.wrapping),
         dom.style("text-align", this.alignment),
         dom.on("contextmenu", (ev) => {

--- a/test/nbrowser/Printing.ts
+++ b/test/nbrowser/Printing.ts
@@ -1,54 +1,9 @@
-/**
- * Testing printing using selenium webdriver is tricky.
- *
- * 1. The `--kiosk-printing` option may be set on chromedriver to cause printing to go to a pdf
- *    without a confirmation. But it doesn't work in headless mode.
- *
- * 2. As long as we use `setTimeout(() => window.print(), 0)` instead of plain `window.print()`,
- *    it is possible to interact with the print dialog in chrome (although next steps are
- *    unclear), e.g.:
- *    ```
- *    const windowHandles = await driver.getAllWindowHandles();
- *    await driver.switchTo().window(windowHandles[1]);
- *    driver.sendKeys(Key.ENTER);
- *    ```
- *    This, however, doesn't work in headless either.
- *
- * 3. There is a command `Emulation.setEmulatedMedia`, can do the equivalent of dev console's
- *    simulation of `@media print`. That's what we use here. We don't get to see anything about
- *    pagination, but we can at least check whether various elements are visible for printing.
- */
 import { serveCustomViews, Serving } from "test/nbrowser/customUtil";
 import * as gu from "test/nbrowser/gristUtils";
+import { checkPrintSection } from "test/nbrowser/printUtils";
 import { setupTestSuite } from "test/nbrowser/testUtils";
 
 import { assert, driver } from "mocha-webdriver";
-
-function emulateMediaPrint(print: boolean) {
-  return (driver as any).sendDevToolsCommand("Emulation.setEmulatedMedia", { media: print ? "print" : "screen" });
-}
-
-async function checkPrintSection(sectionName: string, checkFunc: () => Promise<void>) {
-  const numTabs = (await driver.getAllWindowHandles()).length;
-  await driver.executeScript("window.debugPrinting = 1");
-  await gu.openSectionMenu("viewLayout", sectionName);
-  await driver.findWait(".test-print-section", 500).click();
-  await driver.sleep(100);    // Just to be sure we don't continue before setTimeout(0), used in printing.
-  try {
-    await emulateMediaPrint(true);
-    await checkFunc();
-  } finally {
-    // Ensure the dialog's window (if it ever opened, only non-headless) is gone.
-    await gu.waitToPass(async () => assert.lengthOf(await driver.getAllWindowHandles(), numTabs), 5000);
-
-    // Ensure that `afterprint` callback gets triggered, needed for mac.
-    await gu.waitToPass(() => driver.executeScript("window.afterPrintCallback?.()"));
-
-    await emulateMediaPrint(false);
-    await gu.waitToPass(() => driver.executeScript("window.finishPrinting()"));
-    await driver.executeScript("window.debugPrinting = 0");
-  }
-}
 
 describe("Printing", function() {
   this.timeout(30000);

--- a/test/nbrowser/RowHeights.ts
+++ b/test/nbrowser/RowHeights.ts
@@ -1,4 +1,5 @@
 import * as gu from "test/nbrowser/gristUtils";
+import { checkPrintSection } from "test/nbrowser/printUtils";
 import { setupTestSuite } from "test/nbrowser/testUtils";
 
 import { assert, driver, Key } from "mocha-webdriver";
@@ -143,4 +144,94 @@ describe("RowHeights", function() {
     assert.equal(await driver.find(".test-row-height-max").isPresent(), false);
     assert.equal(await driver.find(".test-row-height-expand").isPresent(), false);
   });
+
+  // Long enough to be cut off at any of the heights used below.
+  const LONG_DOC = "# Tape & Optimism\n\n- Find tape\n- Apply tape\n- Believe in the tape\n- Reapply tape";
+
+  it("should mark Markdown cells that are cut off by the max height", async function() {
+    // See app/client/lib/markdownOverflow.ts for why these cells are measured.
+    await makeMarkdownDoc("RowHeights2", true, [LONG_DOC, "Just the one line.", ""]);
+
+    await setMaxRowHeight(3);
+    await checkOverflowing([true, false, false]);
+
+    // Expanding every row to the max height doesn't change which cells are cut off.
+    await driver.find(".test-row-height-expand").click();
+    await checkOverflowing([true, false, false]);
+    await driver.find(".test-row-height-expand").click();
+
+    // A height that fits the whole cell clears the mark.
+    await setMaxRowHeight(20);
+    await checkOverflowing([false, false, false]);
+
+    // A one-line height cuts off the second cell too, but not the empty one.
+    await setMaxRowHeight(1);
+    await checkOverflowing([true, true, false]);
+
+    // Back to auto, where nothing is cut off.
+    await setMaxRowHeight(null);
+    await checkOverflowing([false, false, false]);
+  });
+
+  it("should mark cut-off Markdown cells that don't wrap", async function() {
+    // With wrapping off, text running off the side is not what the max height is hiding, so it
+    // should not count as cut off. Only being too tall should.
+    await makeMarkdownDoc("RowHeights3", false, [
+      // Several blocks, so it's tall even with nothing wrapping.
+      "# Tape & Optimism\n\nFind tape.\n\nApply tape.",
+      // One block, which only runs off the side.
+      "A single line about tape that is far too long to fit within the width of this column.",
+    ]);
+
+    await setMaxRowHeight(2);
+    await checkOverflowing([true, false]);
+  });
+
+  it("should mark cut-off Markdown cells when printing", async function() {
+    // Printed rows are detached copies, so Printing.ts marks them itself.
+    await makeMarkdownDoc("RowHeights4", true, [LONG_DOC, "Just the one line."]);
+    await setMaxRowHeight(3);
+    await checkOverflowing([true, false]);
+
+    await checkPrintSection("MarkdownTable", async () => {
+      assert.deepEqual(
+        await driver.findAll(".print-all-rows .field_clip.markdown", el => el.matches(".overflowing")),
+        [true, false]);
+    });
+  });
+
+  // Creates a doc with one Markdown column holding the given values, and opens it with the widget
+  // panel showing, ready for setMaxRowHeight.
+  async function makeMarkdownDoc(docName: string, wrap: boolean, values: string[]) {
+    const session = await gu.session().teamSite.user("user1").login();
+    const docId = await session.tempNewDoc(cleanup, docName, { load: false });
+    await session.createHomeApi().applyUserActions(docId, [
+      ["AddTable", "MarkdownTable", [
+        { id: "Doc", type: "Text", widgetOptions: JSON.stringify({ widget: "Markdown", wrap }) },
+      ]],
+      ["BulkAddRecord", "MarkdownTable", values.map(() => null), { Doc: values }],
+    ]);
+    await session.loadDoc(`/doc/${docId}/p/2`);
+    await gu.openWidgetPanel();
+  }
+
+  /** Sets the max row height, or clears it back to "auto" for null. */
+  async function setMaxRowHeight(lines: number | null) {
+    await driver.find(".test-row-height-max input").click();
+    if (lines === null) {
+      await gu.sendKeys(await gu.selectAllKey(), Key.DELETE);
+      await gu.getCell({ col: "Doc", rowNum: 1 }).click();    // Commit by clicking away.
+    } else {
+      await gu.sendKeys(await gu.selectAllKey(), String(lines), Key.ENTER);
+    }
+  }
+
+  // The class is set from a ResizeObserver, so it lands a moment after the layout changes.
+  async function checkOverflowing(expected: boolean[]) {
+    await gu.waitToPass(async () => {
+      assert.deepEqual(await gu.getVisibleGridCells({ col: "Doc", rowNums: expected.map((_, i) => i + 1),
+        mapper: el => el.find(".field_clip").matches(".overflowing"),
+      }), expected);
+    });
+  }
 });

--- a/test/nbrowser/printUtils.ts
+++ b/test/nbrowser/printUtils.ts
@@ -1,0 +1,52 @@
+/**
+ * Testing printing using selenium webdriver is tricky.
+ *
+ * 1. The `--kiosk-printing` option may be set on chromedriver to cause printing to go to a pdf
+ *    without a confirmation. But it doesn't work in headless mode.
+ *
+ * 2. As long as we use `setTimeout(() => window.print(), 0)` instead of plain `window.print()`,
+ *    it is possible to interact with the print dialog in chrome (although next steps are
+ *    unclear), e.g.:
+ *    ```
+ *    const windowHandles = await driver.getAllWindowHandles();
+ *    await driver.switchTo().window(windowHandles[1]);
+ *    driver.sendKeys(Key.ENTER);
+ *    ```
+ *    This, however, doesn't work in headless either.
+ *
+ * 3. There is a command `Emulation.setEmulatedMedia`, can do the equivalent of dev console's
+ *    simulation of `@media print`. That's what we use here. We don't get to see anything about
+ *    pagination, but we can at least check whether various elements are visible for printing.
+ */
+import * as gu from "test/nbrowser/gristUtils";
+
+import { assert, driver } from "mocha-webdriver";
+
+function emulateMediaPrint(print: boolean) {
+  return (driver as any).sendDevToolsCommand("Emulation.setEmulatedMedia", { media: print ? "print" : "screen" });
+}
+
+/**
+ * Prints the named section, runs checkFunc while `@media print` is in effect, and tidies up.
+ */
+export async function checkPrintSection(sectionName: string, checkFunc: () => Promise<void>) {
+  const numTabs = (await driver.getAllWindowHandles()).length;
+  await driver.executeScript("window.debugPrinting = 1");
+  await gu.openSectionMenu("viewLayout", sectionName);
+  await driver.findWait(".test-print-section", 500).click();
+  await driver.sleep(100);    // Just to be sure we don't continue before setTimeout(0), used in printing.
+  try {
+    await emulateMediaPrint(true);
+    await checkFunc();
+  } finally {
+    // Ensure the dialog's window (if it ever opened, only non-headless) is gone.
+    await gu.waitToPass(async () => assert.lengthOf(await driver.getAllWindowHandles(), numTabs), 5000);
+
+    // Ensure that `afterprint` callback gets triggered, needed for mac.
+    await gu.waitToPass(() => driver.executeScript("window.afterPrintCallback?.()"));
+
+    await emulateMediaPrint(false);
+    await gu.waitToPass(() => driver.executeScript("window.finishPrinting()"));
+    await driver.executeScript("window.debugPrinting = 0");
+  }
+}


### PR DESCRIPTION
Markdown cells opt out of -webkit-line-clamp, because their lines aren't of a uniform height and the clamp misplaces them. That also cost them the overflow ellipsis, so a cut-off cell said nothing.

Measure them instead and set an "overflowing" class, drawn as an ellipsis over a fade in the bottom right corner.

- Printing measures separately: the rows it prints are detached copies the observer never sees, hidden until "@media print" applies.
- checkPrintSection moves to printUtils, a describe-free module, so importing it doesn't register the Printing suite in unrelated runs.

<img width="1000" height="1212" alt="pr-3-fill" src="https://github.com/user-attachments/assets/9e8147fa-872c-4095-9ea0-1e0d547a33d6" />
