### PR TITLE
Honor no_proxy / NO_PROXY for proxied outbound requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ Grist can be configured in many ways. Here are the main environment variables it
 | GRIST_HOST | hostname to use when listening on a port. Also decides the address a doc worker publishes for its peers, and the identity derived from it: set it to `0.0.0.0` to listen on every interface, and leave it unset to listen only on `localhost`. |
 | GRIST_PROXY_FOR_UNTRUSTED_URLS | Full URL of proxy for delivering webhook payloads. Default value is `direct` for delivering payloads without proxying. |
 | HTTPS_PROXY or https_proxy | Full URL of reverse web proxy (corporate proxy) for fetching the custom widgets repository or the OIDC config from the issuer. |
+| NO_PROXY or no_proxy | Comma or whitespace separated list of hosts to reach directly, bypassing the proxies set by `HTTPS_PROXY` and `GRIST_PROXY_FOR_UNTRUSTED_URLS`. Uses the usual `no_proxy` semantics: `*` bypasses every host, an entry matches a host or any of its subdomains (`.example.com` or `example.com`), and an optional `:port` suffix restricts the match to that port. |
 | GRIST_ID_PREFIX | for subdomains of form o-*, expect or produce o-${GRIST_ID_PREFIX}*. |
 | GRIST_IGNORE_SESSION | if set, Grist will not use a session for authentication. |
 | GRIST_INCLUDE_CUSTOM_SCRIPT_URL | if set, will load the referenced URL in a `<script>` tag on all app pages. |

--- a/app/server/lib/ProxyAgent.ts
+++ b/app/server/lib/ProxyAgent.ts
@@ -5,18 +5,59 @@ import fetch, { RequestInit } from "node-fetch";
 import { ProxyAgent, ProxyAgentOptions } from "proxy-agent";
 
 /**
+ * Returns true if requests to `requestUrl` should skip the proxy according to a
+ * `no_proxy`-style bypass list, using the de-facto standard semantics:
+ *
+ *  - the list is separated by commas and/or whitespace;
+ *  - `*` on its own bypasses the proxy for every host;
+ *  - an entry matches when it equals the request host or is a dot-suffix of it
+ *    (a leading dot on the entry is not significant: `.example.com` == `example.com`);
+ *  - an optional `:port` suffix on an entry must match the request's port
+ *    (defaulting to 80 for http and 443 for https).
+ *
+ * Matching is case-insensitive on the host.
+ */
+export function shouldProxyBypass(requestUrl: URL | string, noProxy: string | undefined): boolean {
+  if (!noProxy) { return false; }
+  const url = new URL(requestUrl);
+  const host = url.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  const port = url.port || (url.protocol === "https:" ? "443" : url.protocol === "http:" ? "80" : "");
+
+  for (let entry of noProxy.split(/[\s,]+/)) {
+    if (!entry) { continue; }
+    if (entry === "*") { return true; }
+    entry = entry.toLowerCase();
+    const portMatch = /^(.*):(\d+)$/.exec(entry);
+    if (portMatch) {
+      if (portMatch[2] !== port) { continue; }
+      entry = portMatch[1];
+    }
+    entry = entry.replace(/^\.+/, "");
+    if (!entry) { continue; }
+    if (host === entry || host.endsWith("." + entry)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * GristProxyAgent derives from ProxyAgent which is a class that is responsible for proxying the request using either
  * HttpProxyAgent or HttpsProxyAgent (or other supported proxy agents)
  * depending on the URL requested when using fetch().
  *
  * We configure the getProxyForUrl to not let ProxyAgent magically read the env variables
  * itself (using `proxy-from-env` module), we already do that ourselves and need to keep the control for that.
+ *
+ * `noProxy` holds a `no_proxy`-style bypass list (see `shouldProxyBypass`); requests whose URL
+ * matches it are made directly instead of through the proxy.
  */
 export class GristProxyAgent extends ProxyAgent {
-  constructor(public readonly proxyUrl: string, opts?: Omit<ProxyAgentOptions, "getProxyForUrl">) {
+  constructor(public readonly proxyUrl: string, public readonly noProxy?: string,
+    opts?: Omit<ProxyAgentOptions, "getProxyForUrl">) {
     super({
       ...opts,
-      getProxyForUrl: () => this.proxyUrl,
+      getProxyForUrl: (url: string) => shouldProxyBypass(url, this.noProxy) ? "" : this.proxyUrl,
     });
   }
 }
@@ -32,14 +73,20 @@ export function getProxyAgentConfiguration() {
     preferredEnvVar: "GRIST_PROXY_FOR_UNTRUSTED_URLS",
   });
 
+  const noProxy = appSettings.section("proxy").readString({
+    envVar: ["NO_PROXY", "no_proxy"],
+    preferredEnvVar: "NO_PROXY",
+  });
+
   return {
     proxyForTrustedRequestsUrl,
     proxyForUntrustedRequestsUrl,
+    noProxy,
   };
 }
 
 function generateProxyAgents() {
-  const { proxyForTrustedRequestsUrl, proxyForUntrustedRequestsUrl } = getProxyAgentConfiguration();
+  const { proxyForTrustedRequestsUrl, proxyForUntrustedRequestsUrl, noProxy } = getProxyAgentConfiguration();
 
   if (process.env.GRIST_HTTPS_PROXY) {
     log.warn("GRIST_HTTPS_PROXY is deprecated in favor of GRIST_PROXY_FOR_UNTRUSTED_URLS. " +
@@ -47,9 +94,9 @@ function generateProxyAgents() {
   }
 
   return {
-    trusted: proxyForTrustedRequestsUrl ? new GristProxyAgent(proxyForTrustedRequestsUrl) : undefined,
+    trusted: proxyForTrustedRequestsUrl ? new GristProxyAgent(proxyForTrustedRequestsUrl, noProxy) : undefined,
     untrusted: (proxyForUntrustedRequestsUrl && proxyForUntrustedRequestsUrl !== "direct") ?
-      new GristProxyAgent(proxyForUntrustedRequestsUrl) : undefined,
+      new GristProxyAgent(proxyForUntrustedRequestsUrl, noProxy) : undefined,
   };
 }
 

--- a/test/server/lib/ProxyAgent.ts
+++ b/test/server/lib/ProxyAgent.ts
@@ -1,6 +1,6 @@
 import log from "app/server/lib/log";
 import {
-  agents, fetchUntrustedWithAgent, GristProxyAgent, test_generateProxyAgents,
+  agents, fetchUntrustedWithAgent, GristProxyAgent, shouldProxyBypass, test_generateProxyAgents,
 } from "app/server/lib/ProxyAgent";
 import { getAvailablePort } from "app/server/lib/serverUtils";
 import { serveSomething, Serving } from "test/server/customUtil";
@@ -94,6 +94,68 @@ describe("ProxyAgent", function() {
 
       assert.isUndefined(proxyAgents.untrusted);
     });
+
+    it("should pass the no_proxy env var to both proxy agents", function() {
+      process.env.HTTPS_PROXY = proxyForTrustedUrlExample;
+      process.env.GRIST_PROXY_FOR_UNTRUSTED_URLS = proxyForUntrustedUrlExample;
+      process.env.no_proxy = "example.com, .internal";
+
+      const proxyAgents = test_generateProxyAgents();
+
+      assert.equal(proxyAgents.trusted?.noProxy, "example.com, .internal");
+      assert.equal(proxyAgents.untrusted?.noProxy, "example.com, .internal");
+    });
+
+    it("should prefer NO_PROXY over no_proxy", function() {
+      process.env.HTTPS_PROXY = proxyForTrustedUrlExample;
+      process.env.NO_PROXY = "from-upper";
+      process.env.no_proxy = "from-lower";
+
+      const proxyAgents = test_generateProxyAgents();
+
+      assert.equal(proxyAgents.trusted?.noProxy, "from-upper");
+    });
+  });
+
+  describe("shouldProxyBypass", function() {
+    it("returns false when the bypass list is empty or undefined", function() {
+      assert.isFalse(shouldProxyBypass("https://example.com", undefined));
+      assert.isFalse(shouldProxyBypass("https://example.com", ""));
+      assert.isFalse(shouldProxyBypass("https://example.com", "  , "));
+    });
+
+    it("bypasses everything when the list is '*'", function() {
+      assert.isTrue(shouldProxyBypass("https://example.com", "*"));
+      assert.isTrue(shouldProxyBypass("http://10.0.0.1:8080", "other, *"));
+    });
+
+    it("matches an exact host", function() {
+      assert.isTrue(shouldProxyBypass("https://example.com/path", "example.com"));
+      assert.isFalse(shouldProxyBypass("https://notexample.com", "example.com"));
+    });
+
+    it("matches a domain suffix, with or without a leading dot", function() {
+      assert.isTrue(shouldProxyBypass("https://api.internal.example.com", ".example.com"));
+      assert.isTrue(shouldProxyBypass("https://api.internal.example.com", "example.com"));
+      assert.isFalse(shouldProxyBypass("https://example.com.evil.com", "example.com"));
+    });
+
+    it("splits the list on commas and whitespace", function() {
+      assert.isTrue(shouldProxyBypass("https://b.com", "a.com, b.com\tc.com"));
+      assert.isTrue(shouldProxyBypass("https://c.com", "a.com, b.com\tc.com"));
+      assert.isFalse(shouldProxyBypass("https://d.com", "a.com, b.com\tc.com"));
+    });
+
+    it("honors an optional port on a bypass entry", function() {
+      assert.isTrue(shouldProxyBypass("https://example.com", "example.com:443"));
+      assert.isFalse(shouldProxyBypass("https://example.com", "example.com:8443"));
+      assert.isTrue(shouldProxyBypass("http://example.com:8080", "example.com:8080"));
+    });
+
+    it("is case-insensitive on the host", function() {
+      assert.isTrue(shouldProxyBypass("https://EXAMPLE.com", "example.com"));
+      assert.isTrue(shouldProxyBypass("https://example.com", "EXAMPLE.COM"));
+    });
   });
 
   describe("proxy error handling", async function() {
@@ -145,6 +207,40 @@ describe("ProxyAgent", function() {
         /warn: ProxyAgent error.*((request.*failed)|(ECONNREFUSED)|(AggregateError))/,
         /warn: ProxyAgent error.*((request.*failed)|(ECONNREFUSED)|(AggregateError))/,
       ]);
+    });
+  });
+
+  describe("proxy bypass", async function() {
+    let serving: Serving;
+    let testProxyServer: TestProxyServer;
+
+    beforeEach(async function() {
+      const port = await getAvailablePort(22340);
+      testProxyServer = await TestProxyServer.Prepare(port);
+      serving = await serveSomething((app) => {
+        app.all("/200", (_, res) => { res.sendStatus(200); res.end(); });
+      });
+      process.env.GRIST_PROXY_FOR_UNTRUSTED_URLS = `http://localhost:${testProxyServer.port}`;
+    });
+
+    afterEach(async function() {
+      await serving.shutdown();
+      await testProxyServer.dispose().catch(() => {});
+    });
+
+    it("routes a request through the proxy when the host is not on the bypass list", async function() {
+      sandbox.stub(agents, "untrusted").value(test_generateProxyAgents().untrusted);
+
+      assert.equal((await fetchUntrustedWithAgent(serving.url + "/200")).status, 200);
+      assert.equal(testProxyServer.proxyCallCounter, 1, "The proxy should have been called");
+    });
+
+    it("connects directly when the host is on the no_proxy bypass list", async function() {
+      process.env.no_proxy = "localhost, 127.0.0.1";
+      sandbox.stub(agents, "untrusted").value(test_generateProxyAgents().untrusted);
+
+      assert.equal((await fetchUntrustedWithAgent(serving.url + "/200")).status, 200);
+      assert.equal(testProxyServer.proxyCallCounter, 0, "The proxy should have been bypassed");
     });
   });
 });


### PR DESCRIPTION
### Context

Closes #2582 (the `no_proxy` part of #855).

`GristProxyAgent` deliberately overrides `getProxyForUrl` to always return the configured proxy URL, short-circuiting `proxy-from-env`. As a result the standard `no_proxy` / `NO_PROXY` environment variable is ignored, and every outbound request is forced through the proxy. In corporate setups where the proxy is only for external traffic, internal hosts become unreachable — e.g. when `GRIST_WIDGET_LIST_URL` points to an internal server, the widget manifest fetch (`WidgetRepository`, using `agents.trusted`) still goes through the proxy and fails.

### Change

- New `shouldProxyBypass(url, noProxy)` helper implementing the de-facto `no_proxy` semantics:
  - comma/whitespace separated list
  - `*` bypasses every host
  - entry matches the host or any subdomain (`.example.com` / `example.com`)
  - optional `:port` suffix restricts the match to that port
  - case-insensitive on the host
- `GristProxyAgent` now reads `NO_PROXY` / `no_proxy` and returns an empty proxy (direct connection) for matching URLs. Applied to both the trusted and untrusted agents.
- Documented the new variable in `README.md` next to `HTTPS_PROXY` / `GRIST_PROXY_FOR_UNTRUSTED_URLS`.

### Tests

`test/server/lib/ProxyAgent.ts`:
- unit tests for `shouldProxyBypass` (empty list, `*`, exact host, domain suffix, list separators, port, case)
- config test that `no_proxy` is passed to both agents and `NO_PROXY` wins over `no_proxy`
- integration tests through `TestProxyServer`: a non-listed host still goes through the proxy; a listed host connects directly (`proxyCallCounter === 0`)

---
_This description and part of the code were drafted with AI assistance, then reviewed and tested manually._