### PR TITLE
Conditional styles formula input: make it detachable

### DIFF
--- a/app/client/ui/RightPanel.ts
+++ b/app/client/ui/RightPanel.ts
@@ -553,7 +553,7 @@ export class RightPanel extends Disposable {
           cssGroupLabel(t("Row style"), { id: "row-style-label" }),
           dom.create(rowHeightConfigTable, activeSection.optionsObj),
           domAsync(imports.loadViewPane().then(ViewPane =>
-            dom.create(ViewPane.ConditionalStyle, t("Row style"), activeSection, this._gristDoc),
+            dom.create(ViewPane.ConditionalStyle, t("Row style"), activeSection, this._gristDoc, "row"),
           )),
         );
       }),

--- a/app/client/widgets/CellStyle.ts
+++ b/app/client/widgets/CellStyle.ts
@@ -135,6 +135,7 @@ export class CellStyle extends Disposable {
         t("Cell style"),
         this._field,
         this._gristDoc,
+        "column",
         fromKo(this._field.config.multiselect),
       ),
     ];

--- a/app/client/widgets/ConditionalStyle.ts
+++ b/app/client/widgets/ConditionalStyle.ts
@@ -1,7 +1,7 @@
 import { GristDoc } from "app/client/components/GristDoc";
 import * as kf from "app/client/lib/koForm";
 import { makeT } from "app/client/lib/localization";
-import { ColumnRec } from "app/client/models/DocModel";
+import { ColumnRec, ViewFieldRec } from "app/client/models/DocModel";
 import { KoSaveableObservable } from "app/client/models/modelUtil";
 import { RuleOwner } from "app/client/models/RuleOwner";
 import { buildHighlightedCode } from "app/client/ui/CodeHighlight";
@@ -43,6 +43,7 @@ export class ConditionalStyle extends Disposable {
     private _label: string,
     private _ruleOwner: RuleOwner,
     private _gristDoc: GristDoc,
+    private _scope: "row" | "column",
     private _disabled?: Observable<boolean>,
   ) {
     super();
@@ -90,7 +91,7 @@ export class ConditionalStyle extends Disposable {
             dom.on("click", () => this._ruleOwner.addEmptyRule()),
             dom.prop("disabled", this._disabled),
           ),
-          this._label === t("Row Style") ? "addRowConditionalStyle" : "addColumnConditionalStyle",
+          this._scope === "row" ? "addRowConditionalStyle" : "addColumnConditionalStyle",
         ),
         dom.hide(use => use(this._ruleOwner.hasRules)),
       ),
@@ -280,6 +281,8 @@ export class ConditionalStyle extends Disposable {
       },
     };
 
+    const actualColId = this._scope === "column" ? (this._ruleOwner as ViewFieldRec).colId.peek() : undefined;
+
     // Don't save on focus loss while the floating editor is open (focus moves during detach).
     const formulaEditor = openFormulaEditor({
       gristDoc: this._gristDoc,
@@ -289,13 +292,20 @@ export class ConditionalStyle extends Disposable {
       refElem,
       setupCleanup: (...args) => setupEditorCleanup(...args, () => floatingExtension.active.get()),
       canDetach: true,
+      assistantInstructions: this._scope === "column" ?
+        "It's used as a formula that will be evaluated as an \"if\" condition to decide " +
+        `whether to apply later user-specified formatting style on cells inside the column with ID "${actualColId}". ` :
+        "It's used as a formula that will be evaluated as an \"if\" condition to decide " +
+        "whether to apply later user-specified formatting style on entire rows. ",
     });
 
     const floatingExtension = FloatingEditor.create(formulaEditor, floatController, {
       gristDoc: this._gristDoc,
       refElem,
       placement: "overlapping",
-      title: `${tableId} · ${t("Conditional Style")}`,
+      title: this._scope === "column" ?
+        `${tableId}.${actualColId} - ${t("Conditional Style")}` :
+        `${tableId} - ${t("Conditional Style")}`,
     });
 
     // Add editor to document holder - this will prevent multiple formula editor instances.

--- a/app/client/widgets/ConditionalStyle.ts
+++ b/app/client/widgets/ConditionalStyle.ts
@@ -13,13 +13,14 @@ import { theme, vars } from "app/client/ui2018/cssVars";
 import { cssDragger } from "app/client/ui2018/draggableList";
 import { icon } from "app/client/ui2018/icons";
 import { setupEditorCleanup } from "app/client/widgets/FieldEditor";
+import { FloatingEditor } from "app/client/widgets/FloatingEditor";
 import { cssError, openFormulaEditor } from "app/client/widgets/FormulaEditor";
 import { isRaisedException, isValidRuleValue } from "app/common/gristTypes";
 import { Style } from "app/common/Styles";
 import { GristObjCode, RowRecord } from "app/plugin/GristData";
 import { decodeObject } from "app/plugin/objtypes";
 
-import { Computed, Disposable, dom, DomContents, makeTestId, Observable, styled } from "grainjs";
+import { Computed, Disposable, dom, DomContents, domDispose, makeTestId, Observable, styled } from "grainjs";
 import debounce from "lodash/debounce";
 
 const testId = makeTestId("test-widget-style-");
@@ -244,22 +245,61 @@ export class ConditionalStyle extends Disposable {
       dom.cls(cssFieldFormula.className),
       dom.cls(cssErrorBorder.className, hasError),
       { tabIndex: "-1" },
-      dom.on("focus", (_, refElem) => {
-        const section = this._gristDoc.viewModel.activeSection();
-        const vsi = section.viewInstance();
-        const editorHolder = openFormulaEditor({
-          gristDoc: this._gristDoc,
-          editingFormula: section.editingFormula,
-          column,
-          editRow: vsi?.moveEditRowToCursor(),
-          refElem,
-          setupCleanup: setupEditorCleanup,
-          canDetach: false,
-        });
-        // Add editor to document holder - this will prevent multiple formula editor instances.
-        this._gristDoc.fieldEditorHolder.autoDispose(editorHolder);
-      }),
+      dom.on("focus", (_, refElem) => this._openRuleFormulaEditor(column, refElem)),
     );
+  }
+
+  private _openRuleFormulaEditor(column: ColumnRec, refElem: Element) {
+    const section = this._gristDoc.viewModel.activeSection();
+    const vsi = section.viewInstance();
+    const editRow = vsi?.moveEditRowToCursor();
+    const position = this._gristDoc.cursorPosition.get();
+    const tableId = column.table.peek().tableId.peek();
+
+    // Controller that moves the editor DOM between the inline placement and the floating popup.
+    const floatController = {
+      attach: async (content: HTMLElement) => {
+        if (refElem.isConnected) {
+          formulaEditor.attach(refElem);
+        } else {
+          formulaEditor.dispose();
+          domDispose(content);
+          if (position) {
+            await this._gristDoc.recursiveMoveToCursorPos(position, true);
+          }
+        }
+      },
+      detach() {
+        return formulaEditor.detach();
+      },
+      autoDispose(el: Disposable) {
+        return formulaEditor.autoDispose(el);
+      },
+      dispose() {
+        formulaEditor.dispose();
+      },
+    };
+
+    // Don't save on focus loss while the floating editor is open (focus moves during detach).
+    const formulaEditor = openFormulaEditor({
+      gristDoc: this._gristDoc,
+      editingFormula: section.editingFormula,
+      column,
+      editRow,
+      refElem,
+      setupCleanup: (...args) => setupEditorCleanup(...args, () => floatingExtension.active.get()),
+      canDetach: true,
+    });
+
+    const floatingExtension = FloatingEditor.create(formulaEditor, floatController, {
+      gristDoc: this._gristDoc,
+      refElem,
+      placement: "overlapping",
+      title: `${tableId} · ${t("Conditional Style")}`,
+    });
+
+    // Add editor to document holder - this will prevent multiple formula editor instances.
+    this._gristDoc.fieldEditorHolder.autoDispose(formulaEditor);
   }
 }
 

--- a/app/client/widgets/FieldBuilder.ts
+++ b/app/client/widgets/FieldBuilder.ts
@@ -5,7 +5,6 @@ import { FormulaTransform } from "app/client/components/FormulaTransform";
 import { GristDoc } from "app/client/components/GristDoc";
 import { addColTypeSuffix, guessWidgetOptionsSync, inferColTypeSuffix } from "app/client/components/TypeConversion";
 import { TypeTransform } from "app/client/components/TypeTransform";
-import { UnsavedChange } from "app/client/components/UnsavedChanges";
 import dom from "app/client/lib/dom";
 import { KoArray } from "app/client/lib/koArray";
 import * as kd from "app/client/lib/koDom";
@@ -25,7 +24,7 @@ import { IOptionFull, menu, select } from "app/client/ui2018/menus";
 import { DiffBox } from "app/client/widgets/DiffBox";
 import { CommentPopup, DiscussionModelImpl } from "app/client/widgets/DiscussionEditor";
 import { buildErrorDom } from "app/client/widgets/ErrorDom";
-import { FieldEditor, saveWithoutEditor } from "app/client/widgets/FieldEditor";
+import { FieldEditor, saveWithoutEditor, setupEditorCleanup } from "app/client/widgets/FieldEditor";
 import { FloatingEditor } from "app/client/widgets/FloatingEditor";
 import { openFormulaEditor } from "app/client/widgets/FormulaEditor";
 import { CommentWithMentions } from "app/client/widgets/MentionTextBox";
@@ -923,21 +922,6 @@ export class FieldBuilder extends Disposable {
       },
     };
 
-    // Create a custom cleanup method, that won't destroy us when we loose focus while being detached.
-    function setupEditorCleanup(
-      owner: MultiHolder, gristDoc: GristDoc,
-      editingFormula: ko.Computed<boolean>, _saveEdit: () => Promise<unknown>,
-    ) {
-      // Just override the behavior on focus lost.
-      const saveOnFocus = () => floatingExtension.active.get() ? void 0 : _saveEdit().catch(reportError);
-      UnsavedChange.create(owner, async () => { await saveOnFocus(); });
-      gristDoc.app.on("clipboard_focus", saveOnFocus);
-      owner.onDispose(() => {
-        gristDoc.app.off("clipboard_focus", saveOnFocus);
-        editingFormula(false);
-      });
-    }
-
     // Get the field model from metatables, as the one provided by the caller might be some floating one, that
     // will change when user navigates around.
     const field = this.gristDoc.docModel.viewFields.getRowModel(this.field.getRowId());
@@ -947,7 +931,7 @@ export class FieldBuilder extends Disposable {
       gristDoc: this.gristDoc,
       field,
       editingFormula: this.field.editingFormula,
-      setupCleanup: setupEditorCleanup,
+      setupCleanup: (...args) => setupEditorCleanup(...args, () => floatingExtension.active.get()),
       editRow,
       refElem,
       editValue,

--- a/app/client/widgets/FieldEditor.ts
+++ b/app/client/widgets/FieldEditor.ts
@@ -483,9 +483,16 @@ function setupReadonlyEditorCleanup(
  * - Arrange for UnsavedChange protection against leaving the page with unsaved changes.
  */
 export function setupEditorCleanup(
-  owner: MultiHolder, gristDoc: GristDoc, editingFormula: ko.Computed<boolean>, _saveEdit: () => Promise<unknown>,
+  owner: MultiHolder,
+  gristDoc: GristDoc,
+  editingFormula: ko.Computed<boolean>,
+  _saveEdit: () => Promise<unknown>,
+  shouldSkipSaveOnFocus?: () => boolean,
 ) {
-  const saveEdit = () => _saveEdit().catch(reportError);
+  const saveEdit = () => {
+    if (shouldSkipSaveOnFocus?.()) { return; }
+    return _saveEdit().catch(reportError);
+  };
 
   // Whenever focus returns to the Clipboard component, close the editor by saving the value.
   gristDoc.app.on("clipboard_focus", saveEdit);

--- a/app/client/widgets/FloatingEditor.ts
+++ b/app/client/widgets/FloatingEditor.ts
@@ -42,6 +42,10 @@ export interface FloatingEditorOptions {
    * Defaults to "fixed".
    */
   placement?: "overlapping" | "adjacent" | "fixed";
+  /**
+   * Optional popup title. When omitted, uses the cursor field as `table.fieldLabel`.
+   */
+  title?: string | (() => string);
 }
 
 export class FloatingEditor extends Disposable {
@@ -72,12 +76,7 @@ export class FloatingEditor extends Disposable {
       // we are kind of simulating always focused editor (even if it is not in the dom for a brief moment).
       FocusLayer.create(tempOwner, { defaultFocusElem: document.activeElement as any });
 
-      // Take some data from gristDoc to create a title.
-      const cursor = this._gristDoc.cursorPosition.get()!;
-      const vs = this._gristDoc.docModel.viewSections.getRowModel(cursor.sectionId!);
-      const table = vs.tableId.peek();
-      const field = vs.viewFields.peek().at(cursor.fieldIndex!)!;
-      const title = `${table}.${field.label.peek()}`;
+      const title = this._resolveTitle();
 
       let content: HTMLElement;
       // Now create the popup. It will be owned by the editor itself.
@@ -118,6 +117,19 @@ export class FloatingEditor extends Disposable {
       // Dispose the focus layer, we only needed it for the time when the dom was moved between parents.
       tempOwner.dispose();
     }
+  }
+
+  private _resolveTitle() {
+    if (typeof this._options.title === "function") {
+      return this._options.title();
+    }
+    if (this._options.title !== undefined) {
+      return this._options.title;
+    }
+    const cursor = this._gristDoc.cursorPosition.get()!;
+    const vs = this._gristDoc.docModel.viewSections.getRowModel(cursor.sectionId!);
+    const field = vs.viewFields.peek().at(cursor.fieldIndex!)!;
+    return `${vs.tableId.peek()}.${field.label.peek()}`;
   }
 
   private _getPopupPosition(): PopupPosition | undefined {

--- a/app/client/widgets/FormulaAssistant.ts
+++ b/app/client/widgets/FormulaAssistant.ts
@@ -6,6 +6,7 @@ import { movable } from "app/client/lib/popupUtils";
 import { logTelemetryEvent } from "app/client/lib/telemetry";
 import { ChatHistory } from "app/client/models/ChatHistory";
 import { ColumnRec, ViewFieldRec } from "app/client/models/DocModel";
+import { reportError } from "app/client/models/errors";
 import { urlState } from "app/client/models/gristUrlState";
 import { basicButton, primaryButton } from "app/client/ui2018/buttons";
 import { theme, vars } from "app/client/ui2018/cssVars";
@@ -90,13 +91,6 @@ export class FormulaAssistant extends Disposable {
   }) {
     super();
 
-    if (!this._options.field) {
-      // TODO: field is not passed only for rules (as there is no preview there available to the user yet)
-      // this should be implemented but it requires creating a helper column to helper column and we don't
-      // have infrastructure for that yet.
-      throw new Error("Formula assistant requires a field to be passed.");
-    }
-
     this._history = this._options.column.chatHistory.peek();
 
     this._chat = Assistant.create(this, {
@@ -122,30 +116,35 @@ export class FormulaAssistant extends Disposable {
     observer.observe(this._options.editor.getDom());
     this.onDispose(() => observer.disconnect());
 
-    // Start bundling all actions from this moment on and close the editor as soon,
-    // as user tries to do something different.
-    const bundleInfo = this._options.gristDoc.docData.startBundlingActions({
-      description: "Formula Editor",
-      prepare: () => this._preparePreview(),
-      finalize: () => this._cleanupPreview(),
-      shouldIncludeInBundle: (actions) => {
-        if (actions.length !== 1) { return false; }
+    if (this._options.field) {
+      // Start bundling all actions from this moment on and close the editor as soon,
+      // as user tries to do something different.
+      const bundleInfo = this._options.gristDoc.docData.startBundlingActions({
+        description: "Formula Editor",
+        prepare: () => this._preparePreview(),
+        finalize: () => this._cleanupPreview(),
+        shouldIncludeInBundle: (actions) => {
+          if (actions.length !== 1) { return false; }
 
-        const actionName = actions[0][0];
-        if (actionName === "ModifyColumn") {
-          const tableId = this._options.column.table.peek().tableId.peek();
-          return actions[0][1] === tableId &&
-            typeof actions[0][2] === "string" &&
-            [this._transformColId, this._options.column.id.peek()].includes(actions[0][2]);
-        } else if (actionName === "UpdateRecord") {
-          return actions[0][1] === "_grist_Tables_column" && actions[0][2] === this._transformColRef;
-        } else {
-          return false;
-        }
-      },
-    });
+          const actionName = actions[0][0];
+          if (actionName === "ModifyColumn") {
+            const tableId = this._options.column.table.peek().tableId.peek();
+            return actions[0][1] === tableId &&
+              typeof actions[0][2] === "string" &&
+              [this._transformColId, this._options.column.id.peek()].includes(actions[0][2]);
+          } else if (actionName === "UpdateRecord") {
+            return actions[0][1] === "_grist_Tables_column" && actions[0][2] === this._transformColRef;
+          } else {
+            return false;
+          }
+        },
+      });
 
-    this._triggerFinalize = bundleInfo.triggerFinalize;
+      this._triggerFinalize = bundleInfo.triggerFinalize;
+    } else {
+      this._triggerFinalize = () => { void this._finalizeWithoutPreview(); };
+    }
+
     this.onDispose(() => {
       if (this._hasExpandedOnce) {
         const suggestionApplied = this._chat.conversationSuggestedFormulas
@@ -179,9 +178,11 @@ export class FormulaAssistant extends Disposable {
         basicButton(t("Cancel"), dom.on("click", () => {
           this._cancel();
         }), testId("cancel-button")),
-        basicButton(t("Preview"), dom.on("click", async () => {
-          await this._preview();
-        }), testId("preview-button")),
+        this._options.field ? basicButton(
+          t("Preview"),
+          dom.on("click", async () => { await this._preview(); }),
+          testId("preview-button"),
+        ) : null,
         primaryButton(t("Save"), dom.on("click", () => {
           this._saveOrClose();
         }), testId("save-button")),
@@ -342,6 +343,11 @@ export class FormulaAssistant extends Disposable {
   }
 
   private async _preparePreview() {
+    const field = this._options.field;
+    if (!field) {
+      return;
+    }
+
     const docData = this._options.gristDoc.docData;
     const tableId = this._options.column.table.peek().tableId.peek();
 
@@ -351,23 +357,23 @@ export class FormulaAssistant extends Disposable {
       label: this._options.column.colId.peek(),
       isFormula: true,
       formula: this._options.column.formula.peek(),
-      widgetOptions: JSON.stringify(this._options.field?.widgetOptionsJson()),
+      widgetOptions: JSON.stringify(field.widgetOptionsJson()),
     }]);
 
     this._transformColRef = colRef;
     this._transformColId = colId;
 
-    const rules = this._options.field?.rulesList();
+    const rules = field.rulesList();
     if (rules) {
       await docData.sendAction(["UpdateRecord", "_grist_Tables_column", colRef, {
-        rules: this._options.field?.rulesList(),
+        rules: field.rulesList(),
       }]);
     }
 
-    this._options.field?.colRef(colRef); // Don't save, it is only in browser.
+    field.colRef(colRef); // Don't save, it is only in browser.
 
     // Update the transform column so that it points to the original column.
-    const transformColumn = this._options.field?.column.peek();
+    const transformColumn = field.column.peek();
     if (transformColumn) {
       transformColumn.isTransforming(true);
       this._options.column.isTransforming(true);
@@ -381,6 +387,7 @@ export class FormulaAssistant extends Disposable {
     const docData = this._options.gristDoc.docData;
     const tableId = this._options.column.table.peek().tableId.peek();
     const column = this._options.column;
+    const field = this._options.field;
     try {
       if (this._action === "save") {
         const formula = this._options.editor.getCellValue();
@@ -392,7 +399,7 @@ export class FormulaAssistant extends Disposable {
       }
       // Switch the column for the field, this isn't sending any actions, we are just restoring it to what it is
       // in database. But now the column has already correct data as it was already calculated.
-      this._options.field?.colRef(column.getRowId());
+      field?.colRef(column.getRowId());
 
       // Now trigger the action in our owner that should dispose us. The save
       // method will be no op if we saved anything.
@@ -413,8 +420,35 @@ export class FormulaAssistant extends Disposable {
       ]);
     } finally {
       // Repeat the change, in case of an error.
-      this._options.field?.colRef(column.getRowId());
+      field?.colRef(column.getRowId());
       column.isTransforming(false);
+    }
+  }
+
+  /**
+   * Save/cancel path used when there is no view field (e.g. conditional style rules).
+   * Skips the temporary transform column used for Preview.
+   */
+  private async _finalizeWithoutPreview() {
+    this._triggerFinalize = noop;
+    const docData = this._options.gristDoc.docData;
+    const tableId = this._options.column.table.peek().tableId.peek();
+    const column = this._options.column;
+    try {
+      if (this._action === "save") {
+        const formula = this._options.editor.getCellValue();
+        await docData.sendActions([
+          ["ModifyColumn", tableId, column.colId.peek(), { formula, isFormula: true }],
+        ]);
+        commands.allCommands.fieldEditSaveHere.run();
+      } else if (this._action === "cancel") {
+        commands.allCommands.fieldEditCancel.run();
+      } else if (this._action !== "close") {
+        throw new Error("Unexpected value for _action");
+      }
+      // "close" (e.g. collapsing the floating editor) leaves the draft editor open.
+    } catch (err) {
+      reportError(err);
     }
   }
 
@@ -520,7 +554,9 @@ export class FormulaAssistant extends Disposable {
   private async _applyFormula(formula: string) {
     this._options.editor.setFormula(formula);
     this._resizeEditor();
-    await this._preview();
+    if (this._options.field) {
+      await this._preview();
+    }
   }
 }
 

--- a/app/client/widgets/FormulaAssistant.ts
+++ b/app/client/widgets/FormulaAssistant.ts
@@ -87,7 +87,8 @@ export class FormulaAssistant extends Disposable {
     column: ColumnRec,
     field?: ViewFieldRec,
     gristDoc: GristDoc,
-    editor: FormulaEditor
+    editor: FormulaEditor,
+    specificInstructions?: string,
   }) {
     super();
 
@@ -548,6 +549,7 @@ export class FormulaAssistant extends Disposable {
       description: message,
       conversationId: this._chat.conversationId,
       state: this._history.get().state,
+      specificInstructions: this._options.specificInstructions,
     });
   }
 
@@ -567,14 +569,15 @@ async function askAI(grist: GristDoc, options: {
   column: ColumnRec,
   description: string,
   conversationId: string,
-  state?: AssistanceState
+  state?: AssistanceState,
+  specificInstructions?: string,
 }) {
-  const { column, description, conversationId, state } = options;
+  const { column, description, conversationId, state, specificInstructions } = options;
   const tableId = column.table.peek().tableId.peek();
   const colId = column.colId.peek();
   return await grist.docComm.getAssistance({
     conversationId,
-    context: { tableId, colId },
+    context: { tableId, colId, specificInstructions },
     text: description,
     state,
   });

--- a/app/client/widgets/FormulaEditor.ts
+++ b/app/client/widgets/FormulaEditor.ts
@@ -36,6 +36,7 @@ export interface IFormulaEditorOptions extends Options {
   column: ColumnRec;
   field?: ViewFieldRec;
   canDetach?: boolean;
+  assistantInstructions?: string;
 }
 
 /**
@@ -258,6 +259,7 @@ export class FormulaEditor extends NewBaseEditor {
           field: this.options.field,
           gristDoc: this.options.gristDoc,
           editor: this,
+          specificInstructions: this.options.assistantInstructions,
         });
       }),
     );
@@ -501,6 +503,7 @@ export function openFormulaEditor(options: {
   onSave?: (column: ColumnRec, formula: string) => Promise<void>,
   onCancel?: () => void,
   canDetach?: boolean,
+  assistantInstructions?: string,
   // Called after editor is created to set up editor cleanup (e.g. saving on click-away).
   setupCleanup: (
     owner: Disposable,
@@ -571,6 +574,7 @@ export function openFormulaEditor(options: {
     cssClass: "formula_editor_sidepane",
     readonly: false,
     canDetach: options.canDetach,
+    assistantInstructions: options.assistantInstructions,
   };
   const editor = FormulaEditor.create(null, editorOptions);
   editor.autoDispose(attachedHolder);

--- a/app/client/widgets/FormulaEditor.ts
+++ b/app/client/widgets/FormulaEditor.ts
@@ -514,8 +514,6 @@ export function openFormulaEditor(options: {
 
   if (options.field) {
     options.column = options.field.origCol();
-  } else if (options.canDetach) {
-    throw new Error("Field is required for detached editor");
   }
 
   // We can't rely on the field passed in, we need to create our own.

--- a/app/common/Assistance.ts
+++ b/app/common/Assistance.ts
@@ -59,6 +59,7 @@ export interface AssistanceContextV1 {
   colId: string;
   evaluateCurrentFormula?: boolean;
   rowId?: number;
+  specificInstructions?: string;
 }
 
 export interface AssistanceContextV2 {

--- a/app/server/lib/OpenAIAssistantV1.ts
+++ b/app/server/lib/OpenAIAssistantV1.ts
@@ -108,6 +108,7 @@ export class OpenAIAssistantV1 implements AssistantV1 {
       message += `${result.error ? "raises an exception" : "returns"}: ${
         result.result
       }`;
+      console.log("new message", message);
       newMessages.push({
         role: "system",
         content: message,
@@ -322,12 +323,14 @@ export class OpenAIAssistantV1 implements AssistantV1 {
     doc: AssistanceDoc,
     request: AssistanceRequestV1,
   ): AssistanceSchemaPromptGenerator {
+    console.log(request.context);
     return async options => ({
       role: "system",
       content:
         "You are a helpful assistant for a user of software called Grist. " +
         "Below are one or more fake Python classes representing the structure of the user's data. " +
         "The function at the end needs completing. " +
+        (request.context.specificInstructions ?? "") +
         "The user will probably give a description of what they want the function (a 'formula') to return. " +
         "If so, your response should include the function BODY as Python code in a markdown block. " +
         "Your response will be automatically concatenated to the code below, so you mustn't repeat any of it. " +


### PR DESCRIPTION
## Context

In the right panel, the formula input for column/row conditional styles can't be expanded to the "detach" mode. This makes writing some long formulas a bit difficult, and we can't use the legacy AI assistant if enabled on the instance.

## Proposed solution

Make the conditional style formula inputs detachable. The idea is to:

- have a detach mode that disables the preview feature in order to bypass the need for a specific field for the preview, allowing users to use a textarea-like input rendered above the UI,
- make the assistant take optional instructions, in order to prepare a prompt that knows that it is currently helping in writing a conditional style formula instead of a normal formula.

## Has this been tested?

<!-- Put an `x` in the box that applies: -->

- [ ] 👍 yes, I added tests to the test suite
- [x] 💭 no, because this PR is a draft and still needs work
- [ ] 🙅 no, because this is not relevant here
- [ ] 🙋 no, because I need help <!-- Detail how we can help you -->

## Screenshots / Screencasts

<!-- delete if not relevant -->
