### PR TITLE
Bump sandbox self-test timeout to 10 seconds

### DIFF
--- a/app/server/lib/NSandbox.ts
+++ b/app/server/lib/NSandbox.ts
@@ -726,9 +726,9 @@ export async function testSandboxFlavor(flavor?: string): Promise<SandboxInfo> {
     info.lastSuccessfulStep = "create";
 
     // Step 2: Run a simple Python call to check if the sandbox can execute code.
-    // Give up after 5 seconds if it takes too long.
+    // Give up after 10 seconds if it takes too long.
     const timeoutProm = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("Sandbox test timed out after 5s")), 5000).unref(),
+      setTimeout(() => reject(new Error("Sandbox test timed out after 10s")), 10000).unref(),
     );
     const result = await Promise.race([sandbox.pyCall("get_version"), timeoutProm]);
     if (typeof result !== "number") {


### PR DESCRIPTION
Hi,
I set up a self-hosted Grist instance recently and ran into the sandbox self-test timeout. My setup (a Hetzner VPS) doesn't allow nested virt and is somewhat slow: Initializing the Pyodide sandbox takes about 6.5s. That initially seemed quite high to me, but loading all Python dependencies inside of the Pyodine environment just genuinely seems to take this long.

This PR bumps the limit from 5s to 10s, not great but still okay probably :slightly_smiling_face: 
Thanks!