### PR TITLE
Inserting column references from other tables into formulas

### DIFF
--- a/app/client/components/GridView.ts
+++ b/app/client/components/GridView.ts
@@ -152,7 +152,6 @@ export default class GridView extends BaseView {
   protected frozenMap: KoArray<ko.Computed<boolean>>;
   protected hoverColumn: ko.Observable<number>;
   private _insertColumnIndex: ko.Observable<number | null>;
-  protected editingFormula: ko.Computed<boolean>;
   protected changeHover: (index: number) => void;
   protected isColSelected: KoArray<ko.Computed<boolean>>;
   protected header: HTMLElement;
@@ -347,13 +346,6 @@ export default class GridView extends BaseView {
 
     this._insertColumnIndex = ko.observable<number | null>(null);
 
-    // Checks if there is active formula editor for a column in this table.
-    this.editingFormula = ko.pureComputed(() => {
-      const isEditing = this.gristDoc.docModel.editingFormula();
-      if (!isEditing) { return false; }
-      return this.viewSection.viewFields().all().some(field => field.editingFormula());
-    });
-
     // Debounced method to change current hover column, this is needed
     // as mouse when moved from field to field will switch the hover-column
     // observable from current index to -1 and then immediately back to current index.
@@ -361,7 +353,7 @@ export default class GridView extends BaseView {
     // will be discarded.
     this.changeHover = debounce((index) => {
       if (this.isDisposed()) { return; }
-      if (this.editingFormula()) {
+      if (this.gristDoc.docModel.editingFormula.peek()) {
         this.hoverColumn(index);
       }
     }, 0);
@@ -1510,7 +1502,7 @@ export default class GridView extends BaseView {
 
                   let filterTriggerCtl: PopupControl;
                   const isTooltip = ko.pureComputed(() =>
-                    this.editingFormula() && !this.isReadonly &&
+                    this.gristDoc.docModel.editingFormula() && !this.isReadonly &&
                     ko.unwrap(this.hoverColumn) === field._index(),
                   );
 
@@ -1535,7 +1527,7 @@ export default class GridView extends BaseView {
                         dom.autoDispose(tooltip),
                         dom.autoDispose(isTooltip.subscribe((show) => {
                           if (show) {
-                            tooltip.show(t(`Click to insert`) + ` $${field.origCol.peek().colId.peek()}`);
+                            tooltip.show(t(`Click to insert`) + ` ${field.displayLabel.peek()}`);
                           } else {
                             tooltip.hide();
                           }
@@ -1784,7 +1776,7 @@ export default class GridView extends BaseView {
             });
 
             const isTooltip = ko.pureComputed(() =>
-              this.editingFormula() && !this.isReadonly &&
+              this.gristDoc.docModel.editingFormula() && !this.isReadonly &&
               ko.unwrap(this.hoverColumn) === field._index(),
             );
 
@@ -1889,7 +1881,7 @@ export default class GridView extends BaseView {
   protected cellMouseDown(elem: HTMLElement, event: MouseEvent) {
     const col = this.domToColModel(elem, selector.CELL);
     if (this.hoverColumn() === col._index()) {
-      return this._tooltipMouseDown(elem, selector.CELL);
+      return this._tooltipMouseDown(elem, selector.CELL, event);
     }
 
     if (event.shiftKey) {
@@ -1906,7 +1898,7 @@ export default class GridView extends BaseView {
   protected colMouseDown(elem: HTMLElement, event: MouseEvent) {
     const col = this.domToColModel(elem, selector.COL);
     if (this.hoverColumn() === col._index()) {
-      return this._tooltipMouseDown(elem, selector.COL);
+      return this._tooltipMouseDown(elem, selector.COL, event);
     }
 
     this._colClickTime = Date.now();
@@ -1915,11 +1907,12 @@ export default class GridView extends BaseView {
     this.cellSelector.row.end(this.getLastDataRowIndex());
   }
 
-  protected _tooltipMouseDown(elem: HTMLElement, elemType: ElemType) {
+  protected _tooltipMouseDown(elem: HTMLElement, elemType: ElemType, event: MouseEvent) {
     const row = this.domToRowModel(elem, elemType);
     const col = this.domToColModel(elem, elemType);
-    // FormulaEditor.ts overrides this command to insert the column id of the clicked column.
-    commands.allCommands.setCursor.run(row, col);
+    // FormulaEditor.ts overrides this command to insert the column id of the clicked column, and
+    // needs the event to keep the click from reaching the section.
+    commands.allCommands.setCursor.run(row, col, event);
   }
 
   protected rowMouseDown(elem: HTMLElement, event: MouseEvent) {
@@ -1936,7 +1929,7 @@ export default class GridView extends BaseView {
   }
 
   protected colMouseMove(event: MouseEvent) {
-    if (this.editingFormula()) { return; }
+    if (this.gristDoc.docModel.editingFormula.peek()) { return; }
 
     const currentCol = Math.min(this.getMousePosCol(event.pageX),
       this.viewSection.viewFields().peekLength - 1);
@@ -1944,7 +1937,7 @@ export default class GridView extends BaseView {
   }
 
   protected cellMouseMove(event: MouseEvent) {
-    if (this.editingFormula()) { return; }
+    if (this.gristDoc.docModel.editingFormula.peek()) { return; }
 
     this.colMouseMove(event);
     this.rowMouseMove(event);

--- a/app/client/components/Importer.ts
+++ b/app/client/components/Importer.ts
@@ -68,6 +68,8 @@ import {
 } from "grainjs";
 import debounce from "lodash/debounce";
 
+import type { KoReactive } from "app/client/models/modelUtil";
+
 const t = makeT("Importer");
 // Custom testId that can be appended conditionally.
 const testId = makeTestId("test-importer-");
@@ -1278,7 +1280,7 @@ export class Importer extends DisposableWithEvents {
    * focus.
    */
   private _setupFormulaEditorCleanup(
-    owner: Disposable, _doc: GristDoc, editingFormula: ko.Computed<boolean>, _saveEdit: () => Promise<unknown>,
+    owner: Disposable, _doc: GristDoc, editingFormula: KoReactive<boolean>, _saveEdit: () => Promise<unknown>,
   ) {
     const saveEdit = () => _saveEdit().catch(reportError);
 

--- a/app/client/declarations.d.ts
+++ b/app/client/declarations.d.ts
@@ -110,6 +110,8 @@ declare module "app/client/models/modelUtil" {
     setAndSaveOrRevert(value: T): Promise<void>;
   }
 
+  type KoReactive<T> = ko.Observable<T> | ko.Computed<T>;
+
   type KoSaveableObservable<T> = ko.Observable<T> & SaveInterface<T>;
   type KoSaveableComputed<T> = ko.Computed<T> & SaveInterface<T>;
 

--- a/app/client/models/DocModel.ts
+++ b/app/client/models/DocModel.ts
@@ -159,8 +159,10 @@ export class DocModel extends Disposable {
   // Flag for tracking whether document is in formula-editing mode
   public editingFormula: ko.Observable<boolean> = ko.observable(false);
 
-  // Table of the column whose formula is currently being edited. Holds an object, not a plain id,
-  // so that an editor being disposed can tell whether the entry is still its own.
+  // Table of the column whose formula is currently being edited, when there is one. It is kept
+  // apart from editingFormula, because an editor does not have to belong to a table (e.g. code
+  // that is not saved in a column). Holds an object, not a plain id, so that an editor being
+  // disposed can tell whether the entry is still its own.
   public editingFormulaTableId = ko.observable<{ tableId: string } | null>(null);
 
   // If the doc has a docTour. Used also to enable the UI button to restart the tour.

--- a/app/client/models/DocModel.ts
+++ b/app/client/models/DocModel.ts
@@ -159,6 +159,10 @@ export class DocModel extends Disposable {
   // Flag for tracking whether document is in formula-editing mode
   public editingFormula: ko.Observable<boolean> = ko.observable(false);
 
+  // Table of the column whose formula is currently being edited. Holds an object, not a plain id,
+  // so that an editor being disposed can tell whether the entry is still its own.
+  public editingFormulaTableId = ko.observable<{ tableId: string } | null>(null);
+
   // If the doc has a docTour. Used also to enable the UI button to restart the tour.
   public readonly hasDocTour: ko.Computed<boolean>;
 

--- a/app/client/models/entities/ViewFieldRec.ts
+++ b/app/client/models/entities/ViewFieldRec.ts
@@ -135,8 +135,8 @@ export function createViewFieldRec(this: ViewFieldRec, docModel: DocModel): void
   }));
   // displayLabel displays label by default but switches to the more helpful colId whenever a
   // formula field in the view is being edited. Only the edited table gets the "$" prefix, since
-  // for other tables it would not be a same-row reference. Clicking a column inserts this exact
-  // text into the formula, so the two must stay in step.
+  // for other tables it would not be a same-row reference. We'll show in the label the exact text
+  // that would be inserted into the formula when that column is clicked.
   this.displayLabel = modelUtil.savingComputed({
     read: () => {
       if (!docModel.editingFormula()) { return this.origCol().label(); }

--- a/app/client/models/entities/ViewFieldRec.ts
+++ b/app/client/models/entities/ViewFieldRec.ts
@@ -134,9 +134,16 @@ export function createViewFieldRec(this: ViewFieldRec, docModel: DocModel): void
     write: (setter, val) => setter(this.column().description, val),
   }));
   // displayLabel displays label by default but switches to the more helpful colId whenever a
-  // formula field in the view is being edited.
+  // formula field in the view is being edited. Only the edited table gets the "$" prefix, since
+  // for other tables it would not be a same-row reference. Clicking a column inserts this exact
+  // text into the formula, so the two must stay in step.
   this.displayLabel = modelUtil.savingComputed({
-    read: () => docModel.editingFormula() ? "$" + this.origCol().colId() : this.origCol().label(),
+    read: () => {
+      if (!docModel.editingFormula()) { return this.origCol().label(); }
+      const editedTable = docModel.editingFormulaTableId();
+      const colId = this.origCol().colId();
+      return this.origCol().table().tableId() === editedTable?.tableId ? "$" + colId : colId;
+    },
     write: (setter, val) => setter(this.column().label, val),
   });
 

--- a/app/client/models/entities/ViewSectionRec.ts
+++ b/app/client/models/entities/ViewSectionRec.ts
@@ -329,8 +329,6 @@ export interface ViewSectionRec extends IRowModel<"_grist_Views_section">, RuleO
   // re-computing the filter when selectedRows changes.
   selectedRowsActive: ko.Computed<boolean>;
 
-  editingFormula: ko.Computed<boolean>;
-
   // Selected fields (columns) for the section.
   selectedFields: ko.Observable<ViewFieldRec[]>;
 
@@ -480,12 +478,6 @@ export function createViewSectionRec(this: ViewSectionRec, docModel: DocModel): 
 
   // All table columns associated with this view section, excluding any hidden helper columns.
   this.columns = this.autoDispose(ko.pureComputed(() => this.table().visibleColumns()));
-  this.editingFormula = ko.pureComputed({
-    read: () => docModel.editingFormula(),
-    write: (val) => {
-      docModel.editingFormula(val);
-    },
-  });
   const defaultOptions: ViewSectionOptions = {
     verticalGridlines: true,
     horizontalGridlines: true,

--- a/app/client/widgets/ConditionalStyle.ts
+++ b/app/client/widgets/ConditionalStyle.ts
@@ -249,7 +249,7 @@ export class ConditionalStyle extends Disposable {
         const vsi = section.viewInstance();
         const editorHolder = openFormulaEditor({
           gristDoc: this._gristDoc,
-          editingFormula: section.editingFormula,
+          editingFormula: this._gristDoc.docModel.editingFormula,
           column,
           editRow: vsi?.moveEditRowToCursor(),
           refElem,

--- a/app/client/widgets/FieldBuilder.ts
+++ b/app/client/widgets/FieldBuilder.ts
@@ -15,7 +15,7 @@ import { makeT } from "app/client/lib/localization";
 import { reportError } from "app/client/models/AppModel";
 import { DataRowModel } from "app/client/models/DataRowModel";
 import { ColumnRec, DocModel, ViewFieldRec } from "app/client/models/DocModel";
-import { SaveableObjObservable, setSaveValue } from "app/client/models/modelUtil";
+import { type KoReactive, SaveableObjObservable, setSaveValue } from "app/client/models/modelUtil";
 import { FieldSettingsMenu } from "app/client/ui/FieldMenus";
 import { translateColumnTypeLabel } from "app/client/ui/GridViewMenus";
 import { cssBlockedCursor, cssLabel, cssRow } from "app/client/ui/RightPanelStyles";
@@ -926,7 +926,7 @@ export class FieldBuilder extends Disposable {
     // Create a custom cleanup method, that won't destroy us when we loose focus while being detached.
     function setupEditorCleanup(
       owner: MultiHolder, gristDoc: GristDoc,
-      editingFormula: ko.Computed<boolean>, _saveEdit: () => Promise<unknown>,
+      editingFormula: KoReactive<boolean>, _saveEdit: () => Promise<unknown>,
     ) {
       // Just override the behavior on focus lost.
       const saveOnFocus = () => floatingExtension.active.get() ? void 0 : _saveEdit().catch(reportError);

--- a/app/client/widgets/FieldEditor.ts
+++ b/app/client/widgets/FieldEditor.ts
@@ -20,6 +20,8 @@ import { CursorPos } from "app/plugin/GristAPI";
 import { Disposable, dom, Emitter, Holder, MultiHolder, Observable, subscribe } from "grainjs";
 import isEqual from "lodash/isEqual";
 
+import type { KoReactive } from "app/client/models/modelUtil";
+
 const t = makeT("FieldEditor");
 
 /**
@@ -483,7 +485,7 @@ function setupReadonlyEditorCleanup(
  * - Arrange for UnsavedChange protection against leaving the page with unsaved changes.
  */
 export function setupEditorCleanup(
-  owner: MultiHolder, gristDoc: GristDoc, editingFormula: ko.Computed<boolean>, _saveEdit: () => Promise<unknown>,
+  owner: MultiHolder, gristDoc: GristDoc, editingFormula: KoReactive<boolean>, _saveEdit: () => Promise<unknown>,
 ) {
   const saveEdit = () => _saveEdit().catch(reportError);
 

--- a/app/client/widgets/FormulaEditor.ts
+++ b/app/client/widgets/FormulaEditor.ts
@@ -26,13 +26,15 @@ import { decodeObject, RaisedException } from "app/plugin/objtypes";
 import { Computed, Disposable, dom, Holder, MultiHolder, Observable, styled, subscribe } from "grainjs";
 import debounce from "lodash/debounce";
 
+import type { KoReactive } from "app/client/models/modelUtil";
+
 // How wide to expand the FormulaEditor when an error is shown in it.
 const minFormulaErrorWidth = 400;
 const t = makeT("FormulaEditor");
 
 export interface IFormulaEditorOptions extends Options {
   cssClass?: string;
-  editingFormula: ko.Computed<boolean>;
+  editingFormula: KoReactive<boolean>;
   column: ColumnRec;
   field?: ViewFieldRec;
   canDetach?: boolean;
@@ -73,6 +75,9 @@ export class FormulaEditor extends NewBaseEditor {
 
     if (!options.readonly) {
       const docModel = options.gristDoc.docModel;
+      // Set here rather than next to editingFormula, which is a flag on the field that turns on
+      // later (only once the user types after a double-click) and is cleared from several places.
+      // The edited table is known as soon as the editor opens, and belongs to this editor alone.
       const editedTable = { tableId: options.column.table.peek().tableId.peek() };
       docModel.editingFormulaTableId(editedTable);
       this.onDispose(() => {
@@ -500,7 +505,7 @@ export function openFormulaEditor(options: {
   column?: ColumnRec,
   // Associated formula from a view field. If provided together with column, this field is used
   field?: ViewFieldRec,
-  editingFormula: ko.Computed<boolean>,
+  editingFormula: KoReactive<boolean>,
   // Needed to get exception value, if any.
   editRow?: DataRowModel,
   // Element over which to position the editor.
@@ -513,7 +518,7 @@ export function openFormulaEditor(options: {
   setupCleanup: (
     owner: Disposable,
     doc: GristDoc,
-    editingFormula: ko.Computed<boolean>,
+    editingFormula: KoReactive<boolean>,
     save: () => Promise<void>,
   ) => void,
 }): FormulaEditor {

--- a/app/client/widgets/FormulaEditor.ts
+++ b/app/client/widgets/FormulaEditor.ts
@@ -71,6 +71,18 @@ export class FormulaEditor extends NewBaseEditor {
 
     this._isEmpty = Computed.create(this, this.editorState, (_use, state) => state === "");
 
+    if (!options.readonly) {
+      const docModel = options.gristDoc.docModel;
+      const editedTable = { tableId: options.column.table.peek().tableId.peek() };
+      docModel.editingFormulaTableId(editedTable);
+      this.onDispose(() => {
+        // Another editor may have replaced us already, so the entry is not always ours to clear.
+        if (docModel.editingFormulaTableId.peek() === editedTable) {
+          docModel.editingFormulaTableId(null);
+        }
+      });
+    }
+
     this._aceEditor = AceEditor.create({
       // A bit awkward, but we need to assume calcSize is not used until attach() has been called
       // and _editorPlacement created.
@@ -416,24 +428,20 @@ export class FormulaEditor extends NewBaseEditor {
   }
 
   // TODO: update regexes to unicode?
-  private _onSetCursor(row?: DataRowModel, col?: ViewFieldRec) {
+  private _onSetCursor(row?: DataRowModel, col?: ViewFieldRec, event?: MouseEvent) {
     // Don't do anything when we are readonly.
     if (this.options.readonly) { return; }
     // If we don't have column information, we can't insert anything.
     if (!col) { return; }
 
-    const colId = col.origCol.peek().colId.peek();
+    event?.stopPropagation();
 
-    if (col.tableId.peek() !== this.options.column.table.peek().tableId.peek()) {
-      // Fall back to default behavior if cursor didn't move to a column in the same table.
-      this.options.gristDoc.onSetCursorPos(row, col).catch(reportError);
-      return;
-    }
+    const textToInsert = col.displayLabel.peek();
 
     const aceObj = this._aceEditor.getEditor();
     if (!aceObj.selection.isEmpty()) {
       // If text selected, replace whole selection
-      aceObj.session.replace(aceObj.selection.getRange(), "$" + colId);
+      aceObj.session.replace(aceObj.selection.getRange(), textToInsert);
     } else {
       // Not a selection, gotta figure out what to replace
       const pos = aceObj.getCursorPosition();
@@ -441,12 +449,12 @@ export class FormulaEditor extends NewBaseEditor {
       const result = _isInIdentifier(line, pos.column); // returns {start, end, id} | null
       if (!result) {
         // Not touching an identifier, insert colId as normal
-        aceObj.insert("$" + colId);
+        aceObj.insert(textToInsert);
         // We are touching an identifier
       } else if (result.ident.startsWith("$")) {
         // If ident is a colId, replace it
         const idRange = AceEditor.makeRange(pos.row, result.start, pos.row, result.end);
-        aceObj.session.replace(idRange, "$" + colId);
+        aceObj.session.replace(idRange, textToInsert);
       }
       // Else touching a normal identifier, don't mangle it
     }

--- a/test/nbrowser/BootPage.ts
+++ b/test/nbrowser/BootPage.ts
@@ -495,7 +495,7 @@ describe("BootPage", function() {
       await driver.get(`${server.getHost()}/admin?boot-key=abc123`);
       await gu.waitForAdminPanel();
       assert.equal(
-        await driver.find(".test-admin-panel-item-value-service-status").getText(),
+        await driver.findWait(".test-admin-panel-item-value-service-status", 2000).getText(),
         "out of service",
       );
       await toggleItem("service-status");

--- a/test/nbrowser/Fork.ts
+++ b/test/nbrowser/Fork.ts
@@ -351,13 +351,17 @@ describe("Fork", function() {
         // Check others without view access to trunk cannot see fork
         await team.user("user2").login();
         await driver.get(forkUrl);
-        assert.match(await driver.findWait(".test-error-header", 2000).getText(), /Access denied/);
-        assert.equal(await driver.find(".test-dm-logo").isDisplayed(), true);
+        await gu.waitToPass(async () => {
+          assert.match(await driver.findWait(".test-error-header", 2000).getText(), /Access denied/);
+          assert.equal(await driver.find(".test-dm-logo").isDisplayed(), true);
+        });
 
         await server.removeLogin();
         await driver.get(forkUrl);
-        assert.match(await driver.findWait(".test-error-header", 2000).getText(), /Access denied/);
-        assert.equal(await driver.find(".test-dm-logo").isDisplayed(), true);
+        await gu.waitToPass(async () => {
+          assert.match(await driver.findWait(".test-error-header", 2000).getText(), /Access denied/);
+          assert.equal(await driver.find(".test-dm-logo").isDisplayed(), true);
+        });
       });
 
       it("fails to create forks with inconsistent user id", async function() {
@@ -379,8 +383,10 @@ describe("Fork", function() {
         // new doc user2 has no access granted via the doc, or
         // workspace, or org).
         await altSession.loadDoc(`/doc/new~${forkId}~${userId}`, { wait: false });
-        assert.match(await driver.findWait(".test-error-header", 2000).getText(), /Access denied/);
-        assert.equal(await driver.find(".test-dm-logo").isDisplayed(), true);
+        await gu.waitToPass(async () => {
+          assert.match(await driver.findWait(".test-error-header", 2000).getText(), /Access denied/);
+          assert.equal(await driver.find(".test-dm-logo").isDisplayed(), true);
+        });
 
         // Same, but as an anonymous user.
         const anonSession = await altSession.anon.login();
@@ -390,8 +396,10 @@ describe("Fork", function() {
 
         // A new doc cannot be created either (because of access mismatch).
         await altSession.loadDoc(`/doc/new~${forkId}~${userId}`, { wait: false });
-        assert.match(await driver.findWait(".test-error-header", 2000).getText(), /Access denied/);
-        assert.equal(await driver.find(".test-dm-logo").isDisplayed(), true);
+        await gu.waitToPass(async () => {
+          assert.match(await driver.findWait(".test-error-header", 2000).getText(), /Access denied/);
+          assert.equal(await driver.find(".test-dm-logo").isDisplayed(), true);
+        });
 
         // Now as a user who *is* allowed to create the fork.
         // But doc forks cannot be casually created this way anymore, so it still doesn't work.

--- a/test/nbrowser/Formulas.ts
+++ b/test/nbrowser/Formulas.ts
@@ -157,9 +157,11 @@ describe("Formulas", function() {
     assert.deepEqual(await gu.getVisibleGridCells("C", [1, 2, 3]), ["true", "false", "true"]);
 
     // ISERR considers exceptions but not AltText values.
+    const revert = await gu.begin();
     await gu.addColumn("D");
     await gu.enterFormula("(ISERR($B)");
     assert.deepEqual(await gu.getVisibleGridCells("D", [1, 2, 3]), ["false", "false", "true"]);
+    await revert();
   });
 
   it("should support formulas returning unmarshallable or weird values", async function() {
@@ -411,5 +413,84 @@ return [
     await driver.findContentWait(".ace_content", /^Friends\.lookupRecords\($/, 1000);
     await driver.sendKeys(Key.ESCAPE, Key.ESCAPE);
     await gu.waitAppFocus();
+  });
+
+  it("should insert column id when clicking a cell in another table", async function() {
+    const revert = await gu.begin();
+    await gu.addNewSection("Table", "New Table");
+    const otherSection = await gu.getActiveSectionTitle();
+
+    await gu.getSection("Films").click();
+    await gu.addColumn("D");
+    await gu.getCell({ col: "D", rowNum: 1, section: "Films" }).click();
+    await gu.waitAppFocus();
+    await driver.sendKeys("=");
+    await gu.waitAppFocus(false);
+
+    // Another table has no "$" prefix, since it would not be a same-row reference.
+    const otherCell = gu.getCell({ col: "A", rowNum: 1, section: otherSection });
+    await driver.withActions(actions => actions.move({ origin: otherCell }));
+    assert.equal(await driver.find(".test-column-formula-tooltip").getText(), "Click to insert A");
+    await otherCell.click();
+
+    await driver.findContentWait(".ace_content", /^A$/, 1000);
+    assert.equal(await gu.getActiveSectionTitle(), "FILMS");
+
+    await driver.sendKeys(Key.ESCAPE);
+    await revert();
+  });
+
+  it("should insert $colId when clicking another section of the same table", async function() {
+    const revert = await gu.begin();
+    await gu.addNewSection("Table", "Films");
+    const otherSection = "Films copy";
+    await gu.renameActiveSection(otherSection);
+
+    await gu.getSection("FILMS").click();
+    await gu.addColumn("D");
+    await gu.getCell({ col: "D", rowNum: 1, section: "FILMS" }).click();
+    await gu.waitAppFocus();
+    await driver.sendKeys("=");
+    await gu.waitAppFocus(false);
+
+    const otherCell = gu.getCell({ col: "$Title", rowNum: 1, section: otherSection });
+    await driver.withActions(actions => actions.move({ origin: otherCell }));
+    assert.equal(await driver.find(".test-column-formula-tooltip").getText(), "Click to insert $Title");
+    await otherCell.click();
+
+    await driver.findContentWait(".ace_content", /^\$Title$/, 1000);
+
+    await driver.sendKeys(Key.ESCAPE);
+    await revert();
+  });
+
+  it("should save the formula on Enter after clicking a cell in another table", async function() {
+    const revert = await gu.begin();
+    await gu.addNewSection("Table", "New Table");
+    const otherSection = await gu.getActiveSectionTitle();
+
+    await gu.getSection("Films").click();
+    await gu.addColumn("E");
+    await gu.getCell({ col: "E", rowNum: 1, section: "Films" }).click();
+    await gu.waitAppFocus();
+    await driver.sendKeys("=");
+    await gu.waitAppFocus(false);
+
+    const otherCell = gu.getCell({ col: "A", rowNum: 1, section: otherSection });
+    await driver.withActions(actions => actions.move({ origin: otherCell }));
+    await otherCell.click();
+    await driver.findContentWait(".ace_content", /^A$/, 1000);
+
+    await driver.sendKeys(Key.ENTER);
+    await gu.waitForServer();
+
+    assert.equal(await driver.find(".ace_content").isPresent(), false);
+    const api = session.createHomeApi().getDocAPI(docId);
+    const columns = await api.getRecords("_grist_Tables_column");
+    const colE = columns.find(col => col.fields.colId === "E");
+    assert.equal(colE?.fields.isFormula, true);
+    assert.equal(colE?.fields.formula, "A");
+
+    await revert();
   });
 });

--- a/test/nbrowser/SupportGrist.ts
+++ b/test/nbrowser/SupportGrist.ts
@@ -103,7 +103,7 @@ describe("SupportGrist", function() {
         await gu.openAccountMenu();
         await driver.find(".test-usermenu-admin-panel").click();
         await driver.findWait(".test-admin-panel", 2000);
-        await driver.find(".test-admin-panel-item-name-telemetry").click();
+        await driver.findWait(".test-admin-panel-item-name-telemetry", 2000).click();
         await driver.sleep(500);  // Wait for section to expand.
         await driver.findContentWait(
           ".test-support-grist-page-telemetry-section button", /Opt out of Telemetry/, 2000).click();


### PR DESCRIPTION
## Context

When editing a formula you can click a column to insert it. This worked only for columns in
the same table, clicking anywhere else just moved the cursor. But lookups are exactly the
case when you need the other table, like `Films.lookupOne(Title=$Name)`.

## Proposed solution

Clicking a column in another table inserts it too, without the `$` prefix, since it is not a
same row reference. Headers show the same text, so what you see is what gets inserted.

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
