### PR TITLE
Visible/hidden columns selection in right panel: add input filters

### DIFF
--- a/app/client/ui/VisibleFieldsConfig.ts
+++ b/app/client/ui/VisibleFieldsConfig.ts
@@ -1,5 +1,6 @@
 import DetailView from "app/client/components/DetailView";
 import { GristDoc } from "app/client/components/GristDoc";
+import { normalizeText } from "app/client/lib/ACIndex";
 import { KoArray, syncedKoArray } from "app/client/lib/koArray";
 import * as kf from "app/client/lib/koForm";
 import { makeT } from "app/client/lib/localization";
@@ -16,13 +17,16 @@ import { visuallyHiddenStyles } from "app/client/ui2018/visuallyHidden";
 import * as gutil from "app/common/gutil";
 import { IWidgetType } from "app/common/widgetTypes";
 
-import { Computed, Disposable, dom, IDomArgs, makeTestId, Observable, styled, subscribe } from "grainjs";
+import { Computed, Disposable, dom, IDomArgs, makeTestId, Observable, styled, subscribe, UseCB } from "grainjs";
 import ko from "knockout";
 import difference from "lodash/difference";
 import isEqual from "lodash/isEqual";
 
 const testId = makeTestId("test-vfc-");
 const t = makeT("VisibleFieldsConfig");
+
+/** Show a filter input once a list has more than this many columns. */
+const FILTER_INPUT_MIN_COUNT = 10;
 
 export type IField = ViewFieldRec | ColumnRec;
 
@@ -36,7 +40,10 @@ interface DraggableFieldsOption {
   skipFirst?: Observable<number>;
 
   // Allows to filter view fields.
-  filterFunc?: (field: ViewFieldRec, index: number) => boolean;
+  filterFunc?: (field: IField, index: number) => boolean;
+
+  // Observable that triggers re-filtering when it changes (e.g. search text).
+  filterTrigger?: Observable<unknown>;
 
   // Allows to prevent updates of the list. This option is to be used when skipFirst option is used
   // and it is useful to prevent the list to update during changes that only affect the skipped
@@ -71,6 +78,9 @@ export class VisibleFieldsConfig extends Disposable {
   });
 
   private _collapseHiddenFields = Observable.create(this, false);
+
+  private _visibleFilter = Observable.create(this, "");
+  private _hiddenFilter = Observable.create(this, "");
 
   /**
    * Set if and only if the corresponding selection is empty, ie: respectively
@@ -114,7 +124,7 @@ export class VisibleFieldsConfig extends Disposable {
   public buildVisibleFieldsConfigHelper(options: DraggableFieldsOption) {
     let fields = this._section.viewFields.peek();
 
-    if (options.skipFirst || options.filterFunc) {
+    if (options.skipFirst || options.filterFunc || options.filterTrigger) {
       const skipFirst = options.skipFirst || Observable.create(this, -1);
       const filterFunc = options.filterFunc || (() => true);
 
@@ -136,6 +146,9 @@ export class VisibleFieldsConfig extends Disposable {
       this.autoDispose(subscribe(skipFirst, update));
       if (options.freeze) {
         this.autoDispose(subscribe(options.freeze, update));
+      }
+      if (options.filterTrigger) {
+        this.autoDispose(subscribe(options.filterTrigger, update));
       }
       fields = newArray;
     }
@@ -170,8 +183,9 @@ export class VisibleFieldsConfig extends Disposable {
       hiddenFields: DraggableFieldsOption,
     }): [HTMLElement, HTMLElement] {
     const fieldsDraggable = this.buildVisibleFieldsConfigHelper(options.visibleFields);
+    const hiddenFields = this._buildFilteredHiddenFields(options.hiddenFields);
     const hiddenFieldsDraggable = kf.draggableList(
-      this._hiddenFields,
+      hiddenFields,
       options.hiddenFields.itemCreateFunc,
       {
         itemClass: cssDragRow.className,
@@ -200,6 +214,8 @@ export class VisibleFieldsConfig extends Disposable {
     const [fieldsDraggable, hiddenFieldsDraggable] = this.buildSectionFieldsConfigHelper({
       visibleFields: {
         itemCreateFunc: field => this._buildVisibleFieldItem(field as ViewFieldRec),
+        filterFunc: field => fieldMatchesFilter(field, this._visibleFilter.get()),
+        filterTrigger: this._visibleFilter,
         draggableOptions: {
           removeButton: false,
           drag_indicator: cssDragger,
@@ -207,6 +223,8 @@ export class VisibleFieldsConfig extends Disposable {
       },
       hiddenFields: {
         itemCreateFunc: field => this._buildHiddenFieldItem(field as ColumnRec),
+        filterFunc: field => fieldMatchesFilter(field, this._hiddenFilter.get()),
+        filterTrigger: this._hiddenFilter,
         draggableOptions: {
           removeButton: false,
           drag_indicator: cssDragger,
@@ -233,6 +251,11 @@ export class VisibleFieldsConfig extends Disposable {
               )
             ),
           ),
+        ),
+        this._buildFilterInput(
+          this._visibleFilter,
+          use => use(use(this._section.viewFields).getObservable()).length,
+          "visible",
         ),
         cssFieldsDraggable(
           cssFieldsDraggable.cls("-disabled", this._disabled),
@@ -290,6 +313,11 @@ export class VisibleFieldsConfig extends Disposable {
           "div",
           dom.hide(this._collapseHiddenFields),
           { id: "hidden-fields-list" },
+          this._buildFilterInput(
+            this._hiddenFilter,
+            use => use(this._hiddenFields.getObservable()).length,
+            "hidden",
+          ),
           cssFieldsDraggable(
             cssFieldsDraggable.cls("-disabled", this._disabled),
             dom.update(
@@ -345,24 +373,28 @@ export class VisibleFieldsConfig extends Disposable {
 
   // Set all checkboxes for the visible fields.
   private _setVisibleCheckboxes(visibleFieldsDraggable: Element, checked: boolean) {
+    const fields = this._section.viewFields.peek().peek()
+      .filter(field => fieldMatchesFilter(field, this._visibleFilter.get()));
     this._setCheckboxesHelper(
       visibleFieldsDraggable,
-      this._section.viewFields.peek().peek(),
+      fields,
       this._visibleFieldsSelection,
       checked,
     );
-    this._showVisibleBatchButtons.set(checked);
+    this._showVisibleBatchButtons.set(checked && fields.length > 0);
   }
 
   // Set all checkboxes for the hidden fields.
   private _setHiddenCheckboxes(hiddenFieldsDraggable: Element, checked: boolean) {
+    const fields = this._hiddenFields.peek()
+      .filter(field => fieldMatchesFilter(field, this._hiddenFilter.get()));
     this._setCheckboxesHelper(
       hiddenFieldsDraggable,
-      this._hiddenFields.peek(),
+      fields,
       this._hiddenFieldsSelection,
       checked,
     );
-    this._showHiddenBatchButtons.set(checked);
+    this._showHiddenBatchButtons.set(checked && fields.length > 0);
   }
 
   // A helper to set all checkboxes. Takes care of setting all checkboxes in the dom and updating
@@ -377,6 +409,68 @@ export class VisibleFieldsConfig extends Disposable {
       // add all ids to the selection
       fields.forEach(field => selection.add(field.id.peek()));
     }
+  }
+
+  private _buildFilteredHiddenFields(options: DraggableFieldsOption): KoArray<ColumnRec> {
+    if (!options.filterFunc && !options.filterTrigger) {
+      return this._hiddenFields;
+    }
+
+    const filterFunc = options.filterFunc || (() => true);
+    const newArray = new KoArray<ColumnRec>();
+
+    const update = () => {
+      const newValues = this._hiddenFields.peek().filter(filterFunc);
+      if (isEqual(newArray.all(), newValues)) { return; }
+      newArray.assign(newValues);
+    };
+    update();
+    this.autoDispose(this._hiddenFields.subscribe(update));
+    if (options.filterTrigger) {
+      this.autoDispose(subscribe(options.filterTrigger, update));
+    }
+    return newArray;
+  }
+
+  private _buildFilterInput(
+    filterObs: Observable<string>,
+    getCount: (use: UseCB) => number,
+    state: "visible" | "hidden",
+  ) {
+    // Show when the unfiltered list is long enough, or when a filter is already active so the
+    // user can clear it after the list shrinks.
+    return dom.maybe(
+      use => getCount(use) > FILTER_INPUT_MIN_COUNT || Boolean(use(filterObs)),
+      () => {
+        let filterInput: HTMLInputElement;
+        return cssFilterRow(
+          cssFilterIcon("Search"),
+          filterInput = cssFilterInput(
+            {
+              "type": "search",
+              "placeholder": t("Filter columns"),
+              "aria-label": state === "visible" ? t("Filter visible columns") : t("Filter hidden columns"),
+            },
+            dom.prop("value", filterObs),
+            dom.on("input", (_ev, elem) => filterObs.set(elem.value)),
+            testId(`${state}-filter`),
+          ),
+          dom.maybe(filterObs, () => cssClearFilterButton(
+            icon("CrossSmall"),
+            {
+              "aria-label": state === "visible" ?
+                t("Clear visible columns filter") :
+                t("Clear hidden columns filter"),
+            },
+            testId(`${state}-filter-clear`),
+            dom.on("click", () => {
+              filterObs.set("");
+              filterInput.focus();
+            }),
+          )),
+        );
+      },
+    );
   }
 
   private _buildHiddenFieldItem(column: IField) {
@@ -455,6 +549,12 @@ export class VisibleFieldsConfig extends Disposable {
     const action = ["BulkAddRecord", rowIds, colInfo];
     await this._gristDoc.docModel.viewFields.sendTableAction(action);
   }
+}
+
+function fieldMatchesFilter(field: IField, filter: string): boolean {
+  const query = normalizeText(filter);
+  if (!query) { return true; }
+  return normalizeText(field.label.peek()).includes(query);
 }
 
 function getFieldNewPosition(fields: KoArray<ViewFieldRec>, item: IField,
@@ -579,4 +679,48 @@ const cssFieldsDraggable = styled("div", `
 const cssHeaderButton = styled(unstyledButton, `
   display: flex;
   align-items: center;
+`);
+
+const cssFilterRow = styled("div", `
+  display: flex;
+  align-items: center;
+  margin: 0 16px 8px 16px;
+  padding: 4px 8px;
+  border: 1px solid ${theme.inputBorder};
+  border-radius: 3px;
+  background-color: ${theme.inputBg};
+`);
+
+const cssFilterIcon = styled(icon, `
+  flex-shrink: 0;
+  margin-right: 6px;
+  --icon-color: ${theme.lightText};
+`);
+
+const cssFilterInput = styled("input", `
+  flex: 1 1 auto;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background-color: transparent;
+  color: ${theme.inputFg};
+  font-size: ${vars.mediumFontSize};
+  padding: 0;
+
+  &::placeholder {
+    color: ${theme.inputPlaceholderFg};
+  }
+
+  /* Hide the native clear button; we render our own. */
+  &::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+  }
+`);
+
+const cssClearFilterButton = styled(unstyledButton, `
+  flex-shrink: 0;
+  margin-left: 4px;
+  line-height: 1;
+  --icon-color: ${theme.lightText};
+  cursor: pointer;
 `);

--- a/static/locales/en.client.json
+++ b/static/locales/en.client.json
@@ -1142,7 +1142,12 @@
         "Hidden {{label}}": "Hidden {{label}}",
         "Show {{label}}": "Show {{label}}",
         "Hide {{label}} (batch mode)": "Hide {{label}} (batch mode)",
-        "Show {{label}} (batch mode)": "Show {{label}} (batch mode)"
+        "Show {{label}} (batch mode)": "Show {{label}} (batch mode)",
+        "Clear hidden columns filter": "Clear hidden columns filter",
+        "Clear visible columns filter": "Clear visible columns filter",
+        "Filter columns": "Filter columns",
+        "Filter hidden columns": "Filter hidden columns",
+        "Filter visible columns": "Filter visible columns"
     },
     "WidgetTitle": {
         "Cancel": "Cancel",
@@ -3458,5 +3463,11 @@
         "You've asked for this.": "You've asked for this.",
         "{{count}} people have asked for this._one": "{{count}} people have asked for this.",
         "{{count}} people have asked for this._other": "{{count}} people have asked for this."
+    },
+    "confirmLeaveOnNavigation": {
+        "Exit without saving": "Exit without saving",
+        "Stay on the page": "Stay on the page",
+        "Unsaved changes": "Unsaved changes",
+        "You have unsaved changes. If you leave now, your changes will be lost.": "You have unsaved changes. If you leave now, your changes will be lost."
     }
 }

--- a/static/locales/fr.client.json
+++ b/static/locales/fr.client.json
@@ -1093,7 +1093,12 @@
         "Show {{label}}": "Montrer {{label}}",
         "Hidden {{label}}": "{{label}} caché",
         "Hide {{label}} (batch mode)": "Masquer {{label}} (mode groupé)",
-        "Show {{label}} (batch mode)": "Montrer {{label}} (mode groupé)"
+        "Show {{label}} (batch mode)": "Montrer {{label}} (mode groupé)",
+        "Clear hidden columns filter": "Réinitialiser le filtre des colonnes cachées",
+        "Clear visible columns filter": "Réinitialiser le filtre des colonnes visibles",
+        "Filter columns": "Filtrer les colonnes",
+        "Filter hidden columns": "Filtrer les colonnes cachées",
+        "Filter visible columns": "Filtrer les colonnes visibles"
     },
     "WidgetTitle": {
         "Override widget title": "Renommer la vue",

--- a/test/nbrowser/VisibleFieldsConfig.ts
+++ b/test/nbrowser/VisibleFieldsConfig.ts
@@ -1,7 +1,7 @@
 import * as gu from "test/nbrowser/gristUtils";
 import { server, setupTestSuite } from "test/nbrowser/testUtils";
 
-import { addToRepl, assert, driver, stackWrapFunc } from "mocha-webdriver";
+import { addToRepl, assert, driver, Key, stackWrapFunc } from "mocha-webdriver";
 
 describe("VisibleFieldsConfig", function() {
   this.timeout(20000);
@@ -380,4 +380,67 @@ describe("VisibleFieldsConfig", function() {
       await gu.undo();
     });
   }
+
+  describe("column filter", function() {
+    async function setFilter(state: "visible" | "hidden", value: string) {
+      const input = await driver.find(`.test-vfc-${state}-filter`);
+      await input.click();
+      await gu.selectAll();
+      await driver.sendKeys(value || Key.DELETE);
+    }
+
+    before(async function() {
+      // After prior tests, columns may all be hidden; show them first.
+      if (await driver.find(".test-vfc-hidden-fields-select-all").isPresent()) {
+        await driver.find(".test-vfc-hidden-fields-select-all").click();
+        await driver.find(".test-vfc-hidden-batch-buttons").findContent("button", /Show/).click();
+        await gu.waitForServer();
+      }
+
+      // Add enough columns for the filter input to appear (> 10).
+      for (const name of ["D", "E", "F", "G", "H", "I", "J", "K"]) {
+        await gu.addColumn(name);
+      }
+    });
+
+    it("should show a filter input above visible columns when there are more than 10", async function() {
+      assert.isTrue(await driver.find(".test-vfc-visible-filter").isPresent());
+      assert.isFalse(await driver.find(".test-vfc-hidden-filter").isPresent());
+    });
+
+    it("should filter visible columns by name", async function() {
+      await setFilter("visible", "A");
+      assert.deepEqual(
+        await driver.findAll(".test-vfc-visible-fields .kf_draggable", e => e.getText()),
+        ["A"],
+      );
+
+      await setFilter("visible", "K");
+      assert.deepEqual(
+        await driver.findAll(".test-vfc-visible-fields .kf_draggable", e => e.getText()),
+        ["K"],
+      );
+
+      // Clear filter to restore full list.
+      await setFilter("visible", "");
+      assert.lengthOf(
+        await driver.findAll(".test-vfc-visible-fields .kf_draggable"),
+        11,
+      );
+    });
+
+    it("should show a filter input above hidden columns when there are more than 10", async function() {
+      await driver.find(".test-vfc-visible-fields-select-all").click();
+      await driver.find(".test-vfc-visible-batch-buttons").findContent("button", /Hide/).click();
+      await gu.waitForServer();
+
+      assert.isTrue(await driver.find(".test-vfc-hidden-filter").isPresent());
+
+      await setFilter("hidden", "B");
+      assert.deepEqual(
+        await driver.findAll(".test-vfc-hidden-fields .kf_draggable", e => e.getText()),
+        ["B"],
+      );
+    });
+  });
 });


### PR DESCRIPTION
This adds an input above the visible/hidden columns list in the right panel, when there are a lot of columns shown.

This helps users quickly finding the columns they are interested in.

## Context

When I have a table with lots of columns, it can get annoying to make them visible or hidden through the columns lists in the right panel.

## Proposed solution

This adds an input to filter the visible columns or hidden columns list, if there are more than 10 columns listed.

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
