### PR TITLE
Fix documents broken by multi-line f-string formulas on Python 3.12+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,10 @@ jobs:
           - ':nbrowser-^[^ACFGIMORSTU]:'
           - ':projects:'
         include:
+          - tests: ':python:'
+            node-version: 22.x
+            python-version: '3.13'
+            os: ubuntu-24.04
           - tests: ':lint:python:client:common:smoke:'
             node-version: 22.x
             python-version: '3.10'

--- a/sandbox/grist/codebuilder.py
+++ b/sandbox/grist/codebuilder.py
@@ -70,18 +70,29 @@ def make_formula_body(formula, default_value, assoc_value=None, indent=''):
     unindent_patches.append(textbuilder.Patch(0, len(dummy_def), dummy_def, ''))
 
     atok = asttokens.ASTText(builder.get_text())
-    for node in ast.walk(atok.tree):
-      if isinstance(node, (ast.Constant, ast.JoinedStr)) and "\n" in atok.get_text(node):
-        # We have a constant or f-string that spans multiple lines. If so, revert its indentation.
-        start, end = atok.get_text_range(node)
-        indented_text = atok.get_text(node)
-        unindented_text = indented_text.replace('\n' + indent, '\n')
-        unindent_patches.append(textbuilder.Patch(start, end, indented_text, unindented_text))
+    for node in _multiline_string_nodes(atok, atok.tree):
+      # We have a constant or f-string that spans multiple lines. If so, revert its indentation.
+      start, end = atok.get_text_range(node)
+      indented_text = atok.get_text(node)
+      unindented_text = indented_text.replace('\n' + indent, '\n')
+      unindent_patches.append(textbuilder.Patch(start, end, indented_text, unindented_text))
 
     return textbuilder.Replacer(builder, unindent_patches)
   else:
     return indented_formula_body
 
+
+def _multiline_string_nodes(atok, node):
+  """
+  Yields the outermost string constants and f-strings under `node` whose text spans several lines.
+  Outermost only: since Python 3.12 (PEP 701) the pieces nested inside an f-string have positions
+  of their own, and patching a node together with its descendants would duplicate their text.
+  """
+  if isinstance(node, (ast.Constant, ast.JoinedStr)) and "\n" in atok.get_text(node):
+    yield node
+  else:
+    for child in ast.iter_child_nodes(node):
+      yield from _multiline_string_nodes(atok, child)
 
 
 def _do_make_formula_body(formula, default_value, assoc_value=None):

--- a/sandbox/grist/friendly_errors.py
+++ b/sandbox/grist/friendly_errors.py
@@ -12,9 +12,19 @@ def friendly_message(exc):
     # Imported locally because it's Python 3 only
     from friendly_traceback.core import FriendlyTraceback
 
-    fr = FriendlyTraceback(type(exc), exc, exc.__traceback__)
-    fr.assign_generic()
-    fr.assign_cause()
+    saved_traceback = exc.__traceback__
+    if isinstance(exc, SyntaxError):
+      # A SyntaxError already carries what friendly-traceback needs, and the traceback only holds
+      # our own parser's frames. Hide it: formatting those frames raises AttributeError on Python
+      # 3.13, losing the explanation entirely. Still an issue as of friendly-traceback 0.7.61.
+      exc.__traceback__ = None
+
+    try:
+      fr = FriendlyTraceback(type(exc), exc, exc.__traceback__)
+      fr.assign_generic()
+      fr.assign_cause()
+    finally:
+      exc.__traceback__ = saved_traceback
 
     generic = fr.info["generic"]  # broad explanation for the exception class
     cause = fr.info.get("cause")  # more specific explanation

--- a/sandbox/grist/test_codebuilder.py
+++ b/sandbox/grist/test_codebuilder.py
@@ -181,6 +181,19 @@ return rec
                      " If you want to check for equality, use `==` instead of `=`.\", "
                      "('usercode', 1, 1, 'foo = 1'))")
 
+  def test_multiline_fstring_indent(self):
+    # Since Python 3.12 (PEP 701), the pieces nested inside an f-string have source positions of
+    # their own, so one multi-line f-string yields several overlapping spans. Patching all of them
+    # rather than just the outermost duplicated the string, producing code that doesn't compile.
+    for formula in [
+      'f"""test1\ntest2\ntest3"""',                            # no interpolation
+      'f"""test1\n{1 + 2}\ntest3"""',                          # interpolation
+      'f"""test1\n{f"{1 + 2}"}\ntest3"""',                     # f-string nested in an f-string
+      '"""plain1\nplain2""" + f"""fstr1\n{1 + 2}\nfstr2"""',   # alongside a plain string
+    ]:
+      # Only the `return` gets indented; the contents of the strings are left alone.
+      self.assertEqual(make_body(formula, indent='  '), '  return ' + formula)
+
   def test_make_formula_body_unicode(self):
     # Test that we don't fail when strings include unicode characters
     self.assertEqual(make_body("'résumé' + $foo"), u"return 'résumé' + rec.foo")

--- a/sandbox/grist/test_formula_error.py
+++ b/sandbox/grist/test_formula_error.py
@@ -103,7 +103,7 @@ return 0
                               r"""
                                 File "usercode", line 5
                                   return: 0
-                                        \^
+                                        \^+
                               SyntaxError: invalid syntax
                               """
                             ))
@@ -134,7 +134,7 @@ return 0
                               r"""
                                 File "usercode", line \d+, in other_err
                                   if sum\(3, 5\) > 6:
-                              TypeError: 'int' object is not iterable
+                              ( +[~^]+\n)?TypeError: 'int' object is not iterable
                               """
                             ))
 

--- a/sandbox/pyodide/package_filenames.json
+++ b/sandbox/pyodide/package_filenames.json
@@ -3,7 +3,7 @@
   "asttokens-2.4.0-cp313-none-any.whl",
   "chardet-5.1.0-cp313-none-any.whl",
   "et_xmlfile-1.0.1-cp313-none-any.whl",
-  "executing-1.1.1-cp313-none-any.whl",
+  "executing-2.2.1-cp313-none-any.whl",
   "friendly_traceback-0.7.48-cp313-none-any.whl",
   "iso8601-0.1.12-cp313-none-any.whl",
   "lazy_object_proxy-1.12.0-cp313-cp313-pyodide_2025_0_wasm32.whl",

--- a/sandbox/requirements.in
+++ b/sandbox/requirements.in
@@ -12,3 +12,4 @@ python-dateutil
 sortedcontainers
 unittest-xml-reporting
 typing-extensions  # used by astroid before Python 3.11
+executing>=2.2.1  # indirect; must be recent enough to read Python 3.12+ bytecode

--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -14,8 +14,9 @@ chardet==5.1.0
     # via -r core/sandbox/requirements.in
 et-xmlfile==1.0.1
     # via openpyxl
-executing==1.1.1
+executing==2.2.1
     # via
+    #   -r core/sandbox/requirements.in
     #   friendly-traceback
     #   stack-data
 friendly-traceback==0.7.48


### PR DESCRIPTION
Such a formula generated code that did not compile, failing gencode.make_module() for the whole schema. The document became unusable, reporting KeyError '<table>' or "'DocModel' object has no attribute 'tables'" for every action.

Affects engines on 3.12+: since 1.7.13 that means the pyodide sandbox (Pyodide 0.28 bundles CPython 3.13), and source installs with a recent python3. Reported in
https://community.getgrist.com/t/document-broken-when-updating-to-1-7-16-or-higher/14105

Also on 3.13: friendly-traceback needs an `executing` upgrade. Added a CI leg on 3.13.
