### PR TITLE
Fix download of documents at old schema versions

### DIFF
--- a/app/server/lib/DocApi.ts
+++ b/app/server/lib/DocApi.ts
@@ -81,7 +81,7 @@ import { downloadDSV } from "app/server/lib/ExportDSV";
 import { collectTableSchemaInFrictionlessFormat } from "app/server/lib/ExportTableSchema";
 import { streamXLSX } from "app/server/lib/ExportXLSX";
 import { expressWrap } from "app/server/lib/expressWrap";
-import { filterDocumentInPlace } from "app/server/lib/filterUtils";
+import { filterDocumentInPlace, makeFilterOptions } from "app/server/lib/filterUtils";
 import { googleAuthTokenMiddleware } from "app/server/lib/GoogleAuth";
 import { exportToDrive } from "app/server/lib/GoogleExport";
 import { GristServer } from "app/server/lib/GristServer";
@@ -709,13 +709,7 @@ export class DocWorkerApi {
       const srcDocId = stringParam(req.body.srcDocId, "srcDocId");
       if (srcDocId !== req.specialPermit?.otherDocId) { throw new Error("access denied"); }
       const fname = await this._docManager.storageManager.prepareFork(srcDocId, docId);
-      await filterDocumentInPlace(docSessionFromRequest(req), fname, {
-        removeData: false,
-        removeHistory: false,
-        removeFullCopiesSpecialRight: true,
-        markAction: true,
-        disableTriggers: true,
-      });
+      await filterDocumentInPlace(docSessionFromRequest(req), fname, makeFilterOptions());
       res.json({ srcDocId, docId });
     }));
 

--- a/app/server/lib/DocWorker.ts
+++ b/app/server/lib/DocWorker.ts
@@ -10,7 +10,7 @@ import { Client } from "app/server/lib/Client";
 import { Comm } from "app/server/lib/Comm";
 import { DocApiUsageTracker } from "app/server/lib/DocApiUsageTracker";
 import { DocSession, docSessionFromRequest } from "app/server/lib/DocSession";
-import { filterDocumentInPlace } from "app/server/lib/filterUtils";
+import { filterDocumentInPlace, makeFilterOptions } from "app/server/lib/filterUtils";
 import { GristServer } from "app/server/lib/GristServer";
 import { IDocStorageManager } from "app/server/lib/IDocStorageManager";
 import log from "app/server/lib/log";
@@ -92,13 +92,8 @@ export class DocWorker {
       removeHistory = true;
     }
 
-    await filterDocumentInPlace(docSessionFromRequest(mreq), tmpPath, {
-      removeData,
-      removeHistory,
-      removeFullCopiesSpecialRight: true,
-      markAction: true,
-      disableTriggers: true,
-    });
+    await filterDocumentInPlace(docSessionFromRequest(mreq), tmpPath,
+      makeFilterOptions({ removeData, removeHistory }));
     // NOTE: We may want to reconsider the mimeType used for Grist files.
     return res.type("application/x-sqlite3")
       .download(

--- a/app/server/lib/filterUtils.ts
+++ b/app/server/lib/filterUtils.ts
@@ -15,13 +15,34 @@ import { OpenMode, quoteIdent, SQLiteDB } from "app/server/lib/SQLiteDB";
  * allow us for example to permit downloads of documents with row-level filters
  * in place.
  */
-export async function filterDocumentInPlace(docSession: OptDocSession, filename: string, options: {
-  removeData: boolean,
-  removeHistory: boolean,
-  removeFullCopiesSpecialRight: boolean,
-  markAction: boolean,
-  disableTriggers: boolean,
-}) {
+export interface FilterOptions {
+  removeData: boolean;
+  removeHistory: boolean;
+  removeFullCopiesSpecialRight: boolean;
+  markAction: boolean;
+  disableTriggers: boolean;
+}
+
+/**
+ * The filtering a document gets on its way out, as a download or a fork.
+ * Removing data and history is asked for per download; the rest always applies.
+ */
+export function makeFilterOptions(
+  options: { removeData?: boolean, removeHistory?: boolean } = {},
+): FilterOptions {
+  return {
+    removeData: false,
+    removeHistory: false,
+    ...options,
+    removeFullCopiesSpecialRight: true,
+    markAction: true,
+    disableTriggers: true,
+  };
+}
+
+export async function filterDocumentInPlace(
+  docSession: OptDocSession, filename: string, options: FilterOptions,
+) {
   // We ignore docSession for now, since no changes are user-dependent yet.
   if (options.markAction) {
     await markAction(filename);
@@ -89,7 +110,9 @@ async function markAction(filename: string) {
   const db = await SQLiteDB.openDBRaw(filename, OpenMode.OPEN_EXISTING);
   const history = new ActionHistoryImpl(db);
   const states = await history.getRecentStates(1);
-  if (states.length > 0) {
+  // documentSettings arrived in schema version 23; an older document has
+  // nowhere to record the action, and gains the column when it migrates.
+  if (states.length > 0 && await hasColumn(db, "_grist_DocInfo", "documentSettings")) {
     const documentSettings: string = (await db.all("SELECT documentSettings FROM _grist_DocInfo"))[0]?.documentSettings;
     const documentSettingsObj: DocumentSettings = safeJsonParse(documentSettings, {});
     documentSettingsObj.baseAction = states[0];
@@ -100,15 +123,23 @@ async function markAction(filename: string) {
 }
 
 /**
+ * Whether a table has a given column. The pragma yields nothing for a missing
+ * table, so this covers documents predating the table itself.
+ */
+async function hasColumn(db: SQLiteDB, tableId: string, colId: string): Promise<boolean> {
+  const columns = await db.all(`PRAGMA table_info(${quoteIdent(tableId)})`);
+  return columns.some(column => column.name === colId);
+}
+
+/**
  * Disable all triggers, so that they won't run when the document is downloaded and then opened.
  */
 async function disableTriggers(filename: string) {
   const db = await SQLiteDB.openDBRaw(filename, OpenMode.OPEN_EXISTING);
-  // Pre-migration docs may not have the table.
-  const exists = (await db.all(
-    "SELECT name FROM sqlite_master WHERE type='table' AND name='_grist_Triggers'",
-  )).length > 0;
-  if (exists) {
+  // _grist_Triggers arrived in schema version 24, its `enabled` column only in
+  // 39, so check the column. Having no triggers is no protection: SQLite
+  // resolves column names when it prepares the statement.
+  if (await hasColumn(db, "_grist_Triggers", "enabled")) {
     await db.run("UPDATE _grist_Triggers SET enabled = 0");
   }
   await db.close();

--- a/test/server/lib/filterUtils.ts
+++ b/test/server/lib/filterUtils.ts
@@ -1,0 +1,77 @@
+import { makeExceptionalDocSession } from "app/server/lib/DocSession";
+import { filterDocumentInPlace, makeFilterOptions } from "app/server/lib/filterUtils";
+import { OpenMode, SQLiteDB } from "app/server/lib/SQLiteDB";
+import * as testUtils from "test/server/testUtils";
+
+import { join as pathJoin } from "path";
+
+import { assert } from "chai";
+
+describe("filterUtils", function() {
+  let testDir: string;
+
+  testUtils.setTmpLogLevel("warn");
+
+  before(async function() {
+    testDir = await testUtils.createTestDir("filterUtils");
+  });
+
+  // Filtering works in place, so take a copy and leave the fixture alone.
+  async function copyFixture(fixture: string): Promise<string> {
+    const filename = pathJoin(testDir, fixture);
+    await testUtils.copyFixtureDoc(fixture, filename);
+    return filename;
+  }
+
+  // makeFilterOptions() with nothing asked of it is what a plain download uses,
+  // so these exercise the whole sequence rather than one step of it.
+  async function downloadFilter(filename: string) {
+    await filterDocumentInPlace(makeExceptionalDocSession("system"), filename, makeFilterOptions());
+  }
+
+  async function withDb<T>(filename: string, fn: (db: SQLiteDB) => Promise<T>): Promise<T> {
+    const db = await SQLiteDB.openDBRaw(filename, OpenMode.OPEN_EXISTING);
+    try {
+      return await fn(db);
+    } finally {
+      await db.close();
+    }
+  }
+
+  async function getColumns(filename: string, tableId: string): Promise<string[]> {
+    return withDb(filename, async db =>
+      (await db.all(`PRAGMA table_info(${tableId})`)).map(column => column.name as string));
+  }
+
+  it("disables triggers in the document being downloaded", async function() {
+    const filename = await copyFixture("Hello.grist");
+    await withDb(filename, db =>
+      db.run("INSERT INTO _grist_Triggers (tableRef, enabled) VALUES (1, 1)"));
+
+    await downloadFilter(filename);
+
+    const rows = await withDb(filename, db => db.all("SELECT enabled FROM _grist_Triggers"));
+    assert.deepEqual(rows.map(row => row.enabled), [0]);
+  });
+
+  // A column each step of the filtering uses, with a fixture from before it
+  // existed. Filtering must still complete; the document is left as it is, and
+  // gains the column when it is next opened and migrated. Checking the fixture
+  // first is what keeps these honest, so that they fail rather than quietly
+  // stop covering anything should a fixture be regenerated.
+  const oldDocuments = [
+    // _grist_Triggers arrived in schema version 24, `enabled` only in 39.
+    { fixture: "World.grist", tableId: "_grist_Triggers", colId: "enabled" },
+    // documentSettings, which markAction needs, arrived in schema version 23.
+    { fixture: "World-v20.grist", tableId: "_grist_DocInfo", colId: "documentSettings" },
+  ];
+
+  for (const { fixture, tableId, colId } of oldDocuments) {
+    it(`downloads a document predating ${tableId}.${colId}`, async function() {
+      const filename = await copyFixture(fixture);
+      assert.notInclude(await getColumns(filename, tableId), colId);
+
+      await downloadFilter(filename);
+    });
+  }
+});


### PR DESCRIPTION
Summary:
filterDocumentInPlace() runs raw SQL against the copy of a document being downloaded, and two of its steps use columns that an old enough document does not have yet. Either one fails the download with a SQLITE_ERROR.

Now we check for the columns. An old document is left as it is, and gains what it lacks when it is next opened and migrated.

Some filter options were getting repetitive across the app and tests, so a small refactor is included.
