### PR TITLE
Give a modal the keyboard focus before it appears

### DIFF
--- a/app/client/lib/FocusLayer.ts
+++ b/app/client/lib/FocusLayer.ts
@@ -84,13 +84,17 @@ class FocusLayerManager extends Disposable {
     this._focusLayers.push(layer);
     // Move the focus to the new layer. Not just grabFocus, because if the focus is on the previous
     // layer's defaultFocusElem, the new layer might consider it "allowed" and never get the focus.
-    setTimeout(() => layer.defaultFocusElem.focus({ preventScroll: true }), 0);
+    // Deferred, since the element is usually still being built, and cannot take focus until it is
+    // attached to the page.
+    setTimeout(() => layer.focusDefaultElem(), 0);
   }
 
   public removeLayer(layer: FocusLayer) {
     arrayRemove(this._focusLayers, layer);
-    // Give the remaining layers a chance to check focus.
-    this.grabFocus();
+    // Give the remaining layers a chance to check focus, synchronously if the focus fell to the
+    // body along with this layer's element.
+    const focusLost = document.activeElement === document.body;
+    this.grabFocus(focusLost ? layer.defaultFocusElem : undefined);
   }
 
   public getCurrentLayer(): FocusLayer | undefined {
@@ -200,6 +204,13 @@ export class FocusLayer extends Disposable implements FocusLayerOptions {
     manager.addLayer(this);
     this.onDispose(() => manager.removeLayer(this));
     this.autoDispose(dom.onElem(this.defaultFocusElem, "blur", (event, elem) => manager.grabFocus(elem)));
+  }
+
+  /**
+   * Focuses the default element. Has no effect if that element is not attached to the page.
+   */
+  public focusDefaultElem() {
+    this.defaultFocusElem.focus({ preventScroll: true });
   }
 
   public onDefaultFocus() {

--- a/app/client/ui2018/modals.ts
+++ b/app/client/ui2018/modals.ts
@@ -240,6 +240,7 @@ export function modal(
 
   let close = doClose;
   let dialogDom: HTMLElement;
+  let focusLayer!: FocusLayer;
 
   const modalDom = cssModalBacker(
     dom.create((owner) => {
@@ -259,7 +260,7 @@ export function modal(
         testId("modal-dialog"),
         { "role": "dialog", "aria-modal": "true" },
       );
-      FocusLayer.create(owner, {
+      focusLayer = FocusLayer.create(owner, {
         defaultFocusElem: dialogDom,
         allowFocus: elem => (elem !== document.body),
         // Pause mousetrap keyboard shortcuts while the modal is shown. Without this, arrow keys
@@ -275,6 +276,10 @@ export function modal(
   document.body.appendChild(modalDom);
   enableTabTrap(modalDom);
   if (variant === "collapsing") { expandModal(); }
+
+  // Focus now that the dialog is attached, so that it never appears without the focus. The
+  // FocusLayer on its own would only get to it after the current task.
+  focusLayer.focusDefaultElem();
 }
 
 export interface ISaveModalOptions {

--- a/test/projects/modals.ts
+++ b/test/projects/modals.ts
@@ -3,11 +3,22 @@ import { server, setupTestSuite } from "test/projects/testUtils";
 import { assert, driver, Key } from "mocha-webdriver";
 
 describe("modals", function() {
+  this.timeout(20000);
+
   setupTestSuite();
 
-  before(async function() {
-    this.timeout(20000);      // Set a longer default timeout.
+  async function loadPage() {
     await driver.get(`${server.getHost()}/modals`);
+  }
+
+  before(loadPage);
+
+  afterEach(async function() {
+    // A modal left open by a failing test would block the clicks of every later one. Only after a
+    // failure: some tests below pass an open modal on to the next.
+    if (this.currentTest?.state === "failed") {
+      await loadPage();
+    }
   });
 
   async function checkClosed() {
@@ -16,7 +27,10 @@ describe("modals", function() {
   }
 
   async function checkOpen() {
-    assert.equal(await driver.findWait(".test-modal-dialog", 100).isPresent(), true);
+    await driver.findWait(".test-modal-dialog", 1000);
+    // A modal has the focus by the time it appears, so keys typed from here on reach the modal.
+    assert.equal(await driver.find(".test-modal-dialog:focus-within").isPresent(), true,
+      "modal should hold the focus as soon as it appears");
   }
 
   it("should close on click-away, OK, Cancel, Escape, Enter", async function() {
@@ -79,6 +93,7 @@ describe("modals", function() {
     assert.match(await driver.find(".testui-custom-modal-text").getText(), /Closed/);
 
     await driver.find(".testui-custom-modal-opener").click();
+    await checkOpen();
     assert.match(await driver.find(".testui-custom-modal-text").getText(), /Open/);
 
     // Hit Escape to close
@@ -138,7 +153,11 @@ describe("modals", function() {
     await checkOpen();
 
     await driver.find(".testui-nested-modals-open-submodal").click();
-    assert.equal(await driver.findWait(".testui-nested-modals-submodal", 100).isPresent(), true);
+    await driver.findWait(".testui-nested-modals-submodal", 1000);
+    assert.equal(
+      await driver.find(".test-modal-dialog:has(.testui-nested-modals-submodal):focus").isPresent(), true,
+      "nested modal should hold the focus as soon as it opens",
+    );
     await driver.sendKeys(Key.TAB);
     await driver.sendKeys(Key.TAB);
     assert.equal(
@@ -149,6 +168,8 @@ describe("modals", function() {
 
     await driver.find(".testui-nested-modals-close-submodal").click();
     assert.equal(await driver.find(".testui-nested-modals-submodal").isPresent(), false);
+    assert.equal(await driver.find(".test-modal-dialog:focus").isPresent(), true,
+      "focus should return to the first modal as soon as the nested one closes");
     await driver.sendKeys(Key.TAB);
     await driver.sendKeys(Key.chord(Key.SHIFT, Key.TAB));
     assert.equal(


### PR DESCRIPTION
FocusLayer moves the focus in a setTimeout, since a layer is usually created while its element is still being built and cannot take focus until it is attached. That left a window in which the dialog was on screen without the focus. A key pressed then went to whatever was focused before, and for a nested modal the parent's tab trap sent the focus back to the opening button. This is the projects modals test failing now and then on CI.

modal() now focuses the dialog itself, right after attaching it. removeLayer() does the same on the way out: when the focus has fallen to the body it restores it synchronously rather than a tick later, so closing a nested modal hands the focus straight back to its parent. That second part applies to every FocusLayer, not only modals, in the case where its element left the page and took the focus with it.

Checked by setting both of FocusLayer's timers to 250ms and showing consistent failure of the old code and success with the new. The AttachmentsWidget test naturally tests the removeLayer part since its editor is both a cell editor and a modal.
