### PR TITLE
Add keyboard shortcut to maximize/un-maximize the active widget

### DIFF
--- a/app/client/components/commandList.ts
+++ b/app/client/components/commandList.ts
@@ -300,7 +300,7 @@ export const groups: CommendGroupDef[] = [{
     },
     {
       name: "expandSection",
-      keys: ["Mod+Shift+E"],
+      keys: ["Mod+Shift+F"],
       desc: () => t("Maximize the active section"),
     },
     {

--- a/app/client/components/commandList.ts
+++ b/app/client/components/commandList.ts
@@ -300,7 +300,7 @@ export const groups: CommendGroupDef[] = [{
     },
     {
       name: "expandSection",
-      keys: [],
+      keys: ["Mod+Shift+E"],
       desc: () => t("Maximize the active section"),
     },
     {

--- a/test/nbrowser/ExpandSectionShortcut.ts
+++ b/test/nbrowser/ExpandSectionShortcut.ts
@@ -16,16 +16,16 @@ describe("ExpandSectionShortcut", function() {
     await gu.getCell(0, 1).click();
     assert.isFalse(await driver.find(".test-viewLayout-overlay .test-close-button").isPresent());
 
-    // Mod+Shift+E maximizes the active section...
-    await gu.sendKeys(Key.chord(await gu.modKey(), Key.SHIFT, "e"));
+    // Mod+Shift+F maximizes the active section...
+    await gu.sendKeys(Key.chord(await gu.modKey(), Key.SHIFT, "f"));
     await driver.findWait(".test-viewLayout-overlay .test-close-button", 500);
 
     // ...and pressing it again un-maximizes it.
-    await gu.sendKeys(Key.chord(await gu.modKey(), Key.SHIFT, "e"));
+    await gu.sendKeys(Key.chord(await gu.modKey(), Key.SHIFT, "f"));
     assert.isFalse(await driver.find(".test-viewLayout-overlay .test-close-button").isPresent());
 
     // Escape also closes it, as it already does when maximizing via the menu.
-    await gu.sendKeys(Key.chord(await gu.modKey(), Key.SHIFT, "e"));
+    await gu.sendKeys(Key.chord(await gu.modKey(), Key.SHIFT, "f"));
     await driver.findWait(".test-viewLayout-overlay .test-close-button", 500);
     await gu.sendKeys(Key.ESCAPE);
     assert.isFalse(await driver.find(".test-viewLayout-overlay .test-close-button").isPresent());

--- a/test/nbrowser/ExpandSectionShortcut.ts
+++ b/test/nbrowser/ExpandSectionShortcut.ts
@@ -1,0 +1,35 @@
+import * as gu from "test/nbrowser/gristUtils";
+import { setupTestSuite } from "test/nbrowser/testUtils";
+
+import { assert, driver, Key } from "mocha-webdriver";
+
+describe("ExpandSectionShortcut", function() {
+  this.timeout(20000);
+  const cleanup = setupTestSuite();
+
+  it("maximizes and un-maximizes the active section via keyboard shortcut", async function() {
+    const session = await gu.session().teamSite.login();
+    await session.tempNewDoc(cleanup);
+
+    // The overlay element itself is always in the DOM; its close button only renders while a
+    // section is maximized, so that's what indicates the maximized state (same as gu.expandSection()).
+    await gu.getCell(0, 1).click();
+    assert.isFalse(await driver.find(".test-viewLayout-overlay .test-close-button").isPresent());
+
+    // Mod+Shift+E maximizes the active section...
+    await gu.sendKeys(Key.chord(await gu.modKey(), Key.SHIFT, "e"));
+    await driver.findWait(".test-viewLayout-overlay .test-close-button", 500);
+
+    // ...and pressing it again un-maximizes it.
+    await gu.sendKeys(Key.chord(await gu.modKey(), Key.SHIFT, "e"));
+    assert.isFalse(await driver.find(".test-viewLayout-overlay .test-close-button").isPresent());
+
+    // Escape also closes it, as it already does when maximizing via the menu.
+    await gu.sendKeys(Key.chord(await gu.modKey(), Key.SHIFT, "e"));
+    await driver.findWait(".test-viewLayout-overlay .test-close-button", 500);
+    await gu.sendKeys(Key.ESCAPE);
+    assert.isFalse(await driver.find(".test-viewLayout-overlay .test-close-button").isPresent());
+
+    await gu.checkForErrors();
+  });
+});


### PR DESCRIPTION
## What

Adds a keyboard shortcut, `Mod+Shift+E` (i.e. `Ctrl+Shift+E` / `Cmd+Shift+E`), to maximize the currently focused widget/section, and to un-maximize it again by pressing the same shortcut a second time.

Closes #797.

## Why

Maximizing a section (the "expand" icon in a section's menu) is handy when working on a small screen, but until now it was only reachable with the mouse. The issue asked for a keyboard shortcut to do the same.

## How

The maximize/un-maximize feature already existed end-to-end:
- `LayoutBox.maximize()` (`app/client/components/Layout.ts`) toggles `layout.maximizedLeaf` between the current section and `null` — calling it again on an already-maximized section un-maximizes it, so a single shortcut naturally covers both directions.
- `ViewLayout.ts`'s `_expandSection()` calls that on the currently active section, and is already registered as the `expandSection` command, active whenever a section is focused. `Escape` already closes the maximized view via a companion command group.
- `commandList.ts` already declared the `expandSection` command, including its description — it just had `keys: []`.

So this PR is a one-line change: giving `expandSection` a key binding. No other file needed to change. The description is what makes it show up automatically in the in-app keyboard shortcuts help pane (`Mod+/`), so no separate docs update was needed either.

`Mod+Shift+E` was checked against every other binding already declared in `commandList.ts` — it's free, and deliberately avoids the letter `M` (already used by `renameField` and `openDiscussion`) to avoid confusion with "maximize".

## Testing

- `yarn lint` and `tsc --noEmit`: clean.
- `yarn build`: compiles fine.
- `yarn test:client`: all 224 tests pass.
- Added a new nbrowser test, `test/nbrowser/ExpandSectionShortcut.ts`, covering: maximizing via the shortcut, un-maximizing by pressing it again, and closing via `Escape`. It uses its own temporary document rather than reusing `ViewLayoutCollapse.ts`'s shared fixture doc — inserting a test there turned out to disturb shared page/section state across that file's other (order-dependent) tests, so a fully isolated test file was the safer choice.
- Ran the full `ViewLayoutCollapse` suite alongside the new test to confirm no interference: same result as on `main` (1 pre-existing, unrelated flaky failure — `fix: should support anchor links`, a clipboard/toast-timing issue — reproduced identically on `main` without this change).
