### PR TITLE
Fix stale relations in stored Record values breaking renames

### DIFF
--- a/sandbox/grist/engine.py
+++ b/sandbox/grist/engine.py
@@ -37,6 +37,7 @@ import table as table_module
 from timing import DummyTiming
 from user import User # pylint:disable=wrong-import-order
 import useractions
+import usertypes
 import column
 import urllib_patch  # noqa imported for side effect # pylint:disable=unused-import
 
@@ -820,6 +821,7 @@ class Engine(object):
     changes = None
     cleaned = []    # this lists row_ids that can be removed from dirty_rows once we are no
                     # longer iterating on it.
+    is_any_column = isinstance(col.type_obj, usertypes.Any)
     try:
       require_count = len(require_rows)
       for i, row_id in enumerate(itertools.chain(require_rows, dirty_rows)):
@@ -891,6 +893,14 @@ class Engine(object):
             if not changes:
               changes = self._changes_map.setdefault(node, [])
             changes.append((row_id, previous, value))
+            col.set(row_id, value)
+          elif is_any_column:
+            # The new value is equal to the old one, making set() look like a skippable no-op.
+            # But equal values can differ subtly; in particular, Records inside Any values carry
+            # Relation objects, which go stale when a table or column is renamed. So we prefer
+            # the fresh value (with no change to report) when set() is cheap, as it is for Any
+            # columns. Other columns hold only plain data, and their set() may be costly, so
+            # for them we skip it as usual.
             col.set(row_id, value)
 
         exclude.add(row_id)

--- a/sandbox/grist/test_rename_relations.py
+++ b/sandbox/grist/test_rename_relations.py
@@ -1,0 +1,92 @@
+"""
+Tests that formula values holding Record/RecordSet objects in Any columns stay usable across
+renaming the table or column holding them. Such values carry Relation objects for dependency
+tracking; these tests verify that renames don't leave stale relations behind, which used to break
+dependent formulas (AssertionError) or silently stop recalculation.
+"""
+import test_engine
+import testutil
+
+
+class TestRenameRelations(test_engine.EngineTestCase):
+
+  def make_sample(self, lookup_formula, cost_formula):
+    return testutil.parse_test_sample({
+      "SCHEMA": [
+        [1, "Values", [
+          [11, "Key", "Numeric", False, "", "", ""],
+          [12, "Cost", "Numeric", False, "", "", ""],
+        ]],
+        [2, "Sequence", [
+          [21, "ValueKey", "Numeric", False, "", "", ""],
+          [22, "ValueRow", "Any", True, lookup_formula, "", ""],
+          [23, "Cost", "Any", True, cost_formula, "", ""],
+        ]],
+      ],
+      "DATA": {
+        "Values": [
+          ["id", "Key", "Cost"],
+          [1, 1, 10],
+          [2, 2, 20],
+        ],
+        "Sequence": [
+          ["id", "ValueKey"],
+          [1, 1],
+          [2, 2],
+        ],
+      }
+    })
+
+  def check_rename_scenario(self, lookup_formula, cost_formula, rename_action, table_id):
+    """
+    Loads the sample, applies the given rename, and checks that the dependent "Cost" column
+    (in the table named table_id after the rename) both survives the rename and still
+    recalculates when the looked-up records change.
+    """
+    self.load_sample(self.make_sample(lookup_formula, cost_formula))
+    self.apply_user_action(rename_action)
+    self.assertTableData(table_id, cols="subset", data=[
+      ["id", "ValueKey", "Cost"],
+      [1, 1, 10],
+      [2, 2, 20],
+    ])
+    self.update_record("Values", 1, Cost=99)
+    self.assertTableData(table_id, cols="subset", data=[
+      ["id", "ValueKey", "Cost"],
+      [1, 1, 99],
+      [2, 2, 20],
+    ])
+
+  def test_table_rename_with_record_value(self):
+    self.check_rename_scenario(
+      "Values.lookupOne(Key=$ValueKey)", "$ValueRow.Cost",
+      ["RenameTable", "Sequence", "Sequence2"], "Sequence2")
+
+  def test_column_rename_with_record_value(self):
+    self.check_rename_scenario(
+      "Values.lookupOne(Key=$ValueKey)", "$ValueRow.Cost",
+      ["RenameColumn", "Sequence", "ValueRow", "ValueRow2"], "Sequence")
+
+  def test_table_rename_with_recordset_value(self):
+    self.check_rename_scenario(
+      "Values.lookupRecords(Key=$ValueKey)", "SUM($ValueRow.Cost)",
+      ["RenameTable", "Sequence", "Sequence2"], "Sequence2")
+
+  def test_table_rename_with_record_in_frozenset(self):
+    # A container type with value-based equality that the engine doesn't specifically know about.
+    self.check_rename_scenario(
+      "frozenset([Values.lookupOne(Key=$ValueKey)])", "sum(r.Cost for r in $ValueRow)",
+      ["RenameTable", "Sequence", "Sequence2"], "Sequence2")
+
+  def test_table_rename_with_nested_record_value(self):
+    self.check_rename_scenario(
+      "[Values.lookupOne(Key=$ValueKey)]", "$ValueRow[0].Cost",
+      ["RenameTable", "Sequence", "Sequence2"], "Sequence2")
+
+  def test_table_rename_emits_no_changes(self):
+    # A rename doesn't change any computed values, so it should produce no value updates.
+    self.load_sample(self.make_sample("Values.lookupOne(Key=$ValueKey)", "$ValueRow.Cost"))
+    out_actions = self.apply_user_action(["RenameTable", "Sequence", "Sequence2"])
+    updates = [action for action in out_actions.stored + out_actions.calc
+               if getattr(action, 'table_id', None) in ("Sequence", "Sequence2")]
+    self.assertEqual(updates, [])


### PR DESCRIPTION
## Context

When a formula returns a Record/RecordSet in an Any column, the stored value carries a Relation object used for dependency tracking. Renaming the table or column that holds that formula recomputes it, but the fresh value compares equal to the stale one, so the stale object was kept. Dependent formulas then failed with an AssertionError (table rename), or silently stopped recalculating (column rename).

## Proposed solution

Fix at the recompute store gate: when a recomputed value looks unchanged but is in an Any column, store it anyway, without reporting a change.

## Related issues

Fixes grist-core issue #2539.

## Has this been tested?

Test added, which fails on master and passes with this fix.

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

