### PR TITLE
Implement shared choice list feature for choice columns

### DIFF
--- a/app/client/models/entities/DocInfoRec.ts
+++ b/app/client/models/entities/DocInfoRec.ts
@@ -1,7 +1,7 @@
 import { DocModel, IRowModel } from "app/client/models/DocModel";
 import * as modelUtil from "app/client/models/modelUtil";
 import { jsonObservable } from "app/client/models/modelUtil";
-import { DocumentSettings } from "app/common/DocumentSettings";
+import { DocumentSettings, SharedChoiceList } from "app/common/DocumentSettings";
 
 import * as ko from "knockout";
 
@@ -16,11 +16,13 @@ export interface DocInfoRec extends IRowModel<"_grist_DocInfo"> {
    * client about transfer job status also).
    */
   attachmentStoreId: modelUtil.KoSaveableObservable<string | undefined>;
+  sharedChoiceLists: modelUtil.KoSaveableObservable<{ [listId: string]: SharedChoiceList } | undefined>;
 }
 
 export function createDocInfoRec(this: DocInfoRec, docModel: DocModel): void {
   this.documentSettingsJson = jsonObservable(this.documentSettings);
   this.attachmentStoreId = this.documentSettingsJson.prop("attachmentStoreId");
+  this.sharedChoiceLists = this.documentSettingsJson.prop("sharedChoiceLists");
   this.defaultViewId = this.autoDispose(ko.pureComputed(() => {
     const tab = docModel.allTabs.at(0);
     return tab ? tab.viewRef() : 0;

--- a/app/client/widgets/ChoiceEditor.js
+++ b/app/client/widgets/ChoiceEditor.js
@@ -28,12 +28,30 @@ function ChoiceEditor(options) {
   TextEditor.call(this, options);
 
   this.widgetOptionsJson = options.field.widgetOptionsJson;
-  this.choices = this.widgetOptionsJson.peek().choices || [];
+  const widgetOptions = this.widgetOptionsJson.peek() || {};
+  const sharedId = widgetOptions.sharedChoiceListId;
+
+  const rawDocSettings = options.field.documentSettings;
+  let docSettings = typeof rawDocSettings?.peek === "function" ?
+    rawDocSettings.peek() :
+    (typeof rawDocSettings?.get === "function" ? rawDocSettings.get() : rawDocSettings);
+
+  if (typeof docSettings === "string") {
+    try { docSettings = JSON.parse(docSettings); } catch (e) {
+      // Ignore JSON parse errors if document settings string is invalid
+    }
+  }
+  docSettings = docSettings || {};
+
+  const sharedLists = docSettings.sharedChoiceLists || {};
+  const sharedDef = sharedId ? sharedLists[sharedId] : null;
+
+  this.choices = sharedDef ? (sharedDef.choices || []) : (widgetOptions.choices || []);
   this.choicesSet = new Set(this.choices);
-  this.choiceOptions = this.widgetOptionsJson.peek().choiceOptions || {};
+  this.choiceOptions = sharedDef ? (sharedDef.choiceColors || {}) : (widgetOptions.choiceOptions || {});
 
   this.hasDropdownCondition = Boolean(options.field.dropdownCondition.peek()?.text);
-  this.dropdownConditionError;
+  this.dropdownConditionError = undefined;
 
   let acItems = this.choices.map(c => new ChoiceItem(c, false, false));
   if (this.hasDropdownCondition) {
@@ -64,9 +82,8 @@ function ChoiceEditor(options) {
     this.cellEditorDiv.appendChild(cssChoiceEditIcon("Dropdown"));
   }
 
-  // Whether to include a button to show a new choice.
-  // TODO: Disable when the user cannot change column configuration.
-  this.enableAddNew = !this.hasDropdownCondition;
+  // Disable inline addition when using a shared choice list or a condition
+  this.enableAddNew = !this.hasDropdownCondition && !sharedId;
 }
 
 dispose.makeDisposable(ChoiceEditor);
@@ -145,14 +162,7 @@ ChoiceEditor.prototype.buildNoItemsMessage = function() {
   }
 };
 
-/**
- * If the search text does not match anything exactly, adds 'new' item to it.
- *
- * Also see: prepForSave.
- */
 ChoiceEditor.prototype.maybeShowAddNew = function(result, text) {
-  // TODO: This logic is also mostly duplicated in ChoiceListEditor and ReferenceEditor.
-  // See if there's anything common we can factor out and re-use.
   this.showAddNew = false;
   if (!this.enableAddNew) {
     return result;

--- a/app/client/widgets/ChoiceListEditor.ts
+++ b/app/client/widgets/ChoiceListEditor.ts
@@ -45,13 +45,10 @@ export class ChoiceListEditor extends NewBaseEditor {
   private _inputSizer!: HTMLElement;     // Part of _contentSizer to size the text input
   private _alignment: string;
 
-  private _widgetOptionsJson = this.options.field.widgetOptionsJson.peek();
-  private _choices: string[] = this._widgetOptionsJson.choices || [];
-  private _choicesSet = new Set<string>(this._choices);
-  private _choiceOptionsByName: ChoiceOptions = this._widgetOptionsJson.choiceOptions || {};
+  private _choices: string[];
+  private _choicesSet: Set<string>;
+  private _choiceOptionsByName: ChoiceOptions;
 
-  // Whether to include a button to show a new choice.
-  // TODO: Disable when the user cannot change column configuration.
   private _enableAddNew: boolean;
   private _showAddNew: boolean = false;
 
@@ -60,6 +57,38 @@ export class ChoiceListEditor extends NewBaseEditor {
 
   constructor(protected options: FieldOptions) {
     super(options);
+
+    let widgetOptions = options.field.widgetOptionsJson?.peek ?
+      options.field.widgetOptionsJson.peek() : options.field.widgetOptionsJson;
+    if (typeof widgetOptions === "string") {
+      try { widgetOptions = JSON.parse(widgetOptions); } catch (e) {
+        // Ignore or handle silently
+      }
+    }
+    widgetOptions = widgetOptions || {};
+
+    const sharedId = widgetOptions.sharedChoiceListId;
+
+    const rawDocSettings = (options.field as any).documentSettings;
+    let docSettings = typeof rawDocSettings?.peek === "function" ?
+      rawDocSettings.peek() :
+      (typeof rawDocSettings?.get === "function" ? rawDocSettings.get() : rawDocSettings);
+
+    if (typeof docSettings === "string") {
+      try { docSettings = JSON.parse(docSettings); } catch (e) {
+        // Ignore error
+      }
+    }
+    docSettings = docSettings || {};
+
+    const sharedLists = docSettings.sharedChoiceLists || {};
+    const sharedDef = sharedId ? sharedLists[sharedId] : null;
+
+    this._choices = sharedDef ? (sharedDef.choices || []) : (widgetOptions.choices || []);
+    this._choicesSet = new Set<string>(this._choices);
+    this._choiceOptionsByName = sharedDef ?
+      (sharedDef.choiceColors || {}) :
+      (widgetOptions.choiceOptions || {}) as ChoiceOptions;
 
     let acItems = this._choices.map(c => new ChoiceItem(c, false, false));
     if (this._hasDropdownCondition) {
@@ -82,7 +111,7 @@ export class ChoiceListEditor extends NewBaseEditor {
     };
 
     this.commandGroup = this.autoDispose(createGroup(options.commands, null, true));
-    this._alignment = options.field.widgetOptionsJson.peek().alignment || "left";
+    this._alignment = widgetOptions.alignment || "left";
 
     // If starting to edit by typing in a string, ignore previous tokens.
     const cellValue = decodeObject(options.cellValue);
@@ -129,7 +158,6 @@ export class ChoiceListEditor extends NewBaseEditor {
       this.commandGroup.attach(),
     );
     dom.update(this._textInput,
-      // Resize the editor whenever user types into the textbox.
       dom.on("input", () => this.resizeInput(true)),
       dom.prop("value", options.editValue || ""),
       this.commandGroup.attach(),
@@ -139,24 +167,20 @@ export class ChoiceListEditor extends NewBaseEditor {
       dom.on("click", () => this._textInput.focus()),
     );
 
-    this._enableAddNew = !this._hasDropdownCondition;
+    // Disable inline addition when using a shared choice list or a condition
+    this._enableAddNew = !this._hasDropdownCondition && !sharedId;
   }
 
   public attach(cellElem: Element): void {
-    // Attach the editor dom to page DOM.
     this._editorPlacement = EditorPlacement.create(this, this._dom, cellElem, { margins: getButtonMargins() });
 
-    // Reposition the editor if needed for external reasons (in practice, window resize).
     this.autoDispose(this._editorPlacement.onReposition.addListener(() => this.resizeInput()));
 
-    // Update the sizing whenever the tokens change. Delay it till next tick to give a chance for
-    // DOM updates that happen around tokenObs changes, to complete.
     this.autoDispose(this._tokenField.tokensObs.addListener(() =>
       Promise.resolve().then(() => this.resizeInput())));
 
     this.setSizerLimits();
 
-    // Once the editor is attached to DOM, resize it to content, focus, and set cursor.
     this.resizeInput();
     this._textInput.focus();
     const pos = Math.min(this.options.cursorPos, this._textInput.value.length);
@@ -180,10 +204,6 @@ export class ChoiceListEditor extends NewBaseEditor {
     return this._textInput.selectionStart || 0;
   }
 
-  /**
-   * Updates list of valid choices with any new ones that may have been
-   * added from directly inside the editor (via the "add new" item in autocomplete).
-   */
   public async prepForSave() {
     const tokens = this._tokenField.tokensObs.get();
     const newChoices = tokens.filter(({ isNew }) => isNew).map(({ label }) => label);
@@ -194,25 +214,17 @@ export class ChoiceListEditor extends NewBaseEditor {
   }
 
   public setSizerLimits() {
-    // Set the max width of the sizer to the max we could possibly grow to, so that it knows to wrap
-    // once we reach it.
     const rootElem = this._tokenField.getRootElem();
     const maxSize = this._editorPlacement.calcSizeWithPadding(rootElem,
       { width: Infinity, height: Infinity }, { calcOnly: true });
     this._contentSizer.style.maxWidth = Math.ceil(maxSize.width) + "px";
   }
 
-  /**
-   * Helper which resizes the token-field to match its content.
-   */
   protected resizeInput(onlyTextInput: boolean = false) {
     if (this.isDisposed()) { return; }
 
     const rootElem = this._tokenField.getRootElem();
 
-    // To size the content, we need both the tokens and the text typed into _textInput. We
-    // re-create the tokens using cloneNode(true) copies all styles and properties, but not event
-    // handlers. We can skip this step when we know that only _textInput changed.
     if (!onlyTextInput || !this._inputSizer) {
       this._contentSizer.innerHTML = "";
 
@@ -221,16 +233,11 @@ export class ChoiceListEditor extends NewBaseEditor {
           dom.style("width", ""),
           dom.style("height", ""),
           this._inputSizer = cssInputSizer(),
-
-          // Remove the testId('tokenfield') from the cloned element, to simplify tests (so that
-          // selecting .test-tokenfield only returns the actual visible tokenfield container).
           dom.cls("test-tokenfield", false),
         ),
       );
     }
 
-    // Use a separate sizer to size _textInput to the text inside it.
-    // \u200B is a zero-width space; so the sizer will have height even when empty.
     this._inputSizer.textContent = this._textInput.value + "\u200B";
     const rect = this._contentSizer.getBoundingClientRect();
 
@@ -264,11 +271,6 @@ export class ChoiceListEditor extends NewBaseEditor {
     }
   }
 
-  /**
-   * If the search text does not match anything exactly, adds 'new' item to it.
-   *
-   * Also see: prepForSave.
-   */
   private _maybeShowAddNew(result: ACResults<ChoiceItem>, text: string): ACResults<ChoiceItem> {
     this._showAddNew = false;
     if (!this._enableAddNew) {
@@ -408,7 +410,6 @@ const cssInputSizer = styled("div", `
   margin: 3px 2px;
 `);
 
-// Set z-index to be higher than the 1000 set for .cell_editor.
 export const cssChoiceList = styled("div", `
   z-index: 1001;
   box-shadow: 0 0px 8px 0 ${theme.menuShadow};

--- a/app/client/widgets/ChoiceTextBox.ts
+++ b/app/client/widgets/ChoiceTextBox.ts
@@ -10,14 +10,18 @@ import { DataRowModel } from "app/client/models/DataRowModel";
 import { ViewFieldRec } from "app/client/models/entities/ViewFieldRec";
 import { KoSaveableObservable } from "app/client/models/modelUtil";
 import { cssLabel, cssRow } from "app/client/ui/RightPanelStyles";
+import { basicButton, primaryButton, textButton } from "app/client/ui2018/buttons";
 import { testId, theme } from "app/client/ui2018/cssVars";
 import { icon } from "app/client/ui2018/icons";
+import { textInput } from "app/client/ui/inputs";
+import { select } from "app/client/ui2018/menus";
+import { cssModalButtons, cssModalTitle, modal } from "app/client/ui2018/modals";
 import { ChoiceListEntry } from "app/client/widgets/ChoiceListEntry";
 import { choiceToken } from "app/client/widgets/ChoiceToken";
 import { NTextBox } from "app/client/widgets/NTextBox";
 import { Style } from "app/common/Styles";
 
-import { Computed, dom, styled } from "grainjs";
+import { Computed, dom, DomContents, Observable, styled } from "grainjs";
 
 export type IChoiceOptions = Style;
 export type ChoiceOptions = Record<string, IChoiceOptions | undefined>;
@@ -26,7 +30,7 @@ export type ChoiceOptionsByName = Map<string, IChoiceOptions | undefined>;
 const t = makeT("ChoiceTextBox");
 
 /**
- * ChoiceTextBox - A textbox for choice values.
+ * ChoiceTextBox - A textbox for choice values with support for shared lists.
  */
 export class ChoiceTextBox extends NTextBox {
   private _choices: KoSaveableObservable<string[]>;
@@ -34,14 +38,39 @@ export class ChoiceTextBox extends NTextBox {
   private _choiceValuesSet: Computed<Set<string>>;
   private _choiceOptions: KoSaveableObservable<ChoiceOptions | null | undefined>;
   private _choiceOptionsByName: Computed<ChoiceOptionsByName>;
+  private _sharedChoiceListId: KoSaveableObservable<string | undefined>;
 
   constructor(field: ViewFieldRec) {
     super(field);
     this._choices = this.options.prop("choices");
     this._choiceOptions = this.options.prop("choiceOptions");
-    this._choiceValues = Computed.create(this, use => use(this._choices) || []);
+    this._sharedChoiceListId = this.options.prop("sharedChoiceListId");
+
+    this._choiceValues = Computed.create(this, (use) => {
+      const sharedId = use(this._sharedChoiceListId);
+      if (sharedId) {
+        const docSettings = use(this.field.documentSettings);
+        const sharedLists = docSettings?.sharedChoiceLists || {};
+        if (sharedLists[sharedId]) {
+          return sharedLists[sharedId].choices || [];
+        }
+      }
+      return use(this._choices) || [];
+    });
+
     this._choiceValuesSet = Computed.create(this, this._choiceValues, (_use, values) => new Set(values));
-    this._choiceOptionsByName = Computed.create(this, use => toMap(use(this._choiceOptions)));
+
+    this._choiceOptionsByName = Computed.create(this, (use) => {
+      const sharedId = use(this._sharedChoiceListId);
+      if (sharedId) {
+        const docSettings = use(this.field.documentSettings);
+        const sharedLists = docSettings?.sharedChoiceLists || {};
+        if (sharedLists[sharedId]?.choiceColors) {
+          return toMap(sharedLists[sharedId].choiceColors as unknown as ChoiceOptions);
+        }
+      }
+      return toMap(use(this._choiceOptions));
+    });
   }
 
   public buildDom(row: DataRowModel) {
@@ -73,33 +102,29 @@ export class ChoiceTextBox extends NTextBox {
     );
   }
 
-  public buildConfigDom(gristDoc: GristDoc) {
-    return [
+  public buildConfigDom(gristDoc: GristDoc): DomContents {
+    return dom("div",
       super.buildConfigDom(gristDoc),
       this.buildChoicesConfigDom(),
       dom.create(DropdownConditionConfig, this.field, gristDoc),
-    ];
+    );
   }
 
-  public buildTransformConfigDom() {
-    return [
-      this.buildChoicesConfigDom(),
-    ];
+  public buildTransformConfigDom(): DomContents {
+    return dom("div", this.buildChoicesConfigDom());
   }
 
-  public buildFormConfigDom() {
-    return [
+  public buildFormConfigDom(): DomContents {
+    return dom("div",
       this.buildChoicesConfigDom(),
       dom.create(FormSelectConfig, this.field),
       dom.create(FormOptionsSortConfig, this.field),
       dom.create(FormFieldRulesConfig, this.field),
-    ];
+    );
   }
 
-  public buildFormTransformConfigDom() {
-    return [
-      this.buildChoicesConfigDom(),
-    ];
+  public buildFormTransformConfigDom(): DomContents {
+    return dom("div", this.buildChoicesConfigDom());
   }
 
   protected getChoiceValuesSet(): Computed<Set<string>> {
@@ -110,15 +135,43 @@ export class ChoiceTextBox extends NTextBox {
     return this._choiceOptionsByName;
   }
 
-  protected save(choices: string[], choiceOptions: ChoiceOptionsByName, renames: Record<string, string>) {
+  protected async save(choices: string[], choiceOptions: ChoiceOptionsByName, renames: Record<string, string>) {
+    const sharedId = this._sharedChoiceListId.peek();
+    const optionsObj = toObject(choiceOptions);
+
+    if (sharedId) {
+      const docModel = this._getDocModel();
+      const docSettings = this.field.documentSettings.peek() || {};
+      const currentShared = docSettings.sharedChoiceLists || {};
+      const target = currentShared[sharedId];
+
+      if (target) {
+        const updatedTarget = {
+          ...target,
+          choices,
+          choiceColors: optionsObj as any,
+        };
+
+        await docModel.docInfoRow.documentSettingsJson.setAndSave({
+          ...docSettings,
+          sharedChoiceLists: {
+            ...currentShared,
+            [sharedId]: updatedTarget,
+          },
+        });
+      }
+
+      return this.field.config.updateChoices(renames, {});
+    }
+
     const options = {
       choices,
-      choiceOptions: toObject(choiceOptions),
+      choiceOptions: optionsObj,
     };
     return this.field.config.updateChoices(renames, options);
   }
 
-  protected buildChoicesConfigDom() {
+  protected buildChoicesConfigDom(): DomContents {
     const disabled = Computed.create(null,
       use => use(this.field.disableModify) ||
         use(use(this.field.column).disableEditData) ||
@@ -130,7 +183,75 @@ export class ChoiceTextBox extends NTextBox {
         (use(this.field.config.options.mixed("choices")) || use(this.field.config.options.mixed("choiceOptions"))),
     );
 
-    return [
+    const listSelectOptions = Computed.create(this, (use) => {
+      const docSettings = use(this.field.documentSettings);
+      const sharedLists = docSettings?.sharedChoiceLists || {};
+      return [
+        { label: t("Custom (Column-specific)"), value: "" },
+        ...Object.entries(sharedLists).map(([id, def]) => ({
+          label: (def as any).name || id,
+          value: id,
+        })),
+      ];
+    });
+
+    const selectedList = Computed.create(this, (use) => {
+      const id = use(this._sharedChoiceListId);
+      if (!id) { return ""; }
+      const docSettings = use(this.field.documentSettings);
+      const sharedLists = docSettings?.sharedChoiceLists || {};
+      return sharedLists[id] ? id : "";
+    });
+
+    selectedList.onWrite((val: string) => {
+      void this._sharedChoiceListId.setAndSave(val || undefined);
+    });
+
+    return dom("div",
+      cssLabel(t("SOURCE LIST")),
+      cssRow(
+        dom.autoDispose(listSelectOptions),
+        dom.autoDispose(selectedList),
+        cssFullWidthSelect(
+          select(
+            selectedList,
+            listSelectOptions,
+            {
+              defaultLabel: t("Custom (Column-specific)"),
+            },
+          ),
+        ),
+        testId("choice-list-source-select"),
+      ),
+      cssRow(
+        textButton(
+          t("Create new shared list..."),
+          dom.on("click", () => this._createSharedChoiceList()),
+          testId("choice-list-create-new"),
+        ),
+        dom.domComputed(
+          (use) => {
+            const id = use(this._sharedChoiceListId);
+            if (!id) { return null; }
+            const docSettings = use(this.field.documentSettings);
+            const sharedLists = docSettings?.sharedChoiceLists || {};
+            return sharedLists[id] ? id : null;
+          },
+          (validId) => {
+            if (!validId) { return null; }
+            return textButton(
+              t("Delete shared list"),
+              dom.on("click", () => this._deleteSharedChoiceList()),
+              dom.style("color", "var(--grist-color-error, #e53935)"),
+              dom.style("margin-left", "8px"),
+              testId("choice-list-delete-shared"),
+            );
+          },
+        ),
+        dom.style("margin-top", "4px"),
+        dom.style("margin-bottom", "6px"),
+      ),
+
       cssLabel(t("CHOICES")),
       cssRow(
         dom.autoDispose(disabled),
@@ -144,18 +265,134 @@ export class ChoiceTextBox extends NTextBox {
           mixed,
         ),
       ),
-    ];
+    );
+  }
+
+  private _getDocModel() {
+    return (this.field as any)._table?.docModel || (this.field.column.peek().table() as any).docModel;
+  }
+
+  private _createSharedChoiceList() {
+    modal((ctl, owner) => {
+      const nameObs = Observable.create(owner, "");
+      const canSave = Computed.create(owner, use => Boolean(use(nameObs).trim()));
+
+      const onSave = async () => {
+        const name = nameObs.get().trim();
+        if (!name) { return; }
+        ctl.close();
+
+        const docModel = this._getDocModel();
+        const docSettings = this.field.documentSettings.peek() || {};
+        const currentShared = docSettings.sharedChoiceLists || {};
+
+        const sharedId = "shared_" + Date.now();
+        const choices = this._choices.peek() || [];
+        const choiceColors = (this._choiceOptions.peek() || {}) as any;
+
+        const newSharedList = {
+          id: sharedId,
+          name,
+          choices,
+          choiceColors,
+        };
+
+        await docModel.docInfoRow.documentSettingsJson.setAndSave({
+          ...docSettings,
+          sharedChoiceLists: {
+            ...currentShared,
+            [sharedId]: newSharedList,
+          },
+        });
+
+        await this._sharedChoiceListId.setAndSave(sharedId);
+      };
+
+      return [
+        cssModalTitle(t("Create shared choice list")),
+        cssModalInputWrapper(
+          textInput(
+            nameObs,
+            (elem) => { setTimeout(() => elem.focus(), 0); },
+            dom.on("keydown", (e) => {
+              if (e.key === "Enter" && canSave.get()) {
+                e.preventDefault();
+                void onSave();
+              }
+            }),
+            testId("shared-choice-list-name-input"),
+          ),
+        ),
+        cssModalButtons(
+          primaryButton(
+            t("Create"),
+            dom.prop("disabled", use => !use(canSave)),
+            dom.on("click", () => void onSave()),
+            testId("shared-choice-list-create-confirm-btn"),
+          ),
+          basicButton(
+            t("Cancel"),
+            dom.on("click", () => ctl.close()),
+            testId("shared-choice-list-cancel-btn"),
+          ),
+        ),
+      ];
+    });
+  }
+
+  private _deleteSharedChoiceList() {
+    const sharedId = this._sharedChoiceListId.peek();
+    if (!sharedId) { return; }
+
+    const docSettings = this.field.documentSettings.peek() || {};
+    const sharedLists = docSettings.sharedChoiceLists || {};
+    const target = sharedLists[sharedId];
+    const name = target?.name || sharedId;
+
+    modal((ctl) => {
+      const onDelete = async () => {
+        ctl.close();
+        const docModel = this._getDocModel();
+        const updatedShared = { ...sharedLists };
+        delete updatedShared[sharedId];
+
+        await this._sharedChoiceListId.setAndSave(undefined);
+
+        await docModel.docInfoRow.documentSettingsJson.setAndSave({
+          ...docSettings,
+          sharedChoiceLists: updatedShared,
+        });
+      };
+
+      return [
+        cssModalTitle(t("Delete shared choice list")),
+        cssModalMessage(
+          t(`Are you sure you want to delete the shared list "${name}"? Columns using it will revert to custom choices.`),
+        ),
+        cssModalButtons(
+          primaryButton(
+            t("Delete"),
+            dom.style("background-color", "var(--grist-color-error, #e53935)"),
+            dom.on("click", () => void onDelete()),
+            testId("shared-choice-list-delete-confirm-btn"),
+          ),
+          basicButton(
+            t("Cancel"),
+            dom.on("click", () => ctl.close()),
+            testId("shared-choice-list-delete-cancel-btn"),
+          ),
+        ),
+      ];
+    });
   }
 }
 
-// Converts a POJO containing choice options to an ES6 Map
 function toMap(choiceOptions?: ChoiceOptions | null): ChoiceOptionsByName {
   if (!choiceOptions) { return new Map(); }
 
   return new Map(Object.entries(choiceOptions));
 }
 
-// Converts an ES6 Map containing choice options to a POJO
 function toObject(choiceOptions: ChoiceOptionsByName): ChoiceOptions {
   const object: ChoiceOptions = {};
   for (const [choice, options] of choiceOptions.entries()) {
@@ -163,6 +400,13 @@ function toObject(choiceOptions: ChoiceOptionsByName): ChoiceOptions {
   }
   return object;
 }
+
+const cssFullWidthSelect = styled("div", `
+  width: 100%;
+  & > * {
+    width: 100%;
+  }
+`);
 
 const cssChoiceField = styled("div.field_clip", `
   padding: 0 3px;
@@ -185,4 +429,22 @@ const cssChoiceEditIcon = styled(icon, `
   background-color: ${theme.lightText};
   display: block;
   height: inherit;
+`);
+
+const cssModalInputWrapper = styled("div", `
+  margin: 16px 0 24px 0;
+  width: 100%;
+  isolation: isolate;
+
+  & input {
+    width: 100%;
+    box-sizing: border-box;
+  }
+`);
+
+const cssModalMessage = styled("div", `
+  margin: 16px 0 24px 0;
+  font-size: 13px;
+  line-height: 18px;
+  color: ${theme.text};
 `);

--- a/app/common/DocumentSettings-ti.ts
+++ b/app/common/DocumentSettings-ti.ts
@@ -4,12 +4,23 @@
 import * as t from "ts-interface-checker";
 // tslint:disable:object-literal-key-quotes
 
+export const SharedChoiceList = t.iface([], {
+  "name": "string",
+  "choices": t.array("string"),
+  "choiceColors": t.opt(t.iface([], {
+    [t.indexKey]: "string",
+  })),
+});
+
 export const DocumentSettings = t.iface([], {
   "locale": "string",
   "currency": t.opt("string"),
   "engine": t.opt("EngineCode"),
   "attachmentStoreId": t.opt("string"),
   "baseAction": t.opt("DocState"),
+  "sharedChoiceLists": t.opt(t.iface([], {
+    [t.indexKey]: "SharedChoiceList",
+  })),
 });
 
 export const EngineCode = t.lit("python3");
@@ -20,6 +31,7 @@ export const DocState = t.iface([], {
 });
 
 const exportedTypeSuite: t.ITypeSuite = {
+  SharedChoiceList,
   DocumentSettings,
   EngineCode,
   DocState,

--- a/app/common/DocumentSettings.ts
+++ b/app/common/DocumentSettings.ts
@@ -2,6 +2,12 @@ import DocumentSettingsTI from "app/common/DocumentSettings-ti";
 
 import { CheckerT, createCheckers } from "ts-interface-checker";
 
+export interface SharedChoiceList {
+  name: string;
+  choices: string[];
+  choiceColors?: { [choice: string]: string };
+}
+
 export interface DocumentSettings {
   locale: string;
   currency?: string;
@@ -17,6 +23,7 @@ export interface DocumentSettings {
   // action to treat as a starting point, e.g. when a fork or
   // copy is made.
   baseAction?: DocState;
+  sharedChoiceLists?: { [listId: string]: SharedChoiceList };
 }
 
 /**

--- a/app/common/WidgetOptions.ts
+++ b/app/common/WidgetOptions.ts
@@ -8,4 +8,5 @@ export interface WidgetOptions extends NumberFormatOptions {
   timeFormat?: string;
   widget?: "HyperLink";
   choices?: string[];
+  sharedChoiceListKey?: string;
 }

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -1293,7 +1293,16 @@
         "HEADER STYLE": "HEADER STYLE"
     },
     "ChoiceTextBox": {
-        "CHOICES": "CHOICES"
+        "CHOICES": "CHOICES",
+        "SOURCE LIST": "SOURCE LIST",
+        "Custom (Column-specific)": "Custom (Column-specific)",
+        "Create new shared list...": "Create new shared list...",
+        "Create shared choice list": "Create shared choice list",
+        "Create": "Create",
+        "Cancel": "Cancel",
+        "Delete shared choice list": "Delete shared choice list",
+        "Delete shared list": "Delete shared list",
+        "Delete": "Delete"
     },
     "ColumnEditor": {
         "COLUMN DESCRIPTION": "COLUMN DESCRIPTION",


### PR DESCRIPTION
### Summary of Changes

Implements support for **Reusable (Shared) Choice Lists** across Choice and Choice List columns.

This allows users to define a single choice list and reuse it across multiple columns within the same document, ensuring consistent options and colors without needing to duplicate configurations manually.

> **Scope Note:** Shared choice lists are scoped **per document** (persisted in document settings), not globally across the entire workspace.

### Demo Video

- **YouTube Walkthrough**:  https://youtu.be/JprKAwfZKLU
  *(Demonstrates creating, editing, and using shared choice lists across two different documents).*

### Key Additions & Updates

- **Document Settings Model**:
  - Added `sharedChoiceLists` schema to `DocumentSettings` / `DocInfoRec` to persist shared lists and color mappings at the document level.
  - Updated Type-Interface definitions (`DocumentSettings-ti.ts`) and widget option typings (`WidgetOptions.ts`).

- **Choice Configuration UI (`ChoiceTextBox.ts`)**:
  - Added "SOURCE LIST" dropdown in the side panel to switch between column-specific custom choices and available document-level shared lists.
  - Added a "Create new shared list..." modal dialog to create reusable lists directly from current column configurations.
  - Added deletion support with confirmation handling when a shared list is removed.
  - Resolved input styling and focus stability issues inside the modal dialog by using standard `textInput` and isolated wrapper styling.

- **Choice & Choice List Editors (`ChoiceEditor.js`, `ChoiceListEditor.ts`)**:
  - Updated autocomplete suggestions and token editors to read from the active shared list definition when linked.
  - Disabled inline ad-hoc choice creation when a column is linked to a shared list to prevent accidental drift from the shared definition.

- **Localization**:
  - Added client-side translation strings in `en.client.json`.

### Testing

- Verified creating, selecting, and deleting shared choice lists via the column configuration panel.
- Verified that choice tokens, options, and colors remain consistent across multiple columns referencing the same shared list.
- Verified document-level isolation by testing behavior across two separate documents.