### PR TITLE
Trim entries when parsing ALLOWED_WEBHOOK_DOMAINS

### DIFF
--- a/app/server/lib/FlexServer.ts
+++ b/app/server/lib/FlexServer.ts
@@ -73,6 +73,7 @@ import log, { logAsJson } from "app/server/lib/log";
 import { disableCache, noop } from "app/server/lib/middleware";
 import { testSandboxFlavor } from "app/server/lib/NSandbox";
 import { OAuth2Clients } from "app/server/lib/OAuth2Clients";
+import { isWildcardDomainList } from "app/server/lib/outgoingRequests";
 import { IPermitStore } from "app/server/lib/Permit";
 import { getAppPathTo, getAppRoot, getInstanceRoot, getUnpackedAppRoot } from "app/server/lib/places";
 import { addPluginEndpoints, limitToPlugins } from "app/server/lib/PluginEndpoint";
@@ -2083,7 +2084,7 @@ export class FlexServer implements GristServer {
     // If all webhook targets are accepted, and no proxy is defined, issue
     // a warning. This warning can be removed by explicitly setting the proxy
     // to the empty string.
-    if (allowedWebhookDomains === "*" && proxyForUntrustedRequestsUrl === undefined) {
+    if (isWildcardDomainList(allowedWebhookDomains) && proxyForUntrustedRequestsUrl === undefined) {
       log.warn("Setting an ALLOWED_WEBHOOK_DOMAINS wildcard without GRIST_PROXY_FOR_UNTRUSTED_URLS " +
         "exposes your internal network");
     }

--- a/app/server/lib/outgoingRequests.ts
+++ b/app/server/lib/outgoingRequests.ts
@@ -27,8 +27,26 @@ export function isRequestFunctionEnabled(): boolean {
   return isAffirmative(process.env.GRIST_ENABLE_REQUEST_FUNCTION);
 }
 
+/**
+ * Split a comma-separated domain list, trimming entries and dropping empty
+ * ones. All readers of such a list should use this, so that a stray space or
+ * newline cannot make them disagree.
+ */
+export function parseDomainList(domains: string | undefined): string[] {
+  return (domains || "").split(",").map(s => s.trim()).filter(Boolean);
+}
+
+/**
+ * Whether a domain list is the "*" wildcard, meaning any domain is allowed.
+ * Only a list that is nothing but "*" counts, so listing it alongside other
+ * entries is not a wildcard.
+ */
+export function isWildcardDomainList(domains: string | undefined): boolean {
+  return (domains || "").trim() === "*";
+}
+
 export function isAllowedWebhookWildcard(): boolean {
-  return process.env.ALLOWED_WEBHOOK_DOMAINS === "*";
+  return isWildcardDomainList(process.env.ALLOWED_WEBHOOK_DOMAINS);
 }
 
 /**
@@ -38,6 +56,5 @@ export function isAllowedWebhookWildcard(): boolean {
  */
 export function getAllowedWebhookDomains(): string[] {
   if (isAllowedWebhookWildcard()) { return []; }
-  return (process.env.ALLOWED_WEBHOOK_DOMAINS || "")
-    .split(",").map(s => s.trim()).filter(Boolean);
+  return parseDomainList(process.env.ALLOWED_WEBHOOK_DOMAINS);
 }

--- a/app/server/lib/requestUtils.ts
+++ b/app/server/lib/requestUtils.ts
@@ -18,6 +18,7 @@ import { RequestWithGrist } from "app/server/lib/GristServer";
 import { getHomeUrl } from "app/server/lib/gristSettings";
 import log from "app/server/lib/log";
 import { LogMethods } from "app/server/lib/LogMethods";
+import { isWildcardDomainList, parseDomainList } from "app/server/lib/outgoingRequests";
 import { Permit } from "app/server/lib/Permit";
 
 import http, { IncomingMessage, ServerResponse } from "http";
@@ -562,11 +563,12 @@ export function getExtraAttachmentOptions(req: Request): {
  * Returns true if `urlString` is allowed under `allowedDomains`.
  *
  * `allowedDomains` is a comma-separated list of domain entries
- * (e.g. `"example.com,trusted.org"`). A single entry of `*` is a wildcard
+ * (e.g. `"example.com,trusted.org"`). A list of just `*` is a wildcard
  * that allows any domain.
  * Each entry is matched against the URL's host using base-domain matching
  * (see {@link matchesBaseDomain}), so `example.com` also allows
- * `sub.example.com`. Empty entries "example.com,,other.com" are ignored.
+ * `sub.example.com`. Empty entries "example.com,,other.com" and whitespace
+ * around entries are ignored.
  * `undefined` and `""` means an empty list, so no domains are allowed.
  *
  * Summary of logic, allowed when all of the those are true:
@@ -574,8 +576,8 @@ export function getExtraAttachmentOptions(req: Request): {
  * - the URL's protocol is `https:`, OR it's `http:` with hostname `localhost`
  *   (the http+localhost exception is for local dev/testing)
  * - the URL's host matches one of the entries in `allowedDomains` (or
- *   `allowedDomains === "*"`, which allows any host), if list is empty then it
- *   is not allowed.
+ *   `allowedDomains` is just `*`, which allows any host), if list is empty
+ *   then it is not allowed.
  */
 export function isUrlAllowed(allowedDomains: string | undefined, urlString: string) {
   let url: URL;
@@ -592,7 +594,7 @@ export function isUrlAllowed(allowedDomains: string | undefined, urlString: stri
 
   // Support a wildcard that allows all domains.
   // Allow either https or http if it is set.
-  if (allowedDomains === "*") {
+  if (isWildcardDomainList(allowedDomains)) {
     return true;
   }
 
@@ -602,9 +604,7 @@ export function isUrlAllowed(allowedDomains: string | undefined, urlString: stri
     return false;
   }
 
-  return (allowedDomains || "").split(",").some(domain =>
-    domain && matchesBaseDomain(url.host, domain),
-  );
+  return parseDomainList(allowedDomains).some(domain => matchesBaseDomain(url.host, domain));
 }
 
 /**

--- a/test/server/lib/requestUtils.ts
+++ b/test/server/lib/requestUtils.ts
@@ -3,6 +3,7 @@ import {
   BufferedResponse,
   buildProxyRequestUrl,
   forwardHttpRequest,
+  isUrlAllowed,
   proxyHttpRequest,
   ProxyHttpRequestOptions,
   relayBufferedResponse,
@@ -56,6 +57,44 @@ describe("requestUtils", function() {
     for (const origin of apiErrorTestCases) {
       it(`throws an ApiError on invalid origin '${origin}'`, function() {
         assert.throws(() => trustOrigin({ headers: { origin } } as any));
+      });
+    }
+  });
+
+  describe("isUrlAllowed", function() {
+    const combinations: [string | undefined, string, boolean][] = [
+      // A wildcard waives the https requirement too.
+      ["*", "https://example.com/hook", true],
+      ["*", "http://localhost:8080/hook", true],
+      ["*", "http://192.168.0.1/hook", true],
+      // Whitespace is ignored, so a value read from a config file with a
+      // trailing newline still works.
+      ["*\n", "http://localhost:8080/hook", true],
+      [" * ", "http://localhost:8080/hook", true],
+      ["example.com, other.com", "https://other.com/hook", true],
+      // Only a list of just "*" is a wildcard. Listed alongside anything else
+      // it is a domain entry, and matches no host.
+      ["example.com,*", "http://169.254.169.254/hook", false],
+      ["example.com,*", "https://evil.org/hook", false],
+      ["example.com,*", "https://example.com/hook", true],
+      [undefined, "https://example.com/hook", false],
+      ["", "https://example.com/hook", false],
+      [",,", "https://example.com/hook", false],
+      ["example.com", "https://example.com/hook", true],
+      ["example.com", "https://sub.example.com/hook", true],
+      ["example.com", "https://notexample.com/hook", false],
+      ["example.com", "https://example.com.evil.org/hook", false],
+      // The host includes the port, so a port in the URL needs one in the entry.
+      ["localhost:8080", "http://localhost:8080/hook", true],
+      ["localhost", "http://localhost:8080/hook", false],
+      // Short of a wildcard, http is only for localhost.
+      ["example.com", "http://example.com/hook", false],
+      ["*", "ftp://example.com/file", false],
+      ["*", "not a url", false],
+    ];
+    for (const [allowedDomains, url, allowed] of combinations) {
+      it(`${allowed ? "allows" : "forbids"} '${url}' under ${JSON.stringify(allowedDomains)}`, function() {
+        assert.equal(isUrlAllowed(allowedDomains, url), allowed);
       });
     }
   });


### PR DESCRIPTION
Three places parsed ALLOWED_WEBOOK_DOMAINS and disagreed about whitespace. isUrlAllowed() compared the raw value against "*", so "*\n" rejected every webhook URL, while the admin panel trimmed and reported "*" as configured. A space after a comma silently dropped the following entry.

Parse the list in one place, and use it everywhere it is read. A value is still a wildcard only when the whole of it is "*"; the only new allowances are hosts the operator had already listed.

Reported in #2520.
