### PR TITLE
fix: use visible field's colId, not helper display column's, for header=colId export

### DIFF
--- a/app/server/lib/Export.ts
+++ b/app/server/lib/Export.ts
@@ -54,6 +54,12 @@ export class ActiveDocSourceDirect implements ActiveDocSource {
 export interface ExportColumn {
   id: number;
   colId: string;
+  /**
+   * The colId of the underlying visible column, as opposed to `colId` which may refer to a
+   * helper display column (e.g. for Reference columns). Used for the `header=colId` export option,
+   * so that exported headers name the field the user configured rather than an internal helper column.
+   */
+  rawColId: string;
   label: string;
   type: string;
   formatter: BaseFormatter;
@@ -233,6 +239,7 @@ export async function doExportTable(
       return {
         id: displayCol.id,
         colId: displayCol.colId,
+        rawColId: tc.colId,
         label: tc.label,
         type: tc.type,
         formatter: createFullFormatterFromDocData(docData, tc.id),
@@ -321,6 +328,7 @@ export async function doExportSection(
     return {
       id: displayCol.id,
       colId: displayCol.colId,
+      rawColId: col.colId,
       label: col.label,
       type: col.type,
       formatter: createFullFormatterFromDocData(docData, col.id, field?.id),

--- a/app/server/lib/ExportDSV.ts
+++ b/app/server/lib/ExportDSV.ts
@@ -136,7 +136,9 @@ function convertToDsv(data: ExportData, options: ConvertToDsvOptions) {
   // create formatters for columns
   const formatters = viewColumns.map(col => col.formatter);
   // Arrange the data into a row-indexed matrix, starting with column headers.
-  const colPropertyAsHeader = header ?? "label";
+  // Note: "colId" here refers to the visible field's own colId (rawColId), not `col.colId`,
+  // which may point at an internal helper display column (e.g. for Reference columns).
+  const colPropertyAsHeader = header === "colId" ? "rawColId" : "label";
   const csvMatrix = [viewColumns.map(col => col[colPropertyAsHeader])];
   // populate all the rows with values as strings
   rowIds.forEach((row) => {

--- a/app/server/lib/ExportTableSchema.ts
+++ b/app/server/lib/ExportTableSchema.ts
@@ -62,7 +62,9 @@ export async function collectTableSchemaInFrictionlessFormat(
     title: tableName,
     schema: {
       fields: columns.map(col => ({
-        name: col[header || "label"],
+        // "colId" here refers to the visible field's own colId (rawColId), not `col.colId`,
+        // which may point at an internal helper display column (e.g. for Reference columns).
+        name: col[header === "colId" ? "rawColId" : "label"],
         ...(col.description ? { description: col.description } : {}),
         ...buildTypeField(col, settings.locale),
       })),


### PR DESCRIPTION
## Context

When exporting with `?header=colId` (added in #692), Reference and formula fields show `gristHelper_Display` (or similar internal helper colId) as the header instead of the field's own colId. Context: #954.

## Proposed solution

Reference/formula columns are rendered via an internal helper "display column" (e.g. `gristHelper_Display7`) that holds the formatted value — `ExportColumn.colId` intentionally points at that helper column's colId because it's also used (via `ServerColumnGetters`) to look up the actual cell value to export. The `header=colId` option was reusing that same field for the header text, so it leaked the helper column's internal colId instead of the user-visible field's colId.

Added `ExportColumn.rawColId`, the visible field's own colId, and use it specifically for `header=colId` in `ExportDSV.ts` (CSV/TSV) and `ExportTableSchema.ts` (table-schema endpoint). The existing `colId` field is untouched, so cell-value lookup for Reference/formula columns is unaffected.

## Related issues

Closes #999

## Has this been tested?

- [x] 🙋 no, because I need help — I verified the logic by tracing `ServerColumnGetters`/`doExportTable`/`doExportSection` and confirmed `access`/value lookup still uses `col.id`/`col.colId` (helper column) unchanged, only the header now uses `rawColId`. I wasn't able to run the full test suite in this environment (large yarn install), so a maintainer/CI run to confirm the existing `DocApiDownloads.ts` header=colId tests plus a manual check with a Reference column would be appreciated.
