### PR TITLE
Display API endpoint and sample curl command on the API key screen

### DIFF
--- a/app/client/ui/AccountPage.ts
+++ b/app/client/ui/AccountPage.ts
@@ -196,6 +196,7 @@ designed to ensure that you're the only person who can access your account, even
             onDelete: () => this._deleteApiKey(),
             anonymous: false,
             inputArgs: [{ size: "5" }], // Lower size so that input can shrink below ~152px.
+            apiUrl: this._appModel.api.getBaseUrl(),
           }),
         )),
       ]),

--- a/app/client/ui/ApiKey.ts
+++ b/app/client/ui/ApiKey.ts
@@ -16,6 +16,9 @@ interface IWidgetOptions {
   // When anonymous, no modifications are permitted to profile information.
   // TODO: add browser test for this option.
   inputArgs?: IDomArgs<HTMLInputElement>;
+  // Base URL used to build a sample curl command showing how to call the API. When omitted,
+  // the curl command is not shown.
+  apiUrl?: string;
 }
 
 const testId = makeTestId("test-apikey-");
@@ -33,8 +36,10 @@ export class ApiKey extends Disposable {
   private _onCreateCB: () => Promise<void>;
   private _anonymous: boolean;
   private _inputArgs: IDomArgs<HTMLInputElement>;
+  private _apiUrl?: string;
   private _loading = observable(false);
   private _isHidden: Observable<boolean> = Observable.create(this, true);
+  private _showCurl: Observable<boolean> = Observable.create(this, false);
 
   constructor(options: IWidgetOptions) {
     super();
@@ -43,6 +48,7 @@ export class ApiKey extends Disposable {
     this._onCreateCB = options.onCreate;
     this._anonymous = Boolean(options.anonymous);
     this._inputArgs = options.inputArgs ?? [];
+    this._apiUrl = options.apiUrl;
   }
 
   public buildDom() {
@@ -76,6 +82,17 @@ export class ApiKey extends Disposable {
           ),
         ),
         description(this._getDescription(), testId("description")),
+        this._apiUrl ? [
+          cssCurlToggle(
+            dom.text(use => use(this._showCurl) ? t("Hide Curl command") : t("Show Curl command")),
+            dom.on("click", () => this._showCurl.set(!this._showCurl.get())),
+            testId("curl-toggle"),
+          ),
+          dom.maybe(this._showCurl, () => cssCurlCommand(
+            dom.text(use => this._getCurlCommand(use(this._isHidden))),
+            testId("curl-command"),
+          )),
+        ] : null,
       )),
       dom.maybe(use => !(use(this._apiKey) || this._anonymous), () => [
         basicButton(t("Create"), dom.on("click", () => this._onCreate()), testId("create"),
@@ -113,6 +130,11 @@ make API calls for your own account."), testId("description")),
     );
   }
 
+  private _getCurlCommand(hideKey: boolean): string {
+    const key = hideKey ? "…" : this._apiKey.get();
+    return `curl -H "Authorization: Bearer ${key}" ${this._apiUrl}/api/orgs`;
+  }
+
   private _showRemoveKeyModal(): void {
     confirmModal(
       t("Remove API Key"), t("Remove"),
@@ -132,6 +154,29 @@ const description = styled("div", `
   margin-top: 8px;
   color: ${theme.lightText};
   font-size: ${vars.mediumFontSize};
+`);
+
+const cssCurlToggle = styled("div", `
+  display: inline-block;
+  margin-top: 8px;
+  color: ${theme.controlFg};
+  font-size: ${vars.mediumFontSize};
+  cursor: pointer;
+  &:hover {
+    color: ${theme.controlHoverFg};
+  }
+`);
+
+const cssCurlCommand = styled("div", `
+  margin-top: 8px;
+  padding: 8px;
+  color: ${theme.inputFg};
+  background-color: ${theme.hover};
+  border-radius: 3px;
+  font-family: monospace;
+  font-size: ${vars.mediumFontSize};
+  white-space: pre-wrap;
+  word-break: break-all;
 `);
 
 const cssInput = styled("input", `

--- a/test/fixtures/projects/ApiKey.ts
+++ b/test/fixtures/projects/ApiKey.ts
@@ -31,7 +31,7 @@ function setupTest() {
   }
 
   return [
-    testBox(dom.create(ApiKey, { apiKey, onCreate, onDelete })),
+    testBox(dom.create(ApiKey, { apiKey, onCreate, onDelete, apiUrl: "https://example.com" })),
   ];
 }
 

--- a/test/projects/ApiKey.ts
+++ b/test/projects/ApiKey.ts
@@ -41,6 +41,28 @@ describe("ApiKeyWidget", function() {
     ]);
   });
 
+  it("should show a curl command with the api endpoint when toggled", async function() {
+    // Curl command should be hidden by default.
+    assert.deepEqual(await driver.findAll(".test-apikey-curl-command"), []);
+    assert.equal(await driver.find(".test-apikey-curl-toggle").getText(), "Show Curl command");
+
+    // Toggling should reveal the curl command, with the key masked since the key itself
+    // is still hidden.
+    await driver.find(".test-apikey-curl-toggle").click();
+    assert.equal(await driver.find(".test-apikey-curl-toggle").getText(), "Hide Curl command");
+    assert.match(await driver.find(".test-apikey-curl-command").getText(),
+      /^curl -H "Authorization: Bearer …" https:\/\/example\.com\/api\/orgs$/);
+
+    // Revealing the key should also reveal it within the curl command.
+    await driver.find(".test-apikey-key").click();
+    assert.equal(await driver.find(".test-apikey-curl-command").getText(),
+      'curl -H "Authorization: Bearer e03ab513535137a7ec60978b40c9a896db6d8706" https://example.com/api/orgs');
+
+    // Toggling again should hide the curl command.
+    await driver.find(".test-apikey-curl-toggle").click();
+    assert.deepEqual(await driver.findAll(".test-apikey-curl-command"), []);
+  });
+
   it("should show key when selected and hide when unselected", async function() {
     // Click the key, and check that the type is now 'text', causing it to be shown.
     const apiKey = await driver.find(".test-apikey-key");


### PR DESCRIPTION
## Summary
Per #741, the API key screen (Profile Settings > API) showed the key itself but gave no indication of the actual API endpoint or how to use the key, making it harder to get started with the REST API.

This adds an optional `apiUrl` to the `ApiKey` widget. When provided, a "Show Curl command" toggle appears below the key, and expanding it reveals:
```
curl -H "Authorization: Bearer <key>" <apiUrl>/api/orgs
```
using the actual base URL (via `AppModel.api.getBaseUrl()`, so it's correct for self-hosted/Electron installs, not just docs.getgrist.com) and the actual API key.

Per the discussion on the issue, the key is still masked by default — the curl command mirrors whatever the existing key field's show/hide state is (`_isHidden`), so revealing the key also reveals it in the curl command, and hiding it re-masks both.

## Changes
- `app/client/ui/ApiKey.ts`: new optional `apiUrl` option, `_showCurl` toggle state, `_getCurlCommand()` helper, and `cssCurlToggle`/`cssCurlCommand` styles.
- `app/client/ui/AccountPage.ts`: pass `apiUrl: this._appModel.api.getBaseUrl()` to the existing `ApiKey` instantiation.
- `test/fixtures/projects/ApiKey.ts` / `test/projects/ApiKey.ts`: pass a sample `apiUrl` in the test fixture and add a new mocha-webdriver test covering: hidden by default, toggling reveals the command with the key masked, revealing the key also reveals it in the curl command, and toggling again hides it.

## Testing
- `tsc -b tsconfig.json --force`: clean, no errors.
- `eslint` on all changed files: clean.
- Ran the actual `ApiKeyWidget` browser suite (`npm run test:projects`, headless Chrome) — all 5 tests pass, including the 4 pre-existing ones (unaffected) and the 1 new one.
- Verified the new test actually fails on `main` (`NoSuchElementError` for the toggle) to confirm it's exercising the change, not a tautology.

Closes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)