### PR TITLE
"view as" popups: add a user filter when there are lots of users

### DIFF
--- a/app/client/aclui/ACLUsers.ts
+++ b/app/client/aclui/ACLUsers.ts
@@ -1,3 +1,4 @@
+import { normalizeText } from "app/client/lib/ACIndex";
 import { makeT } from "app/client/lib/localization";
 import { DocPageModel } from "app/client/models/DocPageModel";
 import { urlState } from "app/client/models/gristUrlState";
@@ -5,24 +6,37 @@ import { createUserImage } from "app/client/ui/UserImage";
 import { cssMemberImage, cssMemberListItem, cssMemberPrimary,
   cssMemberSecondary, cssMemberText } from "app/client/ui/UserItem";
 import { testId, theme, vars } from "app/client/ui2018/cssVars";
+import { cssTextInput } from "app/client/ui2018/editableLabel";
+import { icon } from "app/client/ui2018/icons";
 import { gristFloatingMenuClass, menu, menuCssClass, menuItemLink } from "app/client/ui2018/menus";
+import { unstyledButton } from "app/client/ui2018/unstyled";
 import { PermissionDataWithExtraUsers } from "app/common/ActiveDocAPI";
 import { IGristUrlState, userOverrideParams } from "app/common/gristUrls";
 import { waitGrainObs } from "app/common/gutil";
 import { FullUser } from "app/common/LoginSessionAPI";
+import { tokens } from "app/common/ThemePrefs";
 import { ANONYMOUS_USER_EMAIL, EVERYONE_EMAIL } from "app/common/UserAPI";
 import { getRealAccess, UserAccessData } from "app/common/UserAPI";
 import { getUserRoleText } from "app/common/UserAPI";
 
-import { Disposable, dom, Observable, styled } from "grainjs";
+import { Computed, Disposable, dom, IDisposableOwner, input, Observable, styled, UseCB } from "grainjs";
 import noop from "lodash/noop";
 import { cssMenu, cssMenuWrap, defaultMenuOptions, IMenuOptions, IPopupOptions, setPopupToCreateDom } from "popweasel";
 
 const t = makeT("ACLUsers");
 const userT = makeT("UserManagerModel");
 
+const FILTER_THRESHOLD = 10;
+
 function isSpecialEmail(email: string) {
   return email === ANONYMOUS_USER_EMAIL || email === EVERYONE_EMAIL;
+}
+
+function userMatchesFilter(user: UserAccessData, filter: string): boolean {
+  if (!filter) { return true; }
+  const q = normalizeText(filter);
+  return normalizeText(user.name || "").includes(q) ||
+    normalizeText(user.email || "").includes(q);
 }
 
 export class ACLUsersPopup extends Disposable {
@@ -68,6 +82,7 @@ export class ACLUsersPopup extends Disposable {
     }
   }
 
+  // Render a popup to select a user to "view as", listing users in groups (shared, attribute table, example users).
   // Optionally have document page reverts to the default page upon activation of the view as mode
   // by setting `options.resetDocPage` to true.
   public attachPopup(elem: Element, options: IPopupOptions & { resetDocPage?: boolean }) {
@@ -76,40 +91,157 @@ export class ACLUsersPopup extends Disposable {
         (user: UserAccessData) => this._buildUserRow(user, options);
       const buildExampleUserRow =
         (user: UserAccessData) => this._buildUserRow(user, { isExampleUser: true, ...options });
+
+      const filter = this._createUserFilter(ctl);
+      const shareUsers = filter.filterUsers(this._shareUsers);
+      const attributeTableUsers = filter.filterUsers(this._attributeTableUsers);
+      const exampleUsers = filter.filterUsers(this._exampleUsers);
+      const showExampleUsers = this._showExampleUsers();
+
       return cssMenuWrap(cssMenu(
         dom.cls(menuCssClass),
         dom.cls(gristFloatingMenuClass),
         cssUsers.cls(""),
-        cssHeader(t("Shared users"), dom.show(this._shareUsers.length > 0)),
-        dom.forEach(this._shareUsers, buildRow),
-        (this._attributeTableUsers.length > 0) ? cssHeader(t("Other users from table")) : null,
-        dom.forEach(this._attributeTableUsers, buildExampleUserRow),
+        // Drop the menu's top padding so sticky can sit at top: 0 without jitter.
+        cssUsers.cls("-with-sticky-heading", filter.showFilter),
+        filter.filterDom,
+        cssHeader(t("Shared users"),
+          dom.show(use => use(shareUsers).length > 0)),
+        dom.forEach(shareUsers, buildRow),
+        cssHeader(t("Other users from table"),
+          dom.show(use => use(attributeTableUsers).length > 0)),
+        dom.forEach(attributeTableUsers, buildExampleUserRow),
         // Include example users only if there are not many "real" users.
         // It might be better to have an expandable section with these users, collapsed
         // by default, but that's beyond my UI ken.
-        this._showExampleUsers() ? [
-          (this._exampleUsers.length > 0) ? cssHeader(t("Example Users")) : null,
-          dom.forEach(this._exampleUsers, buildExampleUserRow),
+        showExampleUsers ? [
+          cssHeader(t("Example Users"),
+            dom.show(use => use(exampleUsers).length > 0)),
+          dom.forEach(exampleUsers, buildExampleUserRow),
         ] : null,
-        (el) => { setTimeout(() => el.focus(), 0); },
-        dom.onKeyDown({ Escape: () => ctl.close() }),
+        filter.noResults(use =>
+          use(shareUsers).length === 0 &&
+          use(attributeTableUsers).length === 0 &&
+          (!showExampleUsers || use(exampleUsers).length === 0)),
+        ...filter.openArgs(),
       ));
     }, { ...defaultMenuOptions, ...options });
   }
 
+  // Render a popup to select a user to "view as", listing all users without any grouping.
   // See 'attachPopup' for more info on the 'resetDocPage' option.
   public menu(options: IMenuOptions) {
-    return menu(() => {
+    return menu((ctl) => {
       this.load().catch(noop);
+
+      const filter = this._createUserFilter(ctl);
+      const filteredUsers = filter.filterUsers(this.allUsers);
+
       return [
-        cssMenuHeader("view as"),
-        dom.forEach(this.allUsers, user => menuItemLink(
+        filter.filterDom,
+        // When the filter is shown, its sticky header replaces this label.
+        filter.showFilter ? null : cssMenuHeader("view as"),
+        dom.forEach(filteredUsers, user => menuItemLink(
           `${user.name || user.email} (${getUserRoleText(user)})`,
           testId("acl-user-access"),
           this._viewAs(user),
         )),
+        filter.noResults(use => use(filteredUsers).length === 0),
+        // Standard menus keep cssMenuElem top padding; clear it so sticky spacing matches attachPopup.
+        ...filter.openArgs({ clearPaddingTop: true }),
       ];
     }, options);
+  }
+
+  /**
+   * Shared filter state/UI for the "view as" menus (attachPopup and menu).
+   */
+  private _createUserFilter(ctl: IDisposableOwner & { close(): void }) {
+    const showFilter = this.getUsers().length > FILTER_THRESHOLD;
+    const filterText = Observable.create(ctl, "");
+    let filterInput: HTMLInputElement | undefined;
+
+    return {
+      showFilter,
+      /** Filter a static list or an observable list of users. */
+      filterUsers: (users: UserAccessData[] | Observable<UserAccessData[]>) =>
+        Computed.create(ctl, (use) => {
+          const list = Array.isArray(users) ? users : use(users);
+          const q = use(filterText).trim();
+          return q ? list.filter(u => userMatchesFilter(u, q)) : list;
+        }),
+      /** Sticky filter input, or null when below the threshold. */
+      filterDom: showFilter ? this._buildFilter(filterText, (el) => { filterInput = el; }) : null,
+      /** Empty-state message when a filter is active and isEmpty is true. */
+      noResults: (isEmpty: (use: UseCB) => boolean) => {
+        const noMatching = Computed.create(ctl, use =>
+          Boolean(use(filterText).trim()) && isEmpty(use));
+        return dom.maybe(noMatching, () =>
+          cssNoResults(t("No matching users"), testId("acl-user-filter-empty")),
+        );
+      },
+      /** Focus/width lock and Escape-to-clear, applied to the menu root. */
+      openArgs: (options: { clearPaddingTop?: boolean } = {}) => [
+        (el: HTMLElement) => {
+          setTimeout(() => {
+            if (showFilter) {
+              if (options.clearPaddingTop) {
+                el.style.paddingTop = "0";
+              }
+              // Lock width to the initial layout so filtering doesn't shrink/grow the popup.
+              el.style.width = `${el.getBoundingClientRect().width}px`;
+            }
+            // Bypass weasel.menu's auto-focus on the menu container to focus the filter input.
+            // The better way to handle that for accessibility purpose would be to stop using weasel.menu directly
+            setTimeout(() => (filterInput || el).focus(), 0);
+          }, 0);
+        },
+        dom.onKeyDown({
+          Escape$: (ev) => {
+            if (filterText.get()) {
+              filterText.set("");
+              filterInput?.focus();
+              ev.stopPropagation();
+            } else {
+              ctl.close();
+            }
+          },
+        }),
+      ],
+    };
+  }
+
+  private _buildFilter(
+    filterText: Observable<string>,
+    onInputCreated: (el: HTMLInputElement) => void,
+  ) {
+    let filterInput: HTMLInputElement;
+    return cssStickyFilterContainer(
+      cssFilterHeader(t("Search users"), { id: "acl-user-filter-header" }),
+      cssFilterInputContainer(
+        filterInput = cssFilterInput(filterText, { onInput: true },
+          dom.cls(cssTextInput.className),
+          {
+            "type": "search",
+            "placeholder": t("Filter by name or email"),
+            "aria-labelledby": "acl-user-filter-header",
+          },
+          (el) => { onInputCreated(el); },
+          testId("acl-user-filter"),
+        ),
+        dom.maybe(filterText, () => cssFilterClearButton(
+          icon("CrossSmall"),
+          { "aria-label": t("Clear filter") },
+          testId("acl-user-filter-clear"),
+          dom.on("click", () => {
+            filterText.set("");
+            filterInput.focus();
+          }),
+        )),
+        // Prevent clicks on the filter from closing the menu.
+        dom.on("click", ev => ev.stopPropagation()),
+      ),
+    );
   }
 
   private async _fetchData() {
@@ -165,6 +297,10 @@ export class ACLUsersPopup extends Disposable {
 
 const cssUsers = styled("div", `
   max-width: unset;
+  &-with-sticky-heading {
+    /* Cancel cssMenuElem's top padding; sticky header owns that spacing instead. */
+    padding: 0 0 16px 0;
+  }
 `);
 
 const cssUserItem = styled(cssMemberListItem, `
@@ -184,12 +320,28 @@ const cssRole = styled("span", `
   font-weight: normal;
 `);
 
+const cssStickyFilterContainer = styled("div", `
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  /* Replaces the menu's top padding so spacing is inside the sticky layer. */
+  padding-top: 8px;
+  background-color: ${theme.menuBg};
+  padding-bottom: 16px;
+  border-bottom: 1px solid ${tokens.decorationSecondary};
+  margin-bottom: 11px;
+`);
+
 const cssHeader = styled("div", `
   margin: 11px 24px 14px 24px;
   font-weight: 700;
   text-transform: uppercase;
   font-size: ${vars.xsmallFontSize};
   color: ${theme.darkText};
+
+  .${cssStickyFilterContainer.className} + & {
+    margin-top: 16px;
+  }
 `);
 
 const cssMenuHeader = styled("div", `
@@ -199,4 +351,44 @@ const cssMenuHeader = styled("div", `
   text-transform: uppercase;
   font-size: ${vars.xsmallFontSize};
   color: ${theme.darkText};
+`);
+
+const cssFilterHeader = styled(cssHeader, `
+  margin: 0;
+  padding: 11px 24px 14px 24px;
+`);
+
+const cssFilterInputContainer = styled("div", `
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin: 0 24px;
+`);
+
+const cssFilterInput = styled(input, `
+  flex: 1 1 auto;
+  min-width: 0;
+  width: auto;
+
+  &::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+  }
+`);
+
+const cssFilterClearButton = styled(unstyledButton, `
+  --icon-color: ${theme.lightText};
+  position: absolute;
+  top: 0;
+  right: 8px;
+  bottom: 0;
+  margin: auto;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+`);
+
+const cssNoResults = styled("div", `
+  margin: 8px 24px 0 24px;
+  font-style: italic;
+  color: ${theme.lightText};
 `);

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -1273,7 +1273,11 @@
         "Users from table": "Users from table",
         "View as": "View as",
         "Other users from table": "Other users from table",
-        "Shared users": "Shared users"
+        "Shared users": "Shared users",
+        "Search users": "Search users",
+        "Filter by name or email": "Filter by name or email",
+        "Clear filter": "Clear filter",
+        "No matching users": "No matching users"
     },
     "TypeTransform": {
         "Apply": "Apply",

--- a/static/locales/fr.client.json
+++ b/static/locales/fr.client.json
@@ -1337,7 +1337,11 @@
         "Users from table": "Utilisateurs de la table d'appairage",
         "View as": "Voir en tant que",
         "Other users from table": "Autres utilisateurs de la table",
-        "Shared users": "Utilisateurs partagés"
+        "Shared users": "Utilisateurs partagés",
+        "Search users": "Rechercher",
+        "Filter by name or email": "Filtrer par nom ou e-mail",
+        "Clear filter": "Effacer le filtre",
+        "No matching users": "Aucun utilisateur correspondant"
     },
     "ConditionalStyle": {
         "Add conditional style": "Ajouter un style conditionnel",

--- a/test/nbrowser/AccessRulesViewAsFilter.ts
+++ b/test/nbrowser/AccessRulesViewAsFilter.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for the "View as" list users filter.
+ * Covers both the Access Rules page "view as" dropdown button and the Tools "Access Rules (…)" menu.
+ */
+import { startEditingAccessRules } from "test/nbrowser/aclTestUtils";
+import * as gu from "test/nbrowser/gristUtils";
+import { setupTestSuite } from "test/nbrowser/testUtils";
+
+import { assert, driver, Key } from "mocha-webdriver";
+
+/** Emails used to push the shared-user count above the filter threshold. */
+const EXTRA_FILTER_USERS = Array.from({ length: 12 }, (_, i) => `filter-user-${i + 1}@example.com`);
+
+interface ViewAsEntry {
+  name: string;
+  /** CSS selector for a listed user row/item inside the open menu. */
+  itemSelector: string;
+  open: () => Promise<void>;
+}
+
+async function openAclViewAsPopup() {
+  await startEditingAccessRules();
+  await driver.findContentWait("button", /View as/, 3000).click();
+  await gu.findOpenMenu();
+}
+
+async function closeViewAsMenu() {
+  if (!(await driver.find(".grist-floating-menu").isPresent())) { return; }
+  // Escape clears an active filter before closing; send a second time if still open.
+  await driver.sendKeys(Key.ESCAPE);
+  if (await driver.find(".grist-floating-menu").isPresent()) {
+    await driver.sendKeys(Key.ESCAPE);
+  }
+  await gu.waitToPass(async () => {
+    assert.isFalse(await driver.find(".grist-floating-menu").isPresent());
+  });
+}
+
+async function filterWith(text: string) {
+  const input = driver.find(".test-acl-user-filter");
+  await input.click();
+  await gu.sendKeys(await gu.selectAllKey(), Key.DELETE, text);
+}
+
+async function menuItemsCount(itemSelector: string): Promise<number> {
+  return (await driver.findAll(`.grist-floating-menu ${itemSelector}`)).length;
+}
+
+describe("AccessRulesViewAsFilter", function() {
+  this.timeout(20000);
+  const cleanup = setupTestSuite();
+  let mainSession: gu.Session;
+  let docId: string;
+
+  afterEach(() => gu.checkForErrors());
+
+  before(async function() {
+    mainSession = await gu.session().teamSite.user("user1").login();
+    docId = await mainSession.tempNewDoc(cleanup, "AccessRulesViewAsFilter", { load: false });
+    const api = mainSession.createHomeApi();
+    await api.updateDocPermissions(docId, { users: {
+      [gu.translateUser("user2").email]: "owners",
+      [gu.translateUser("user3").email]: "editors",
+    } });
+  });
+
+  describe("with few users", function() {
+    before(async function() {
+      await mainSession.loadDoc(`/doc/${docId}`);
+    });
+
+    afterEach(async () => closeViewAsMenu());
+
+    it("does not show a filter in the ACL View as popup", async function() {
+      await openAclViewAsPopup();
+      assert.isFalse(await driver.find(".test-acl-user-filter").isPresent());
+      // Make sure that users are still listed
+      const count = await menuItemsCount(".test-acl-user-item");
+      assert.isBelow(count, 10);
+      assert.isAbove(count, 0);
+    });
+
+    it("does not show a filter in the Tools View as menu", async function() {
+      await gu.openAccessRulesDropdown();
+      assert.isFalse(await driver.find(".test-acl-user-filter").isPresent());
+      // Make sure that users are still listed
+      const count = await menuItemsCount(".test-acl-user-access");
+      assert.isBelow(count, 10);
+      assert.isAbove(count, 0);
+    });
+  });
+
+  describe("with many users", function() {
+    const popups: ViewAsEntry[] = [
+      { name: "ACL View as popup", itemSelector: ".test-acl-user-item", open: openAclViewAsPopup },
+      { name: "Tools View as menu", itemSelector: ".test-acl-user-access", open: gu.openAccessRulesDropdown },
+    ];
+
+    before(async function() {
+      const api = mainSession.createHomeApi();
+      const users: Record<string, "viewers"> = {};
+      for (const email of EXTRA_FILTER_USERS) {
+        users[email] = "viewers";
+      }
+      await api.updateDocPermissions(docId, { users });
+      // Add a user-attribute row with a Name that does not appear in the Email, so we can
+      // assert name-based filtering independently of email matching.
+      await api.applyUserActions(docId, [
+        ["AddTable", "NamedUsers", [{ id: "Email" }, { id: "Name" }]],
+        ["AddRecord", "NamedUsers", null, { Email: "secret-email@example.com", Name: "Jane Doe" }],
+        ["AddRecord", "_grist_ACLResources", -1, { tableId: "*", colIds: "*" }],
+        ["AddRecord", "_grist_ACLRules", null, {
+          resource: -1,
+          userAttributes: JSON.stringify({
+            name: "NamedUser",
+            tableId: "NamedUsers",
+            charId: "Email",
+            lookupColId: "Email",
+          }),
+        }],
+      ]);
+      await mainSession.loadDoc(`/doc/${docId}`);
+    });
+
+    for (const popup of popups) {
+      describe(popup.name, function() {
+        afterEach(async () => closeViewAsMenu());
+
+        it("shows the filter and focuses it on open", async function() {
+          await popup.open();
+          await gu.waitToPass(async () => {
+            assert.isTrue(await driver.find(".test-acl-user-filter").isPresent());
+            assert.isTrue(await driver.find(".test-acl-user-filter").hasFocus());
+          });
+          assert.isAbove(await menuItemsCount(popup.itemSelector), 10);
+        });
+
+        it("filters the list by name or email", async function() {
+          await popup.open();
+          await gu.waitToPass(async () => {
+            assert.isTrue(await driver.find(".test-acl-user-filter").hasFocus());
+          });
+
+          // Filter by name
+          await filterWith("Doe");
+          await gu.waitToPass(async () => {
+            assert.isTrue(
+              await driver.findContent(
+                `.grist-floating-menu ${popup.itemSelector}`, "Jane Doe").isPresent(),
+            );
+            assert.isFalse(
+              await driver.findContent(
+                `.grist-floating-menu ${popup.itemSelector}`, EXTRA_FILTER_USERS[0]).isPresent(),
+            );
+            assert.equal(await menuItemsCount(popup.itemSelector), 1);
+          });
+
+          // Filter by email
+          await filterWith("filter-user-1@");
+          await gu.waitToPass(async () => {
+            assert.isTrue(
+              await driver.findContent(`.grist-floating-menu ${popup.itemSelector}`, EXTRA_FILTER_USERS[0]).isPresent(),
+            );
+            assert.isFalse(
+              await driver.findContent(`.grist-floating-menu ${popup.itemSelector}`, EXTRA_FILTER_USERS[1]).isPresent(),
+            );
+            assert.isFalse(
+              await driver.findContent(`.grist-floating-menu ${popup.itemSelector}`, "Jane Doe").isPresent(),
+            );
+            assert.equal(await menuItemsCount(popup.itemSelector), 1);
+          });
+
+          // Check when there is no match
+          await filterWith("azdf");
+          await gu.waitToPass(async () => {
+            assert.equal(await menuItemsCount(popup.itemSelector), 0);
+            assert.isTrue(await driver.find(".test-acl-user-filter-empty").isPresent());
+          });
+        });
+
+        it("resets the list when the clear button is clicked", async function() {
+          await popup.open();
+          await gu.waitToPass(async () => {
+            assert.isTrue(await driver.find(".test-acl-user-filter").hasFocus());
+          });
+
+          const totalBefore = await menuItemsCount(popup.itemSelector);
+          await filterWith("filter-user-1");
+          await gu.waitToPass(async () => {
+            assert.isBelow(await menuItemsCount(popup.itemSelector), totalBefore);
+            assert.isTrue(await driver.find(".test-acl-user-filter-clear").isPresent());
+          });
+
+          await driver.find(".test-acl-user-filter-clear").click();
+          await gu.waitToPass(async () => {
+            assert.equal(await driver.find(".test-acl-user-filter").value(), "");
+            assert.equal(await menuItemsCount(popup.itemSelector), totalBefore);
+            assert.isFalse(await driver.find(".test-acl-user-filter-clear").isPresent());
+          });
+        });
+
+        it("Escape clears the filter first, then closes the menu", async function() {
+          await popup.open();
+          await gu.waitToPass(async () => {
+            assert.isTrue(await driver.find(".test-acl-user-filter").hasFocus());
+          });
+
+          const totalBefore = await menuItemsCount(popup.itemSelector);
+          await filterWith("filter-user-1");
+          await gu.waitToPass(async () => {
+            assert.isBelow(await menuItemsCount(popup.itemSelector), totalBefore);
+          });
+
+          // First Escape: clear filter, keep menu open.
+          await driver.sendKeys(Key.ESCAPE);
+          await gu.waitToPass(async () => {
+            assert.equal(await driver.find(".test-acl-user-filter").value(), "");
+            assert.equal(await menuItemsCount(popup.itemSelector), totalBefore);
+            assert.isTrue(await driver.find(".grist-floating-menu").isPresent());
+          });
+
+          // Second Escape: close menu.
+          await driver.sendKeys(Key.ESCAPE);
+          await gu.waitToPass(async () => {
+            assert.isFalse(await driver.find(".grist-floating-menu").isPresent());
+          });
+        });
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Context

On documents with lots of users, it can be tricky to use the "view as" feature because there is no quick way to find the user we want to test ACLs with.

## Proposed solution

This adds an input that filters the users list when we detect there are more than 10 users to list in the "view as" popups.

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts


https://github.com/user-attachments/assets/77fc8a41-20bb-41a5-8cc5-edb958398ebe


