### PR TITLE
Fix JSON import options modal

### DIFF
--- a/app/client/components/ParseOptions.ts
+++ b/app/client/components/ParseOptions.ts
@@ -74,12 +74,14 @@ export function buildParseOptionsForm(
     start_with_row: t("Start with row"),
     NUM_ROWS: t("Number of rows"),
     encoding: t("Character encoding. See [the supported codecs]({{link}})", { link: "https://tinyurl.com/py3codecs" }),
+    includes: t("Includes (list of tables separated by semicolon)"),
+    excludes: t("Excludes (list of tables separated by semicolon)"),
   };
 
   return [
     cssParseOptionForm(
       items.map(item => cssParseOption(
-        cssParseOptionName(markdown(labelsByName[item.name])),
+        cssParseOptionName(markdown(labelsByName[item.name] ?? item.name)),
         optionToInput(owner, item.type, optionsMap.get(item.name)!),
         testId("parseopts-opt"),
       )),

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -2468,7 +2468,9 @@
         "Quotes in fields are doubled": "Quotes in fields are doubled",
         "Skip leading whitespace": "Skip leading whitespace",
         "Start with row": "Start with row",
-        "Character encoding. See [the supported codecs]({{link}})": "Character encoding. See [the supported codecs]({{link}})"
+        "Character encoding. See [the supported codecs]({{link}})": "Character encoding. See [the supported codecs]({{link}})",
+        "Excludes (list of tables separated by semicolon)": "Excludes (list of tables separated by semicolon)",
+        "Includes (list of tables separated by semicolon)": "Includes (list of tables separated by semicolon)"
     },
     "OpenAccessibilityModal": {
         " or ": " or ",

--- a/test/client/components/ParseOptions.ts
+++ b/test/client/components/ParseOptions.ts
@@ -1,0 +1,50 @@
+import "test/client/_helpers/setupI18n";
+
+import * as Markdown from "app/client/lib/markdown";
+
+import { assert } from "chai";
+import { dom } from "grainjs";
+import { popGlobals, pushGlobals } from "grainjs/dist/cjs/lib/browserGlobals";
+import { JSDOM } from "jsdom";
+import * as sinon from "sinon";
+
+describe("ParseOptions", function() {
+  let buildParseOptionsForm: typeof import("app/client/components/ParseOptions").buildParseOptionsForm;
+  let originalDocument: any;
+  let originalWindow: any;
+
+  before(async function() {
+    const jsdom = new JSDOM("<!doctype html><html><body></body></html>");
+    originalDocument = (global as any).document;
+    originalWindow = (global as any).window;
+    (global as any).document = jsdom.window.document;
+    (global as any).window = jsdom.window;
+    pushGlobals(jsdom.window);
+    sinon.stub(Markdown, "markdown").callsFake(source => source as string);
+    ({ buildParseOptionsForm } = await import("app/client/components/ParseOptions"));
+  });
+
+  after(function() {
+    sinon.restore();
+    (global as any).document = originalDocument;
+    (global as any).window = originalWindow;
+    popGlobals();
+  });
+
+  it("renders JSON import options", function() {
+    const elem = dom("div", dom.create(buildParseOptionsForm, [{
+      name: "includes",
+      type: "string",
+      visible: true,
+    }, {
+      name: "excludes",
+      type: "string",
+      visible: true,
+    }], { includes: "", excludes: "" }, () => undefined, () => undefined));
+
+    assert.deepEqual(Array.from(elem.querySelectorAll(".test-parseopts-opt"), option => option.textContent?.trim()), [
+      "Includes (list of tables separated by semicolon)",
+      "Excludes (list of tables separated by semicolon)",
+    ]);
+  });
+});


### PR DESCRIPTION
## Context

Opening Import Options for a JSON file crashes because the localized parse-option label map does not include the JSON parser's `includes` and `excludes` options. The resulting undefined value is passed to the Markdown renderer.

User impact: JSON imports can now open and edit their import options instead of showing a client error.

## Proposed solution

Add localized labels for both JSON options and fall back to the option name for any future parser option that has no mapped label. Add a component regression test covering the JSON option schema.

## Related issues

Fixes #2286

## Has this been tested?

- [x] yes, I added tests to the test suite

Verification performed:

- ESLint passed for the changed component and test.
- TypeScript project build passed.
- Focused ParseOptions test passed: 1 passing.
- Full client unit suite passed: 225 passing, 3 pending.

## Screenshots / Screencasts

Not applicable; the regression is covered by the component test.