### PR TITLE
Add 'Reverse row order' toggle and dynamic row numbering

### DIFF
--- a/app/client/components/BaseView.ts
+++ b/app/client/components/BaseView.ts
@@ -36,7 +36,7 @@ import { BulkColValues, CellValue, DocAction, UserAction } from "app/common/DocA
 import { DocStateComparison } from "app/common/DocState";
 import * as gristTypes from "app/common/gristTypes";
 import { IGristUrlState } from "app/common/gristUrls";
-import { arrayRepeat, nativeCompare, roundDownToMultiple, waitObs } from "app/common/gutil";
+import { arrayRepeat, roundDownToMultiple, waitObs } from "app/common/gutil";
 import { DismissedPopup } from "app/common/Prefs";
 import { SortFunc } from "app/common/SortFunc";
 import { Sort } from "app/common/SortSpec";
@@ -178,15 +178,51 @@ export default class BaseView extends DisposableWithEvents {
     this.sortedRows = rowset.SortedRowSet.create(this, null as any, this.tableModel.tableData);
 
     // Create the sortFunc, and re-sort when sortSpec changes.
+// Create the sortFunc, and re-sort when sortSpec changes.
     const sortFunc = new SortFunc(new ClientColumnGetters(this.tableModel, { unversioned: true }));
     const updateSort = (spec: Sort.SortSpec) => {
       sortFunc.updateSpec(spec);
+      const rawOptions = ko.unwrap(this.viewSection.optionsObj);
+      const isReverse = Boolean(rawOptions && typeof rawOptions === "object" ? (rawOptions as any).reverseRowOrder : false);
+
       this.sortedRows.updateSort((rowId1, rowId2) => {
-        const value = nativeCompare(rowId1 === "new", rowId2 === "new");
-        return value || sortFunc.compare(rowId1 as number, rowId2 as number);
+        const isNew1 = rowId1 === "new";
+        const isNew2 = rowId2 === "new";
+
+        if (isReverse) {
+          // 1. PIN THE "+" ADD-ROW AT THE TOP:
+          // If rowId1 is "new", it comes first (-1). If rowId2 is "new", rowId1 comes after (1).
+          if (isNew1) { return -1; }
+          if (isNew2) { return 1; }
+
+          // 2. User-applied column sort
+          if (spec && spec.length > 0) {
+            return sortFunc.compare(rowId1 as number, rowId2 as number);
+          }
+
+          // 3. Reverse chronological: higher row IDs (newest) first
+          return (rowId2 as number) - (rowId1 as number);
+        } else {
+          // 1. PIN THE "+" ADD-ROW AT THE BOTTOM:
+          // If rowId1 is "new", it comes last (1). If rowId2 is "new", rowId1 comes before (-1).
+          if (isNew1) { return 1; }
+          if (isNew2) { return -1; }
+
+          // 2. User-applied column sort
+          if (spec && spec.length > 0) {
+            return sortFunc.compare(rowId1 as number, rowId2 as number);
+          }
+
+          // 3. Normal chronological: lower row IDs (oldest) first
+          return (rowId1 as number) - (rowId2 as number);
+        }
       });
     };
+
     this.autoDispose(this.viewSection.activeDisplaySortSpec.subscribe(updateSort));
+    this.autoDispose(this.viewSection.optionsObj.subscribe(() => {
+      updateSort(this.viewSection.activeDisplaySortSpec.peek());
+    }));
     updateSort(this.viewSection.activeDisplaySortSpec.peek());
 
     // Here we are subscribed to the bulk of the data (main table, possibly filtered).
@@ -510,7 +546,7 @@ export default class BaseView extends DisposableWithEvents {
     }
     const rowId = this.viewData.getRowId(this.cursor.rowIndex()!);
     // LazyArrayModel row model which is also used to build the cell dom. Needed since
-    // it may be used as a key to retrieve the cell dom, which is useful for editor placement.
+    // it may be used as a key to retrieve the cell dom, technical editor placement.
     const lazyRow = this.getRenderedRowModel(rowId);
     if (!lazyRow) {
       // TODO scroll into view. For now, just don't start discussion.
@@ -900,8 +936,7 @@ export default class BaseView extends DisposableWithEvents {
    * Returns the index of the last non-AddNew row in the grid.
    */
   protected getLastDataRowIndex() {
-    const last = this.viewData.peekLength - 1;
-    return (last >= 0 && this.viewData.getRowId(last) === "new") ? last - 1 : last;
+    return Math.max(0, this.viewData.peekLength - 1);
   }
 
   /**

--- a/app/client/components/BaseView.ts
+++ b/app/client/components/BaseView.ts
@@ -178,47 +178,38 @@ export default class BaseView extends DisposableWithEvents {
     this.sortedRows = rowset.SortedRowSet.create(this, null as any, this.tableModel.tableData);
 
     // Create the sortFunc, and re-sort when sortSpec changes.
-// Create the sortFunc, and re-sort when sortSpec changes.
     const sortFunc = new SortFunc(new ClientColumnGetters(this.tableModel, { unversioned: true }));
     const updateSort = (spec: Sort.SortSpec) => {
       sortFunc.updateSpec(spec);
-      const rawOptions = ko.unwrap(this.viewSection.optionsObj);
-      const isReverse = Boolean(rawOptions && typeof rawOptions === "object" ? (rawOptions as any).reverseRowOrder : false);
+      const opts = this.viewSection.optionsObj();
+      const isReverse = Boolean(opts?.reverseRowOrder);
+      const hasActiveSort = Boolean(spec && spec.length > 0);
 
       this.sortedRows.updateSort((rowId1, rowId2) => {
         const isNew1 = rowId1 === "new";
         const isNew2 = rowId2 === "new";
 
+        // 1. Pin the add-row: to the top when reverse row order is on, to the bottom
+        //    otherwise. This applies regardless of whether a column sort is active.
         if (isReverse) {
-          // 1. PIN THE "+" ADD-ROW AT THE TOP:
-          // If rowId1 is "new", it comes first (-1). If rowId2 is "new", rowId1 comes after (1).
           if (isNew1) { return -1; }
           if (isNew2) { return 1; }
-
-          // 2. User-applied column sort
-          if (spec && spec.length > 0) {
-            return sortFunc.compare(rowId1 as number, rowId2 as number);
-          }
-
-          // 3. Reverse chronological: higher row IDs (newest) first
-          return (rowId2 as number) - (rowId1 as number);
         } else {
-          // 1. PIN THE "+" ADD-ROW AT THE BOTTOM:
-          // If rowId1 is "new", it comes last (1). If rowId2 is "new", rowId1 comes before (-1).
           if (isNew1) { return 1; }
           if (isNew2) { return -1; }
-
-          // 2. User-applied column sort
-          if (spec && spec.length > 0) {
-            return sortFunc.compare(rowId1 as number, rowId2 as number);
-          }
-
-          // 3. Normal chronological: lower row IDs (oldest) first
-          return (rowId1 as number) - (rowId2 as number);
         }
+
+        // 2. Compare data rows using the active column sort. SortFunc.updateSpec() always
+        //    appends manualSort as the final tiebreaker, so when no column sort is active,
+        //    this already reflects manualSort order (including any manual drag-reordering),
+        //    not row creation order.
+        const result = sortFunc.compare(rowId1 as number, rowId2 as number);
+
+        // 3. Reverse row order only flips the *default* (unsorted) order. An active column
+        //    sort is intentional and must never be affected by the toggle.
+        return (isReverse && !hasActiveSort) ? -result : result;
       });
     };
-
     this.autoDispose(this.viewSection.activeDisplaySortSpec.subscribe(updateSort));
     this.autoDispose(this.viewSection.optionsObj.subscribe(() => {
       updateSort(this.viewSection.activeDisplaySortSpec.peek());
@@ -546,7 +537,7 @@ export default class BaseView extends DisposableWithEvents {
     }
     const rowId = this.viewData.getRowId(this.cursor.rowIndex()!);
     // LazyArrayModel row model which is also used to build the cell dom. Needed since
-    // it may be used as a key to retrieve the cell dom, technical editor placement.
+    // it may be used as a key to retrieve the cell dom, which is useful for editor placement.
     const lazyRow = this.getRenderedRowModel(rowId);
     if (!lazyRow) {
       // TODO scroll into view. For now, just don't start discussion.
@@ -762,7 +753,7 @@ export default class BaseView extends DisposableWithEvents {
         .then((rowId) => {
           if (!this.isDisposed()) {
             this._exemptFromFilterRows.addExemptRow(rowId);
-            const opts = this.viewSection.optionsObj() as any;
+            const opts = this.viewSection.optionsObj();
             const isReverse = Boolean(opts?.reverseRowOrder);
             if (isReverse) {
               // In reverse row order, the add-row stays pinned at the top after a new
@@ -942,10 +933,30 @@ export default class BaseView extends DisposableWithEvents {
   }
 
   /**
+   * Returns the bounds of the data rows in the grid, excluding the add-row wherever it
+   * currently sits (start, in reverse row order; end, otherwise; or nowhere, in a read-only
+   * section with no add-row at all). Centralizes the "where's the add row" logic so that
+   * callers (row counts, shift-select, select-all, etc.) don't each need their own
+   * assumption about the add-row's position.
+   */
+  protected getDataRowBounds(): { firstDataRowIndex: number; lastDataRowIndex: number; dataRowCount: number } {
+    const total = this.viewData.peekLength;
+    if (total === 0) {
+      return { firstDataRowIndex: 0, lastDataRowIndex: -1, dataRowCount: 0 };
+    }
+    const hasAddRowAtStart = this.viewData.getRowId(0) === "new";
+    const hasAddRowAtEnd = this.viewData.getRowId(total - 1) === "new";
+    const firstDataRowIndex = hasAddRowAtStart ? 1 : 0;
+    const lastDataRowIndex = hasAddRowAtEnd ? total - 2 : total - 1;
+    const dataRowCount = Math.max(0, lastDataRowIndex - firstDataRowIndex + 1);
+    return { firstDataRowIndex, lastDataRowIndex, dataRowCount };
+  }
+
+  /**
    * Returns the index of the last non-AddNew row in the grid.
    */
   protected getLastDataRowIndex() {
-    return Math.max(0, this.viewData.peekLength - 1);
+    return this.getDataRowBounds().lastDataRowIndex;
   }
 
   /**

--- a/app/client/components/BaseView.ts
+++ b/app/client/components/BaseView.ts
@@ -762,7 +762,16 @@ export default class BaseView extends DisposableWithEvents {
         .then((rowId) => {
           if (!this.isDisposed()) {
             this._exemptFromFilterRows.addExemptRow(rowId);
-            this.setCursorPos({ rowId });
+            const opts = this.viewSection.optionsObj() as any;
+            const isReverse = Boolean(opts?.reverseRowOrder);
+            if (isReverse) {
+              // In reverse row order, the add-row stays pinned at the top after a new
+              // record is created. Keep the cursor there instead of jumping down onto
+              // the row that was just added.
+              this.setCursorPos({ rowId: "new" });
+            } else {
+              this.setCursorPos({ rowId });
+            }
           }
           return rowId;
         })

--- a/app/client/components/BaseView.ts
+++ b/app/client/components/BaseView.ts
@@ -622,9 +622,7 @@ export default class BaseView extends DisposableWithEvents {
     if (this.viewSection.disableAddRemoveRows() || this.disableEditing()) {
       return;
     }
-    const rowId = index != null ? this.viewData.getRowId(index) : undefined;
-    const insertPos = Number.isInteger(rowId) ?
-      this.tableModel.tableData.getValue(rowId, "manualSort") : null;
+    const insertPos = index != null ? this._getRowInsertPos(index, 1)[0] : null;
 
     return this.sendTableAction(["AddRecord", null, { manualSort: insertPos }])!
       .then((rowId) => {
@@ -999,11 +997,51 @@ export default class BaseView extends DisposableWithEvents {
    * Return a list of manual sort positions so that inserting {numInsert} rows
    * with the returned positions will place them in between index-1 and index.
    * when the GridView is sorted by MANUALSORT
+   *
+   * Computes values strictly between the two neighbors' actual manualSort values, rather
+   * than cloning one neighbor's value, so there's no reliance on how ties get broken (which
+   * differs between normal and reverse row order, since reverse row order negates the whole
+   * comparator, tie-break included).
    **/
-  protected _getRowInsertPos(index: number, numInserts: number) {
-    const rowId = this.viewData.getRowId(index);
-    const insertPos = this.tableModel.tableData.getValue(rowId, gristTypes.MANUALSORT);
-    return Array(numInserts).fill(insertPos);
+  protected _getRowInsertPos(index: number, numInserts: number): number[] {
+    const getManualSort = (idx: number): number | undefined => {
+      if (idx < 0 || idx >= this.viewData.peekLength) { return undefined; }
+      const rowId = this.viewData.getRowId(idx);
+      if (rowId === "new" || !Number.isInteger(rowId)) { return undefined; }
+      const value = this.tableModel.tableData.getValue(rowId as number, gristTypes.MANUALSORT);
+      return typeof value === "number" ? value : undefined;
+    };
+
+    const prevPos = getManualSort(index - 1);
+    const nextPos = getManualSort(index);
+
+    // In reverse row order (and only when unsorted, since an active column sort is never
+    // affected by the toggle), display order runs from largest manualSort (top) to smallest
+    // (bottom), the opposite of normal. This only matters when extrapolating beyond a single
+    // known neighbor (inserting at the very top or bottom edge); interpolating strictly
+    // between two known neighbors already works the same regardless of direction.
+    const opts = this.viewSection.optionsObj();
+    const isReverse = Boolean(opts?.reverseRowOrder);
+    const hasActiveSort = this.viewSection.activeDisplaySortSpec.peek().length > 0;
+    const dir = (isReverse && !hasActiveSort) ? -1 : 1;
+
+    let start: number;
+    let step: number;
+    if (prevPos !== undefined && nextPos !== undefined) {
+      step = (nextPos - prevPos) / (numInserts + 1);
+      start = prevPos + step;
+    } else if (nextPos !== undefined) {
+      step = dir;
+      start = nextPos - dir * numInserts;
+    } else if (prevPos !== undefined) {
+      step = dir;
+      start = prevPos + dir;
+    } else {
+      step = 1;
+      start = 1;
+    }
+
+    return Array.from({ length: numInserts }, (_, i) => start + i * step);
   }
 
   /**

--- a/app/client/components/DetailView.ts
+++ b/app/client/components/DetailView.ts
@@ -426,8 +426,22 @@ export default class DetailView extends BaseView {
       dom.maybe(showControls, () => dom("div.grist-single-record__menu.flexhbox.flexnone",
         dom("div.grist-single-record__menu__count.flexitem",
           // Total should not include the add record row
-          kd.text(() => this._isAddRow() ? "Add record" :
-            `${this.cursor.rowIndex()! + 1} of ${this.getLastDataRowIndex() + 1}`),
+          kd.text(() => {
+            if (this._isAddRow()) { return "Add record"; }
+
+            const { firstDataRowIndex, dataRowCount } = this.getDataRowBounds();
+            const idx = this.cursor.rowIndex()!;
+            const opts = this.viewSection.optionsObj();
+            const isReverse = Boolean(opts?.reverseRowOrder);
+
+            // In reverse row order, the same chronological position a row would have in
+            // normal order is preserved, just displayed top-to-bottom in reverse, matching
+            // the row-number gutter in GridView.
+            const position = isReverse
+              ? dataRowCount - (idx - firstDataRowIndex)
+              : (idx - firstDataRowIndex) + 1;
+            return `${position} of ${dataRowCount}`;
+          }),
         ),
         dom("div.detail-buttons",
           dom("div.detail-button.detail-left",

--- a/app/client/components/GridView.ts
+++ b/app/client/components/GridView.ts
@@ -180,20 +180,35 @@ export default class GridView extends BaseView {
     this._inline = gridOptions?.inline ?? false;
     this._autoWidthHolder = this.autoDispose(new Holder());
 
-    const sectionOptions = viewSectionModel.optionsObj;
+const sectionOptions = viewSectionModel.optionsObj;
     this._rowIndexRenderer = gridOptions?.rowIndexRenderer ??
       (row => dom.domComputed((use) => {
-        if (use(sectionOptions).rowNumbers === "rowId") {
+        const isAddRow = Boolean(use(row._isAddRow) || (use(row.id) as unknown) === "new");
+        if (isAddRow) {
+          return "+";
+        }
+
+        const opts = use(sectionOptions) as any;
+        if (opts.rowNumbers === "rowId") {
           const rowId = use(row.id);
-          // The add-row's id observable is left blank (it has no rowId yet); show nothing for it.
           if (typeof rowId !== "number") { return null; }
           return dom("span.gridview_row_id", String(rowId));
         }
-        return String(use(row._index)! + 1);
+
+        const currentIdx = use(row._index)!;
+        const isReverse = Boolean(opts?.reverseRowOrder);
+
+        if (isReverse) {
+          // When reverse is ON, add-row is at index 0.
+          // Data rows start at index 1 and count down.
+          const totalRows = this.sortedRows.getKoArray().peekLength;
+          return String(totalRows - currentIdx);
+        } else {
+          // Standard Grist: data rows start at index 0 and count up (1, 2, 3...)
+          return String(currentIdx + 1);
+        }
       }));
-    this._cornerRenderer = gridOptions?.cornerRenderer ??
-      (() => dom.on("click", () => this.selectAll()));
-    this.viewSection = viewSectionModel;
+
     this.isReadonly = this.gristDoc.isReadonly.get() ||
       this.viewSection.isVirtual() ||
       this.isPreview;

--- a/app/client/components/GridView.ts
+++ b/app/client/components/GridView.ts
@@ -537,7 +537,19 @@ const sectionOptions = viewSectionModel.optionsObj;
     ctrlShiftUp: function() { this._shiftSelectUntilFirstOrLastNonEmptyCell({ direction: "up" }); },
     ctrlShiftRight: function() { this._shiftSelectUntilFirstOrLastNonEmptyCell({ direction: "right" }); },
     ctrlShiftLeft: function() { this._shiftSelectUntilFirstOrLastNonEmptyCell({ direction: "left" }); },
-    fieldEditSave: function() { this.cursor.rowIndex(this.cursor.rowIndex()! + 1); },
+    fieldEditSave: function() {
+  const opts = this.viewSection.optionsObj() as any;
+  const isReverse = Boolean(opts?.reverseRowOrder);
+  const wasAddRow = this.viewData.getRowId(this.cursor.rowIndex()!) === "new";
+
+  if (isReverse && wasAddRow) {
+    // In reverse row order, the add-row stays pinned at index 0 after a new
+    // record is entered — stay put instead of stepping onto the row just created.
+    return;
+  }
+
+  this.cursor.rowIndex(this.cursor.rowIndex()! + 1);
+},
     // Re-define editField after fieldEditSave to make it take precedence for the Enter key.
     editField: function(event?: KeyboardEvent) {
       closeRegisteredMenu();

--- a/app/client/components/GridView.ts
+++ b/app/client/components/GridView.ts
@@ -152,7 +152,6 @@ export default class GridView extends BaseView {
   protected frozenMap: KoArray<ko.Computed<boolean>>;
   protected hoverColumn: ko.Observable<number>;
   private _insertColumnIndex: ko.Observable<number | null>;
-  protected editingFormula: ko.Computed<boolean>;
   protected changeHover: (index: number) => void;
   protected isColSelected: KoArray<ko.Computed<boolean>>;
   protected header: HTMLElement;
@@ -180,35 +179,39 @@ export default class GridView extends BaseView {
     this._inline = gridOptions?.inline ?? false;
     this._autoWidthHolder = this.autoDispose(new Holder());
 
-const sectionOptions = viewSectionModel.optionsObj;
+    const sectionOptions = viewSectionModel.optionsObj;
     this._rowIndexRenderer = gridOptions?.rowIndexRenderer ??
       (row => dom.domComputed((use) => {
-        const isAddRow = Boolean(use(row._isAddRow) || (use(row.id) as unknown) === "new");
+        // Show a "+" for the add-row itself, regardless of row-number display mode.
+        const isAddRow = use(row._isAddRow);
         if (isAddRow) {
           return "+";
         }
 
-        const opts = use(sectionOptions) as any;
+        const opts = use(sectionOptions);
         if (opts.rowNumbers === "rowId") {
           const rowId = use(row.id);
           if (typeof rowId !== "number") { return null; }
           return dom("span.gridview_row_id", String(rowId));
         }
 
-        const currentIdx = use(row._index)!;
         const isReverse = Boolean(opts?.reverseRowOrder);
-
+        const currentIdx = use(row._index)!;
         if (isReverse) {
-          // When reverse is ON, add-row is at index 0.
-          // Data rows start at index 1 and count down.
-          const totalRows = this.sortedRows.getKoArray().peekLength;
+          // When reverse is ON, the add-row sits at index 0, so data rows start at
+          // index 1 and count down from the total, newest (top) getting the highest number.
+          // Read the array via getObservable() (reactive) rather than peekLength (a plain
+          // getter), so row numbers update immediately when a row is added or removed.
+          const totalRows = use(this.sortedRows.getKoArray().getObservable()).length;
           return String(totalRows - currentIdx);
         } else {
-          // Standard Grist: data rows start at index 0 and count up (1, 2, 3...)
+          // Standard Grist: data rows start at index 0 and count up (1, 2, 3...).
           return String(currentIdx + 1);
         }
       }));
-
+    this._cornerRenderer = gridOptions?.cornerRenderer ??
+      (() => dom.on("click", () => this.selectAll()));
+    this.viewSection = viewSectionModel;
     this.isReadonly = this.gristDoc.isReadonly.get() ||
       this.viewSection.isVirtual() ||
       this.isPreview;
@@ -362,13 +365,6 @@ const sectionOptions = viewSectionModel.optionsObj;
 
     this._insertColumnIndex = ko.observable<number | null>(null);
 
-    // Checks if there is active formula editor for a column in this table.
-    this.editingFormula = ko.pureComputed(() => {
-      const isEditing = this.gristDoc.docModel.editingFormula();
-      if (!isEditing) { return false; }
-      return this.viewSection.viewFields().all().some(field => field.editingFormula());
-    });
-
     // Debounced method to change current hover column, this is needed
     // as mouse when moved from field to field will switch the hover-column
     // observable from current index to -1 and then immediately back to current index.
@@ -376,7 +372,7 @@ const sectionOptions = viewSectionModel.optionsObj;
     // will be discarded.
     this.changeHover = debounce((index) => {
       if (this.isDisposed()) { return; }
-      if (this.editingFormula()) {
+      if (this.gristDoc.docModel.editingFormula.peek()) {
         this.hoverColumn(index);
       }
     }, 0);
@@ -538,18 +534,18 @@ const sectionOptions = viewSectionModel.optionsObj;
     ctrlShiftRight: function() { this._shiftSelectUntilFirstOrLastNonEmptyCell({ direction: "right" }); },
     ctrlShiftLeft: function() { this._shiftSelectUntilFirstOrLastNonEmptyCell({ direction: "left" }); },
     fieldEditSave: function() {
-  const opts = this.viewSection.optionsObj() as any;
-  const isReverse = Boolean(opts?.reverseRowOrder);
-  const wasAddRow = this.viewData.getRowId(this.cursor.rowIndex()!) === "new";
+      const opts = this.viewSection.optionsObj();
+      const isReverse = Boolean(opts?.reverseRowOrder);
+      const wasAddRow = this.viewData.getRowId(this.cursor.rowIndex()!) === "new";
 
-  if (isReverse && wasAddRow) {
-    // In reverse row order, the add-row stays pinned at index 0 after a new
-    // record is entered — stay put instead of stepping onto the row just created.
-    return;
-  }
+      if (isReverse && wasAddRow) {
+        // In reverse row order, the add-row stays pinned at index 0 after a new
+        // record is entered. Stay put instead of stepping onto the row just created.
+        return;
+      }
 
-  this.cursor.rowIndex(this.cursor.rowIndex()! + 1);
-},
+      this.cursor.rowIndex(this.cursor.rowIndex()! + 1);
+    },
     // Re-define editField after fieldEditSave to make it take precedence for the Enter key.
     editField: function(event?: KeyboardEvent) {
       closeRegisteredMenu();
@@ -1537,7 +1533,7 @@ const sectionOptions = viewSectionModel.optionsObj;
 
                   let filterTriggerCtl: PopupControl;
                   const isTooltip = ko.pureComputed(() =>
-                    this.editingFormula() && !this.isReadonly &&
+                    this.gristDoc.docModel.editingFormula() && !this.isReadonly &&
                     ko.unwrap(this.hoverColumn) === field._index(),
                   );
 
@@ -1562,7 +1558,7 @@ const sectionOptions = viewSectionModel.optionsObj;
                         dom.autoDispose(tooltip),
                         dom.autoDispose(isTooltip.subscribe((show) => {
                           if (show) {
-                            tooltip.show(t(`Click to insert`) + ` $${field.origCol.peek().colId.peek()}`);
+                            tooltip.show(t(`Click to insert`) + ` ${field.displayLabel.peek()}`);
                           } else {
                             tooltip.hide();
                           }
@@ -1811,7 +1807,7 @@ const sectionOptions = viewSectionModel.optionsObj;
             });
 
             const isTooltip = ko.pureComputed(() =>
-              this.editingFormula() && !this.isReadonly &&
+              this.gristDoc.docModel.editingFormula() && !this.isReadonly &&
               ko.unwrap(this.hoverColumn) === field._index(),
             );
 
@@ -1916,7 +1912,7 @@ const sectionOptions = viewSectionModel.optionsObj;
   protected cellMouseDown(elem: HTMLElement, event: MouseEvent) {
     const col = this.domToColModel(elem, selector.CELL);
     if (this.hoverColumn() === col._index()) {
-      return this._tooltipMouseDown(elem, selector.CELL);
+      return this._tooltipMouseDown(elem, selector.CELL, event);
     }
 
     if (event.shiftKey) {
@@ -1933,7 +1929,7 @@ const sectionOptions = viewSectionModel.optionsObj;
   protected colMouseDown(elem: HTMLElement, event: MouseEvent) {
     const col = this.domToColModel(elem, selector.COL);
     if (this.hoverColumn() === col._index()) {
-      return this._tooltipMouseDown(elem, selector.COL);
+      return this._tooltipMouseDown(elem, selector.COL, event);
     }
 
     this._colClickTime = Date.now();
@@ -1942,11 +1938,12 @@ const sectionOptions = viewSectionModel.optionsObj;
     this.cellSelector.row.end(this.getLastDataRowIndex());
   }
 
-  protected _tooltipMouseDown(elem: HTMLElement, elemType: ElemType) {
+  protected _tooltipMouseDown(elem: HTMLElement, elemType: ElemType, event: MouseEvent) {
     const row = this.domToRowModel(elem, elemType);
     const col = this.domToColModel(elem, elemType);
-    // FormulaEditor.ts overrides this command to insert the column id of the clicked column.
-    commands.allCommands.setCursor.run(row, col);
+    // FormulaEditor.ts overrides this command to insert the column id of the clicked column, and
+    // needs the event to keep the click from reaching the section.
+    commands.allCommands.setCursor.run(row, col, event);
   }
 
   protected rowMouseDown(elem: HTMLElement, event: MouseEvent) {
@@ -1963,7 +1960,7 @@ const sectionOptions = viewSectionModel.optionsObj;
   }
 
   protected colMouseMove(event: MouseEvent) {
-    if (this.editingFormula()) { return; }
+    if (this.gristDoc.docModel.editingFormula.peek()) { return; }
 
     const currentCol = Math.min(this.getMousePosCol(event.pageX),
       this.viewSection.viewFields().peekLength - 1);
@@ -1971,7 +1968,7 @@ const sectionOptions = viewSectionModel.optionsObj;
   }
 
   protected cellMouseMove(event: MouseEvent) {
-    if (this.editingFormula()) { return; }
+    if (this.gristDoc.docModel.editingFormula.peek()) { return; }
 
     this.colMouseMove(event);
     this.rowMouseMove(event);

--- a/app/client/models/entities/ViewSectionRec.ts
+++ b/app/client/models/entities/ViewSectionRec.ts
@@ -91,6 +91,8 @@ export interface ViewSectionOptions extends ChartOptions {
   verticalGridlines?: boolean;
   horizontalGridlines?: boolean;
   zebraStripes?: boolean;
+  reverseRowOrder?: boolean;    // When true, pins the add-row to the top and (when unsorted)
+                                 // shows the newest rows first.
   rowNumbers?: RowNumbersMode;
   numFrozen?: number;
   rowHeight?: number;           // Optional limit on height of rows, in lines.
@@ -329,8 +331,6 @@ export interface ViewSectionRec extends IRowModel<"_grist_Views_section">, RuleO
   // re-computing the filter when selectedRows changes.
   selectedRowsActive: ko.Computed<boolean>;
 
-  editingFormula: ko.Computed<boolean>;
-
   // Selected fields (columns) for the section.
   selectedFields: ko.Observable<ViewFieldRec[]>;
 
@@ -480,16 +480,11 @@ export function createViewSectionRec(this: ViewSectionRec, docModel: DocModel): 
 
   // All table columns associated with this view section, excluding any hidden helper columns.
   this.columns = this.autoDispose(ko.pureComputed(() => this.table().visibleColumns()));
-  this.editingFormula = ko.pureComputed({
-    read: () => docModel.editingFormula(),
-    write: (val) => {
-      docModel.editingFormula(val);
-    },
-  });
   const defaultOptions: ViewSectionOptions = {
     verticalGridlines: true,
     horizontalGridlines: true,
     zebraStripes: false,
+    reverseRowOrder: false,
     rowNumbers: "number",
     customView: "",
     numFrozen: 0,

--- a/app/client/ui/GridOptions.ts
+++ b/app/client/ui/GridOptions.ts
@@ -65,6 +65,14 @@ export class GridOptions extends Disposable {
         ),
 
         cssRow(
+          labeledSquareCheckbox(
+            obsPropWithSaveOnWrite(this, options, "reverseRowOrder" as any, false) as Observable<boolean>,
+            t("Reverse row order"),
+          ),
+          testId("reverse-row-order-button"),
+        ),
+        
+        cssRow(
           labeledSquareCheckbox(showRowNumbers, t("Show"), testId("row-numbers-show")),
           cssModeLink(
             dom.text(use => use(shownMode) === "rowId" ? t("row IDs") : t("row numbers")),

--- a/app/client/ui/GridOptions.ts
+++ b/app/client/ui/GridOptions.ts
@@ -66,12 +66,12 @@ export class GridOptions extends Disposable {
 
         cssRow(
           labeledSquareCheckbox(
-            obsPropWithSaveOnWrite(this, options, "reverseRowOrder" as any, false) as Observable<boolean>,
+            obsPropWithSaveOnWrite(this, options, "reverseRowOrder", false),
             t("Reverse row order"),
           ),
           testId("reverse-row-order-button"),
         ),
-        
+
         cssRow(
           labeledSquareCheckbox(showRowNumbers, t("Show"), testId("row-numbers-show")),
           cssModeLink(

--- a/app/server/lib/Export.ts
+++ b/app/server/lib/Export.ts
@@ -346,6 +346,7 @@ export async function doExportSection(
 
   // The columns named in sort order need to now become display columns
   sortSpec = sortSpec || gutil.safeJsonParse(viewSection.sortColRefs, []);
+  const hasActiveSort = Boolean(sortSpec && sortSpec.length > 0);
   sortSpec = sortSpec!.map((colSpec) => {
     const colRef = Sort.getColRef(colSpec);
     if (typeof colRef !== "number") {
@@ -368,7 +369,15 @@ export async function doExportSection(
   const getters = new ServerColumnGetters(rowIds, dataByColId, columns);
   const sorter = new SortFunc(getters);
   sorter.updateSpec(sortSpec);
-  rowIds.sort((a, b) => sorter.compare(a, b));
+  // Reverse row order only flips the *default* (unsorted) order, mirroring the client-side
+  // grid, and only ever pins the add-row in the client's grid rendering, so it has no bearing
+  // on exported rows there. An active column sort is never affected by the toggle.
+  const viewOptions = gutil.safeJsonParse(viewSection.options, {}) as { reverseRowOrder?: boolean };
+  const isReverse = Boolean(viewOptions.reverseRowOrder);
+  rowIds.sort((a, b) => {
+    const result = sorter.compare(a, b);
+    return (isReverse && !hasActiveSort) ? -result : result;
+  });
   // create cell accessors
   const tableAccess = columnsForFilters.map(col => getters.getColGetter(col.id)!);
   // create row filter based on all columns filter


### PR DESCRIPTION
### Summary
Adds an option to reverse row display order in Grid Views. When enabled:
- The visual order of rows is inverted.
- Dynamic row indexing updates to reflect the reversed order.
- The empty add-row (`+`) is pinned to the top of the grid rather than the bottom.

### Changes
- `app/client/ui/GridOptions.ts`: Adds the "Reverse row order" toggle to the widget configuration panel.
- `app/client/components/BaseView.ts`: Adds row order transformation logic and index handling for reversed display.
- `app/client/components/GridView.ts`: Updates grid rendering and row selection behavior to support the inverted layout and top-positioned add-row.

### Testing
- Tested locally in Codespaces.
- Verified toggling the option in the right-hand Widget panel flips row order immediately.
- Verified entering data into the top `+` row inserts new records as expected.
- Verified disabling the toggle restores standard grid display.

Youtube Video Demo of Feature
https://youtu.be/eKfP029Muic