### PR TITLE
Fix random exit-codes due to process.exit(pid)

### DIFF
--- a/app/server/lib/shutdown.js
+++ b/app/server/lib/shutdown.js
@@ -86,7 +86,7 @@ function signalExit(signal) {
       // in a situation when Grist is the init (pid 1) process in a container
       // See https://github.com/gristlabs/grist-core/pull/830 (and #892)
       const signalNumber = os.constants.signals[signal];
-      process.exit(process.pid, 128 + signalNumber);
+      process.exit(128 + signalNumber);
     });
 }
 


### PR DESCRIPTION
Hi,
I recently set up Grist as a systemd service and noticed that the unit failed with strange exit codes. The `signalExit` function currently calls `process.exit` like this:

https://github.com/gristlabs/grist-core/blob/fa9f5a0f72e8f30efafa44fc6a4d9e6fdbd466a5/app/server/lib/shutdown.js#L89

The [`process.exit` API](https://nodejs.org/api/process.html#processexitcode) only takes one argument though, and interprets the `pid` as an exit code and discards the second argument in this case. This should now work correctly :)

Thanks!