### PR TITLE
Fix FieldBuilder disposal logic

### DIFF
--- a/app/client/widgets/FieldBuilder.ts
+++ b/app/client/widgets/FieldBuilder.ts
@@ -50,6 +50,7 @@ import {
   Observable,
   styled,
   toKo,
+  domDispose,
 } from "grainjs";
 import * as ko from "knockout";
 import isEqual from "lodash/isEqual";
@@ -218,6 +219,15 @@ export class FieldBuilder extends Disposable {
         return UserTypeImpl.getWidgetConstructor(this.options().widget, this._readOnlyPureType());
       }
     })).onlyNotifyUnequal());
+
+    // Cell DOM outlives this FieldBuilder by a tick; dispose bindings early so nothing
+    // re-evaluates against an already-disposed widget. Must run before widgetImpl (reverse order).
+    this.onDispose(() => {
+      for (const elem of this._rowMap.values()) {
+        domDispose(elem);
+      }
+      this._rowMap.clear();
+    });
 
     // Computed builder for the widget.
     this.widgetImpl = this.autoDispose(koUtil.computedBuilder(() => {

--- a/app/client/widgets/FieldBuilder.ts
+++ b/app/client/widgets/FieldBuilder.ts
@@ -44,13 +44,13 @@ import {
   Computed,
   Disposable,
   dom as grainjsDom,
+  domDispose,
   fromKo,
   makeTestId,
   MultiHolder,
   Observable,
   styled,
   toKo,
-  domDispose,
 } from "grainjs";
 import * as ko from "knockout";
 import isEqual from "lodash/isEqual";

--- a/test/nbrowser/RecordLayout.ts
+++ b/test/nbrowser/RecordLayout.ts
@@ -317,6 +317,40 @@ describe("RecordLayout", function() {
     }
   });
 
+  it("should not throw when hiding all fields of a card with a choice list", async function() {
+    const session = await gu.session().login();
+    await session.tempNewDoc(cleanup);
+
+    const choiceOpts = JSON.stringify({ choices: ["red", "green", "blue"] });
+
+    await gu.sendActions([
+      ["ModifyColumn", "Table1", "A", { type: "ChoiceList", widgetOptions: choiceOpts }],
+      ["ModifyColumn", "Table1", "B", { type: "Choice", widgetOptions: choiceOpts }],
+      ["ModifyColumn", "Table1", "C", { type: "Text" }],
+    ]);
+    await gu.sendActions([["BulkAddRecord", "Table1", [null], {
+      A: [["L", "red", "green"]],
+      B: ["red"],
+    }]]);
+
+    await gu.addNewSection(/Card$/, /Table1/, { selectBy: /TABLE1/ });
+
+    const sectionId = await gu.getSectionId();
+    await gu.sendActions([
+      ["UpdateRecord", "_grist_Views_section", sectionId, {
+        sortColRefs: "[1]",
+      }],
+    ]);
+    await gu.reloadDoc();
+
+    await gu.openWidgetPanel("widget");
+    await gu.selectAllVisibleColumns();
+    await gu.hideColumns();
+    await driver.sleep(10); // just for next tick.
+
+    await gu.checkForErrors();
+  });
+
   // Helper to delete a layout box using the on-hover "x" circle.
   async function deleteBox(cell: WebElement) {
     await cell.mouseMove();


### PR DESCRIPTION
When card fields are hidden - their widgets objects are disposed before their dom elements.
Some widgets, like `ChoiceList`, still have some reactive bindings that can trigger while the
widget itself is disposed causing errors in JS (that are caused by accessing disposed objects).

To fix that, the FieldBuilder (the owner of those widgets) will dispose the dom it creates together
with itself.