### PR TITLE
Let people rename attachments in documents with access rules

### DIFF
--- a/app/server/lib/GranularAccess.ts
+++ b/app/server/lib/GranularAccess.ts
@@ -1661,15 +1661,18 @@ export class GranularAccess implements GranularAccessForBundle {
       await this.update();
       return;
     }
-    // A share brings rules with it, so while one exists any metadata change may alter
-    // the rules. A change to _grist_Shares counts too, since the action may have just
-    // removed the last share.
-    const sharesInPlay = this._docData.getMetaTable("_grist_Shares").getRowIds().length > 0 ||
-      docActions.some(action => getTableId(action) === "_grist_Shares");
-    if (sharesInPlay && docActions.some(action => isMetadataTable(getTableId(action)))) {
+    // A share carries rules derived from the document metadata, so while a share exists
+    // any metadata change may change the rules. Check the actions too, since _docData is
+    // already updated here and a bundle that removed the last share leaves none to count.
+    const touchesShares = docActions.some(action => getTableId(action) === "_grist_Shares");
+    const haveShares = this._docData.getMetaTable("_grist_Shares").numRecords() > 0;
+    const touchesMetadata = docActions.some(action => isMetadataTable(getTableId(action)));
+    if (touchesShares || (haveShares && touchesMetadata)) {
       await this.update();
       return;
     }
+    // No rules means nothing to rebuild. A share would have implied rules, since every
+    // share gets default rules from ACLRulesReader, and share changes were caught above.
     if (!this._ruler.haveRules()) {
       return;
     }

--- a/app/server/lib/GranularAccess.ts
+++ b/app/server/lib/GranularAccess.ts
@@ -17,9 +17,11 @@ import {
   getRowIds,
   getRowIdsFromDocAction,
   isBulkAction,
+  isBulkUpdateRecord,
   isDataAction,
   isSomeAddRecordAction,
   isSomeRemoveRecordAction,
+  isUpdateRecord,
 } from "app/common/DocActions";
 import { CellValue, ColValues, DocAction, getTableId, isSchemaAction } from "app/common/DocActions";
 import { getColIdsFromDocAction, TableDataAction, UserAction } from "app/common/DocActions";
@@ -87,6 +89,16 @@ const COLUMN_GRANULAR_UPDATE_ACTIONS = [
 
 function isAddOrUpdateRecordAction([actionName]: UserAction): boolean {
   return ADD_OR_UPDATE_RECORD_ACTIONS.includes(String(actionName));
+}
+
+/**
+ * Is this an action that does nothing but rename attachments? Everything else about
+ * a row of _grist_Attachments is the back end's business.
+ */
+function isAttachmentRenameAction(a: DocAction): boolean {
+  if (!isUpdateRecord(a) && !isBulkUpdateRecord(a)) { return false; }
+  const colIds = getColIdsFromDocAction(a) || [];
+  return colIds.length === 1 && colIds[0] === "fileName";
 }
 
 // A list of key metadata tables that need special handling.  Other metadata tables may
@@ -1649,13 +1661,16 @@ export class GranularAccess implements GranularAccessForBundle {
       await this.update();
       return;
     }
-    const shares = this._docData.getMetaTable("_grist_Shares");
-    if (shares.getRowIds().length > 0 &&
-      docActions.some(action => isMetadataTable(getTableId(action)))) {
+    // A share brings rules with it, so while one exists any metadata change may alter
+    // the rules. A change to _grist_Shares counts too, since the action may have just
+    // removed the last share.
+    const sharesInPlay = this._docData.getMetaTable("_grist_Shares").getRowIds().length > 0 ||
+      docActions.some(action => getTableId(action) === "_grist_Shares");
+    if (sharesInPlay && docActions.some(action => isMetadataTable(getTableId(action)))) {
       await this.update();
       return;
     }
-    if (!shares && !this._ruler.haveRules()) {
+    if (!this._ruler.haveRules()) {
       return;
     }
     // If there is a schema change, redo from scratch for now.
@@ -2748,8 +2763,13 @@ export class GranularAccess implements GranularAccessForBundle {
         if (this._activeBundle?.options?.attachment) {
           return dummyAccessCheck;
         }
-        // Users cannot take actions on _grist_Attachments through the regular
-        // action interface.
+        // Renaming is the one change users may make here, since the attachment editor
+        // offers it. Check it like any other update, so rules still have their say.
+        if (isAttachmentRenameAction(a)) {
+          return accessChecks[severity].update;
+        }
+        // Users cannot take any other action on _grist_Attachments through the
+        // regular action interface.
         throw new Error("_grist_Attachments modification is not allowed");
       }
       // Actions on any metadata table currently require the schemaEdit flag.

--- a/test/server/lib/GranularAccess.ts
+++ b/test/server/lib/GranularAccess.ts
@@ -14,6 +14,7 @@ import {
   TableColValues,
   TableDataAction,
   UpdateRecord,
+  UserAction,
 } from "app/common/DocActions";
 import { OpenDocOptions } from "app/common/DocListAPI";
 import { SHARE_KEY_PREFIX } from "app/common/gristUrls";
@@ -4249,10 +4250,84 @@ describe("GranularAccess", function() {
     // Try to modify _grist_Attachments by shady means.
     await assert.isRejected(owner.getDocAPI(docId).addRows("_grist_Attachments", { fileName: ["A", "B"] }),
       /_grist_Attachments modification is not allowed/);
-    await assert.isRejected(owner.getDocAPI(docId).updateRows("_grist_Attachments", { id: [1], fileName: ["A"] }),
+    // Renaming is allowed (see the test below), but nothing else about the row is.
+    await assert.isRejected(owner.getDocAPI(docId).updateRows("_grist_Attachments", { id: [1], fileIdent: ["A"] }),
       /_grist_Attachments modification is not allowed/);
     await assert.isRejected(owner.getDocAPI(docId).removeRows("_grist_Attachments", [1]),
       /_grist_Attachments modification is not allowed/);
+  });
+
+  // The attachment editor renames files by updating _grist_Attachments.fileName, so
+  // that update needs to survive the lockdown on this table. The lockdown only applies
+  // when there are rules, and a share counts as rules even if the owner wrote none.
+  const attachmentScenarios: { name: string, setup: UserAction[], rulesApply: boolean }[] = [
+    { name: "a plain document", setup: [], rulesApply: false },
+    {
+      name: "a document with rules",
+      rulesApply: true,
+      setup: [
+        ["AddRecord", "_grist_ACLResources", -1, { tableId: "*", colIds: "*" }],
+        ["AddRecord", "_grist_ACLRules", null, {
+          resource: -1, aclFormula: "user.Access in [OWNER]", permissionsText: "all",
+        }],
+      ],
+    },
+    {
+      name: "a document with an unpublished share",
+      rulesApply: true,
+      setup: [
+        // A link id distinct from the one the share tests below use, since
+        // getShareKeyForUrl looks shares up by link id across all documents.
+        ["AddRecord", "_grist_Shares", null, { linkId: "rename-att", options: '{"publish": false}' }],
+      ],
+    },
+  ];
+
+  for (const { name, setup, rulesApply } of attachmentScenarios) {
+    it(`can rename attachments in ${name}`, async function() {
+      await freshDoc();
+      await owner.applyUserActions(docId, [
+        ["AddTable", "Data1", [{ id: "Texts", type: "Attachments" }]],
+        ...setup,
+      ]);
+
+      const i1 = await owner.getDocAPI(docId).uploadAttachment("content1", "1.txt");
+      await owner.getDocAPI(docId).addRows("Data1", { Texts: [[GristObjCode.List, i1]] });
+
+      await assert.isFulfilled(
+        owner.getDocAPI(docId).updateRows("_grist_Attachments", { id: [i1], fileName: ["renamed.txt"] }));
+      const rows = await owner.getDocAPI(docId).getRows("_grist_Attachments");
+      assert.deepEqual(rows.fileName, ["renamed.txt"]);
+
+      if (rulesApply) {
+        // No smuggling another column along with the file name.
+        await assert.isRejected(
+          owner.getDocAPI(docId).updateRows("_grist_Attachments",
+            { id: [i1], fileName: ["other.txt"], fileIdent: ["bogus"] }),
+          /_grist_Attachments modification is not allowed/);
+      }
+
+      // The share tests below expect to find only their own shares in the home database.
+      await removeShares(docId, owner);
+    });
+  }
+
+  it("stops applying a share's rules once the share is gone", async function() {
+    await freshDoc();
+    await owner.applyUserActions(docId, [
+      ["AddRecord", "_grist_Shares", null, { linkId: "share-gone", options: '{"publish": false}' }],
+    ]);
+    const i1 = await owner.getDocAPI(docId).uploadAttachment("content1", "1.txt");
+
+    // A share brings rules with it, which switch on the lockdown of _grist_Attachments.
+    await assert.isRejected(
+      owner.getDocAPI(docId).updateRows("_grist_Attachments", { id: [i1], fileIdent: ["x"] }),
+      /_grist_Attachments modification is not allowed/);
+
+    // Removing the last share should take effect right away, without a reload.
+    await removeShares(docId, owner);
+    await assert.isFulfilled(
+      owner.getDocAPI(docId).updateRows("_grist_Attachments", { id: [i1], fileIdent: ["x"] }));
   });
 
   describe("shares", function() {


### PR DESCRIPTION
I didn't know this, but the Grist web UI allows renaming attachments. This feature broke when combined with access rules. Renaming updates fileName on _grist_Attachments, a table now locked down against all user actions once a document has rules to apply. But fileName-only updates are not actually a concern, so this commit lets them through. For simplicity, only very simple bundles that match what the web client does are accepted.

Also includes a tiny fix to rebuild rules when the share table changes, so removing the last share takes effect without a document reload. Both small issues hit the same user, which is why they are arriving together - lmk if I should split.
