### PR TITLE
[tiny] Introduce GRIST_ACTIVEDOC_TIMEOUT_SECONDS env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ Grist can be configured in many ways. Here are the main environment variables it
 | GRIST_MAX_PARALLEL_REQUESTS_PER_DOC| max number of concurrent API requests allowed per document (default is 10, set to 0 for unlimited) |
 | GRIST_MAX_UPLOAD_ATTACHMENT_MB | max allowed size for attachments (0 or empty for unlimited). |
 | GRIST_MAX_UPLOAD_IMPORT_MB | max allowed size for imports (except .grist files) (0 or empty for unlimited). |
+| GRIST_ACTIVEDOC_TIMEOUT_SECONDS | Number of seconds a document is kept open without any clients before it is closed. Defaults to 30s when NODE_ENV=production is set, otherwise to 5s. |
 | GRIST_OFFER_ALL_LANGUAGES | if set, all translated langauages are offered to the user (by default, only languages with a special 'good enough' key set are offered to user). |
 | GRIST_ORG_IN_PATH | if true, encode org in path rather than domain |
 | GRIST_PAGE_TITLE_SUFFIX | a string to append to the end of the `<title>` in HTML documents. Defaults to `" - Grist"`. Set to `_blank` for no suffix at all. |

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -204,7 +204,10 @@ const DEFAULT_LOCALE = getDefaultLocale();
 // Number of seconds an ActiveDoc is retained without any clients.
 // In dev environment, it is convenient to keep this low for quick tests.
 // In production, it is reasonable to stretch it out a bit.
-const ACTIVEDOC_TIMEOUT = (process.env.NODE_ENV === "production") ? 30 : 5;
+const ACTIVEDOC_TIMEOUT = appSettings.section("externalStorage").flag("activeDocTimeout").requireInt({
+  envVar: "GRIST_ACTIVEDOC_TIMEOUT_SECONDS",
+  defaultValue: process.env.NODE_ENV === "production" ? 30 : 5,
+});
 
 // We'll wait this long between re-measuring sandbox memory.
 const MEMORY_MEASUREMENT_THROTTLE_WAIT_MS = 60 * 1000;


### PR DESCRIPTION
## Context

Currently, there exist no way for an administrator to change the timeout duration since the last client connection.

## Proposed solution

Introduce the `GRIST_ACTIVEDOC_TIMEOUT_SECONDS` env variable.

This is extracted from this PR: #2336 

## Related issues

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- If this does not solve entirely the issue, make also a checklist of what is done or not: -->

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [x] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->