### PR TITLE
Show where a column is referenced, and confirm before deleting a referenced column

### DIFF
--- a/app/client/components/DocComm.ts
+++ b/app/client/components/DocComm.ts
@@ -35,6 +35,7 @@ export class DocComm extends Disposable implements ActiveDocAPI {
   public getFormulaError = this._wrapMethod("getFormulaError");
   public fetchURL = this._wrapMethod("fetchURL");
   public autocomplete = this._wrapMethod("autocomplete");
+  public findColDependents = this._wrapMethod("findColDependents");
   public getActionSummaries = this._wrapMethod("getActionSummaries");
   public startBundleUserActions = this._wrapMethod("startBundleUserActions");
   public stopBundleUserActions = this._wrapMethod("stopBundleUserActions");

--- a/app/client/components/GridView.ts
+++ b/app/client/components/GridView.ts
@@ -24,6 +24,9 @@ import { PasteData } from "app/client/lib/tableUtil";
 import * as tableUtil from "app/client/lib/tableUtil";
 import BaseRowModel from "app/client/models/BaseRowModel";
 import { NEW_FILTER_JSON } from "app/client/models/ColumnFilter";
+import {
+  ColumnReferenceEntry, fetchColumnReferences, revealColumnReferences,
+} from "app/client/models/ColumnReferences";
 import { DataRowModel } from "app/client/models/DataRowModel";
 import { isSyntheticRowId } from "app/client/models/DataTableModelWithDiff";
 import { ViewFieldRec } from "app/client/models/entities/ViewFieldRec";
@@ -48,8 +51,10 @@ import { applyRowHeightLimit } from "app/client/ui/RowHeightConfig";
 import { rowNumbersMenu } from "app/client/ui/RowNumbersMenu";
 import { formatForScreenReader } from "app/client/ui/ScreenReaderFormatters";
 import { ITooltipControl, showTooltip } from "app/client/ui/tooltips";
+import { bigBasicButton } from "app/client/ui2018/buttons";
 import { isNarrowScreen, testId } from "app/client/ui2018/cssVars";
 import { closeRegisteredMenu, menu } from "app/client/ui2018/menus";
+import { saveModal } from "app/client/ui2018/modals";
 import BinaryIndexedTree from "app/common/BinaryIndexedTree";
 import { BulkColValues, CellValue, UserAction } from "app/common/DocActions";
 import { isList } from "app/common/gristTypes";
@@ -1176,7 +1181,7 @@ export default class GridView extends BaseView {
   }
 
   // TODO: Replace alerts with custom notifications
-  protected deleteColumns(selection: CopySelection) {
+  protected deleteColumns(selection: CopySelection): Promise<boolean> {
     const fields = selection.fields;
     if (fields.length === this.viewSection.viewFields().peekLength) {
       reportWarning("You can't delete all the columns on the grid.", {
@@ -1186,14 +1191,58 @@ export default class GridView extends BaseView {
     }
     const columns = fields.filter(col => !col.disableModify());
     const colRefs = columns.map(col => col.colRef.peek());
-    if (colRefs.length > 0) {
-      return this.gristDoc.docData.sendAction(
+    if (colRefs.length === 0) {
+      return Promise.resolve(false);
+    }
+    return this._confirmColumnDeletionIfReferenced(columns).then(async (confirmed): Promise<boolean> => {
+      if (!confirmed) { return false; }
+      await this.gristDoc.docData.sendAction(
         ["BulkRemoveRecord", "_grist_Tables_column", colRefs],
         `Removed columns ${columns.map(col => col.colId.peek()).join(", ")} ` +
         `from ${this.tableModel.tableData.tableId}.`,
-      ).then(() => this.clearSelection());
+      );
+      this.clearSelection();
+      return true;
+    });
+  }
+
+  // If any of the given columns are referenced by formulas elsewhere in the document, asks the
+  // user to confirm the deletion, listing what references them. Resolves to whether to proceed.
+  private async _confirmColumnDeletionIfReferenced(columns: ViewFieldRec[]): Promise<boolean> {
+    const tableId = this.tableModel.tableData.tableId;
+    const referencesByColId = new Map<string, ColumnReferenceEntry[]>();
+    await Promise.all(columns.map(async (col) => {
+      const colId = col.colId.peek();
+      referencesByColId.set(colId, await fetchColumnReferences(this.gristDoc, tableId, colId));
+    }));
+    const referencedColumns = columns.filter(col => (referencesByColId.get(col.colId.peek()) || []).length > 0);
+    if (referencedColumns.length === 0) {
+      return true;
     }
-    return Promise.resolve(false);
+    return new Promise<boolean>((resolve) => {
+      saveModal(ctl => ({
+        title: t("Delete column referenced by other formulas?", { count: referencedColumns.length }),
+        body: referencedColumns.map(col => dom("div",
+          t("{{colId}} is referenced by: {{references}}.", {
+            colId: col.colId.peek(),
+            references: (referencesByColId.get(col.colId.peek()) || [])
+              .map(e => `${e.tableLabel}.${e.colLabel}`).join(", "),
+          }),
+        )),
+        saveLabel: t("Delete"),
+        saveFunc: async () => { resolve(true); },
+        extraButtons: bigBasicButton(
+          t("Show references"),
+          dom.on("click", () => {
+            ctl.close();
+            resolve(false);
+            const target = referencedColumns[0];
+            revealColumnReferences(this.gristDoc, tableId, target.colId.peek()).catch(reportError);
+          }),
+          testId("modal-show-references"),
+        ),
+      }), { onCancel: () => resolve(false) });
+    });
   }
 
   protected hideFields(selection: CopySelection) {

--- a/app/client/models/ColumnReferences.ts
+++ b/app/client/models/ColumnReferences.ts
@@ -48,7 +48,7 @@ export async function fetchColumnReferences(
 /**
  * Shows the given column: same-page columns move the cursor, columns on another page open as
  * an anchor-link popup so the user keeps their place.
- * 
+ *
  * Using only one approach for both cases is buggy.
  */
 export async function navigateToColumn(gristDoc: GristDoc, tableId: string, colId: string): Promise<void> {

--- a/app/client/models/ColumnReferences.ts
+++ b/app/client/models/ColumnReferences.ts
@@ -1,12 +1,9 @@
 import * as commands from "app/client/components/commands";
 import { GristDoc } from "app/client/components/GristDoc";
-import { makeT } from "app/client/lib/localization";
 import { ColumnRec, TableRec } from "app/client/models/DocModel";
-import { reportMessage } from "app/client/models/errors";
+import { urlState } from "app/client/models/gristUrlState";
 
 import { Observable } from "grainjs";
-
-const t = makeT("ColumnReferences");
 
 /**
  * A single column elsewhere in the document whose formula references a given column.
@@ -49,24 +46,35 @@ export async function fetchColumnReferences(
 }
 
 /**
- * Moves the cursor to a view of the given column, so the user can see the formula that
- * references it. Prefers a section the column is already shown in; falls back to the
- * table's raw data section, which always includes every column.
+ * Shows the given column: same-page columns move the cursor, columns on another page open as
+ * an anchor-link popup so the user keeps their place.
+ * 
+ * Using only one approach for both cases is buggy.
  */
 export async function navigateToColumn(gristDoc: GristDoc, tableId: string, colId: string): Promise<void> {
   const table = findTable(gristDoc, tableId);
   const column = findColumn(table, colId);
   if (!table || !column) { return; }
 
-  const colRef = column.getRowId();
   const shownFields = column.viewFields().all().filter(f => !f.viewSection().isRaw.peek());
   const section = shownFields.length ? shownFields[0].viewSection() : table.rawViewSection();
-  const fieldIndex = section.viewFields.peek().all().findIndex(f => f.colRef.peek() === colRef);
+  const sectionId = section.getRowId();
 
-  await gristDoc.moveToCursorPos({
-    sectionId: section.getRowId(),
-    fieldIndex: fieldIndex >= 0 ? fieldIndex : undefined,
-  });
+  const isOnCurrentPage = gristDoc.viewModel.viewSections.peek().peek()
+    .some(s => s.id.peek() === sectionId);
+
+  if (isOnCurrentPage) {
+    const colRef = column.getRowId();
+    const fieldIndex = section.viewFields.peek().all().findIndex(f => f.colRef.peek() === colRef);
+    await gristDoc.moveToCursorPos({
+      sectionId,
+      fieldIndex: fieldIndex >= 0 ? fieldIndex : undefined,
+    });
+  } else {
+    await urlState().pushUrl({
+      hash: { sectionId, colRef: column.getRowId(), popup: true },
+    });
+  }
 }
 
 /**
@@ -77,9 +85,8 @@ export async function navigateToColumn(gristDoc: GristDoc, tableId: string, colI
 export const pendingReferencesReveal = Observable.create<{ tableId: string, colId: string } | null>(null, null);
 
 /**
- * Selects the given column, opens the creator panel to its config, and requests that its
- * "Formula references" section expand and scroll into view. Used from the delete-confirmation
- * dialog so a user can inspect what's using a column without leaving the flow.
+ * Selects a column, opens its config, and reveals its references section. Used by the
+ * delete-confirmation dialog.
  */
 export async function revealColumnReferences(gristDoc: GristDoc, tableId: string, colId: string): Promise<void> {
   pendingReferencesReveal.set({ tableId, colId });

--- a/app/client/models/ColumnReferences.ts
+++ b/app/client/models/ColumnReferences.ts
@@ -1,0 +1,88 @@
+import * as commands from "app/client/components/commands";
+import { GristDoc } from "app/client/components/GristDoc";
+import { makeT } from "app/client/lib/localization";
+import { ColumnRec, TableRec } from "app/client/models/DocModel";
+import { reportMessage } from "app/client/models/errors";
+
+import { Observable } from "grainjs";
+
+const t = makeT("ColumnReferences");
+
+/**
+ * A single column elsewhere in the document whose formula references a given column.
+ */
+export interface ColumnReferenceEntry {
+  tableId: string;
+  colId: string;
+  // Display labels, for showing to the user.
+  tableLabel: string;
+  colLabel: string;
+}
+
+function findTable(gristDoc: GristDoc, tableId: string): TableRec | undefined {
+  return gristDoc.docModel.tables.rowModels.find(t => t.tableId.peek() === tableId);
+}
+
+function findColumn(table: TableRec | undefined, colId: string): ColumnRec | undefined {
+  return table?.columns().all().find(c => c.colId.peek() === colId);
+}
+
+/**
+ * Returns every column elsewhere in the document whose formula statically references
+ * `tableId.colId`, based on a sandbox-side scan of formula source (see
+ * Engine.find_col_dependents in sandbox/grist/engine.py).
+ */
+export async function fetchColumnReferences(
+  gristDoc: GristDoc, tableId: string, colId: string,
+): Promise<ColumnReferenceEntry[]> {
+  const dependents = await gristDoc.docComm.findColDependents(tableId, colId);
+  return dependents.map(({ tableId: depTableId, colId: depColId }) => {
+    const table = findTable(gristDoc, depTableId);
+    const column = findColumn(table, depColId);
+    return {
+      tableId: depTableId,
+      colId: depColId,
+      tableLabel: table?.tableNameDef.peek() ?? depTableId,
+      colLabel: column?.label.peek() ?? depColId,
+    };
+  });
+}
+
+/**
+ * Moves the cursor to a view of the given column, so the user can see the formula that
+ * references it. Prefers a section the column is already shown in; falls back to the
+ * table's raw data section, which always includes every column.
+ */
+export async function navigateToColumn(gristDoc: GristDoc, tableId: string, colId: string): Promise<void> {
+  const table = findTable(gristDoc, tableId);
+  const column = findColumn(table, colId);
+  if (!table || !column) { return; }
+
+  const colRef = column.getRowId();
+  const shownFields = column.viewFields().all().filter(f => !f.viewSection().isRaw.peek());
+  const section = shownFields.length ? shownFields[0].viewSection() : table.rawViewSection();
+  const fieldIndex = section.viewFields.peek().all().findIndex(f => f.colRef.peek() === colRef);
+
+  await gristDoc.moveToCursorPos({
+    sectionId: section.getRowId(),
+    fieldIndex: fieldIndex >= 0 ? fieldIndex : undefined,
+  });
+}
+
+/**
+ * Expand, scroll to, and highlight the "Formula references" section for * a specific column.
+ * Consumed and cleared by buildReferencesConfig (FieldConfig.ts) once it acts on it, so it
+ * doesn't fire again on a later, unrelated column selection.
+ */
+export const pendingReferencesReveal = Observable.create<{ tableId: string, colId: string } | null>(null, null);
+
+/**
+ * Selects the given column, opens the creator panel to its config, and requests that its
+ * "Formula references" section expand and scroll into view. Used from the delete-confirmation
+ * dialog so a user can inspect what's using a column without leaving the flow.
+ */
+export async function revealColumnReferences(gristDoc: GristDoc, tableId: string, colId: string): Promise<void> {
+  pendingReferencesReveal.set({ tableId, colId });
+  await navigateToColumn(gristDoc, tableId, colId);
+  commands.allCommands.fieldTabOpen.run();
+}

--- a/app/client/ui/FieldConfig.ts
+++ b/app/client/ui/FieldConfig.ts
@@ -1,6 +1,10 @@
 import { GristDoc } from "app/client/components/GristDoc";
 import { makeT } from "app/client/lib/localization";
+import {
+  ColumnReferenceEntry, fetchColumnReferences, navigateToColumn, pendingReferencesReveal,
+} from "app/client/models/ColumnReferences";
 import { BEHAVIOR, ColumnRec } from "app/client/models/entities/ColumnRec";
+import { reportError } from "app/client/models/errors";
 import { buildHighlightedCode, cssCodeBlock } from "app/client/ui/CodeHighlight";
 import { cssBlockedCursor, cssFieldFormula, cssLabel, cssRow } from "app/client/ui/RightPanelStyles";
 import { withInfoTooltip } from "app/client/ui/tooltips";
@@ -17,8 +21,10 @@ import { sanitizeIdent } from "app/common/gutil";
 import { components, tokens } from "app/common/ThemePrefs";
 import { CursorPos } from "app/plugin/GristAPI";
 
-import { bundleChanges, Computed, dom, DomContents, DomElementArg, fromKo, MultiHolder,
-  Observable, styled } from "grainjs";
+import {
+  bundleChanges, Computed, dom, DomContents, DomElementArg, fromKo, MultiHolder,
+  Observable, styled
+} from "grainjs";
 import * as ko from "knockout";
 
 const t = makeT("FieldConfig");
@@ -408,13 +414,13 @@ export function buildFormulaConfig(
         dom.prop("disabled", use => use(isSummaryTable) || use(disableOtherActions)),
         testId("field-set-trigger"),
       )),
-    ] : /* type == 'data' */ [
+    ] : /* type == 'data' */[
       menu(behaviorLabel(),
         [
           dom.domComputed(origColumn.hasTriggerFormula, hasTrigger => hasTrigger ?
-          // If we have trigger, we will convert it directly to a formula column
+            // If we have trigger, we will convert it directly to a formula column
             convertTriggerToFormulaOption() :
-          // else we will convert to empty column and open up the editor
+            // else we will convert to empty column and open up the editor
             convertDataColumnToFormulaOption(),
           ),
           clearAndResetOption(),
@@ -444,6 +450,91 @@ export function buildFormulaConfig(
       ]),
     ]),
   ]);
+}
+
+// A collapsible "formula references" that shows which other formulas in the document
+// reference this column. Collapsed by default, and fetches nothing until the user expands
+// it, so merely selecting a column in the grid never triggers a sandbox round-trip.
+export function buildReferencesConfig(owner: MultiHolder, origColumn: ColumnRec, gristDoc: GristDoc) {
+  const expanded = Observable.create(owner, false);
+  const references = Observable.create<ColumnReferenceEntry[] | null>(owner, null);
+  let rootElem: HTMLElement | undefined;
+
+  const refresh = () => {
+    const tableId = origColumn.table.peek().tableId.peek();
+    const colId = origColumn.colId.peek();
+    if (!tableId || !colId) { references.set([]); return; }
+    references.set(null);
+    fetchColumnReferences(gristDoc, tableId, colId)
+      .then((result) => { if (!owner.isDisposed()) { references.set(result); } })
+      .catch(reportError);
+  };
+
+  const expandAndReveal = () => {
+    expanded.set(true);
+    if (references.get() === null) { refresh(); }
+    if (rootElem) {
+      rootElem.scrollIntoView({ block: "center", behavior: "smooth" });
+      flashHighlight(rootElem);
+    }
+  };
+
+  // Collapse and drop stale results when the selected column changes,
+  // doesn't fetch until re-expanded
+  const onColumnMayHaveChanged = () => {
+    const pending = pendingReferencesReveal.get();
+    const tableId = origColumn.table.peek().tableId.peek();
+    const colId = origColumn.colId.peek();
+    if (pending?.tableId === tableId && pending.colId === colId) {
+      pendingReferencesReveal.set(null);
+      expandAndReveal();
+    } else {
+      expanded.set(false);
+      references.set(null);
+    }
+  };
+  owner.autoDispose(origColumn.id.subscribe(onColumnMayHaveChanged));
+  owner.autoDispose(pendingReferencesReveal.addListener(onColumnMayHaveChanged));
+  onColumnMayHaveChanged();
+
+  const toggle = () => {
+    const isExpanding = !expanded.get();
+    expanded.set(isExpanding);
+    if (isExpanding && references.get() === null) {
+      refresh();
+    }
+  };
+
+  return cssReferencesSection(
+    (elem) => { rootElem = elem; },
+    cssReferencesToggle(
+      icon("Dropdown", dom.style("transform", use => use(expanded) ? "" : "rotate(-90deg)")),
+      t("FORMULA REFERENCES"),
+      dom.on("click", toggle),
+      testId("field-references-toggle"),
+    ),
+    dom.maybe(expanded, () => dom.domComputed(references, (entries) => {
+      if (entries === null) {
+        return cssRow(cssReferenceHint(t("Checking references…")));
+      }
+      if (entries.length === 0) {
+        return cssRow(cssReferenceHint(t("Not referenced by any other formulas.")));
+      }
+      return entries.map(entry => cssReferenceRow(
+        dom.on("click", () => navigateToColumn(gristDoc, entry.tableId, entry.colId).catch(reportError)),
+        cssReferenceLabel(`${entry.tableLabel} · ${entry.colLabel}`),
+        testId("field-references-item"),
+      ));
+    })),
+  );
+}
+
+function flashHighlight(elem: HTMLElement) {
+  const flashClass = `${cssReferencesSection.className}-flash`;
+  elem.classList.remove(flashClass);
+  void elem.offsetWidth; // Force a reflow so the animation restarts if triggered again quickly.
+  elem.classList.add(flashClass);
+  setTimeout(() => elem.classList.remove(flashClass), 1400);
 }
 
 interface BuildFormulaOptions {
@@ -527,6 +618,46 @@ const cssColTieConnectors = styled("div", `
 
 const cssEmptySeparator = styled("div", `
   margin-top: 16px;
+`);
+
+const cssReferencesSection = styled("div", `
+  scroll-margin: 60px 0;
+
+  &-flash {
+    animation: cssReferencesFlash 1.4s ease-out;
+  }
+
+  /* Two pulses to grab attention to the section */
+  @keyframes cssReferencesFlash {
+    0%, 100% { background-color: transparent; }
+    10%, 50% { background-color: ${components.buttonGroupSelectedBg}; }
+    30%, 70% { background-color: transparent; }
+  }
+`);
+
+const cssReferencesToggle = styled(cssLabel, `
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+`);
+
+const cssReferenceHint = styled("span", `
+  color: ${theme.lightText};
+`);
+
+const cssReferenceRow = styled(cssRow, `
+  cursor: pointer;
+  color: ${theme.controlFg};
+  &:hover {
+    text-decoration: underline;
+  }
+`);
+
+const cssReferenceLabel = styled("span", `
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `);
 
 const cssInput = styled(textInput, `

--- a/app/client/ui/FieldConfig.ts
+++ b/app/client/ui/FieldConfig.ts
@@ -23,7 +23,7 @@ import { CursorPos } from "app/plugin/GristAPI";
 
 import {
   bundleChanges, Computed, dom, DomContents, DomElementArg, fromKo, MultiHolder,
-  Observable, styled
+  Observable, styled,
 } from "grainjs";
 import * as ko from "knockout";
 
@@ -452,20 +452,34 @@ export function buildFormulaConfig(
   ]);
 }
 
-// A collapsible "formula references" that shows which other formulas in the document
-// reference this column. Collapsed by default, and fetches nothing until the user expands
-// it, so merely selecting a column in the grid never triggers a sandbox round-trip.
+// Column ("tableId.colId") the user last expanded the references section for. Module-level
+// because the config panel is rebuilt whenever the active section changes - including
+// transiently while a cross-page reference popup is open - so we can restore it afterwards.
+let lastExpandedReferencesKey: string | null = null;
+
+// Collapsible list of other formulas referencing this column. Collapsed by default and fetches
+// nothing until expanded, so selecting a column never costs a sandbox round-trip.
 export function buildReferencesConfig(owner: MultiHolder, origColumn: ColumnRec, gristDoc: GristDoc) {
   const expanded = Observable.create(owner, false);
   const references = Observable.create<ColumnReferenceEntry[] | null>(owner, null);
   let rootElem: HTMLElement | undefined;
 
-  const refresh = () => {
-    const tableId = origColumn.table.peek().tableId.peek();
+  // origColumn is a floating row model that can transiently point at no row (e.g. while the
+  // active section is switching), so table.peek() can be null.
+  const getCurrentColumnKey = (): { tableId: string, colId: string } | null => {
+    if (!origColumn.id.peek()) { return null; }
+    const table = origColumn.table.peek();
+    if (!table) { return null; }
+    const tableId = table.tableId.peek();
     const colId = origColumn.colId.peek();
-    if (!tableId || !colId) { references.set([]); return; }
+    return (tableId && colId) ? { tableId, colId } : null;
+  };
+
+  const refresh = () => {
+    const key = getCurrentColumnKey();
+    if (!key) { references.set([]); return; }
     references.set(null);
-    fetchColumnReferences(gristDoc, tableId, colId)
+    fetchColumnReferences(gristDoc, key.tableId, key.colId)
       .then((result) => { if (!owner.isDisposed()) { references.set(result); } })
       .catch(reportError);
   };
@@ -479,19 +493,25 @@ export function buildReferencesConfig(owner: MultiHolder, origColumn: ColumnRec,
     }
   };
 
-  // Collapse and drop stale results when the selected column changes,
-  // doesn't fetch until re-expanded
+  // Collapse and clear when the selected column changes, unless a reveal was requested for it
+  // (see revealColumnReferences) or we're returning to the column the user had expanded.
   const onColumnMayHaveChanged = () => {
     const pending = pendingReferencesReveal.get();
-    const tableId = origColumn.table.peek().tableId.peek();
-    const colId = origColumn.colId.peek();
-    if (pending?.tableId === tableId && pending.colId === colId) {
+    const key = getCurrentColumnKey();
+    if (key && pending?.tableId === key.tableId && pending.colId === key.colId) {
       pendingReferencesReveal.set(null);
+      lastExpandedReferencesKey = `${key.tableId}.${key.colId}`;
       expandAndReveal();
-    } else {
-      expanded.set(false);
-      references.set(null);
+      return;
     }
+    // Re-fetch rather than reuse, so a restored list can't be stale.
+    if (key && lastExpandedReferencesKey === `${key.tableId}.${key.colId}`) {
+      expanded.set(true);
+      refresh();
+      return;
+    }
+    expanded.set(false);
+    references.set(null);
   };
   owner.autoDispose(origColumn.id.subscribe(onColumnMayHaveChanged));
   owner.autoDispose(pendingReferencesReveal.addListener(onColumnMayHaveChanged));
@@ -499,6 +519,8 @@ export function buildReferencesConfig(owner: MultiHolder, origColumn: ColumnRec,
 
   const toggle = () => {
     const isExpanding = !expanded.get();
+    const key = getCurrentColumnKey();
+    lastExpandedReferencesKey = (isExpanding && key) ? `${key.tableId}.${key.colId}` : null;
     expanded.set(isExpanding);
     if (isExpanding && references.get() === null) {
       refresh();

--- a/app/client/ui/RightPanel.ts
+++ b/app/client/ui/RightPanel.ts
@@ -317,7 +317,7 @@ export class RightPanel extends Disposable {
     }));
 
     return domAsync(imports.loadViewPane().then((ViewPane) => {
-      const { buildNameConfig, buildFormulaConfig } = ViewPane.FieldConfig;
+      const { buildNameConfig, buildFormulaConfig, buildReferencesConfig } = ViewPane.FieldConfig;
       return dom.maybe(isColumnValid, () =>
         buildConfigContainer(
           cssSection(
@@ -359,6 +359,11 @@ export class RightPanel extends Disposable {
             cssLabel(t("TRANSFORM")),
             dom.maybe<FieldBuilder | null>(fieldBuilder, builder => builder.buildTransformDom()),
             testId("panel-transform"),
+          ),
+          cssSeparator(),
+          cssSection(
+            dom.hide(isMultiSelect),
+            dom.create(buildReferencesConfig, origColumn, this._gristDoc),
           ),
           this._disableIfReadonly(),
         ),

--- a/app/common/ActiveDocAPI.ts
+++ b/app/common/ActiveDocAPI.ts
@@ -459,6 +459,13 @@ export interface ActiveDocAPI {
   autocomplete(txt: string, tableId: string, columnId: string, rowId: UIRowId | null): Promise<ISuggestionWithValue[]>;
 
   /**
+   * Returns a list of {tableId, colId} for every column whose formula statically references
+   * the given column (based on the same name-resolution logic used to rewrite formulas on
+   * rename).
+   */
+  findColDependents(tableId: string, colId: string): Promise<{ tableId: string, colId: string }[]>;
+
+  /**
    * Get recent actions in ActionGroup format with summaries included.
    */
   getActionSummaries(): Promise<GetActionSummariesResult>;

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -275,10 +275,10 @@ export class ActiveDoc extends EventEmitter {
    */
   public static keepDocOpen(target: ActiveDoc, propertyKey: string, descriptor: PropertyDescriptor) {
     const origFunc = descriptor.value;
-    descriptor.value = function(this: ActiveDoc) {
+    descriptor.value = function (this: ActiveDoc) {
       const result = origFunc.apply(this, arguments);
       this._inactivityTimer.disableUntilFinish(timeoutReached(Deps.KEEP_DOC_OPEN_TIMEOUT_MS, result))
-        .catch(() => {});
+        .catch(() => { });
       return result;
     };
   }
@@ -807,9 +807,11 @@ export class ActiveDoc extends EventEmitter {
   @ActiveDoc.keepDocOpen
   public async createEmptyDoc(docSession: OptDocSession,
     options?: { useExisting?: boolean }): Promise<ActiveDoc> {
-    await this.loadDoc(docSession, { forceNew: true,
+    await this.loadDoc(docSession, {
+      forceNew: true,
       skipInitialTable: true,
-      ...options });
+      ...options
+    });
     // Makes sure docPluginManager is ready in case new doc is used to import new data
     await this.docPluginManager?.ready;
     this._fullyLoaded = true;
@@ -844,7 +846,7 @@ export class ActiveDoc extends EventEmitter {
             return this._beforeMigration(docSession, "storage", currentVersion, newVersion);
           },
           afterMigration: async (newVersion, success) => {
-            return this._afterMigration(docSession, "storage",  newVersion, success);
+            return this._afterMigration(docSession, "storage", newVersion, success);
           },
         });
       }
@@ -1697,9 +1699,11 @@ export class ActiveDoc extends EventEmitter {
     // point.
     // Undos are best effort now by default.
     return this._applyUserActionsWithExtendedOptions(
-      docSession, actions, { bestEffort: undo,
-        oldestSource,
-        fromOwnHistory, ...(options || {}) });
+      docSession, actions, {
+        bestEffort: undo,
+      oldestSource,
+      fromOwnHistory, ...(options || {})
+    });
   }
 
   /**
@@ -1766,6 +1770,16 @@ export class ActiveDoc extends EventEmitter {
     await this.waitForInitialization();
     const user = await this._granularAccess.getCachedUser(docSession);
     return this._pyCall("autocomplete", txt, tableId, columnId, rowId, user.toJSON());
+  }
+
+  public async findColDependents(
+    docSession: DocSession,
+    tableId: string,
+    colId: string,
+  ): Promise<{ tableId: string, colId: string }[]> {
+    if (!await this._granularAccess.canScanData(docSession)) { return []; }
+    await this.waitForInitialization();
+    return this._pyCall("find_col_dependents", tableId, colId);
   }
 
   /**
@@ -1899,8 +1913,10 @@ export class ActiveDoc extends EventEmitter {
     // can be associated with an arbitrary doc worker, rather than tied to the
     // same worker as the trunk.  We use a Permit for authorization.
     const permitStore = this._server.getPermitStore();
-    const permitKey = await permitStore.setPermit({ docId: forkIds.docId,
-      otherDocId: this.docName });
+    const permitKey = await permitStore.setPermit({
+      docId: forkIds.docId,
+      otherDocId: this.docName
+    });
     try {
       const url = await this._server.getHomeUrlByDocId(
         forkIds.docId,
@@ -2070,8 +2086,10 @@ export class ActiveDoc extends EventEmitter {
       if (!user.email) { continue; }
       const email = normalizeEmail(user.email);
       if (!isShared.has(email)) {
-        result.attributeTableUsers.push({ email: user.email, name: user.name || "",
-          id: 0, access: user.access === undefined ? "editors" : user.access });
+        result.attributeTableUsers.push({
+          email: user.email, name: user.name || "",
+          id: 0, access: user.access === undefined ? "editors" : user.access
+        });
       }
     }
 
@@ -2437,7 +2455,7 @@ export class ActiveDoc extends EventEmitter {
     return timingResults;
   }
 
-  public async getTimings(): Promise<FormulaTimingInfo[] | void>  {
+  public async getTimings(): Promise<FormulaTimingInfo[] | void> {
     await this.waitForInitialization();
 
     if (this._modificationLock.isLocked()) {
@@ -2501,7 +2519,7 @@ export class ActiveDoc extends EventEmitter {
       // nothing seems best, as long as we follow the recommendations in migrations.py (never
       // remove/modify/rename metadata tables or columns, or change their meaning).
       this._log.warn(docSession, "Doc is newer (v%s) than this version of Grist (v%s); " +
-      "proceeding with fingers crossed", docSchemaVersion, schemaVersion);
+        "proceeding with fingers crossed", docSchemaVersion, schemaVersion);
     }
 
     if (!this._isSnapshot) {
@@ -2741,8 +2759,8 @@ export class ActiveDoc extends EventEmitter {
   private _makeInfo(docSession: OptDocSession, options: ApplyUAOptions = {}) {
     const user =
       docSession.mode === "system" ? "grist" :
-      // Anonymize user info for form submissions.
-      // Note: This is half-baked and doesn't account for other types of shares besides forms.
+        // Anonymize user info for form submissions.
+        // Note: This is half-baked and doesn't account for other types of shares besides forms.
         getDocSessionShare(docSession) ? ANONYMOUS_USER_EMAIL :
           docSession.displayEmail || "";
     return {
@@ -3021,8 +3039,8 @@ export class ActiveDoc extends EventEmitter {
     // and DataEngine may still do things serially, but it allows them to be busy simultaneously.
     await bluebird.map(tableNames, async (tableName: string) =>
       this._pyCall("load_table", tableName, await this._fetchTableIfPresent(tableName)),
-    // How many tables to query for and push to the data engine in parallel.
-    { concurrency: 3 });
+      // How many tables to query for and push to the data engine in parallel.
+      { concurrency: 3 });
     return this;
   }
 
@@ -3613,7 +3631,7 @@ export class ActiveDoc extends EventEmitter {
   }
 
   private _doStartTiming() {
-    return  this._pyCall("start_timing");
+    return this._pyCall("start_timing");
   }
 
   private _logForkDocumentEvents(
@@ -3669,12 +3687,14 @@ export class ActiveDoc extends EventEmitter {
       if (skip) {
         return;
       }
-      const column: ColumnMetadata = { id, fields: {
-        colRef: colRefs[index],
-        label: String(columnData.label?.[index] ?? ""),
-        isFormula: Boolean(columnData.isFormula?.[index]),
-        type: String(columnData.type?.[index] ?? ""),
-      } };
+      const column: ColumnMetadata = {
+        id, fields: {
+          colRef: colRefs[index],
+          label: String(columnData.label?.[index] ?? ""),
+          isFormula: Boolean(columnData.isFormula?.[index]),
+          type: String(columnData.type?.[index] ?? ""),
+        }
+      };
       const otherFieldNames = without(fieldNames, "label", "isFormula", "type");
       for (const key of otherFieldNames) {
         column.fields[key] = columnData[key][index];
@@ -3732,7 +3752,7 @@ interface ActiveDocAndReq {
 }
 export async function getRealTableId(
   tableId: string,
-  options:  MetaTables | ActiveDocAndReq,
+  options: MetaTables | ActiveDocAndReq,
 ): Promise<string> {
   if (parseInt(tableId)) {
     const metaTables = "metaTables" in options ?

--- a/app/server/lib/ActiveDoc.ts
+++ b/app/server/lib/ActiveDoc.ts
@@ -275,7 +275,7 @@ export class ActiveDoc extends EventEmitter {
    */
   public static keepDocOpen(target: ActiveDoc, propertyKey: string, descriptor: PropertyDescriptor) {
     const origFunc = descriptor.value;
-    descriptor.value = function (this: ActiveDoc) {
+    descriptor.value = function(this: ActiveDoc) {
       const result = origFunc.apply(this, arguments);
       this._inactivityTimer.disableUntilFinish(timeoutReached(Deps.KEEP_DOC_OPEN_TIMEOUT_MS, result))
         .catch(() => { });
@@ -810,7 +810,7 @@ export class ActiveDoc extends EventEmitter {
     await this.loadDoc(docSession, {
       forceNew: true,
       skipInitialTable: true,
-      ...options
+      ...options,
     });
     // Makes sure docPluginManager is ready in case new doc is used to import new data
     await this.docPluginManager?.ready;
@@ -1701,9 +1701,9 @@ export class ActiveDoc extends EventEmitter {
     return this._applyUserActionsWithExtendedOptions(
       docSession, actions, {
         bestEffort: undo,
-      oldestSource,
-      fromOwnHistory, ...(options || {})
-    });
+        oldestSource,
+        fromOwnHistory, ...(options || {}),
+      });
   }
 
   /**
@@ -1915,7 +1915,7 @@ export class ActiveDoc extends EventEmitter {
     const permitStore = this._server.getPermitStore();
     const permitKey = await permitStore.setPermit({
       docId: forkIds.docId,
-      otherDocId: this.docName
+      otherDocId: this.docName,
     });
     try {
       const url = await this._server.getHomeUrlByDocId(
@@ -2088,7 +2088,7 @@ export class ActiveDoc extends EventEmitter {
       if (!isShared.has(email)) {
         result.attributeTableUsers.push({
           email: user.email, name: user.name || "",
-          id: 0, access: user.access === undefined ? "editors" : user.access
+          id: 0, access: user.access === undefined ? "editors" : user.access,
         });
       }
     }
@@ -2519,7 +2519,7 @@ export class ActiveDoc extends EventEmitter {
       // nothing seems best, as long as we follow the recommendations in migrations.py (never
       // remove/modify/rename metadata tables or columns, or change their meaning).
       this._log.warn(docSession, "Doc is newer (v%s) than this version of Grist (v%s); " +
-        "proceeding with fingers crossed", docSchemaVersion, schemaVersion);
+      "proceeding with fingers crossed", docSchemaVersion, schemaVersion);
     }
 
     if (!this._isSnapshot) {
@@ -3039,8 +3039,8 @@ export class ActiveDoc extends EventEmitter {
     // and DataEngine may still do things serially, but it allows them to be busy simultaneously.
     await bluebird.map(tableNames, async (tableName: string) =>
       this._pyCall("load_table", tableName, await this._fetchTableIfPresent(tableName)),
-      // How many tables to query for and push to the data engine in parallel.
-      { concurrency: 3 });
+    // How many tables to query for and push to the data engine in parallel.
+    { concurrency: 3 });
     return this;
   }
 
@@ -3693,7 +3693,7 @@ export class ActiveDoc extends EventEmitter {
           label: String(columnData.label?.[index] ?? ""),
           isFormula: Boolean(columnData.isFormula?.[index]),
           type: String(columnData.type?.[index] ?? ""),
-        }
+        },
       };
       const otherFieldNames = without(fieldNames, "label", "isFormula", "type");
       for (const key of otherFieldNames) {

--- a/app/server/lib/DocWorker.ts
+++ b/app/server/lib/DocWorker.ts
@@ -139,6 +139,7 @@ export class DocWorker {
       startBundleUserActions: method("editors", "startBundleUserActions"),
       stopBundleUserActions: method("editors", "stopBundleUserActions"),
       autocomplete: method("viewers", "autocomplete"),
+      findColDependents: method("viewers", "findColDependents"),
       fetchURL: method("viewers", "fetchURL"),
       getActionSummaries: method("viewers", "getActionSummaries"),
       reloadDoc: method("editors", "reloadDoc"),

--- a/sandbox/grist/engine.py
+++ b/sandbox/grist/engine.py
@@ -1514,6 +1514,30 @@ class Engine(object):
     results.sort(key=lambda r: r[0][0] if type(r[0]) == tuple else r[0])
     return results
 
+  def find_col_dependents(self, table_id, col_id):
+    """
+    Returns a list of {tableId, colId} for every column whose formula statically references
+    the given column, based on the same name-resolution logic used to rewrite formulas on
+    rename (see useractions._prepare_formula_renames).
+    """
+    seen = set()
+    dependents = []
+    for (formula_info, _pos, ref_table_id, ref_col_id) in self.gencode.grist_names():
+      if (ref_table_id, ref_col_id) != (table_id, col_id):
+        continue
+      (dep_table_id, dep_col_id) = formula_info
+      if (dep_table_id, dep_col_id) == (table_id, col_id):
+        continue
+      # Skip internal helper columns (e.g. the "gristHelper_Display")
+      if not column.is_visible_column(dep_col_id):
+        continue
+      key = (dep_table_id, dep_col_id)
+      if key in seen:
+        continue
+      seen.add(key)
+      dependents.append({"tableId": dep_table_id, "colId": dep_col_id})
+    return dependents
+
   def _get_undo_checkpoint(self):
     """
     You may call _get_undo_checkpoint() and pass its result into _undo_to_checkpoint() to undo

--- a/sandbox/grist/main.py
+++ b/sandbox/grist/main.py
@@ -101,6 +101,10 @@ def run(sandbox):
     return eng.autocomplete(txt, table_id, column_id, row_id, user)
 
   @export
+  def find_col_dependents(table_id, col_id):
+    return eng.find_col_dependents(table_id, col_id)
+
+  @export
   def find_col_from_values(values, n, opt_table_id):
     return eng.find_col_from_values(values, n, opt_table_id)
 

--- a/sandbox/grist/test_find_col_dependents.py
+++ b/sandbox/grist/test_find_col_dependents.py
@@ -1,0 +1,58 @@
+import test_engine
+
+
+class TestFindColDependents(test_engine.EngineTestCase):
+  def setUp(self):
+    super(TestFindColDependents, self).setUp()
+    self.apply_user_action(["AddTable", "People", [
+      {"id": "name", "type": "Text"},
+    ]])
+    self.apply_user_action(["AddTable", "Games", [
+      {"id": "name", "type": "Text"},
+    ]])
+    self.add_records("People", ["name"], [["Bob"], ["Alice"]])
+    self.add_records("Games", ["name"], [["Chess"]])
+
+  def test_direct_dollar_reference(self):
+    self.add_column("People", "greeting", formula="'Hi ' + $name")
+    self.assertEqual(
+        self.engine.find_col_dependents("People", "name"),
+        [{"tableId": "People", "colId": "greeting"}])
+
+  def test_rec_attribute_reference(self):
+    self.add_column("People", "greeting", formula="'Hi ' + rec.name")
+    self.assertEqual(
+        self.engine.find_col_dependents("People", "name"),
+        [{"tableId": "People", "colId": "greeting"}])
+
+  def test_lookup_reference(self):
+    self.add_column("Games", "winner", formula="People.lookupOne(name=$name).name")
+    self.assertEqual(
+        self.engine.find_col_dependents("People", "name"),
+        [{"tableId": "Games", "colId": "winner"}])
+
+  def test_no_false_positive_on_same_named_column_in_other_table(self):
+    # "name" also exists on Games, but nothing references People.name.
+    self.assertEqual(self.engine.find_col_dependents("People", "name"), [])
+
+  def test_dedupes_multiple_references_in_one_formula(self):
+    self.add_column("People", "greeting", formula="($name + $name).upper()")
+    self.assertEqual(
+        self.engine.find_col_dependents("People", "name"),
+        [{"tableId": "People", "colId": "greeting"}])
+
+  def test_no_self_reference(self):
+    # A column referencing itself (e.g. via rec.name in a trigger formula) shouldn't
+    # be reported as its own dependent.
+    self.add_column("People", "name2", formula="rec.name2 or ''", isFormula=False)
+    self.assertEqual(self.engine.find_col_dependents("People", "name2"), [])
+
+  def test_skips_hidden_display_helper_column(self):
+    # Auto-generated "gristHelper_Display" should be ignored because they are not user
+    # created formlas
+    self.apply_user_action(["AddTable", "Fans", [
+      {"id": "favorite", "type": "Ref:People"},
+    ]])
+    favorite_ref = self.engine.docmodel.get_column_rec("Fans", "favorite").id
+    self.apply_user_action(["SetDisplayFormula", "Fans", None, favorite_ref, "$favorite.name"])
+    self.assertEqual(self.engine.find_col_dependents("People", "name"), [])

--- a/test/nbrowser/ColumnOps.ntest.js
+++ b/test/nbrowser/ColumnOps.ntest.js
@@ -211,7 +211,7 @@ describe("ColumnOps.ntest", function() {
     // delete shortcut should delete all selected columns
     await gu.selectGridArea([1, 0], [1, 1]);
     await gu.sendKeys([$.ALT, "-"]);
-    await gu.waitForServer();
+    await gu.confirmColumnDeletionIfPrompted();
     assert.deepEqual(await gu.getGridLabels("Country"),
       ["Continent", "Region", "SurfaceArea", "IndepYear", "Population", "LifeExpectancy",
         "GNP", "GNPOld", "LocalName", "GovernmentForm", "HeadOfState", "Capital", "Code2"]);
@@ -221,7 +221,7 @@ describe("ColumnOps.ntest", function() {
     // delete menu item should delete all selected columns
     await gu.selectGridArea([1, 2], [1, 8]);
     await gu.clickColumnMenuItem("SurfaceArea", "Delete", true);
-    await gu.waitForServer();
+    await gu.confirmColumnDeletionIfPrompted();
     assert.deepEqual(await gu.getGridLabels("Country"),
       ["Code", "Name", "GNPOld", "LocalName", "GovernmentForm", "HeadOfState", "Capital", "Code2"]);
     // Undo to restore changes

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -1905,8 +1905,20 @@ namespace gristUtils {
 
   export async function deleteColumn(col: IColHeader | string) {
     await openColumnMenu(col, "Delete column");
-    await waitForServer();
+    await confirmColumnDeletionIfPrompted();
     await wipeToasts();
+  }
+
+  /**
+   * Accepts confirmation dialog, when deleting a column references in a formula.
+   * Safe to call when no confirmation appears.
+   */
+  export async function confirmColumnDeletionIfPrompted() {
+    await waitForServer();
+    if (await driver.find(".test-modal-show-references").isPresent()) {
+      await driver.find(".test-modal-confirm").click();
+      await waitForServer();
+    }
   }
 
   export async function deleteRow(rowNum: number) {


### PR DESCRIPTION
## Context

There's no way to see what depends on a column before deleting or changing it. Today,
deleting a column just removes it — if other formulas reference it, they silently break
and you only find out later from a `#REF` error.

## Proposed solution

- A collapsible **"FORMULA REFERENCES"** section at the bottom of the column config panel,
  listing formulas elsewhere that reference the selected column. Collapsed by default —
  fetches nothing until expanded, so no cost.
- A **confirmation dialog before deleting** a column that's referenced elsewhere, listing
  what depends on it. unreferenced columns still delete instantly, unchanged.
- A **"Show references"** button in that dialog to jump to and inspect them before deciding.

Reuses the same formula-reference lookup Grist already uses to rewrite formulas on rename,
so it's not a new way of finding references, just a new use of the existing one.

## Related issues

- Closes #2533
- Related to #1203

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [x] 👍 yes, I added tests to the test suite

## Screenshots / Screencasts
<img width="285" height="295" alt="image" src="https://github.com/user-attachments/assets/88bce178-f77b-4c76-a0b0-64204897832c" />
<img width="651" height="260" alt="image" src="https://github.com/user-attachments/assets/afaf14e2-9a8f-415a-86d1-ab169a8b1c2f" />

