### PR TITLE
Render chart date axes in the column's timezone

### DIFF
--- a/app/client/components/ChartView.ts
+++ b/app/client/components/ChartView.ts
@@ -21,7 +21,7 @@ import { icon } from "app/client/ui2018/icons";
 import { IOptionFull, linkSelect, menu, menuItem, menuText, select } from "app/client/ui2018/menus";
 import { gristThemeObs } from "app/client/ui2018/theme";
 import { unstyledButton } from "app/client/ui2018/unstyled";
-import { nativeCompare, unwrap } from "app/common/gutil";
+import { nativeCompare, removePrefix, unwrap } from "app/common/gutil";
 import { Sort } from "app/common/SortSpec";
 import { BaseFormatter } from "app/common/ValueFormatter";
 import { decodeObject } from "app/plugin/objtypes";
@@ -36,6 +36,7 @@ import isNumber from "lodash/isNumber";
 import merge from "lodash/merge";
 import sum from "lodash/sum";
 import union from "lodash/union";
+import moment from "moment-timezone";
 
 import type { Annotations, Config, Datum, ErrorBar, Layout, LayoutAxis, Margin,
   PlotData as PlotlyPlotData } from "plotly.js";
@@ -134,16 +135,18 @@ interface DataOptions extends Data {
 // Convert a list of Series into a set of Plotly traces.
 type ChartFunc = (series: Series[], options: ChartOptions, dataOptions?: DataOptions) => PlotData;
 
-// Helper for converting numeric Date/DateTime values (seconds since Epoch) to JS Date objects for
-// use with plotly.
-function dateGetter(getter: RowPropGetter): RowPropGetter {
+// Helper for converting numeric Date/DateTime values (seconds since Epoch) to date strings for
+// use with plotly, rendered in the given timezone.
+function dateGetter(getter: RowPropGetter, timezone: string): RowPropGetter {
   return (r: number) => {
     // 0's will turn into nulls, and non-numbers will turn into NaNs and then nulls. This prevents
     // Plotly from including 1970-01-01 onto X axis, which usually makes the plot useless.
     const val = (getter(r) as number) * 1000;
     // Plotly recommends using strings for dates rather than Date objects or timestamps. They are
     // interpreted more consistently. See https://github.com/plotly/plotly.js/issues/1532#issuecomment-290420534.
-    return val ? new Date(val).toISOString() : null;
+    // Plotly discards the UTC offset and plots the wall clock it is given, so the string must
+    // spell out the time as the user sees it elsewhere in the document.
+    return val ? moment.tz(val, timezone).toISOString(true) : null;
   };
 }
 
@@ -240,7 +243,9 @@ export class ChartView extends BaseView {
         const colId: string = field.displayColModel.peek().colId.peek();
         const getter = this.tableModel.tableData.getRowPropFunc(colId) as RowPropGetter;
         const pureType = field.displayColModel().pureType();
-        const fullGetter = (pureType === "Date" || pureType === "DateTime") ? dateGetter(getter) : getter;
+        // Date values are always UTC-based; a DateTime column carries its timezone in its type.
+        const timezone = removePrefix(field.displayColModel().type(), "DateTime:") || "UTC";
+        const fullGetter = (pureType === "Date" || pureType === "DateTime") ? dateGetter(getter, timezone) : getter;
         return {
           pureType,
           label: field.label(),

--- a/test/nbrowser/ChartView1.ts
+++ b/test/nbrowser/ChartView1.ts
@@ -596,15 +596,15 @@ describe("ChartView1", function() {
     assert.deepEqual(data[0].type, "scatter");
     assert.deepEqual(data[0].name, "largeValue");
     assert.deepEqual(data[0].x, [
-      "2018-01-15T00:00:00.000Z", "2018-01-31T00:00:00.000Z", "2018-02-14T00:00:00.000Z",
-      "2018-03-04T00:00:00.000Z", "2018-03-14T00:00:00.000Z", "2018-03-26T00:00:00.000Z",
+      "2018-01-15T00:00:00.000+00:00", "2018-01-31T00:00:00.000+00:00", "2018-02-14T00:00:00.000+00:00",
+      "2018-03-04T00:00:00.000+00:00", "2018-03-14T00:00:00.000+00:00", "2018-03-26T00:00:00.000+00:00",
     ]);
     assert.deepEqual(data[0].y, [22, 33, 11, 44, 22, 55]);
     assert.deepEqual(data[1].type, "scatter");
     assert.deepEqual(data[1].name, "value");
     assert.deepEqual(data[0].x, [
-      "2018-01-15T00:00:00.000Z", "2018-01-31T00:00:00.000Z", "2018-02-14T00:00:00.000Z",
-      "2018-03-04T00:00:00.000Z", "2018-03-14T00:00:00.000Z", "2018-03-26T00:00:00.000Z",
+      "2018-01-15T00:00:00.000+00:00", "2018-01-31T00:00:00.000+00:00", "2018-02-14T00:00:00.000+00:00",
+      "2018-03-04T00:00:00.000+00:00", "2018-03-14T00:00:00.000+00:00", "2018-03-26T00:00:00.000+00:00",
     ]);
     assert.deepEqual(data[1].y, [16, 2, 3, 4, 5, 6]);
   });
@@ -847,5 +847,22 @@ describe("ChartView1", function() {
     await checkAxisConfig({ xaxis: "Group", yaxis: ["Y1", "Y2"] });
     await gu.checkForErrors();
     await gu.undo(2);
+  });
+
+  it("should render datetimes on X-axis in the column's timezone", async function() {
+    // Both values are 09:30 New York time: the first in winter (UTC-5), the second in summer
+    // (UTC-4). Plotly ignores timezone offsets, so what it renders is the wall clock we give it.
+    await api.applyUserActions(doc.id, [
+      ["AddTable", "DateTimes", [
+        { id: "When", type: "DateTime:America/New_York" },
+        { id: "Value", type: "Numeric" },
+      ]],
+      ["BulkAddRecord", "DateTimes", [null, null], { When: [1516026600, 1531661400], Value: [1, 2] }],
+    ]);
+    await gu.addNewPage(/Chart/, /DateTimes/);
+
+    const { data } = await getChartData();
+    assert.deepEqual(data[0].x, ["2018-01-15T09:30:00.000-05:00", "2018-07-15T09:30:00.000-04:00"]);
+    assert.deepEqual(data[0].y, [1, 2]);
   });
 });


### PR DESCRIPTION
## Context

ChartView was passing date.toISOString() to plotly, i.e. the UTC time, and plotly was rendering them as UTC, making DateTime columns in any non-UTC timezone look wrong on the chart.

## Proposed solution

Instead of `Date.prototype.toISOString()`, format DateTime values with `moment` in the column's timezone. Use the `keepOffset=true` option to keep time in the right timezone and the offset (which plotly discards). Date columns end up unaffected, since they are always interpreted as UTC timestamps.

## Related issues

Fixes #2558

## Has this been tested?

- [x] 👍 yes, I added tests to the test suite
- [ ] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->
