### PR TITLE
Canonicalize tmp dirs handed to the pyodide sandbox

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,12 +43,21 @@ jobs:
             node-version: 22.x
             python-version: '3.11'
             os: macos-latest
+          - tests: ':pyodide:'
+            node-version: 22.x
+            python-version: '3.11'
+            os: windows-2022
           - tests: ':smoke:'
             edition: full
             node-version: 22.x
             python-version: '3.11'
             os: ubuntu-24.04
     steps:
+      # Package scripts are written for a POSIX shell.
+      - name: Run package scripts through bash
+        if: contains(matrix.os, 'windows')
+        run: yarn config set script-shell bash
+
       - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
@@ -61,9 +70,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          # skipping system python on windows currently.
+          cache: ${{ !contains(matrix.os, 'windows') && 'pip' || '' }}
 
       - name: Install Python packages
+        # skipping system python on windows currently.
+        if: "!contains(matrix.os, 'windows')"
         run: |
           pip install virtualenv
           yarn run install:python
@@ -137,14 +149,28 @@ jobs:
           GRIST_DOCS_MINIO_PORT: 9000
           GRIST_DOCS_MINIO_BUCKET: grist-docs-test
 
+      # Force TEMP into a weird form on Windows, to catch canonicalization
+      # that doesn't handle it. This is how non-short directory names get
+      # shortened to DIR~1 and similar. Sigh.
+      - name: Use stressful TEMP for windows
+        if: contains(matrix.os, 'windows') && contains(matrix.tests, ':pyodide:')
+        shell: cmd
+        run: |
+          for %%I in ("%TEMP%") do echo TEMP=%%~sI>> %GITHUB_ENV%
+          for %%I in ("%TEMP%") do echo TMP=%%~sI>> %GITHUB_ENV%
+
       - name: Run a couple of tests using pyodide
         if: contains(matrix.tests, ':pyodide:')
+        shell: bash
         run: |
           cd sandbox/pyodide
           make setup
           cd ../..
-          yarn run test:server -g 'ActiveDoc.useQuerySet|Sandbox'
-          yarn run test:nbrowser -g 'Importer.*should.show.correct.preview'
+          yarn run test:server -g 'ActiveDoc.useQuerySet|ActiveDocImport parsing|Sandbox|createTmpDir'
+          # No browser tests on windows yet.
+          if [[ "$RUNNER_OS" != "Windows" ]]; then
+            yarn run test:nbrowser -g 'Importer.*should.show.correct.preview'
+          fi
         env:
           MOCHA_WEBDRIVER_HEADLESS: 1
           GRIST_SANDBOX_FLAVOR: pyodide
@@ -225,6 +251,7 @@ jobs:
 
       - name: Prepare for saving artifact
         if: failure()
+        shell: bash
         run: |
           ARTIFACT_NAME=logs-$(echo $TESTS | sed 's/[^-a-zA-Z0-9]/_/g')
           echo "Artifact name is '$ARTIFACT_NAME'"

--- a/app/server/lib/serverUtils.ts
+++ b/app/server/lib/serverUtils.ts
@@ -5,6 +5,7 @@ import { getLogMeta } from "app/server/lib/sessionUtils";
 import { OpenMode, SQLiteDB } from "app/server/lib/SQLiteDB";
 
 import { ChildProcess } from "child_process";
+import * as fs from "fs";
 import * as net from "net";
 import * as path from "path";
 
@@ -83,6 +84,23 @@ export function isPathWithin(outer: string, inner: string): boolean {
   const index = rel.indexOf(path.sep);
   const firstDir = index < 0 ? rel : rel.slice(0, index);
   return firstDir !== "..";
+}
+
+/**
+ * Resolve a path to the spelling the OS itself treats as canonical.
+ * Throws if the path does not exist.
+ *
+ * On Linux and macOS this resolves symlinks and does nothing further, which is
+ * all fs.realpath does too. Windows has two more: 8.3 short names
+ * (C:\Users\CHIMP~1\...) and arbitrary casing.
+ *
+ * fs.realpath.native used instead of fs.realpath since, because of sandboxing,
+ * it is important to be consistent with tools outside of node.
+ *
+ * Needed for Deno/Pyodide Windows setup.
+ */
+export function canonicalPath(target: string): Promise<string> {
+  return fromCallback(cb => fs.realpath.native(target, cb));
 }
 
 /**

--- a/app/server/lib/uploads.ts
+++ b/app/server/lib/uploads.ts
@@ -13,11 +13,12 @@ import { guessExt } from "app/server/lib/guessExt";
 import log from "app/server/lib/log";
 import { fetchUntrustedWithAgent } from "app/server/lib/ProxyAgent";
 import { optStringParam } from "app/server/lib/requestUtils";
-import { isPathWithin } from "app/server/lib/serverUtils";
+import { canonicalPath, isPathWithin } from "app/server/lib/serverUtils";
 import * as shutdown from "app/server/lib/shutdown";
 import { drainWhenSettled } from "app/server/utils/streams";
 
 import stream from "node:stream";
+import * as os from "os";
 import * as path from "path";
 
 import { fromCallback } from "bluebird";
@@ -409,14 +410,19 @@ interface TmpDirResult {
  * cleanup callback with an asynchronous version.
  */
 export async function createTmpDir(options: tmp.DirOptions): Promise<TmpDirResult> {
-  const fullOptions = { prefix: "grist-upload-", unsafeCleanup: true, ...options };
+  const fullOptions = {
+    prefix: "grist-upload-",
+    unsafeCleanup: true,
+    tmpdir: await canonicalPath(os.tmpdir()),
+    ...options,
+  };
 
   const [tmpDir, tmpCleanup]: [string, CleanupCB] = await fromCallback(
     (cb: any) => tmp.dir(fullOptions, cb), { multiArgs: true });
 
   // The `tmp` library sometimes forcibly resolves the path,
   // doing it here makes it predictable behaviour and resistant to library behaviour changes.
-  const realTmpDir = await fse.realpath(tmpDir);
+  const realTmpDir = await canonicalPath(tmpDir);
 
   async function cleanupCallback() {
     // Using fs-extra is better because it's asynchronous.

--- a/buildtools/install_edition.sh
+++ b/buildtools/install_edition.sh
@@ -21,7 +21,9 @@ fi
 
 EDITION="${GRIST_EDITION:-}"
 if [[ -z "$EDITION" && -e grist-edition ]]; then
-  EDITION="$(cat grist-edition)"
+  # Strip whitespace: set-community-edition writes this file with `echo >`, which
+  # under cmd (so, on Windows) leaves a trailing space and CRLF.
+  EDITION="$(tr -d '[:space:]' < grist-edition)"
 fi
 if [[ -z "$EDITION" ]]; then
   echo "+ No edition selected; defaulting to full edition."

--- a/sandbox/pyodide/Makefile
+++ b/sandbox/pyodide/Makefile
@@ -31,6 +31,10 @@ clean_code:
 	rm -rf _build/worker # old path
 	rm -rf _build/pyodide
 
+# Run setup.sh through bash rather than directly: on Windows make falls back to
+# cmd, which cannot execute a .sh, but can run bash - the same reason the
+# fetch_packages recipe below is fine as it is.
+#   https://github.com/actions/runner-images/issues/7253
 setup:
-	./setup.sh
+	bash ./setup.sh
 	make fetch_packages

--- a/sandbox/pyodide/pipe.js
+++ b/sandbox/pyodide/pipe.js
@@ -58,30 +58,21 @@ class GristPipe {
   }
 
   async loadCode() {
-    // Load python packages. Pyodide takes a wheel's package name from the last
-    // "/"-separated part of what it is given, up to the first "-". Windows
-    // separators are not separators to it, so a native path arrives as one long
-    // name: under C:\...\grist-desktop\ every wheel becomes "c:\...\grist", they
-    // collide, and all but the first are discarded as duplicates. Forward
-    // slashes parse correctly, and Windows opens them happily.
+    // Load python packages. Pyodide names a wheel after the last "/"-separated
+    // part of its path, so hand it forward slashes: a native Windows path is
+    // all one part, leaving every wheel with the same name but the first
+    // discarded as a duplicate.
     const src = path.join(__dirname, "_build", "packages");
     const libs = (await listLibs(src)).available;
-    const lsty = libs.map(item => item.fullName.split(path.sep).join("/"));
-    await this.pyodide.loadPackage(lsty, {
-      messageCallback: (msg) => this.log("[package]", msg),
-      errorCallback: (msg) => this.log("[package error]", msg),
-    });
-
-    // loadPackage resolves even when it loaded nothing, reporting trouble only
-    // through errorCallback. Without this check, a failed load first shows up
-    // much later as an ImportError from deep inside the data engine.
-    const loaded = new Set(Object.keys(this.pyodide.loadedPackages || {}));
-    const missing = libs.filter(
-      item => !loaded.has(item.standardName) && !loaded.has(item.name));
-    if (missing.length) {
-      throw new Error(
-        `Pyodide loaded ${loaded.size} of ${libs.length} packages. Missing: ` +
-        missing.map(item => item.name).join(", "));
+    const loaded = await this.pyodide.loadPackage(
+      libs.map(item => item.fullName.replaceAll(path.sep, "/")), {
+        messageCallback: (msg) => this.log("[package]", msg),
+        errorCallback: (msg) => this.log("[package error]", msg),
+      });
+    // loadPackage resolves even when it loaded nothing, so check. Otherwise the
+    // first sign of trouble is an ImportError from inside the data engine.
+    if (loaded.length !== libs.length) {
+      throw new Error(`Pyodide loaded ${loaded.length} of ${libs.length} packages`);
     }
 
     // Load Grist data engine code.

--- a/test/server/Sandbox.ts
+++ b/test/server/Sandbox.ts
@@ -270,7 +270,9 @@ describe("Sandbox", function() {
       const mainPyPath = getSandboxPaths(sandboxRoot, "main.py");
       const sandboxContent = await sandbox.pyCall("test_read_file", mainPyPath.sandbox);
       const hostContent = fs.readFileSync(mainPyPath.host, "utf8");
-      assert.equal(sandboxContent, hostContent);
+      // The sandbox reads via python's text mode, which normalizes newlines, while
+      // node reports what is on disk - and git checks files out with CRLF on windows.
+      assert.equal(sandboxContent, hostContent.replace(/\r\n/g, "\n"));
       assert.isAbove(sandboxContent.length, 10);
 
       // Try to add a file using os.system.
@@ -315,7 +317,7 @@ describe("Sandbox", function() {
       try {
         let sandboxContent = "";
         try {
-          sandboxContent = await sandbox.pyCall("test_read_file", path.join("/tmp", fname));
+          sandboxContent = await sandbox.pyCall("test_read_file", path.posix.join("/tmp", fname));
         } catch (e) {
           // File not found or PermissionError is acceptable.
           if (!String(e).match(/FileNotFoundError/) &&
@@ -370,7 +372,7 @@ return 'done'
       }
       try {
         const sandboxRoot = await sandbox.pyCall("test_get_sandbox_root");
-        const mainFile = path.join(sandboxRoot, "main.py");
+        const mainFile = path.posix.join(sandboxRoot, "main.py");
 
         // pyodide works on a copy of the original files
         await sandbox.pyCall("test_write_file", mainFile, "# A rambunctious little edit");
@@ -397,7 +399,7 @@ return 'done'
         this.skip();
       }
       const sandboxRoot = await sandbox.pyCall("test_get_sandbox_root");
-      const mainFile = path.join(sandboxRoot, "main.py");
+      const mainFile = path.posix.join(sandboxRoot, "main.py");
 
       // gvisor mounts the sandbox files as read-only
       await assert.isRejected(
@@ -455,6 +457,9 @@ return 'done'
   });
 });
 
+// Paths inside a sandbox are posix paths whatever the host is, so join them
+// with path.posix. On Windows plain path.join yields backslashes, which the
+// sandbox reads as ordinary characters in a filename rather than separators.
 function getSubDirs(dir: string, root: string): string[] {
   // Walk directories but replace the root with the given root
   return [root, ...fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
@@ -462,14 +467,14 @@ function getSubDirs(dir: string, root: string): string[] {
       return [];
     }
     const full = path.join(dir, entry.name);
-    const mapped = path.join(root, entry.name);
+    const mapped = path.posix.join(root, entry.name);
     return getSubDirs(full, mapped);
   })];
 }
 
 function getSandboxPaths(sandboxRoot: string, fname: string) {
   return {
-    sandbox: path.join(sandboxRoot, fname),
+    sandbox: path.posix.join(sandboxRoot, fname),
     host: path.join(testUtils.appRoot, "sandbox/grist", fname),
   };
 }

--- a/test/server/lib/ActiveDoc.ts
+++ b/test/server/lib/ActiveDoc.ts
@@ -50,7 +50,7 @@ const UNSUPPORTED_FORMULA: CellValue = [GristObjCode.Exception, "Formula not sup
 tmp.setGracefulCleanup();
 
 describe("ActiveDoc", async function() {
-  this.timeout(10000);
+  this.timeout(testUtils.sandboxTimeout(10000));
 
   // Turn off logging for this test, and restore afterwards.
   testUtils.setTmpLogLevel("warn");

--- a/test/server/lib/ActiveDocImport.js
+++ b/test/server/lib/ActiveDocImport.js
@@ -14,7 +14,7 @@ const {getFileUploadInfo, globalUploadSet, moveUpload} = require("app/server/lib
 tmp.setGracefulCleanup();
 
 describe("ActiveDocImport", function() {
-  this.timeout(10000);
+  this.timeout(testUtils.sandboxTimeout(10000));
 
   // Turn off logging for this test, and restore afterwards.
   testUtils.setTmpLogLevel("warn");

--- a/test/server/lib/uploads.ts
+++ b/test/server/lib/uploads.ts
@@ -1,3 +1,4 @@
+import { canonicalPath } from "app/server/lib/serverUtils";
 import { createTmpDir, Deps, fetchDoc, fetchURL, moveUpload, UploadSet } from "app/server/lib/uploads";
 import { globalUploadSet } from "app/server/lib/uploads";
 import { createFile } from "test/server/docTools";
@@ -38,6 +39,27 @@ describe("uploads", function() {
       // Check that neither file nor directory exist.
       assert.isFalse(await fse.pathExists(filePath));
       assert.isFalse(await fse.pathExists(tmpDir));
+    });
+
+    it("should return fully canonical paths, including for nested dirs", async function() {
+      // Imports are staged in a tmp dir nested inside the one handed to the sandbox as
+      // a read permission (see moveUpload), so both have to be canonical for the
+      // sandbox's own canonicalizing permission checks to match.
+      const { tmpDir, cleanupCallback } = await createTmpDir({ prefix: "test-uploads-" });
+      try {
+        assert.strictEqual(await canonicalPath(tmpDir), tmpDir);
+
+        const nested = await createTmpDir({ dir: tmpDir, prefix: "test-nested-" });
+        try {
+          assert.strictEqual(await canonicalPath(nested.tmpDir), nested.tmpDir);
+          // DocPluginManager passes import paths to the sandbox relative to the outer dir.
+          assert.isFalse(path.relative(tmpDir, nested.tmpDir).startsWith(".."));
+        } finally {
+          await nested.cleanupCallback();
+        }
+      } finally {
+        await cleanupCallback();
+      }
     });
   });
 

--- a/test/server/testUtils.ts
+++ b/test/server/testUtils.ts
@@ -363,6 +363,16 @@ export class EnvironmentSnapshot {
   }
 }
 
+/**
+ * Scale a timeout for suites dominated by sandbox startup. Pyodide takes far
+ * longer to start than the other flavors, enough that a limit tight enough to
+ * notice an operation getting unexpectedly slow is not achievable under it.
+ * Other flavors keep the limit as given, which is where that signal is useful.
+ */
+export function sandboxTimeout(ms: number): number {
+  return getSandboxFlavor() === "pyodide" ? ms * 3 : ms;
+}
+
 const createdInThisRun = new Set<string>();
 
 export async function createTestDir(suiteName: string): Promise<string> {


### PR DESCRIPTION
Importing a file on Windows failed with a fatal sandbox error:

```
Import failed: Failed to parse CSV file.
Error: [Sandbox] PipeFromSandbox is closed: NotCapable: Requires read
access to "C:\Users\...\AppData\Local\Temp\grist-tmp-...\....csv"
```

Deno checks read permission twice, once on the path as given when the file is opened, and again on its canonicalized form when metadata is read from the already-open file. `createTmpDir` resolved with `fs.realpath`, which leaves Windows 8.3 short names alone, and `%TEMP%` is commonly the short form there — so the grant read `C:\Users\ENDEMO~1\...` while Deno canonicalized to the long one, and the sandbox could open the file but not stat it. Use the OS-level call instead. Same reasoning as #1907, which canonicalized these for macOS, where `/var` is a symlink.

`tmp` needs the same root passed explicitly, or it rejects the nested dirs `moveUpload` creates.

Added relevant Windows tests to CI: the pyodide job now runs on `windows-2022` too, with `%TEMP%` forced to its short form so a regression here fails a test. Getting that far needed small fixes to scripts that assumed a POSIX shell, and longer timeouts under the slower sandbox.

`sandbox/pyodide/pipe.js` shortens the package check added in #2517. `loadPackage` returns what it loaded, so counting that is enough.

Reported at https://community.getgrist.com/t/import-from-file-error/14110

