### PR TITLE
test: wait for auto-check toggle state to settle after refresh

### DIFF
--- a/test/nbrowser/AdminPanel.ts
+++ b/test/nbrowser/AdminPanel.ts
@@ -371,9 +371,13 @@ describe("AdminPanel", function() {
     await gu.waitForAdminPanel();
     await waitForStatus(/Newer version available/);
     fakeServer.resume();
-    // Expand and see if the toggle is off.
+    // Expand and see if the toggle is off. The auto-check setting loads from local storage
+    // asynchronously and can briefly render its "enabled by default" initial state before the
+    // persisted value lands, so poll rather than asserting once.
     await toggleItem("updates");
-    assert.isFalse(await isEnabled(autoCheckToggle()));
+    await gu.waitToPass(async () => {
+      assert.isFalse(await isEnabled(autoCheckToggle()));
+    }, 2000);
   });
 
   it("shows up-to-date message", async function() {


### PR DESCRIPTION
## Context

Small follow-on from the CI-flakiness discussion in #938. Looked at 9 recent failing `CI` runs on `main` and found failures spread across nearly every `nbrowser` matrix shard, in different test suites each time. One specific instance: `test/nbrowser/AdminPanel.ts`'s "should check for updates" test failed with `AssertionError: expected true to be false` on the final assertion.

## Proposed solution

The auto-check toggle's enabled/disabled state is read from local storage on load and can briefly render its "enabled by default" initial state before the persisted value lands. The test's final assertion checked it once, immediately after `toggleItem("updates")`, with nothing waiting for that settle.

Wrapped it in `gu.waitToPass()` — the same pattern already used a few lines up in the "should show sandbox" test for an equivalent case (a value that settles asynchronously after render). No new helper needed; this follows the existing local convention rather than introducing a new one.

## Related issues

#938

## Has this been tested?

- [ ] 👍 yes, I added tests to the test suite
- [x] 🙅 no, because this is not relevant here (this PR only fixes an existing test)

`tsc --noEmit` and `eslint` both pass clean on the changed file. I wasn't able to run the nbrowser suite itself locally (needs a Chrome install + full service stack); relying on CI to confirm.
