### PR TITLE
Fix the fast-runner races in Pages, ChoiceList and DetailView

### DIFF
--- a/app/client/components/DetailView.ts
+++ b/app/client/components/DetailView.ts
@@ -8,6 +8,7 @@ import { GristDoc } from "app/client/components/GristDoc";
 import { renderAllRows } from "app/client/components/Printing";
 import RecordLayout from "app/client/components/RecordLayout";
 import { viewCommands } from "app/client/components/RegionFocusSwitcher";
+import { isEventOnLink } from "app/client/lib/domUtils";
 import kd from "app/client/lib/koDom";
 import koDomScrolly from "app/client/lib/koDomScrolly";
 import { makeT } from "app/client/lib/localization";
@@ -130,6 +131,9 @@ export default class DetailView extends BaseView {
 
     // Double-clicking on a field also starts editing the field.
     this.autoDispose(dom.onMatchElem(this.viewPane, ".g_record_detail_el", "dblclick", (event, elem) => {
+      // A cell click followed by a click on its link icon can arrive here as a double click.
+      if (isEventOnLink(event)) { return; }
+
       this.activateEditorAtCursor({
         event,
       });

--- a/app/client/components/GridView.ts
+++ b/app/client/components/GridView.ts
@@ -13,6 +13,7 @@ import { SelectionSummary } from "app/client/components/SelectionSummary";
 import viewCommon from "app/client/components/viewCommon";
 import { onDblClickMatchElem } from "app/client/lib/dblclick";
 import { testId as oldTestId } from "app/client/lib/dom";
+import { isEventOnLink } from "app/client/lib/domUtils";
 import { FocusLayer } from "app/client/lib/FocusLayer";
 import { KoArray } from "app/client/lib/koArray";
 import * as kd from "app/client/lib/koDom";
@@ -380,6 +381,9 @@ export default class GridView extends BaseView {
     // --------------------------------------------------
     // Set up DOM event handling.
     onDblClickMatchElem(this.scrollPane, ".field:not(.column_name)", (event) => {
+      // A cell click followed by a click on its link icon can arrive here as a double click.
+      if (isEventOnLink(event)) { return; }
+
       if (this.gridOptions?.onCellDblClick) {
         this.gridOptions.onCellDblClick(this.cursor.getCursorPos());
       } else {

--- a/app/client/components/duplicatePage.ts
+++ b/app/client/components/duplicatePage.ts
@@ -1,5 +1,6 @@
 import { duplicateWidgets } from "app/client/components/duplicateWidget";
 import { GristDoc } from "app/client/components/GristDoc";
+import { onceAttached } from "app/client/lib/domUtils";
 import { makeT } from "app/client/lib/localization";
 import { logTelemetryEvent } from "app/client/lib/telemetry";
 import { cssInput } from "app/client/ui/cssInput";
@@ -14,14 +15,15 @@ const t = makeT("duplicatePage");
 export async function buildDuplicatePageDialog(gristDoc: GristDoc, pageId: number) {
   const pagesTable = gristDoc.docModel.pages;
   const pageName = pagesTable.rowModels[pageId].view.peek().name.peek();
-  let inputEl: HTMLInputElement;
-  setTimeout(() => { inputEl.focus(); inputEl.select(); }, 100);
+  const inputEl = cssInput({ value: pageName + " (copy)" });
+  // The suggested name is meant to be typed over, so it has to arrive selected.
+  onceAttached(inputEl, () => { inputEl.focus(); inputEl.select(); });
 
   confirmModal("Duplicate page", "Save", () => duplicatePage(gristDoc, pageId, inputEl.value), {
     explanation: dom("div", [
       cssField(
         cssLabel("Name"),
-        inputEl = cssInput({ value: pageName + " (copy)" }),
+        inputEl,
       ),
       t("Note that this does not copy data, but creates another view of the same data."),
     ]),

--- a/app/client/lib/domUtils.ts
+++ b/app/client/lib/domUtils.ts
@@ -16,12 +16,34 @@ export function makeTestId(prefix: string) {
   };
 }
 
+/**
+ * Calls the callback once elem is in the document, or straight away if it already is.
+ *
+ * An element is built before its caller inserts it, and focus() does nothing to a detached one,
+ * so taking the focus has to wait. A timer is the wrong thing to wait on: its callback runs only
+ * between tasks, so a busy main thread holds it off however short the delay. This runs on the
+ * insertion itself, at the end of the task that does it, which nothing can push back.
+ */
+export function onceAttached(elem: Element, callback: () => void): void {
+  if (elem.isConnected) {
+    callback();
+    return;
+  }
+  const observer = new MutationObserver(() => {
+    if (!elem.isConnected) { return; }
+    observer.disconnect();
+    callback();
+  });
+  observer.observe(document, { childList: true, subtree: true });
+  dom.onDisposeElem(elem, () => observer.disconnect());
+}
+
 export function autoFocus() {
-  return (el: HTMLElement) => void setTimeout(() => el.focus(), 10);
+  return (el: HTMLElement) => onceAttached(el, () => el.focus());
 }
 
 export function autoSelect() {
-  return (el: HTMLElement) => void setTimeout(() => (el as any).select?.(), 10);
+  return (el: HTMLElement) => onceAttached(el, () => (el as any).select?.());
 }
 
 /**
@@ -155,4 +177,18 @@ export function attachMouseOverOnMove<T extends EventTarget>(elem: T, callback: 
   }
   reset();
   return { reset };
+}
+
+/**
+ * Whether a mouse event landed on a link.
+ *
+ * The event's own target is not enough for a double click. A double click made of two clicks on
+ * different elements is dispatched on the closest ancestor the two share, so selecting a cell and
+ * then clicking the link icon inside it reports the cell, not the link. What is under the pointer
+ * is the second click's element either way.
+ */
+export function isEventOnLink(event: Event): boolean {
+  if ((event.target as HTMLElement | null)?.closest("a")) { return true; }
+  const { clientX, clientY } = event as MouseEvent;
+  return Boolean(document.elementFromPoint(clientX, clientY)?.closest("a"));
 }

--- a/app/client/ui/ColumnFilterMenu.ts
+++ b/app/client/ui/ColumnFilterMenu.ts
@@ -305,11 +305,15 @@ export function columnFilterMenu(owner: IDisposableOwner, opts: IFilterMenuOptio
               cssCheckboxSquare(
                 { type: "checkbox" },
                 dom.on("change", (_ev, elem) => {
-                  if (elem.checked) {
-                    columnFilter.add(key);
-                  } else {
+                  // The listener above writes these boxes on a debounce, so just after All or
+                  // None they can still show the filter as it was. A click then toggles away
+                  // from a stale value and deletes what was meant to be added. Ask the filter.
+                  if (columnFilter.includes(key)) {
                     columnFilter.delete(key);
+                  } else {
+                    columnFilter.add(key);
                   }
+                  elem.checked = columnFilter.includes(key);
                 }),
                 (elem) => { elem.checked = columnFilter.includes(key); checkboxMap.set(key, elem); },
               ),

--- a/app/client/ui/PagePanels.ts
+++ b/app/client/ui/PagePanels.ts
@@ -35,7 +35,8 @@ const t = makeT("PagePanels");
 
 const AUTO_EXPAND_TIMEOUT_MS = 400;
 
-// delay must be greater than the time needed for transientInput to update focus (ie: 10ms);
+// Moving the focus arrives as a blur then a focus, in separate events. The delay keeps the
+// watcher from reading document.activeElement in the gap and deciding focus left the panel.
 const DELAY_BEFORE_TESTING_FOCUS_CHANGE_MS = 12;
 
 // data attributes added when panels are fully collapsed or expanded

--- a/app/client/ui/transientInput.ts
+++ b/app/client/ui/transientInput.ts
@@ -6,6 +6,7 @@
  * Escape, it calls close(), which should destroy the <input>.
  */
 
+import { onceAttached } from "app/client/lib/domUtils";
 import { reportError } from "app/client/models/AppModel";
 import { theme } from "app/client/ui2018/cssVars";
 
@@ -30,12 +31,12 @@ export function transientInput({ initialValue, save, close }: ITransientInputOpt
       close();
     } catch (err) {
       reportError(err);
-      delayedFocus();
+      focusWhenAttached();
     }
   }
 
-  function delayedFocus() {
-    setTimeout(() => { input.focus(); input.select(); }, 10);
+  function focusWhenAttached() {
+    onceAttached(input, () => { input.focus(); input.select(); });
   }
 
   const input = cssInput({ type: "text", placeholder: "Enter name" },
@@ -47,7 +48,7 @@ export function transientInput({ initialValue, save, close }: ITransientInputOpt
     }),
     ...args,
   );
-  delayedFocus();
+  focusWhenAttached();
   return input;
 }
 

--- a/app/client/widgets/ChoiceListEntry.ts
+++ b/app/client/widgets/ChoiceListEntry.ts
@@ -1,3 +1,4 @@
+import { onceAttached } from "app/client/lib/domUtils";
 import { makeT } from "app/client/lib/localization";
 import { IToken, TokenField } from "app/client/lib/TokenField";
 import { cssBlockedCursor } from "app/client/ui/RightPanelStyles";
@@ -313,7 +314,7 @@ export class ChoiceListEntry extends Disposable {
   }
 
   private _focusOnOpen(elem: HTMLInputElement): void {
-    setTimeout(() => focus(elem), 0);
+    onceAttached(elem, () => focus(elem));
   }
 
   private _renderToken(token: ChoiceItem) {

--- a/test/nbrowser/ChoiceList.ts
+++ b/test/nbrowser/ChoiceList.ts
@@ -135,8 +135,21 @@ async function renameEntry(from: string, to: string) {
 }
 
 async function clickEntry(label: string) {
-  const entry = await driver.findWait(`.test-choice-list-entry .test-token-label[value='${label}']`, 100);
+  const selector = `.test-choice-list-entry .test-token-label[value='${label}']`;
+  const entry = await driver.findWait(selector, 100);
   await entry.click();
+  // Clicking the label is what focuses it and selects its text. Keys sent before that lands go
+  // to whatever held the focus before, and the rename silently does not happen.
+  await gu.waitForEditorFocus(selector);
+}
+
+/**
+ * Reads the ChoiceList column after a page switch, which renders the section before its rows, so
+ * this waits rather than reading once.
+ */
+async function assertFilteredCells(expected: string[]) {
+  await gu.waitToPass(async () =>
+    assert.deepEqual(await gu.getVisibleGridCells({ rowNums: [1, 2, 3], cols: ["ChoiceList"] }), expected));
 }
 
 async function saveChoiceEntries() {
@@ -748,12 +761,13 @@ describe("ChoiceList", function() {
 
     await driver.sendKeys(Key.ENTER);
     await gu.waitAppFocus(false);
-    // waitToPass used to avoid "stale element not found in the current frame" error with getEditModeFillColors
+    // These getters find the tokens then read them one at a time, so a re-render in between
+    // raises "stale element not found". They read the same tokens, so they retry together.
     await gu.waitToPass(async () => {
       assert.deepEqual(await getEditModeFillColors(), [DARK_GREEN_FILL, BLUE_FILL,  BLACK_FILL, WHITE_FILL]);
+      assert.deepEqual(await getEditModeTextColors(), [WHITE_TEXT,      BLACK_TEXT, WHITE_TEXT, BLACK_TEXT]);
+      assert.deepEqual(await getEditModeFontOptions(), [{ bold, underline, strikethrough }, {}, {}, { underline }]);
     }, 1000);
-    assert.deepEqual(await getEditModeTextColors(), [WHITE_TEXT,      BLACK_TEXT, WHITE_TEXT, BLACK_TEXT]);
-    assert.deepEqual(await getEditModeFontOptions(), [{ bold, underline, strikethrough }, {}, {}, { underline }]);
 
     // Undo, then re-do, verifying after each invocation
     await driver.find(".test-choice-list-entry .test-tokenfield .test-tokenfield-input").click();
@@ -954,7 +968,9 @@ describe("ChoiceList", function() {
     await gu.sendKeys(Key.ENTER);
     await gu.waitForServer();
     await gu.getCell("ChoiceList", 3).click();
-    await gu.enterCell(["one", Key.ENTER, "foo", Key.ENTER]);
+    // The third Enter closes the editor. Without it nothing is sent, so the wait for the server
+    // waits for nothing and the cell is written, with its old names, after the rename below.
+    await gu.enterCell(["one", Key.ENTER, "foo", Key.ENTER, Key.ENTER]);
     await gu.waitForServer();
 
     // Make sure right panel is open and has right focus.
@@ -1008,37 +1024,21 @@ describe("ChoiceList", function() {
 
     // Go back to Table1
     await gu.getPageItem("Table1").click();
-    // Make sure grid is filtered
-    assert.deepEqual(await gu.getVisibleGridCells({ rowNums: [1, 2, 3], cols: ["ChoiceList"] }), [
-      "one",
-      "one\nfoo",
-      "", // new row
-    ]);
+    // Make sure grid is filtered.
+    await assertFilteredCells(["one", "one\nfoo", ""]);
     // Rename one to five, foo to bar
     await editChoiceEntries();
     await renameEntry("one", "five");
     await renameEntry("foo", "bar");
     await saveChoiceEntries();
     // Make sure that there are still two records - filter should be changed to new values.
-    assert.deepEqual(await gu.getVisibleGridCells({ rowNums: [1, 2, 3], cols: ["ChoiceList"] }), [
-      "five",
-      "five\nbar",
-      "", // new row
-    ]);
+    await assertFilteredCells(["five", "five\nbar", ""]);
     // Make sure that it also renamed filters in diffrent section.
     await gu.getPageItem("Table1 (copy)").click();
-    assert.deepEqual(await gu.getVisibleGridCells({ rowNums: [1, 2, 3], cols: ["ChoiceList"] }), [
-      "five",
-      "five\nbar",
-      "", // new row
-    ]);
+    await assertFilteredCells(["five", "five\nbar", ""]);
     // Go back to previous names, filter still should work.
     await gu.undo();
-    assert.deepEqual(await gu.getVisibleGridCells({ rowNums: [1, 2, 3], cols: ["ChoiceList"] }), [
-      "one",
-      "one\nfoo",
-      "", // new row
-    ]);
+    await assertFilteredCells(["one", "one\nfoo", ""]);
   },
   // Test if the column is reverted to state before the test
   () => gu.getVisibleGridCells({ rowNums: [1, 2, 3], cols: ["ChoiceList"] })));

--- a/test/nbrowser/ColumnFilterMenu.ts
+++ b/test/nbrowser/ColumnFilterMenu.ts
@@ -154,6 +154,26 @@ describe("ColumnFilterMenu", function() {
     );
   });
 
+  it("includes a value clicked while its checkbox still shows the old filter", async () => {
+    // The checkboxes follow the filter on a debounce, so just after None they can still show
+    // the old state, and a click there deletes instead of adding. The window is a moment wide,
+    // so it is made here rather than waited for.
+    await driver.findContent(".test-filter-menu-bulk-action", /None/).click();
+    const label = await driver.findContentWait(".test-filter-menu-value", /^Aba$/, 1000)
+      .findClosest("label");
+    await driver.executeScript((elem: HTMLElement) => {
+      elem.querySelector("input")!.checked = true;
+    }, label);
+
+    await label.click();
+    await driver.find(".test-filter-menu-apply-btn").click();
+
+    assert.deepEqual(
+      await gu.getVisibleGridCells({ cols: ["Name"], rowNums: [1, 2] }),
+      ["Aba", ""],
+    );
+  });
+
   it("should take other filters into account", async () => {
     const session = await gu.session().teamSite.login();
     doc = await session.tempDoc(cleanup, "SortFilterIconTest.grist");

--- a/test/nbrowser/DetailView.ts
+++ b/test/nbrowser/DetailView.ts
@@ -1,7 +1,7 @@
 import * as gu from "test/nbrowser/gristUtils";
 import { cleanupExtraWindows, server, setupTestSuite } from "test/nbrowser/testUtils";
 
-import { assert, driver } from "mocha-webdriver";
+import { assert, driver, Key } from "mocha-webdriver";
 
 describe("DetailView", function() {
   this.timeout(20000);
@@ -31,6 +31,11 @@ describe("DetailView", function() {
     await fieldA.click(); // second is to edit it
     assert.equal(await driver.find(".test-widget-text-editor").isPresent(), true);
     await gu.checkTextEditor("some text");
+
+    // The tests below assert that no editor is open. One left behind here is still on its way
+    // out while they look, which on a quick machine is what they find.
+    await gu.sendKeys(Key.ESCAPE);
+    await driver.wait(async () => !(await driver.find(".test-widget-text-editor").isPresent()), 1000);
   });
 
   it("does not opens cell for editing when clicked on link", async () => {
@@ -43,6 +48,24 @@ describe("DetailView", function() {
 
     assert.equal(await fieldB.getText(), server.getHost());
     await driver.sleep(100); // This click is ignored, so wait for a bit.
+    assert.equal(await driver.find(".test-widget-text-editor").isPresent(), false);
+  });
+
+  it("does not open cell for editing when the link is double-clicked", async () => {
+    // A double click made of two clicks on different elements lands on the ancestor they share:
+    // here the cell, not the link. Raised directly, since two driver clicks may not be doubled.
+    const fieldB = await gu.getDetailCell("B", 1);
+    await driver.executeScript((cell: HTMLElement, link: HTMLElement) => {
+      const box = link.getBoundingClientRect();
+      cell.dispatchEvent(new MouseEvent("dblclick", {
+        bubbles: true,
+        clientX: box.left + box.width / 2,
+        clientY: box.top + box.height / 2,
+      }));
+    }, fieldB, await fieldB.find(".test-tb-link-icon"));
+
+    assert.equal(await fieldB.getText(), server.getHost());
+    await driver.sleep(100); // The double click is ignored, so wait for a bit.
     assert.equal(await driver.find(".test-widget-text-editor").isPresent(), false);
   });
 });

--- a/test/nbrowser/Pages.ts
+++ b/test/nbrowser/Pages.ts
@@ -227,6 +227,28 @@ describe("Pages", function() {
     assert.deepEqual(await gu.getPageNames(), ["Interactions", "Documents", "People", "User & Leads", "Overview"]);
   });
 
+  it("opens the rename editor holding the focus, with the name selected", async () => {
+    // Renaming types over the name, so the editor has to arrive focused with its text selected.
+    // This catches a focus put off by longer than it takes to ask; it would not catch one put
+    // off by a few milliseconds, which is what this used to do.
+    await gu.openPage(/People/);
+    await driver.findContent(".test-treeview-label", "People").doClick();
+
+    const editor = await driver.find(".test-docpage-editor");
+    assert.equal(await editor.hasFocus(), true);
+    const selected = await driver.executeScript<string>(() => {
+      const input = document.activeElement as HTMLInputElement;
+      return input.value.slice(input.selectionStart ?? 0, input.selectionEnd ?? 0);
+    });
+    assert.equal(selected, "People");
+
+    await driver.sendKeys(Key.ESCAPE);
+    assert.deepEqual(
+      await gu.getPageNames(),
+      ["Interactions", "Documents", "People", "User & Leads", "Overview"],
+    );
+  });
+
   it("should not allow blank page name", async () => {
     // Begin renaming of People page
     await gu.openPageMenu("People");
@@ -362,7 +384,10 @@ describe("Pages", function() {
   it("should allow saving collapsed state", async () => {
     // Collapse Interactions and save. It should remain collapsed on page reload.
     await driver.findContent(".test-treeview-itemHeader", /Interactions/).find(".test-treeview-itemArrow").doClick();
-    assert.deepEqual(await gu.getPageNames(), ["Interactions", "", "People", "User & Leads", "Overview"]);
+    // The arrow collapses the tree on the spot, but the children go on their own schedule, so
+    // read this until it settles rather than once.
+    await gu.waitToPass(async () =>
+      assert.deepEqual(await gu.getPageNames(), ["Interactions", "", "People", "User & Leads", "Overview"]));
     await gu.openPageMenu("Interactions");
     await gu.findOpenMenuItem(".test-docpage-collapse-by-default", "Set default: Collapse").click();
     await gu.waitForServer();
@@ -380,7 +405,8 @@ describe("Pages", function() {
 
     // Expand Interactions and save. It should remain expanded on page reload.
     await driver.findContent(".test-treeview-itemHeader", /Interactions/).find(".test-treeview-itemArrow").doClick();
-    assert.deepEqual(await gu.getPageNames(), ["Interactions", "Documents", "People", "User & Leads", "Overview"]);
+    await gu.waitToPass(async () =>
+      assert.deepEqual(await gu.getPageNames(), ["Interactions", "Documents", "People", "User & Leads", "Overview"]));
     await gu.openPageMenu("Interactions");
     await gu.findOpenMenuItem(".test-docpage-expand-by-default", "Set default: Expand").click();
     await gu.waitForServer();


### PR DESCRIPTION
These three suites fail on macos-14 consistently, which will soon be a tested platform for Grist Desktop. The fixes here were developed and tested against macos-14. They won't have as much of an effect in grist-core CI, but should still help.

Five places took the focus on a timer, since an element cannot take the focus before it is in the page. But a timer callback only runs between tasks, so a busy main thread delays it however short the delay was set to. onceAttached waits for the element to be added instead.

The filter menu read the checkbox to decide whether a click was adding or removing a value, and its listener updates that box on a debounce. Click None and then quickly click a value: the box still shows the old state, so the click removes the value rather than adding it.

Double-clicking a cell's link icon opened the editor on top of the link. Two clicks on different elements arrive as one double click on the element they share, here the cell, so checking the event's target missed it.

In the tests: a ChoiceList rename left its cell editor open, and that editor saved itself afterwards, on top of the rename. DetailView's first test left an editor open, so the two tests after it, which check that none is open, were waiting for that one to close. A Pages test read the page tree straight after clicking the collapse arrow, before the children had redrawn. Two ChoiceList helpers typed into the token editor before it had the focus.
