### PR TITLE
Give axios its own connection pool in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -260,7 +260,8 @@
       "test/report-why-tests-hang",
       "test/init-mocha-webdriver",
       "test/split-tests",
-      "test/chai-as-promised"
+      "test/chai-as-promised",
+      "test/axios-own-agent"
     ]
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/test/axios-own-agent.js
+++ b/test/axios-own-agent.js
@@ -1,0 +1,24 @@
+/**
+ * Give axios its own connection pool, keeping the sockets it uses out of the shared one.
+ *
+ * Through follow-redirects, axios leaves a socket.destroy listener on the 'timeout'
+ * event of each keep-alive socket it uses, and does not remove it. Node sets a five
+ * second idle timeout on pooled sockets, so the next caller to reuse one -- node-fetch,
+ * and hence our API client -- has it closed five seconds into any request the server is
+ * slow to answer, reported as "socket hang up". The nbrowser suites run into this by
+ * uploading a fixture document through axios in a before hook; that socket is then
+ * reused for the first applyUserActions of the suite.
+ *
+ * A separate pool is enough because axios disables the socket timeout for the duration
+ * of its own requests, leaving nothing to trigger the listener. See axios#6113, and
+ * remove this once it is fixed upstream.
+ */
+
+// axios.create() merges the defaults as an instance is made, so this has to run before
+// anything that makes one, which is what mocha's require list is for.
+const http = require("http");
+const https = require("https");
+const axios = require("axios");
+
+axios.defaults.httpAgent = new http.Agent({ keepAlive: true });
+axios.defaults.httpsAgent = new https.Agent({ keepAlive: true });

--- a/test/server/lib/docapi/DocApiWebhooks.ts
+++ b/test/server/lib/docapi/DocApiWebhooks.ts
@@ -33,8 +33,6 @@ import { signal } from "test/server/lib/helpers/Signal";
 import * as testUtils from "test/server/testUtils";
 import { waitForIt } from "test/server/wait";
 
-import { Agent } from "http";
-
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 import { assert } from "chai";
 import * as express from "express";
@@ -47,12 +45,6 @@ import fetch from "node-fetch";
 import { createClient, RedisClient } from "redis";
 
 const webhooksTestPort = Number(process.env.WEBHOOK_TEST_PORT || 34365);
-const axiosInstance = axios.create({
-  // FIXME: disable keepAlive, otherwise since axios in version 1.13.2
-  // we have a "socket hang up" error (regression in axios?)
-  // Maybe related to the use of agentkeepalive (present in yarn.lock)
-  httpAgent: new Agent({ keepAlive: false }),
-});
 
 async function getWorkspaceId(api: UserAPIImpl, name: string) {
   const workspaces = await api.getOrgWorkspaces("current");
@@ -113,7 +105,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
 
     async function oldSubscribeCheck(requestBody: any, status: number, ...errors: RegExp[]) {
       const { serverUrl, docIds, chimpy } = getCtx();
-      const resp = await axiosInstance.post(
+      const resp = await axios.post(
         `${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1/_subscribe`,
         requestBody, chimpy,
       );
@@ -125,7 +117,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
 
     async function postWebhookCheck(requestBody: any, status: number, ...errors: RegExp[]) {
       const { serverUrl, docIds, chimpy } = getCtx();
-      const resp = await axiosInstance.post(
+      const resp = await axios.post(
         `${serverUrl}/api/docs/${docIds.Timesheets}/webhooks`,
         requestBody, chimpy,
       );
@@ -138,7 +130,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
 
     async function userCheck(user: AxiosRequestConfig, requestBody: any, status: number, responseBody: any) {
       const { serverUrl, docIds } = getCtx();
-      const resp = await axiosInstance.post(
+      const resp = await axios.post(
         `${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1/_unsubscribe`,
         requestBody, user,
       );
@@ -151,7 +143,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
 
     async function userDeleteCheck(user: AxiosRequestConfig, webhookId: string, status: number, ...errors: RegExp[]) {
       const { serverUrl, docIds } = getCtx();
-      const resp = await axiosInstance.delete(
+      const resp = await axios.delete(
         `${serverUrl}/api/docs/${docIds.Timesheets}/webhooks/${webhookId}`,
         user,
       );
@@ -168,7 +160,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
 
     async function subscribeWebhook(): Promise<SubscriptionInfo> {
       const { serverUrl, docIds, chimpy } = getCtx();
-      const subscribeResponse = await axiosInstance.post(
+      const subscribeResponse = await axios.post(
         `${serverUrl}/api/docs/${docIds.Timesheets}/tables/Table1/_subscribe`,
         { eventTypes: ["add"], url: "https://example.com" }, chimpy,
       );
@@ -179,14 +171,14 @@ function addWebhooksTests(getCtx: () => TestContext) {
 
     async function getRegisteredWebhooks() {
       const { serverUrl, docIds, chimpy } = getCtx();
-      const response = await axiosInstance.get(
+      const response = await axios.get(
         `${serverUrl}/api/docs/${docIds.Timesheets}/webhooks`, chimpy);
       return response.data.webhooks;
     }
 
     async function deleteWebhookCheck(webhookId: any) {
       const { serverUrl, docIds, chimpy } = getCtx();
-      const response = await axiosInstance.delete(
+      const response = await axios.delete(
         `${serverUrl}/api/docs/${docIds.Timesheets}/webhooks/${webhookId}`, chimpy);
       return response.data;
     }
@@ -196,7 +188,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
       const registerResponse = await postWebhookCheck({
         webhooks: [{ fields: { tableId: "Table1", eventTypes: ["add"], url: "https://example.com" } }],
       }, 200);
-      const resp = await axiosInstance.get(`${serverUrl}/api/docs/${docIds.Timesheets}/webhooks`, chimpy);
+      const resp = await axios.get(`${serverUrl}/api/docs/${docIds.Timesheets}/webhooks`, chimpy);
       try {
         assert.equal(resp.status, 200);
         assert.isAtLeast(resp.data.webhooks.length, 1);
@@ -313,7 +305,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
       const delta = {
         users: { "kiwi@getgrist.com": "editors" as string | null },
       };
-      let accessResp = await axiosInstance.patch(`${homeUrl}/api/docs/${docIds.Timesheets}/access`, { delta }, chimpy);
+      let accessResp = await axios.patch(`${homeUrl}/api/docs/${docIds.Timesheets}/access`, { delta }, chimpy);
       await flushAuth();
       assert.equal(accessResp.status, 200);
 
@@ -329,7 +321,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
         404, `Webhook not found "${subscribeResponse.webhookId}"`);
 
       delta.users["kiwi@getgrist.com"] = null;
-      accessResp = await axiosInstance.patch(`${homeUrl}/api/docs/${docIds.Timesheets}/access`, { delta }, chimpy);
+      accessResp = await axios.patch(`${homeUrl}/api/docs/${docIds.Timesheets}/access`, { delta }, chimpy);
       assert.equal(accessResp.status, 200);
       await flushAuth();
     });
@@ -342,14 +334,14 @@ function addWebhooksTests(getCtx: () => TestContext) {
       const delta = {
         users: { "kiwi@getgrist.com": "editors" as string | null },
       };
-      let accessResp = await axiosInstance.patch(`${homeUrl}/api/docs/${docIds.Timesheets}/access`, { delta }, chimpy);
+      let accessResp = await axios.patch(`${homeUrl}/api/docs/${docIds.Timesheets}/access`, { delta }, chimpy);
       assert.equal(accessResp.status, 200);
       await flushAuth();
 
       await check(subscribeResponse.webhookId, 403, /No owner access/);
 
       delta.users["kiwi@getgrist.com"] = null;
-      accessResp = await axiosInstance.patch(`${homeUrl}/api/docs/${docIds.Timesheets}/access`, { delta }, chimpy);
+      accessResp = await axios.patch(`${homeUrl}/api/docs/${docIds.Timesheets}/access`, { delta }, chimpy);
       assert.equal(accessResp.status, 200);
       await flushAuth();
     });
@@ -418,7 +410,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
       for (let i = 1; i <= 9; i++) {
         const last = i === 9;
         m = moment.utc();
-        const response = await axiosInstance.get(`${serverUrl}/api/docs/${docId}/tables/Table1/records`,
+        const response = await axios.get(`${serverUrl}/api/docs/${docId}/tables/Table1/records`,
           chimpy);
         await delay(100);
         if (i <= 4) {
@@ -576,7 +568,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
 
     function unsubscribe(docId: string, data: any, tableId = "Table1") {
       const { serverUrl, chimpy } = getCtx();
-      return axiosInstance.post(
+      return axios.post(
         `${serverUrl}/api/docs/${docId}/tables/${tableId}/_unsubscribe`,
         data, chimpy,
       );
@@ -592,7 +584,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
       enabled?: boolean,
     }) {
       const { serverUrl, chimpy } = getCtx();
-      const { data, status } = await axiosInstance.post(
+      const { data, status } = await axios.post(
         `${serverUrl}/api/docs/${docId}/tables/${options?.tableId ?? "Table1"}/_subscribe`,
         {
           eventTypes: options?.eventTypes ?? ["add", "update"],
@@ -607,7 +599,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
 
     async function clearQueue(docId: string) {
       const { serverUrl, chimpy } = getCtx();
-      const deleteResult = await axiosInstance.delete(
+      const deleteResult = await axios.delete(
         `${serverUrl}/api/docs/${docId}/webhooks/queue`, chimpy,
       );
       assert.equal(deleteResult.status, 200);
@@ -615,7 +607,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
 
     async function readStats(docId: string): Promise<WebhookSummary[]> {
       const { serverUrl, chimpy } = getCtx();
-      const result = await axiosInstance.get(
+      const result = await axios.get(
         `${serverUrl}/api/docs/${docId}/webhooks`, chimpy,
       );
       assert.equal(result.status, 200);
@@ -742,7 +734,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
         },
       ) {
         const { serverUrl, chimpy } = getCtx();
-        await axiosInstance.post(`${serverUrl}/api/docs/${docId}/apply`, [
+        await axios.post(`${serverUrl}/api/docs/${docId}/apply`, [
           ["ModifyColumn", tableId, isReadyColumn, { type: "Bool" }],
         ], chimpy);
 
@@ -797,7 +789,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
             await doc.updateRows("Table1", { id: [2], A: [7], B: [true] });
             await doc.updateRows("Table1", { id: [2], A: [8] });
 
-            await axiosInstance.post(`${serverUrl}/api/docs/${docId}/apply`, [
+            await axios.post(`${serverUrl}/api/docs/${docId}/apply`, [
               ["BulkAddRecord", "Table1", [3, 4, 5, 6], { A: [9, 10, 11, 12], B: [true, true, false, false] }],
               ["BulkUpdateRecord", "Table1", [1, 2, 3, 4, 5, 6], {
                 A: [101, 102, 13, 14, 15, 16],
@@ -809,7 +801,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
               ["RemoveColumn", "Table12", "C"],
             ], chimpy);
 
-            await axiosInstance.post(`${serverUrl}/api/docs/${docId}/apply`, [
+            await axios.post(`${serverUrl}/api/docs/${docId}/apply`, [
               ["AddRecord", "Table12", 7, { A3: 17, B3: false }],
               ["UpdateRecord", "Table12", 7, { A3: 18, B3: true }],
               ["AddRecord", "Table12", 8, { A3: 19, B3: true }],
@@ -826,7 +818,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
             await receivedLastEvent;
 
             await Promise.all(subscribeResponses.map(async (subscribeResponse) => {
-              const unsubscribeResponse = await axiosInstance.post(
+              const unsubscribeResponse = await axios.post(
                 `${serverUrl}/api/docs/${docId}/tables/Table12/_unsubscribe`,
                 subscribeResponse, chimpy,
               );
@@ -910,7 +902,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
         const ws1 = (await userApi.getOrgWorkspaces("current"))[0].id;
         docId = await userApi.newDoc({ name: "testdoc2" }, ws1);
         doc = userApi.getDocAPI(docId);
-        await axiosInstance.post(`${serverUrl}/api/docs/${docId}/apply`, [
+        await axios.post(`${serverUrl}/api/docs/${docId}/apply`, [
           ["ModifyColumn", "Table1", "B", { type: "Bool" }],
         ], chimpy);
         await userApi.applyUserActions(docId, [["AddTable", "Table2", [{ id: "Foo" }, { id: "Bar" }]]]);
@@ -928,7 +920,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
         const ws1 = (await userApi.getOrgWorkspaces("current"))[0].id;
         const docId = await userApi.newDoc({ name: "testdoc2" }, ws1);
         const doc = userApi.getDocAPI(docId);
-        await axiosInstance.post(`${serverUrl}/api/docs/${docId}/apply`, [
+        await axios.post(`${serverUrl}/api/docs/${docId}/apply`, [
           ["ModifyColumn", "Table1", "B", { type: "Bool" }],
         ], chimpy);
 
@@ -1013,7 +1005,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
         });
         successCalled.assertNotCalled();
         longFinished.assertNotCalled();
-        assert.isTrue((await axiosInstance.delete(
+        assert.isTrue((await axios.delete(
           `${serverUrl}/api/docs/${docId}/webhooks/queue`, chimpy,
         )).status === 200);
         controller5.abort();
@@ -1041,7 +1033,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
         const ws1 = (await userApi.getOrgWorkspaces("current"))[0].id;
         const docId = await userApi.newDoc({ name: "testdoc4" }, ws1);
         const doc = userApi.getDocAPI(docId);
-        await axiosInstance.post(`${serverUrl}/api/docs/${docId}/apply`, [
+        await axios.post(`${serverUrl}/api/docs/${docId}/apply`, [
           ["ModifyColumn", "Table1", "B", { type: "Bool" }],
         ], chimpy);
 
@@ -1079,12 +1071,12 @@ function addWebhooksTests(getCtx: () => TestContext) {
         const ws1 = (await userApi.getOrgWorkspaces("current"))[0].id;
         const docId = await userApi.newDoc({ name: "testdoc5" }, ws1);
         const doc = userApi.getDocAPI(docId);
-        await axiosInstance.post(`${serverUrl}/api/docs/${docId}/apply`, [
+        await axios.post(`${serverUrl}/api/docs/${docId}/apply`, [
           ["ModifyColumn", "Table1", "B", { type: "Bool" }],
         ], chimpy);
 
         const modifyColumn = async (newValues: { [key: string]: any; }) => {
-          await axiosInstance.post(`${serverUrl}/api/docs/${docId}/apply`, [
+          await axios.post(`${serverUrl}/api/docs/${docId}/apply`, [
             ["UpdateRecord", "Table1", newRowIds[0], newValues],
           ], chimpy);
         };
@@ -1345,7 +1337,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
         const doc = userApi.getDocAPI(docId);
         const formulaEvaluatedAtDocLoad = "NOW()";
 
-        await axiosInstance.post(`${serverUrl}/api/docs/${docId}/apply`, [
+        await axios.post(`${serverUrl}/api/docs/${docId}/apply`, [
           ["ModifyColumn", "Table1", "C", { isFormula: true, formula: formulaEvaluatedAtDocLoad }],
         ], chimpy);
 
@@ -1456,7 +1448,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
 
             const doc = userApi.getDocAPI(docId);
             const fork = await doc.fork();
-            const { data: errorData } = await axiosInstance.post(
+            const { data: errorData } = await axios.post(
               `${serverUrl}/api/docs/${fork.docId}/webhooks`,
               {
                 webhooks: [{
@@ -1469,7 +1461,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
             );
             assert.equal(errorData.error, "Unsaved document copies cannot have webhooks");
 
-            const { data } = await axiosInstance.post(
+            const { data } = await axios.post(
               `${serverUrl}/api/docs/${docId}/webhooks`,
               {
                 webhooks: [{
@@ -1501,7 +1493,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
             const { unsubscribeKey, ...fieldsWithoutUnsubscribeKey } = stats[0].fields;
             assert.deepEqual(fieldsWithoutUnsubscribeKey, expectedFields);
 
-            const resp = await axiosInstance.patch(
+            const resp = await axios.patch(
               `${serverUrl}/api/docs/${docId}/webhooks/${webhooks.webhooks[0].id}`, fields, chimpy,
             );
 
@@ -1524,7 +1516,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
               }
             }
 
-            const unsubscribeResp = await axiosInstance.delete(
+            const unsubscribeResp = await axios.delete(
               `${serverUrl}/api/docs/${docId}/webhooks/${webhooks.webhooks[0].id}`, chimpy,
             );
             assert.equal(unsubscribeResp.status, 200, JSON.stringify(pick(unsubscribeResp, ["data", "status"])));
@@ -1597,9 +1589,9 @@ function addWebhooksTests(getCtx: () => TestContext) {
       anonConfig.headers!.Origin = allowedOrigin;
       let response: AxiosResponse;
       for (response of [
-        await axiosInstance.post(url, data, anonConfig),
-        await axiosInstance.get(url, anonConfig),
-        await axiosInstance.options(url, anonConfig),
+        await axios.post(url, data, anonConfig),
+        await axios.get(url, anonConfig),
+        await axios.options(url, anonConfig),
       ]) {
         assert.equal(response.status, 200);
         assert.equal(response.headers["access-control-allow-methods"], "GET, PATCH, PUT, POST, DELETE, OPTIONS");
@@ -1612,9 +1604,9 @@ function addWebhooksTests(getCtx: () => TestContext) {
       for (const config of [anonConfig, chimpyConfig]) {
         config.headers!.Origin = forbiddenOrigin;
         for (response of [
-          await axiosInstance.post(url, data, config),
-          await axiosInstance.get(url, config),
-          await axiosInstance.options(url, config),
+          await axios.post(url, data, config),
+          await axios.get(url, config),
+          await axios.options(url, config),
         ]) {
           if (config === anonConfig) {
             // Requests without credentials are still OK.
@@ -1636,7 +1628,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
       // One possible header is X-Requested-With, which we removed at the start of the test.
       // The other is Content-Type: application/json, which we have been using implicitly above because axios
       // automatically treats the given data object as data. Passing a string instead prevents this.
-      response = await axiosInstance.post(url, JSON.stringify(data), anonConfig);
+      response = await axios.post(url, JSON.stringify(data), anonConfig);
       assert.equal(response.status, 401);
       assert.deepEqual(response.data, {
         error: "Unauthenticated requests require one of the headers" +
@@ -1644,7 +1636,7 @@ function addWebhooksTests(getCtx: () => TestContext) {
       });
 
       // ^ that's for requests without credentials, otherwise we get the same 403 as earlier.
-      response = await axiosInstance.post(url, JSON.stringify(data), chimpyConfig);
+      response = await axios.post(url, JSON.stringify(data), chimpyConfig);
       assert.equal(response.status, 403);
       assert.deepEqual(response.data, { error: "Credentials not supported for cross-origin requests" });
     });


### PR DESCRIPTION
Code that mixes axios with node-fetch against the same server can lose a socket mid-request, reported as "socket hang up". Through follow-redirects, axios leaves a socket.destroy listener on the 'timeout' event of each keep-alive socket it uses and does not remove it. Node sets a five second idle timeout on pooled sockets, so the next caller to reuse one has it closed five seconds into any request the server is slow to answer.

Giving axios its own agents keeps those sockets out of the shared pool. axios disables the socket timeout for the duration of its own requests, so the listener has no effect there.
