### PR TITLE
Adding autocomplete after `lookupOne` calls.

### DIFF
--- a/app/client/components/AceEditorCompletions.ts
+++ b/app/client/components/AceEditorCompletions.ts
@@ -96,11 +96,12 @@ function initCustomCompleter() {
   // The default regex just matches identifiers. We expand it to include periods (to capture
   // attributes) and "$", for Grist column names. In addition, we autocomplete lookup formulas
   // with the function name, to give suggestions for lookup keyword arguments. A completed
-  // `lookupOne(...)` call is matched together with the attribute after it, so that the server
-  // can suggest columns of the looked-up record. One level of parens is allowed inside the
-  // arguments (e.g. a function call). Keep in sync with the similar regex in engine.py.
+  // `lookupOne(...)` or `lookupRecords(...)` call is matched together with the attribute after
+  // it, so that the server can suggest columns of the looked-up table. One level of parens is
+  // allowed inside the arguments (e.g. a function call). Keep in sync with the similar regex
+  // in engine.py.
   const prefixMatchRegex = new RegExp([
-    /\w+\.lookupOne\((?:[^()]|\([^()]*\))*\)\.[\w\u00A2-\uFFFF]*$/,
+    /\w+\.(?:lookupOne|lookupRecords)\((?:[^()]|\([^()]*\))*\)\.[\w\u00A2-\uFFFF]*$/,
     /\w+\.(?:lookupRecords|lookupOne)\([\w.$\u00A2-\uFFFF]*$/,
     /[\w.$\u00A2-\uFFFF]+$/,
   ].map(r => r.source).join("|"));

--- a/app/client/components/AceEditorCompletions.ts
+++ b/app/client/components/AceEditorCompletions.ts
@@ -99,13 +99,13 @@ function initCustomCompleter() {
   // with the function name, to give suggestions for lookup keyword arguments. A completed
   // `lookupOne(...)` or `lookupRecords(...)` call is matched together with the attribute after
   // it, so that the server can suggest columns of the looked-up table. One level of parens is
-  // allowed inside the arguments (e.g. a function call). A trailing comma inside a still-open
-  // call is matched with everything before it, so the server can suggest a further argument.
+  // allowed inside the arguments (e.g. a function call). Inside a still-open call, everything
+  // before a partially typed argument is matched too, so the server can suggest a further
+  // argument after a comma.
   // Keep in sync with the similar regex in engine.py.
   const prefixMatchRegex = new RegExp([
     /\w+\.(?:lookupOne|lookupRecords)\((?:[^()]|\([^()]*\))*\)\.[\w\u00A2-\uFFFF]*$/,
-    /\w+\.(?:lookupRecords|lookupOne)\((?:[^()]|\([^()]*\))*,\s*$/,
-    /\w+\.(?:lookupRecords|lookupOne)\([\w.$\u00A2-\uFFFF]*$/,
+    /\w+\.(?:lookupRecords|lookupOne)\((?:(?:[^()]|\([^()]*\))*,)?\s*[\w.$\u00A2-\uFFFF]*$/,
     /[\w.$\u00A2-\uFFFF]+$/,
   ].map(r => r.source).join("|"));
 

--- a/app/client/components/AceEditorCompletions.ts
+++ b/app/client/components/AceEditorCompletions.ts
@@ -97,9 +97,10 @@ function initCustomCompleter() {
   // attributes) and "$", for Grist column names. In addition, we autocomplete lookup formulas
   // with the function name, to give suggestions for lookup keyword arguments. A completed
   // `lookupOne(...)` call is matched together with the attribute after it, so that the server
-  // can suggest columns of the looked-up record.
+  // can suggest columns of the looked-up record. One level of parens is allowed inside the
+  // arguments (e.g. a function call). Keep in sync with the similar regex in engine.py.
   const prefixMatchRegex = new RegExp([
-    /\w+\.lookupOne\([^()]*\)\.[\w\u00A2-\uFFFF]*$/,
+    /\w+\.lookupOne\((?:[^()]|\([^()]*\))*\)\.[\w\u00A2-\uFFFF]*$/,
     /\w+\.(?:lookupRecords|lookupOne)\([\w.$\u00A2-\uFFFF]*$/,
     /[\w.$\u00A2-\uFFFF]+$/,
   ].map(r => r.source).join("|"));

--- a/app/client/components/AceEditorCompletions.ts
+++ b/app/client/components/AceEditorCompletions.ts
@@ -41,7 +41,8 @@ export function setupAceEditorCompletions(editor: Ace.Editor, options: ICompleti
     return (
       prefix.endsWith(".") ||  // to get fresh attributes of references
       prefix.endsWith(".lookupone(") ||  // to get initial argument suggestions
-      prefix.endsWith(".lookuprecords(")
+      prefix.endsWith(".lookuprecords(") ||
+      /,\s*$/.test(prefix)  // to get suggestions for the next lookup argument
     );
   }.bind(completer);
 
@@ -98,10 +99,12 @@ function initCustomCompleter() {
   // with the function name, to give suggestions for lookup keyword arguments. A completed
   // `lookupOne(...)` or `lookupRecords(...)` call is matched together with the attribute after
   // it, so that the server can suggest columns of the looked-up table. One level of parens is
-  // allowed inside the arguments (e.g. a function call). Keep in sync with the similar regex
-  // in engine.py.
+  // allowed inside the arguments (e.g. a function call). A trailing comma inside a still-open
+  // call is matched with everything before it, so the server can suggest a further argument.
+  // Keep in sync with the similar regex in engine.py.
   const prefixMatchRegex = new RegExp([
     /\w+\.(?:lookupOne|lookupRecords)\((?:[^()]|\([^()]*\))*\)\.[\w\u00A2-\uFFFF]*$/,
+    /\w+\.(?:lookupRecords|lookupOne)\((?:[^()]|\([^()]*\))*,\s*$/,
     /\w+\.(?:lookupRecords|lookupOne)\([\w.$\u00A2-\uFFFF]*$/,
     /[\w.$\u00A2-\uFFFF]+$/,
   ].map(r => r.source).join("|"));

--- a/app/client/components/AceEditorCompletions.ts
+++ b/app/client/components/AceEditorCompletions.ts
@@ -95,8 +95,14 @@ function initCustomCompleter() {
 
   // The default regex just matches identifiers. We expand it to include periods (to capture
   // attributes) and "$", for Grist column names. In addition, we autocomplete lookup formulas
-  // with the function name, to give suggestions for lookup keyword arguments.
-  const prefixMatchRegex = /\w+\.(?:lookupRecords|lookupOne)\([\w.$\u00A2-\uFFFF]*$|[\w.$\u00A2-\uFFFF]+$/;
+  // with the function name, to give suggestions for lookup keyword arguments. A completed
+  // `lookupOne(...)` call is matched together with the attribute after it, so that the server
+  // can suggest columns of the looked-up record.
+  const prefixMatchRegex = new RegExp([
+    /\w+\.lookupOne\([^()]*\)\.[\w\u00A2-\uFFFF]*$/,
+    /\w+\.(?:lookupRecords|lookupOne)\([\w.$\u00A2-\uFFFF]*$/,
+    /[\w.$\u00A2-\uFFFF]+$/,
+  ].map(r => r.source).join("|"));
 
   // Monkey-patch getCompletionPrefix. This is based on the source code in
   // node_modules/ace-builds/src-noconflict/ext-language_tools.js, simplified to do the one thing

--- a/sandbox/grist/engine.py
+++ b/sandbox/grist/engine.py
@@ -1449,6 +1449,21 @@ class Engine(object):
         result = [(r, None) for r in result]
         return sorted(result)
 
+    # A completed `Table.lookupOne(...)` evaluates to a record, so suggest columns after the dot.
+    # rlcompleter can't do this itself, as it never evaluates calls.
+    match = re.match(r"(\w+)\.lookupOne\([^()]*\)\.(\w*)$", txt)
+    if match:
+      lookup_table_id, prefix = match.group(1), match.group(2)
+      if lookup_table_id in self.tables:
+        lookup_table = self.tables[lookup_table_id]
+        start = txt[:len(txt) - len(prefix)]
+        result = [
+          (start + col_id, None)
+          for col_id in lookup_table.all_columns
+          if (column.is_visible_column(col_id) or col_id == 'id') and col_id.startswith(prefix)
+        ]
+        return sorted(result)
+
     # replace $ with rec. and add a dummy rec object
     tweaked_txt = DOLLAR_REGEX.sub(r'rec.', txt)
     # convert a bare $ with nothing after it also

--- a/sandbox/grist/engine.py
+++ b/sandbox/grist/engine.py
@@ -1450,8 +1450,10 @@ class Engine(object):
         return sorted(result)
 
     # A completed `Table.lookupOne(...)` evaluates to a record, so suggest columns after the dot.
-    # rlcompleter can't do this itself, as it never evaluates calls.
-    match = re.match(r"(\w+)\.lookupOne\([^()]*\)\.(\w*)$", txt)
+    # rlcompleter can't do this itself, as it never evaluates calls. One level of parens is
+    # allowed inside the arguments (e.g. a function call). Keep in sync with the similar regex
+    # in AceEditorCompletions.ts.
+    match = re.match(r"(\w+)\.lookupOne\((?:[^()]|\([^()]*\))*\)\.(\w*)$", txt)
     if match:
       lookup_table_id, prefix = match.group(1), match.group(2)
       if lookup_table_id in self.tables:

--- a/sandbox/grist/engine.py
+++ b/sandbox/grist/engine.py
@@ -1430,13 +1430,13 @@ class Engine(object):
 
     # Table.lookup methods are special to suggest arguments after '(' or after a comma, once
     # at least one argument is already there.
-    match = re.match(r"(\w+)\.(lookupRecords|lookupOne)\(.*$", txt)
+    match = re.match(r"(\w+)\.(lookupRecords|lookupOne)\(", txt)
     if match:
       lookup_table_id = match.group(1)
       if lookup_table_id in self.tables:
         lookup_table = self.tables[lookup_table_id]
         used_kwargs = _get_used_lookup_kwargs(txt)
-        if used_kwargs is not None:
+        if used_kwargs is not None: # None means that the user is still typing
           # Add a space after the comma, unless the user already typed one or there isn't one.
           start = txt if txt.endswith(("(", " ")) else txt + " "
           # order_by is a keyword argument like any column, not tied to a particular column.
@@ -1534,8 +1534,12 @@ class Engine(object):
     ]
 
     # If we changed the prefix (expanding the $ symbol) we now need to change it back.
+    # Function matches are tuples, whose names never contain the prefix.
     if tweaked_txt != txt:
-      results = [(txt + result[len(tweaked_txt):], value) for result, value in results]
+      results = [
+        (result if isinstance(result, tuple) else txt + result[len(tweaked_txt):], value)
+        for result, value in results
+      ]
     # pylint:disable=unidiomatic-typecheck
     results.sort(key=lambda r: r[0][0] if type(r[0]) == tuple else r[0])
     return results

--- a/sandbox/grist/engine.py
+++ b/sandbox/grist/engine.py
@@ -3,6 +3,7 @@
 The data engine ties the code generated from the schema with the document data, and with
 dependency tracking.
 """
+import ast
 import itertools
 import logging
 import re
@@ -1427,27 +1428,33 @@ class Engine(object):
     """
     table = self.tables[table_id]
 
-    # Table.lookup methods are special to suggest arguments after '('
-    match = re.match(r"(\w+)\.(lookupRecords|lookupOne)\($", txt)
+    # Table.lookup methods are special to suggest arguments after '(' or after a comma, once
+    # at least one argument is already there.
+    match = re.match(r"(\w+)\.(lookupRecords|lookupOne)\(.*$", txt)
     if match:
-      # Get the 'Table1' in 'Table1.lookupRecords('
       lookup_table_id = match.group(1)
       if lookup_table_id in self.tables:
         lookup_table = self.tables[lookup_table_id]
-        # Add a keyword argument with no value for each column name in the lookup table.
-        result = [
-          txt + col_id + "="
-          for col_id in lookup_table.all_columns
-          if column.is_visible_column(col_id) or col_id == 'id'
-        ]
-        # Add specific complete lookups involving reference columns.
-        result += [
-          txt + option
-          for option in lookup_autocomplete_options(lookup_table, table, reverse_only=False)
-        ]
-        # Add a dummy empty example value for each result to produce the correct shape.
-        result = [(r, None) for r in result]
-        return sorted(result)
+        used_kwargs = _get_used_lookup_kwargs(txt)
+        if used_kwargs is not None:
+          # Add a space after the comma, unless the user already typed one or there isn't one.
+          start = txt if txt.endswith(("(", " ")) else txt + " "
+          # order_by is a keyword argument like any column, not tied to a particular column.
+          arg_names = list(lookup_table.all_columns) + ['order_by']
+          result = [
+            (start + arg_name + "=", None)
+            for arg_name in arg_names
+            if (column.is_visible_column(arg_name) or arg_name in ('id', 'order_by'))
+            and arg_name not in used_kwargs
+          ]
+          # For the first argument, also add specific complete lookups involving reference
+          # columns, e.g. `address=$id)`.
+          if not used_kwargs:
+            result += [
+              (txt + option, None)
+              for option in lookup_autocomplete_options(lookup_table, table, reverse_only=False)
+            ]
+          return sorted(result)
 
     # A completed `Table.lookupOne(...)` evaluates to a record, and `Table.lookupRecords(...)`
     # to a RecordSet, whose fields give a list of values instead of a single one. Either way the
@@ -1560,6 +1567,26 @@ class Engine(object):
       del self.out_actions.direct[len_stored:]
       del self.out_actions.undo[len_undo:]
       del self.out_actions.retValues[len_ret:]
+
+
+def _get_used_lookup_kwargs(txt):
+  """
+  `txt` is a `Table.lookupOne(...)` or `Table.lookupRecords(...)` call, still open, e.g.
+  `Table.lookupOne(` or `Table.lookupOne(A=1, `. Returns the list of keyword argument names
+  already used (empty if none yet), or None if `txt` isn't parseable as such a call, or if the
+  last argument is an unfinished name rather than a complete `key=value` pair.
+  """
+  tweaked = DOLLAR_REGEX.sub('rec.', txt).rstrip()
+  if tweaked.endswith(','):
+    tweaked = tweaked[:-1]
+  try:
+    tree = ast.parse(tweaked + ')', mode='eval')
+  except SyntaxError:
+    return None
+  call = tree.body
+  if not isinstance(call, ast.Call) or call.args:
+    return None
+  return [kw.arg for kw in call.keywords if kw.arg]
 
 
 # end

--- a/sandbox/grist/engine.py
+++ b/sandbox/grist/engine.py
@@ -1449,11 +1449,13 @@ class Engine(object):
         result = [(r, None) for r in result]
         return sorted(result)
 
-    # A completed `Table.lookupOne(...)` evaluates to a record, so suggest columns after the dot.
+    # A completed `Table.lookupOne(...)` evaluates to a record, and `Table.lookupRecords(...)`
+    # to a RecordSet, whose fields give a list of values instead of a single one. Either way the
+    # field names are the columns of the looked up table, so suggest those after the dot.
     # rlcompleter can't do this itself, as it never evaluates calls. One level of parens is
     # allowed inside the arguments (e.g. a function call). Keep in sync with the similar regex
     # in AceEditorCompletions.ts.
-    match = re.match(r"(\w+)\.lookupOne\((?:[^()]|\([^()]*\))*\)\.(\w*)$", txt)
+    match = re.match(r"(\w+)\.(?:lookupOne|lookupRecords)\((?:[^()]|\([^()]*\))*\)\.(\w*)$", txt)
     if match:
       lookup_table_id, prefix = match.group(1), match.group(2)
       if lookup_table_id in self.tables:

--- a/sandbox/grist/test_completion.py
+++ b/sandbox/grist/test_completion.py
@@ -482,8 +482,6 @@ class TestCompletion(test_engine.EngineTestCase):
     )
 
   def test_suggest_lookup_attributes(self):
-    # A completed `lookupOne()` returns a record, so suggest its columns after the dot.
-    # This works with no arguments, which is useful for a table holding a single row.
     self.assertEqual(
       self.autocomplete("Schools.lookupOne().", "Address", "city"),
       [
@@ -497,7 +495,6 @@ class TestCompletion(test_engine.EngineTestCase):
       ],
     )
 
-    # Arguments don't change the suggestions, they only narrow which record is found.
     self.assertEqual(
       self.autocomplete("Schools.lookupOne(name=$city).", "Address", "city"),
       [
@@ -511,7 +508,6 @@ class TestCompletion(test_engine.EngineTestCase):
       ],
     )
 
-    # Typing part of a column name filters the suggestions.
     self.assertEqual(
       self.autocomplete("Schools.lookupOne().last", "Address", "city"),
       [
@@ -520,10 +516,9 @@ class TestCompletion(test_engine.EngineTestCase):
       ],
     )
 
-    # An unknown table gives nothing.
     self.assertEqual(self.autocomplete("NoSuchTable.lookupOne().", "Address", "city"), [])
 
-    # `lookupRecords` returns a RecordSet, not a record, so columns are not suggested for it.
+    # lookupRecords() should not be affected
     self.assertEqual(
       self.autocomplete("Schools.lookupRecords().", "Address", "city"),
       [

--- a/sandbox/grist/test_completion.py
+++ b/sandbox/grist/test_completion.py
@@ -410,6 +410,7 @@ class TestCompletion(test_engine.EngineTestCase):
         'Schools.lookupRecords(lastModified=',
         'Schools.lookupRecords(lastModifier=',
         'Schools.lookupRecords(name=',
+        'Schools.lookupRecords(order_by=',
         'Schools.lookupRecords(yearFounded=',
       ],
     )
@@ -427,6 +428,7 @@ class TestCompletion(test_engine.EngineTestCase):
         'Schools.lookupRecords(lastModified=',
         'Schools.lookupRecords(lastModifier=',
         'Schools.lookupRecords(name=',
+        'Schools.lookupRecords(order_by=',
         'Schools.lookupRecords(yearFounded=',
       ],
     )
@@ -441,6 +443,7 @@ class TestCompletion(test_engine.EngineTestCase):
         'Students.lookupRecords(id=',
         'Students.lookupRecords(lastName=',
         'Students.lookupRecords(lastVisit=',
+        'Students.lookupRecords(order_by=',
         'Students.lookupRecords(school=',
         'Students.lookupRecords(school=$id)',
         'Students.lookupRecords(schoolCities=',
@@ -473,12 +476,55 @@ class TestCompletion(test_engine.EngineTestCase):
         'Students.lookupRecords(moreAddresses=',
         'Students.lookupRecords(moreAddresses=CONTAINS($address))',
         'Students.lookupRecords(moreAddresses=CONTAINS($address2))',
+        'Students.lookupRecords(order_by=',
         'Students.lookupRecords(school=',
         'Students.lookupRecords(school=$id)',
         'Students.lookupRecords(schoolCities=',
         'Students.lookupRecords(schoolIds=',
         'Students.lookupRecords(schoolName=',
       ],
+    )
+
+  def test_suggest_lookup_further_arguments(self):
+    # After a comma, suggest the remaining unused columns, excluding the one already typed.
+    # order_by is offered like a plain column, and disappears once used too.
+    self.assertEqual(
+      self.autocomplete("Schools.lookupOne(name=$city,", "Address", "city"),
+      [
+        'Schools.lookupOne(name=$city, address=',
+        'Schools.lookupOne(name=$city, budget=',
+        'Schools.lookupOne(name=$city, id=',
+        'Schools.lookupOne(name=$city, lastModified=',
+        'Schools.lookupOne(name=$city, lastModifier=',
+        'Schools.lookupOne(name=$city, order_by=',
+        'Schools.lookupOne(name=$city, yearFounded=',
+      ],
+    )
+
+    # A space already typed after the comma isn't duplicated.
+    self.assertEqual(
+      self.autocomplete("Schools.lookupOne(name=$city, ", "Address", "city"),
+      self.autocomplete("Schools.lookupOne(name=$city,", "Address", "city"),
+    )
+
+    # Using order_by removes it from the suggestions too, like any other used argument.
+    self.assertEqual(
+      self.autocomplete("Schools.lookupOne(name=$city, order_by=\"id\",", "Address", "city"),
+      [
+        'Schools.lookupOne(name=$city, order_by="id", address=',
+        'Schools.lookupOne(name=$city, order_by="id", budget=',
+        'Schools.lookupOne(name=$city, order_by="id", id=',
+        'Schools.lookupOne(name=$city, order_by="id", lastModified=',
+        'Schools.lookupOne(name=$city, order_by="id", lastModifier=',
+        'Schools.lookupOne(name=$city, order_by="id", yearFounded=',
+      ],
+    )
+
+    # An unfinished argument name (no '=' yet) isn't a comma-triggered case: fall back to the
+    # plain function signature, instead of appending suggestions after the partial word.
+    self.assertEqual(
+      self.autocomplete("Schools.lookupOne(nam", "Address", "city"),
+      [('Schools.lookupOne', '(colName=<value>, ...)', True)],
     )
 
   def test_suggest_lookup_attributes(self):

--- a/sandbox/grist/test_completion.py
+++ b/sandbox/grist/test_completion.py
@@ -518,12 +518,18 @@ class TestCompletion(test_engine.EngineTestCase):
 
     self.assertEqual(self.autocomplete("NoSuchTable.lookupOne().", "Address", "city"), [])
 
-    # lookupRecords() should not be affected
+    # lookupRecords() returns a RecordSet, but a field on it gives a list of values for that
+    # column across all matched records, so the same columns are suggested as for lookupOne().
     self.assertEqual(
       self.autocomplete("Schools.lookupRecords().", "Address", "city"),
       [
-        ('Schools.lookupRecords', '(colName=<value>, ...)', True),
-        'Schools.lookupRecords(address=$id)',
+        'Schools.lookupRecords().address',
+        'Schools.lookupRecords().budget',
+        'Schools.lookupRecords().id',
+        'Schools.lookupRecords().lastModified',
+        'Schools.lookupRecords().lastModifier',
+        'Schools.lookupRecords().name',
+        'Schools.lookupRecords().yearFounded',
       ],
     )
 

--- a/sandbox/grist/test_completion.py
+++ b/sandbox/grist/test_completion.py
@@ -481,6 +481,57 @@ class TestCompletion(test_engine.EngineTestCase):
       ],
     )
 
+  def test_suggest_lookup_attributes(self):
+    # A completed `lookupOne()` returns a record, so suggest its columns after the dot.
+    # This works with no arguments, which is useful for a table holding a single row.
+    self.assertEqual(
+      self.autocomplete("Schools.lookupOne().", "Address", "city"),
+      [
+        'Schools.lookupOne().address',
+        'Schools.lookupOne().budget',
+        'Schools.lookupOne().id',
+        'Schools.lookupOne().lastModified',
+        'Schools.lookupOne().lastModifier',
+        'Schools.lookupOne().name',
+        'Schools.lookupOne().yearFounded',
+      ],
+    )
+
+    # Arguments don't change the suggestions, they only narrow which record is found.
+    self.assertEqual(
+      self.autocomplete("Schools.lookupOne(name=$city).", "Address", "city"),
+      [
+        'Schools.lookupOne(name=$city).address',
+        'Schools.lookupOne(name=$city).budget',
+        'Schools.lookupOne(name=$city).id',
+        'Schools.lookupOne(name=$city).lastModified',
+        'Schools.lookupOne(name=$city).lastModifier',
+        'Schools.lookupOne(name=$city).name',
+        'Schools.lookupOne(name=$city).yearFounded',
+      ],
+    )
+
+    # Typing part of a column name filters the suggestions.
+    self.assertEqual(
+      self.autocomplete("Schools.lookupOne().last", "Address", "city"),
+      [
+        'Schools.lookupOne().lastModified',
+        'Schools.lookupOne().lastModifier',
+      ],
+    )
+
+    # An unknown table gives nothing.
+    self.assertEqual(self.autocomplete("NoSuchTable.lookupOne().", "Address", "city"), [])
+
+    # `lookupRecords` returns a RecordSet, not a record, so columns are not suggested for it.
+    self.assertEqual(
+      self.autocomplete("Schools.lookupRecords().", "Address", "city"),
+      [
+        ('Schools.lookupRecords', '(colName=<value>, ...)', True),
+        'Schools.lookupRecords(address=$id)',
+      ],
+    )
+
   def autocomplete(self, formula, table, column, user=None, row_id=None):
     """
     Mild convenience over self.engine.autocomplete.

--- a/sandbox/grist/test_completion.py
+++ b/sandbox/grist/test_completion.py
@@ -527,6 +527,23 @@ class TestCompletion(test_engine.EngineTestCase):
       ],
     )
 
+  def test_suggest_lookup_attributes_with_call_argument(self):
+    # One level of parens inside the arguments (e.g. a function call) should still be
+    # recognized, as long as the lookupOne call itself is closed before the dot.
+    schools_cols = ['address', 'budget', 'id', 'lastModified', 'lastModifier', 'name', 'yearFounded']
+
+    def expect(txt, cols):
+      self.assertEqual(self.autocomplete(txt, "Address", "city"), [txt + c for c in cols])
+
+    expect("Schools.lookupOne(name=UPPER($city)).", schools_cols)
+    self.assertEqual(
+      self.autocomplete("Schools.lookupOne(name=UPPER($city)).last", "Address", "city"),
+      [
+        'Schools.lookupOne(name=UPPER($city)).lastModified',
+        'Schools.lookupOne(name=UPPER($city)).lastModifier',
+      ],
+    )
+
   def autocomplete(self, formula, table, column, user=None, row_id=None):
     """
     Mild convenience over self.engine.autocomplete.

--- a/test/nbrowser/UserManager.ts
+++ b/test/nbrowser/UserManager.ts
@@ -73,7 +73,7 @@ const assertMaxInheritedRole = stackWrapFunc(async function(inheritLabel: string
 });
 
 describe("UserManager", function() {
-  this.timeout(20000);
+  this.timeout(30000);
   gu.bigScreen();
   const cleanup = setupTestSuite();
 


### PR DESCRIPTION
Fixed autocomplete for Table.lookupOne(). so it suggests columns of the looked up table. Works with empty parens and with arguments, also with one level of nested parens like UPPER($x). lookupRecords() gets the same treatment now, its fields give a list of values per column, same column names as lookupOne().

Also added argument completion after a comma inside a lookup call, e.g. lookupOne(A=1, suggests the remaining unused columns plus order_by.

Tests (only python) where added.