### PR TITLE
Show a loading spinner while custom widgets load

### DIFF
--- a/app/client/components/WidgetFrame.ts
+++ b/app/client/components/WidgetFrame.ts
@@ -231,11 +231,15 @@ export class WidgetFrame extends DisposableWithEvents {
       testId("ready", use => use(this._readyCalled) && !use(this._isEmpty)),
       (elem) => { this._options.onElem(elem); },
     );
-    // Show a spinner over the iframe until the widget signals it's ready (by calling
-    // grist.ready()). Skipped for the empty placeholder page, which loads instantly.
+    // Show a spinner for as long as the iframe itself is hidden (see `_visible` above), i.e.
+    // while a `showAfterReady` widget is still applying the theme. Not every widget calls
+    // grist.ready(), so we can't gate this on _readyCalled directly: that would spin forever
+    // for such widgets. `showAfterReady` is only set for gallery widgets whose manifest opts
+    // in via the `renderAfterReady` flag, declaring that they do call ready() - so this wait
+    // is already known to be bounded.
     return cssWidgetFrameContainer(
       this._iframe,
-      dom.maybe(use => !use(this._readyCalled) && !use(this._isEmpty), () =>
+      dom.maybe(use => !use(this._visible) && !use(this._isEmpty), () =>
         cssSpinnerOverlay(loadingSpinner(), testId("spinner"))),
     );
   }

--- a/app/client/components/WidgetFrame.ts
+++ b/app/client/components/WidgetFrame.ts
@@ -9,6 +9,8 @@ import { makeTestId } from "app/client/lib/domUtils";
 import { sanitizeHttpUrl } from "app/client/lib/sanitizeUrl";
 import { ColumnRec, ViewSectionRec } from "app/client/models/DocModel";
 import { reportError } from "app/client/models/errors";
+import { theme } from "app/client/ui2018/cssVars";
+import { loadingSpinner } from "app/client/ui2018/loaders";
 import { gristThemeObs } from "app/client/ui2018/theme";
 import { AccessLevel, ICustomWidget, isSatisfied, matchWidget } from "app/common/CustomWidget";
 import { DisposableWithEvents } from "app/common/DisposableWithEvents";
@@ -25,7 +27,7 @@ import { CellFormatType } from "app/plugin/GristAPI";
 import { GristObjCode } from "app/plugin/GristData";
 
 import { MsgType, Rpc } from "grain-rpc";
-import { Computed, Disposable, dom, Observable } from "grainjs";
+import { Computed, Disposable, dom, Observable, styled } from "grainjs";
 import debounce from "lodash/debounce";
 import flatMap from "lodash/flatMap";
 import identity from "lodash/identity";
@@ -229,7 +231,13 @@ export class WidgetFrame extends DisposableWithEvents {
       testId("ready", use => use(this._readyCalled) && !use(this._isEmpty)),
       (elem) => { this._options.onElem(elem); },
     );
-    return this._iframe;
+    // Show a spinner over the iframe until the widget signals it's ready (by calling
+    // grist.ready()). Skipped for the empty placeholder page, which loads instantly.
+    return cssWidgetFrameContainer(
+      this._iframe,
+      dom.maybe(use => !use(this._readyCalled) && !use(this._isEmpty), () =>
+        cssSpinnerOverlay(loadingSpinner(), testId("spinner"))),
+    );
   }
 
   // Appends access level to query string.
@@ -294,6 +302,29 @@ export class WidgetFrame extends DisposableWithEvents {
     this._widget.set(widget || null);
   }
 }
+
+// Wraps the widget iframe so a loading spinner can be overlaid on top of it. Takes over the
+// flex-item role the bare iframe used to play in its parent (see iframe.custom_view in
+// CustomView.css), so the iframe keeps sizing itself to fill it exactly as before.
+const cssWidgetFrameContainer = styled("div", `
+  position: relative;
+  display: flex;
+  flex: auto;
+  width: 100%;
+  height: 100%;
+`);
+
+const cssSpinnerOverlay = styled("div", `
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: ${theme.mainPanelBg};
+  /* Purely a visual mask: some widgets are interactive before calling grist.ready()
+     (e.g. showing a confirmation button), so clicks must pass through to the iframe. */
+  pointer-events: none;
+`);
 
 const throwError = (access: AccessLevel) => {
   throw new Error("Access not granted. Current access level " + access);


### PR DESCRIPTION
## What

Shows a loading spinner over a custom widget's iframe while it loads, instead of a fully blank canvas.

Closes #2423.

## Why

Custom widgets are rendered in an iframe pointing at an external page. Until that page finishes loading and calls `grist.ready()`, users just see a blank area — which is easy to mistake for something being broken, especially since external widgets typically load slower than Grist's native views (table, card, etc.).

## How

`WidgetFrame` (the single place in the app that builds a custom-widget `<iframe>`, used by grid/card custom views and the calendar widget) already tracks widget readiness internally via a `_readyCalled` observable, set once the widget sends its `grist.ready()` message, and reset to `false` whenever the iframe is rebuilt for an empty/new widget.

This PR reuses that existing state instead of adding new one:
- `buildDom()` now wraps the `<iframe>` in a small container and overlays a spinner (the existing `loadingSpinner()` component from `app/client/ui2018/loaders.ts`, already used elsewhere in the app, e.g. in the importer preview) on top of it.
- The spinner is shown while `!readyCalled && !isEmpty`, and disappears as soon as the widget calls `grist.ready()`.
- It's skipped entirely for the internal empty placeholder page (no widget configured yet), which loads instantly and doesn't need one.
- The overlay uses `pointer-events: none`, so it never blocks interaction with widgets that are interactive *before* calling `grist.ready()` (e.g. a widget showing a confirmation button first). I caught this the hard way: without it, the existing `test-custom-widget-ready` e2e test failed because the overlay intercepted a click meant for a button inside the iframe.
- The `<iframe>` element itself, its classes, and the `test-custom-widget-ready` test hook (which the external [grist-widget](https://github.com/gristlabs/grist-widget) repo's own test suite depends on, per a comment in `test/nbrowser/CustomView.ts`) are left completely untouched — only wrapped.

The whole change is contained in `app/client/components/WidgetFrame.ts`; no other file needed changes.

## Testing

- `yarn lint` and `tsc --noEmit`: clean.
- `yarn build`: compiles fine.
- `yarn test:client`: all 224 tests pass.
- `yarn test:nbrowser --grep CustomView`: same result before and after this change (19 passing / 3 pre-existing failures unrelated to this PR, reproduced identically on `main`, likely due to a local Chrome version newer than the one pinned for CI — see CONTRIBUTING.md). The critical `informs about ready called` test, which asserts on the `test-custom-widget-ready` class staying on the `<iframe>`, passes.
- Manually verified in a running instance with a mock slow-loading widget: the spinner appears immediately, is centered and themed correctly in both the widget area, and disappears cleanly the moment the widget calls `grist.ready()`.
