### PR TITLE
Give the autocomplete dropdown a signal tests can wait on

### DIFF
--- a/app/client/lib/autocomplete.ts
+++ b/app/client/lib/autocomplete.ts
@@ -61,6 +61,8 @@ export class Autocomplete<Item extends ACItem> extends Disposable {
   // Currently selected element.
   protected _selected: HTMLElement | null = null;
 
+  // The menu element, tagged with the search text its items were built for.
+  private _menuElem: HTMLElement;
   private _popper: Popper;
   private _mouseOver: { reset(): void };
   private _lastAsTyped: string;
@@ -76,7 +78,7 @@ export class Autocomplete<Item extends ACItem> extends Disposable {
     super();
 
     const content = cssMenuWrap(
-      cssMenu(
+      this._menuElem = cssMenu(
         { class: _options.menuCssClass || "" },
         dom.style("min-width", _triggerElem.getBoundingClientRect().width + "px"),
         this._maybeShowNoItemsMessage(),
@@ -193,6 +195,12 @@ export class Autocomplete<Item extends ACItem> extends Disposable {
     this._highlightFunc = acResults.highlightFunc;
     this._items.set(acResults.items);
     this._extraItems.set(acResults.extraItems);
+
+    // Report the search text these items were built for. Searching is asynchronous, so between a
+    // keystroke and the arrival of its results the menu still holds the previous keystroke's items,
+    // with nothing in the DOM to tell the two apart; tests wait on this to know which list they are
+    // reading. Set after the items, so it never describes a list that is not rendered yet.
+    this._menuElem.setAttribute("data-ac-search-text", inputVal);
 
     // Plain update() (which is deferred) may be better, but if _setSelected() causes scrolling
     // before the positions are updated, it causes the entire page to scroll horizontally.

--- a/test/nbrowser/ChoiceList.ts
+++ b/test/nbrowser/ChoiceList.ts
@@ -236,6 +236,7 @@ describe("ChoiceList", function() {
     await gu.getCell({ rowNum: 1, col: "B" }).click();
     await gu.enterCell("fake");
     await getEditorInput().click();
+    await gu.autocomplete.wait("");
     const blueChoice = await driver.findContent(".test-autocomplete li", /Blue/);
     assert.equal(
       await blueChoice.find(".test-choice-list-editor-item-label").getCssValue("background-color"),
@@ -310,6 +311,7 @@ describe("ChoiceList", function() {
 
     // Double-click to open dropdown and select a token.
     await driver.withActions(a => a.doubleClick(gu.getCell({ rowNum: 1, col: "B" })));
+    await gu.autocomplete.wait("");
     await driver.findContent(".test-autocomplete li", /Black/).click();
     assert.deepEqual(await getEditorTokens(), ["Blue", "Green", "Black"]);
 
@@ -403,6 +405,7 @@ describe("ChoiceList", function() {
     await gu.waitAppFocus();
     await driver.sendKeys(Key.ENTER);
     await gu.waitForCellEditor();
+    await gu.autocomplete.wait("");
     await driver.findContent(".test-autocomplete li", /Green/).click();
     assert.deepEqual(await getEditorTokens(), ["Green"]);
 
@@ -416,6 +419,7 @@ describe("ChoiceList", function() {
 
     // Type another token, and click the "+" button in autocomplete. New token should be valid.
     await driver.sendKeys("Apricot");
+    await gu.autocomplete.wait("Apricot");
     const newChoice = await driver.find(".test-autocomplete .test-choice-list-editor-new-item");
     assert.equal(await newChoice.getText(), "Apricot");
     assert.equal(
@@ -426,7 +430,7 @@ describe("ChoiceList", function() {
       await newChoice.find(".test-choice-list-editor-item-label").getCssValue("color"),
       DEFAULT_TEXT,
     );
-    await driver.find(".test-autocomplete .test-choice-list-editor-new-item").click();
+    await newChoice.click();
     assert.deepEqual(await getEditorTokens(), ["Green", "Orange", "Apricot"]);
     assert.deepEqual(await getEditorTokensIsInvalid(), [false, true, false]);
     assert.deepEqual(

--- a/test/nbrowser/DropdownConditionEditor.ts
+++ b/test/nbrowser/DropdownConditionEditor.ts
@@ -104,25 +104,25 @@ describe("DropdownConditionEditor", function() {
 
       // Check that autocomplete values are filtered.
       await gu.sendKeys(Key.ENTER);
-      assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
+      assert.deepEqual(await gu.autocomplete.getOptions(), [
         "Supervisor",
       ]);
-      await gu.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
       await gu.getCell(1, 4).click();
       await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
-      assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
+      assert.deepEqual(await gu.autocomplete.getOptions(), [
         "Trainee",
       ]);
-      await gu.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
       await gu.getCell(1, 6).click();
       await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
-      assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
+      assert.deepEqual(await gu.autocomplete.getOptions(), [
         "Trainee",
         "Supervisor",
       ]);
-      await gu.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       // Change the column type to Choice List and check values are still filtered.
       await gu.setType("Choice List", { apply: true });
@@ -133,10 +133,10 @@ describe("DropdownConditionEditor", function() {
       await gu.getCell(1, 4).click();
       await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
-      assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
+      assert.deepEqual(await gu.autocomplete.getOptions(), [
         "Trainee",
       ]);
-      await gu.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
     });
 
     it("removes dropdown conditions", async function() {
@@ -146,21 +146,21 @@ describe("DropdownConditionEditor", function() {
 
       // Check that autocomplete values are no longer filtered.
       await gu.sendKeys(Key.ENTER);
-      assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
+      assert.deepEqual(await gu.autocomplete.getOptions(), [
         "Trainee",
         "Supervisor",
       ]);
-      await gu.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       // Change the column type back to Choice and check values are still no longer filtered.
       await gu.setType("Choice", { apply: true });
       assert.isFalse(await driver.find(".test-field-dropdown-condition").isPresent());
       await gu.sendKeys(Key.ENTER);
-      assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
+      assert.deepEqual(await gu.autocomplete.getOptions(), [
         "Supervisor",
         "Trainee",
       ]);
-      await gu.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
       await gu.waitAppFocus();
     });
 
@@ -189,10 +189,10 @@ describe("DropdownConditionEditor", function() {
       // Check that the autocomplete dropdown also reports an error.
       await gu.sendKeys(Key.ENTER);
       assert.equal(
-        await driver.find(".test-autocomplete-no-items-message").getText(),
+        await driver.findWait(".test-autocomplete-no-items-message", 1000).getText(),
         "Error in dropdown condition",
       );
-      await gu.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
     });
   });
 
@@ -228,43 +228,43 @@ describe("DropdownConditionEditor", function() {
 
       // Check that autocomplete values are filtered.
       await gu.sendKeys(Key.ENTER);
-      assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
+      assert.deepEqual(await gu.autocomplete.getOptions(), [
         "Pavan Madilyn",
         "Marie Ziyad",
       ]);
-      await gu.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       // Should be no options on row 2 because of $id != 2 part of condition.
       await gu.getCell(2, 2).click();
       await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
-      assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
+      assert.deepEqual(await gu.autocomplete.getOptions(), [
       ]);
-      await gu.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       // Row 3 should be like row 1.
       await gu.getCell(2, 3).click();
       await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
-      assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
+      assert.deepEqual(await gu.autocomplete.getOptions(), [
         "Pavan Madilyn",
         "Marie Ziyad",
       ]);
-      await gu.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       await gu.getCell(2, 4).click();
       await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
-      assert.isEmpty(await driver.findAll(".test-autocomplete li", el => el.getText()));
-      await gu.sendKeys(Key.ESCAPE);
+      assert.isEmpty(await gu.autocomplete.getOptions());
+      await gu.autocomplete.close();
       await gu.getCell(2, 6).click();
       await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
-      assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
+      assert.deepEqual(await gu.autocomplete.getOptions(), [
         "Marie Ziyad",
         "Pavan Madilyn",
       ]);
-      await gu.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       // Change the column type to Reference List and check values are still filtered.
       await gu.setType("Reference List", { apply: true });
@@ -275,8 +275,8 @@ describe("DropdownConditionEditor", function() {
       await gu.getCell(2, 4).click();
       await gu.waitAppFocus();
       await gu.sendKeys(Key.ENTER);
-      assert.isEmpty(await driver.findAll(".test-autocomplete li", el => el.getText()));
-      await gu.sendKeys(Key.ESCAPE);
+      assert.isEmpty(await gu.autocomplete.getOptions());
+      await gu.autocomplete.close();
     });
 
     it("removes dropdown conditions", async function() {
@@ -286,27 +286,27 @@ describe("DropdownConditionEditor", function() {
 
       // Check that autocomplete values are no longer filtered.
       await gu.sendKeys(Key.ENTER);
-      assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
+      assert.deepEqual(await gu.autocomplete.getOptions(), [
         "Emma Thamir",
         "Holger Klyment",
         "Marie Ziyad",
         "Olivier Bipin",
         "Pavan Madilyn",
       ]);
-      await gu.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       // Change the column type back to Reference and check values are still no longer filtered.
       await gu.setType("Reference", { apply: true });
       assert.isFalse(await driver.find(".test-field-dropdown-condition").isPresent());
       await gu.sendKeys(Key.ENTER);
-      assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
+      assert.deepEqual(await gu.autocomplete.getOptions(), [
         "Emma Thamir",
         "Holger Klyment",
         "Marie Ziyad",
         "Olivier Bipin",
         "Pavan Madilyn",
       ]);
-      await gu.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
     });
 
     it("reports errors", async function() {
@@ -338,10 +338,10 @@ describe("DropdownConditionEditor", function() {
       await gu.sendKeys(Key.ENTER);
 
       assert.equal(
-        await driver.findWait(".test-autocomplete-no-items-message", 100).getText(),
+        await driver.findWait(".test-autocomplete-no-items-message", 1000).getText(),
         "Error in dropdown condition",
       );
-      await gu.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       // Check evaluation errors are also reported in the dropdown.
       await driver.find(".test-field-dropdown-condition").click();
@@ -351,10 +351,10 @@ describe("DropdownConditionEditor", function() {
       await gu.sendKeys(Key.ENTER);
 
       assert.equal(
-        await driver.findWait(".test-autocomplete-no-items-message", 100).getText(),
+        await driver.findWait(".test-autocomplete-no-items-message", 1000).getText(),
         "Error in dropdown condition",
       );
-      await gu.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
     });
   });
 
@@ -383,13 +383,11 @@ describe("DropdownConditionEditor", function() {
 
     // Check that user1 (who is an admin) can see dropdown values.
     await gu.sendKeys(Key.ENTER);
-    await waitForDropdown();
-
-    assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), [
+    assert.deepEqual(await gu.autocomplete.getOptions(), [
       "Trainee",
       "Supervisor",
     ]);
-    await gu.sendKeys(Key.ESCAPE);
+    await gu.autocomplete.close();
 
     // Switch to user2 (who is not an admin), and check that they can't see any dropdown values.
     const session = await gu.session().user("user2").login();
@@ -397,11 +395,7 @@ describe("DropdownConditionEditor", function() {
     await gu.getCell(1, 1).click();
     await gu.waitAppFocus();
     await gu.sendKeys(Key.ENTER);
-    assert.deepEqual(await driver.findAll(".test-autocomplete li", el => el.getText()), []);
-    await gu.sendKeys(Key.ESCAPE);
+    assert.deepEqual(await gu.autocomplete.getOptions(), []);
+    await gu.autocomplete.close();
   });
 });
-
-async function waitForDropdown() {
-  await driver.findWait(".test-autocomplete li", 100);
-}

--- a/test/nbrowser/ReferenceColumns.ts
+++ b/test/nbrowser/ReferenceColumns.ts
@@ -88,6 +88,7 @@ describe("ReferenceColumns", function() {
         await gu.waitForCellEditor();
         await gu.sendKeys(await gu.selectAllKey(), "5");
         // Check that the autocomplete has no items yet.
+        await gu.autocomplete.wait("5");
         assert.isEmpty(await driver.findAll(".test-autocomplete .test-ref-editor-new-item"));
         await gu.sendKeys(Key.ENTER);
       });
@@ -99,7 +100,7 @@ describe("ReferenceColumns", function() {
 
       // Once server is responsive, a valid value should not offer a "new item".
       await gu.enterCell(["5"], { validate: false });
-      await driver.findWait(".test-ref-editor-item", 500);
+      await gu.autocomplete.wait("5");
       assert.isFalse(await driver.find(".test-ref-editor-new-item").isPresent());
       await gu.sendKeys(Key.ENTER);
       await gu.waitForServer();
@@ -154,11 +155,6 @@ describe("ReferenceColumns", function() {
   });
 
   describe("autocomplete", function() {
-    const getACOptions = stackWrapFunc(async (limit?: number) => {
-      await driver.findWait(".test-ref-editor-item", 1000);
-      return (await driver.findAll(".test-ref-editor-item", el => el.getText())).slice(0, limit);
-    });
-
     before(async function() {
       await session.tempDoc(cleanup, "Ref-AC-Test.grist");
       await gu.toggleSidePanel("right", "close");
@@ -194,20 +190,20 @@ describe("ReferenceColumns", function() {
       assert.equal(await cell.getText(), "");
       await driver.sendKeys(Key.ENTER);
       // Check the first few items.
-      assert.deepEqual(await getACOptions(3), ["Alice Blue", "Añil", "Aqua"]);
+      assert.deepEqual(await gu.autocomplete.getOptions("", 3), ["Alice Blue", "Añil", "Aqua"]);
       // No item is selected.
       assert.equal(await driver.find(".test-ref-editor-item.selected").isPresent(), false);
-      await driver.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       cell = await gu.getCell({ section: "References", col: "School", rowNum: 6 }).doClick();
       assert.equal(await cell.getText(), "");
       await driver.sendKeys(Key.ENTER);
       // Check the first few items; should be sorted alphabetically.
-      assert.deepEqual(await getACOptions(3),
+      assert.deepEqual(await gu.autocomplete.getOptions("", 3),
         ["2 SCHOOL", "4 SCHOOL", "47 AMER SIGN LANG & ENG LOWER "]);
       // No item is selected.
       assert.equal(await driver.find(".test-ref-editor-item.selected").isPresent(), false);
-      await driver.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
     });
 
     it("should save correct item on click", async function() {
@@ -232,7 +228,7 @@ describe("ReferenceColumns", function() {
       // Edit another cell by starting to type.
       cell = await gu.getCell({ section: "References", col: "Color", rowNum: 4 }).doClick();
       await gu.enterCell(["gr"], { validate: false });
-      await driver.findWait(".test-ref-editor-item", 1000);
+      await gu.autocomplete.wait("gr");
       item = driver.findContent(".test-ref-editor-item", "Medium Sea Green");
       await gu.scrollIntoView(item);
       await item.click();
@@ -266,7 +262,7 @@ describe("ReferenceColumns", function() {
       // Edit another cell by starting to type.
       cell = await gu.getCell({ section: "References", col: "Color", rowNum: 4 }).doClick();
       await gu.enterCell(["gr"], { validate: false });
-      await driver.findWait(".test-ref-editor-item", 1000);
+      await gu.autocomplete.wait("gr");
       await driver.sendKeys(Key.UP, Key.UP, Key.UP, Key.UP, Key.UP);
       assert.equal(await driver.findWait(".test-ref-editor-item.selected", 1000).getText(), "Chocolate");
       await driver.sendKeys(Key.ENTER);
@@ -281,7 +277,7 @@ describe("ReferenceColumns", function() {
     it("should return to text-as-typed when nothing is selected", async function() {
       const cell = await gu.getCell({ section: "References", col: "Color", rowNum: 2 }).doClick();
       await gu.enterCell(["da"], { validate: false });
-      assert.deepEqual(await getACOptions(2), ["Dark Blue", "Dark Cyan"]);
+      assert.deepEqual(await gu.autocomplete.getOptions("da", 2), ["Dark Blue", "Dark Cyan"]);
 
       // Check that the first item is highlighted by default.
       assert.equal(await driver.find(".celleditor_text_editor").value(), "da");
@@ -300,6 +296,7 @@ describe("ReferenceColumns", function() {
       // Clear the typed-in text temporarily. Something changed in a recent version of Chrome,
       // causing the wrong item to be moused over below when the "Add New" option is visible.
       await driver.sendKeys(Key.BACK_SPACE, Key.BACK_SPACE);
+      await gu.autocomplete.wait("");
 
       // Mouse over an item.
       await driver.findContent(".test-ref-editor-item", /Dark Gray/).mouseMove();
@@ -337,7 +334,7 @@ describe("ReferenceColumns", function() {
       const cell = await gu.getCell({ section: "References", col: "Color", rowNum: 2 }).doClick();
       await gu.enterCell(["pinkish"], { validate: false });
       // There are inexact matches.
-      assert.deepEqual(await getACOptions(3),
+      assert.deepEqual(await gu.autocomplete.getOptions("pinkish", 3),
         ["Pink", "Deep Pink", "Hot Pink"]);
       // Nothing is selected, and the "add new" item is present.
       assert.equal(await driver.find(".test-ref-editor-item.selected").isPresent(), false);
@@ -393,7 +390,7 @@ describe("ReferenceColumns", function() {
 
       await driver.sendKeys(Key.ENTER);
       assert.equal(await driver.find(".test-ref-editor-new-item").getText(), "hello");
-      await driver.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       // Change the visible column to the formula column "C2".
       await gu.toggleSidePanel("right", "open");
@@ -407,10 +404,10 @@ describe("ReferenceColumns", function() {
       await gu.waitAppFocus();
       await driver.sendKeys(Key.ENTER);
       assert.equal(await driver.find(".celleditor_text_editor").value(), "hello");
-      await driver.findWait(".test-ref-editor-item", 1000);
+      await gu.autocomplete.wait("hello");
       assert.equal(await driver.find(".test-ref-editor-item.selected").isPresent(), false);
       assert.equal(await driver.find(".test-ref-editor-new-item").isPresent(), false);
-      await driver.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       await gu.undo();
       await gu.toggleSidePanel("right", "close");
@@ -420,47 +417,47 @@ describe("ReferenceColumns", function() {
       let cell = await gu.getCell({ section: "References", col: "Color", rowNum: 1 }).doClick();
       assert.equal(await cell.getText(), "Dark Slate Blue");
       await driver.sendKeys(Key.ENTER);
-      assert.deepEqual(await getACOptions(4),
+      assert.deepEqual(await gu.autocomplete.getOptions("Dark Slate Blue", 4),
         ["Dark Slate Blue", "Dark Slate Gray", "Slate Blue", "Medium Slate Blue"]);
-      await driver.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       // Starting to type Añil with the accent
       await gu.enterCell(["añ"], { validate: false });
-      assert.deepEqual(await getACOptions(2),
+      assert.deepEqual(await gu.autocomplete.getOptions("añ", 2),
         ["Añil", "Alice Blue"]);
-      await driver.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       // Starting to type Añil without the accent should work too
       await gu.enterCell(["an"], { validate: false });
-      assert.deepEqual(await getACOptions(2),
+      assert.deepEqual(await gu.autocomplete.getOptions("an", 2),
         ["Añil", "Alice Blue"]);
-      await driver.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       await gu.enterCell(["blac"], { validate: false });
-      assert.deepEqual(await getACOptions(6),
+      assert.deepEqual(await gu.autocomplete.getOptions("blac", 6),
         ["Black", "Blanched Almond", "Blue", "Blue Violet", "Alice Blue", "Cadet Blue"]);
-      await driver.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       cell = await gu.getCell({ section: "References", col: "Color", rowNum: 3 }).doClick();
       assert.equal(await cell.getText(), "hello");    // Alt-text
       await driver.sendKeys(Key.ENTER);
-      assert.deepEqual(await getACOptions(2),
+      assert.deepEqual(await gu.autocomplete.getOptions("hello", 2),
         ["Honeydew", "Hot Pink"]);
-      await driver.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       cell = await gu.getCell({ section: "References", col: "ColorCode", rowNum: 2 }).doClick();
       assert.equal(await cell.getText(), "#808080");
       await driver.sendKeys(Key.ENTER);
-      assert.deepEqual(await getACOptions(5),
+      assert.deepEqual(await gu.autocomplete.getOptions("#808080", 5),
         ["#808080", "#808000", "#800000", "#800080", "#87CEEB"]);
-      await driver.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       cell = await gu.getCell({ section: "References", col: "XNum", rowNum: 2 }).doClick();
       assert.equal(await cell.getText(), "2019-04-29");
       await driver.sendKeys(Key.ENTER);
-      assert.deepEqual(await getACOptions(4),
+      assert.deepEqual(await gu.autocomplete.getOptions("2019-04-29", 4),
         ["2019-04-29", "2020-04-29", "2019-11-05", "2020-04-28"]);
-      await driver.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
     });
 
     it("should update choices as user types into textbox", async function() {
@@ -468,28 +465,28 @@ describe("ReferenceColumns", function() {
         .find(".test-ref-text").doClick();
       assert.equal(await cell.getText(), "TECHNOLOGY, ARTS AND SCIENCES STUDIO");
       await driver.sendKeys(Key.ENTER);
-      assert.deepEqual(await getACOptions(3), [
+      assert.deepEqual(await gu.autocomplete.getOptions("TECHNOLOGY, ARTS AND SCIENCES STUDIO", 3), [
         "TECHNOLOGY, ARTS AND SCIENCES STUDIO",
         "SCIENCE AND TECHNOLOGY ACADEMY",
         "SCHOOL OF SCIENCE AND TECHNOLOGY",
       ]);
-      await driver.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
       cell = await gu.getCell({ section: "References", col: "School", rowNum: 2 }).doClick();
       await gu.enterCell(["stuy"], { validate: false });
-      assert.deepEqual(await getACOptions(3), [
+      assert.deepEqual(await gu.autocomplete.getOptions("stuy", 3), [
         "STUYVESANT HIGH SCHOOL",
         "BEDFORD STUY COLLEGIATE CHARTER SCH",
         "BEDFORD STUY NEW BEGINNINGS CHARTER",
       ]);
       await driver.sendKeys(Key.BACK_SPACE);
-      assert.deepEqual(await getACOptions(3), [
+      assert.deepEqual(await gu.autocomplete.getOptions("stu", 3), [
         "STUART M TOWNSEND MIDDLE SCHOOL",
         "STUDIO SCHOOL (THE)",
         "STUYVESANT HIGH SCHOOL",
       ]);
       await driver.sendKeys(" bre");
       assert.equal(await driver.find(".celleditor_text_editor").value(), "stu bre");
-      assert.deepEqual(await getACOptions(3), [
+      assert.deepEqual(await gu.autocomplete.getOptions("stu bre", 3), [
         "ST BRENDAN SCHOOL",
         "BRONX STUDIO SCHOOL-WRITERS-ARTISTS",
         "BROOKLYN STUDIO SECONDARY SCHOOL",
@@ -509,20 +506,21 @@ describe("ReferenceColumns", function() {
         .find(".test-ref-text").doClick();
       assert.equal(await cell.getText(), "Red");
       await driver.sendKeys(Key.ENTER);
-      await driver.findWait(".test-ref-editor-item", 1000);
+      await gu.autocomplete.wait("Red");
       assert.deepEqual(
         await driver.findContent(".test-ref-editor-item", /Dark Red/).findAll("span", e => e.getText()),
         ["Red"]);
       assert.deepEqual(
         await driver.findContent(".test-ref-editor-item", /Rebecca Purple/).findAll("span", e => e.getText()),
         ["Re"]);
-      await driver.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
 
       cell = await gu.getCell({ section: "References", col: "School", rowNum: 1 })
         .find(".test-ref-text").doClick();
       await gu.enterCell(["br tech"], { validate: false });
+      await gu.autocomplete.wait("br tech");
       assert.deepEqual(
-        await driver.findContentWait(".test-ref-editor-item", /BROOKLYN TECH/, 1000).findAll("span", e => e.getText()),
+        await driver.findContent(".test-ref-editor-item", /BROOKLYN TECH/).findAll("span", e => e.getText()),
         ["BR", "TECH"]);
       assert.deepEqual(
         await driver.findContent(".test-ref-editor-item", /BUFFALO.*TECHNOLOGY/).findAll("span", e => e.getText()),
@@ -530,7 +528,7 @@ describe("ReferenceColumns", function() {
       assert.deepEqual(
         await driver.findContent(".test-ref-editor-item", /ENERGY TECH/).findAll("span", e => e.getText()),
         ["TECH"]);
-      await driver.sendKeys(Key.ESCAPE);
+      await gu.autocomplete.close();
     });
 
     it("should reflect changes to the target column", async function() {
@@ -539,8 +537,8 @@ describe("ReferenceColumns", function() {
       const cell = await gu.getCell({ section: "References", col: "Color", rowNum: 4 }).doClick();
       assert.equal(await cell.getText(), "");
       await driver.sendKeys(Key.ENTER);
-      assert.deepEqual(await getACOptions(2), ["Alice Blue", "Añil"]);
-      await driver.sendKeys(Key.ESCAPE);
+      assert.deepEqual(await gu.autocomplete.getOptions("", 2), ["Alice Blue", "Añil"]);
+      await gu.autocomplete.close();
 
       // Change a color
       await gu.getCell({ section: "Colors", col: "Color Name", rowNum: 1 }).doClick();
@@ -551,10 +549,10 @@ describe("ReferenceColumns", function() {
       await cell.click();
       await gu.waitAppFocus();
       await driver.sendKeys(Key.ENTER);
-      assert.deepEqual(await getACOptions(2), ["Añil", "Aqua"]);
+      assert.deepEqual(await gu.autocomplete.getOptions("", 2), ["Añil", "Aqua"]);
       await driver.sendKeys("H");
-      assert.deepEqual(await getACOptions(2), ["HAZELNUT", "Honeydew"]);
-      await driver.sendKeys(Key.ESCAPE);
+      assert.deepEqual(await gu.autocomplete.getOptions("H", 2), ["HAZELNUT", "Honeydew"]);
+      await gu.autocomplete.close();
 
       // Delete a row.
       await gu.getCell({ section: "Colors", col: "Color Name", rowNum: 1 }).doClick();
@@ -565,8 +563,8 @@ describe("ReferenceColumns", function() {
       // See that the value is gone from the autocomplete.
       await cell.click();
       await gu.enterCell(["H"], { validate: false });
-      assert.deepEqual(await getACOptions(2), ["Honeydew", "Hot Pink"]);
-      await driver.sendKeys(Key.ESCAPE);
+      assert.deepEqual(await gu.autocomplete.getOptions("H", 2), ["Honeydew", "Hot Pink"]);
+      await gu.autocomplete.close();
 
       // Add a row.
       await gu.getCell({ section: "Colors", col: "Color Name", rowNum: 1 }).doClick();
@@ -578,20 +576,20 @@ describe("ReferenceColumns", function() {
       // See that the new value is visible in the autocomplete.
       await cell.click();
       await gu.enterCell(["H"], { validate: false });
-      assert.deepEqual(await getACOptions(2), ["HELIOTROPE", "Honeydew"]);
+      assert.deepEqual(await gu.autocomplete.getOptions("H", 2), ["HELIOTROPE", "Honeydew"]);
       await driver.sendKeys(Key.BACK_SPACE);
-      assert.deepEqual(await getACOptions(2), ["Añil", "Aqua"]);
-      await driver.sendKeys(Key.ESCAPE);
+      assert.deepEqual(await gu.autocomplete.getOptions("", 2), ["Añil", "Aqua"]);
+      await gu.autocomplete.close();
 
       // Undo all the changes.
       await gu.undo(4);
 
       await cell.click();
       await gu.enterCell(["H"], { validate: false });
-      assert.deepEqual(await getACOptions(2), ["Honeydew", "Hot Pink"]);
+      assert.deepEqual(await gu.autocomplete.getOptions("H", 2), ["Honeydew", "Hot Pink"]);
       await driver.sendKeys(Key.BACK_SPACE);
-      assert.deepEqual(await getACOptions(2), ["Alice Blue", "Añil"]);
-      await driver.sendKeys(Key.ESCAPE);
+      assert.deepEqual(await gu.autocomplete.getOptions("", 2), ["Alice Blue", "Añil"]);
+      await gu.autocomplete.close();
     });
   });
 });

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -4186,6 +4186,48 @@ namespace gristUtils {
     },
   };
 
+  /**
+ * Helper for the autocomplete dropdown offered by the Choice, Choice List, Reference and Reference
+ * List editors.
+ *
+ * Its items are rebuilt asynchronously, and a list that has caught up with what the user typed
+ * looks exactly like one that has not, so the editor tags the menu with the search text its items
+ * were built for (see data-ac-search-text in app/client/lib/autocomplete.ts). Waiting for
+ * ".test-autocomplete" alone is not enough: the menu is in the DOM before its first results are,
+ * and one on its way out is still there for the next read, so both read as an empty or a wrong
+ * list with nothing to say so.
+ */
+  // Selector for the dropdown once it is showing results; with `text`, only the dropdown showing
+  // the results for that search text (the whole content of the editor's textbox).
+  function autocompleteMenu(text?: string) {
+    return text === undefined ?
+      ".test-autocomplete[data-ac-search-text]" :
+      `.test-autocomplete[data-ac-search-text=${JSON.stringify(text)}]`;
+  }
+
+  export const autocomplete = {
+    /**
+     * Waits for the dropdown to be showing results. Pass `text` when known: it is what tells the
+     * latest keystroke's list from the one before it.
+     */
+    async wait(text?: string) {
+      await driver.findWait(autocompleteMenu(text), 1000);
+    },
+
+    /** Returns the first `limit` options offered, once the dropdown is showing them. */
+    async getOptions(text?: string, limit?: number): Promise<string[]> {
+      await this.wait(text);
+      return (await driver.findAll(`${autocompleteMenu(text)} li`, el => el.getText())).slice(0, limit);
+    },
+
+    /** Dismisses the dropdown with Escape, and waits for it to be gone. */
+    async close() {
+      await sendKeys(Key.ESCAPE);
+      await driver.wait(async () => !await driver.find(".test-autocomplete").isPresent(), 1000,
+        "autocomplete did not close");
+    },
+  };
+
   export async function switchUser(email: string) {
     await driver.findWait(".test-user-icon", 1000).click();
     await driver.findContentWait(".test-usermenu-other-email", exactMatch(email), 1000).click();

--- a/test/nbrowser/gristUtils.ts
+++ b/test/nbrowser/gristUtils.ts
@@ -4187,19 +4187,19 @@ namespace gristUtils {
   };
 
   /**
- * Helper for the autocomplete dropdown offered by the Choice, Choice List, Reference and Reference
- * List editors.
- *
- * Its items are rebuilt asynchronously, and a list that has caught up with what the user typed
- * looks exactly like one that has not, so the editor tags the menu with the search text its items
- * were built for (see data-ac-search-text in app/client/lib/autocomplete.ts). Waiting for
- * ".test-autocomplete" alone is not enough: the menu is in the DOM before its first results are,
- * and one on its way out is still there for the next read, so both read as an empty or a wrong
- * list with nothing to say so.
- */
-  // Selector for the dropdown once it is showing results; with `text`, only the dropdown showing
-  // the results for that search text (the whole content of the editor's textbox).
+   * Helper for the autocomplete dropdown offered by the Choice, Choice List, Reference and Reference
+   * List editors.
+   *
+   * Its items are rebuilt asynchronously, and a list that has caught up with what the user typed
+   * looks exactly like one that has not, so the editor tags the menu with the search text its items
+   * were built for (see data-ac-search-text in app/client/lib/autocomplete.ts). Waiting for
+   * ".test-autocomplete" alone is not enough: the menu is in the DOM before its first results are,
+   * and one on its way out is still there for the next read, so both read as an empty or a wrong
+   * list with nothing to say so.
+   */
   function autocompleteMenu(text?: string) {
+    // Selector for the dropdown once it is showing results; with `text`, only the dropdown showing
+    // the results for that search text (the whole content of the editor's textbox).
     return text === undefined ?
       ".test-autocomplete[data-ac-search-text]" :
       `.test-autocomplete[data-ac-search-text=${JSON.stringify(text)}]`;


### PR DESCRIPTION
Autocomplete dropdown items are rebuilt asynchronously, and a stale list looks like a current one, so waiting for an item to be present waits for nothing. Autocomplete now sets data-ac-search-text on the menu, naming the search text its rendered items are for.

Adds gu.autocomplete (wait/getOptions/close), used in ReferenceColumns, DropdownConditionEditor and ChoiceList. Three assertions in DropdownConditionEditor expect an empty list, and passed whenever the dropdown had yet to open.
